### PR TITLE
feat(email): configure SendGrid for production email delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,22 @@ See [Development Lifecycle](docs/development_lifecycle.md) for detailed informat
 
 ## Deployment
 
-Ready to run in production? Please [check the Phoenix deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+### Required Environment Variables
+
+The following environment variables must be set in production:
+
+* `DATABASE_URL` - PostgreSQL database connection string
+* `SECRET_KEY_BASE` - Secret key for session encryption (generate with `mix phx.gen.secret`)
+* `TOKEN_SIGNING_SECRET` - Secret for signing authentication tokens
+* `SENDGRID_API_KEY` - SendGrid API key for sending magic link emails (required for authentication)
+
+### Optional Environment Variables
+
+* `RENDER_EXTERNAL_HOSTNAME` - Hostname for the application (defaults to "huddlz.com")
+* `PORT` - Port to bind to (defaults to 4000)
+* `POOL_SIZE` - Database connection pool size (defaults to 10)
+
+Ready to run in production? Please [check the Phoenix deployment guides](https://hexdocs.pm/phoenix/deployment.html) for detailed instructions.
 
 ## License
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -84,4 +84,14 @@ config :phoenix_live_view,
   enable_expensive_runtime_checks: true
 
 # Disable swoosh api client as it is only required for production adapters.
+# To use SendGrid in development, comment out the line below and set SENDGRID_API_KEY
 config :swoosh, :api_client, false
+
+# Optional: Enable SendGrid in development
+# if sendgrid_api_key = System.get_env("SENDGRID_API_KEY") do
+#   config :huddlz, Huddlz.Mailer,
+#     adapter: Swoosh.Adapters.Sendgrid,
+#     api_key: sendgrid_api_key
+#
+#   config :swoosh, :api_client, Swoosh.ApiClient.Req
+# end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -122,4 +122,20 @@ if config_env() == :prod do
   #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
+
+  # Configure SendGrid for production emails (required for magic link authentication)
+  sendgrid_api_key =
+    System.get_env("SENDGRID_API_KEY") ||
+      raise """
+      environment variable SENDGRID_API_KEY is missing.
+      This is required for magic link authentication to work.
+      Get your API key from https://sendgrid.com/
+      """
+
+  config :huddlz, Huddlz.Mailer,
+    adapter: Swoosh.Adapters.Sendgrid,
+    api_key: sendgrid_api_key
+
+  # Configure Swoosh API client to use Req (already included in deps)
+  config :swoosh, :api_client, Swoosh.ApiClient.Req
 end


### PR DESCRIPTION
## Summary
This PR adds SendGrid configuration for production email delivery, which is essential for the magic link authentication system to work in production.

## Changes Made
- Added required \ environment variable check in production
- Configured Swoosh to use SendGrid adapter with Req HTTP client
- Added optional SendGrid configuration for development environment (commented out by default)
- Updated README with deployment environment variables documentation

## Why This Change Is Needed
Huddlz uses magic link authentication, which requires email delivery to function. Without a proper email service configured in production, users cannot sign in.

## Testing
- Verified configuration syntax with \Generated huddlz app
- All tests continue to pass
- Development environment continues to use local adapter by default
- SendGrid will only be activated in production when \ is set

## Environment Variables
This PR makes \ a required environment variable in production. The app will fail to start without it, preventing deployment of a non-functional authentication system.