### PR TITLE
Fix production configuration and branding

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -70,7 +70,6 @@ if config_env() == :prod do
     secret_key_base: secret_key_base,
     check_origin: ["https://#{host}"]
 
-
   config :huddlz,
     token_signing_secret:
       System.get_env("TOKEN_SIGNING_SECRET") ||

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -16,8 +16,10 @@ defmodule HuddlzWeb.Layouts do
     <header class="navbar bg-base-100 px-4 sm:px-6 lg:px-8 shadow">
       <div class="navbar-start">
         <a href="/" class="flex items-center gap-2">
-          <img src={~p"/images/logo.svg"} width="36" />
-          <span class="text-lg font-bold tracking-tight">Huddlz</span>
+          <div class="w-9 h-9 bg-primary rounded-lg flex items-center justify-center text-primary-content font-bold text-lg">
+            h
+          </div>
+          <span class="text-lg font-bold tracking-tight">huddlz</span>
         </a>
       </div>
       <div class="navbar-center">

--- a/lib/huddlz_web/components/layouts/root.html.heex
+++ b/lib/huddlz_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="Huddlz" suffix=" · Phoenix Framework">
+    <.live_title default="huddlz" suffix=" · huddlz">
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />


### PR DESCRIPTION
## Summary

This PR addresses several production configuration issues and branding consistency:

### 🔧 Configuration Fixes
- **WebSocket Origin**: Configure check_origin to accept connections from huddlz.com
- **SSL Enforcement**: Move force_ssl to compile-time config and enable HSTS
- **Client IP Detection**: Add RemoteIp plug for proper IP detection behind Render's proxy
- **Host Configuration**: Use custom domain (huddlz.com) instead of Render's internal hostname
- **Build Process**: Move database migrations from server start to build phase

### 🎨 Branding Fixes
- Update page titles to use lowercase "huddlz" consistently
- Remove "Phoenix Framework" suffix, replace with "huddlz"
- Ensure all pages follow the pattern: "Page Name · huddlz"
- Update navbar to use lowercase "huddlz"
- Replace Phoenix logo with custom "h" logo icon

### 🚀 Deployment Notes
- Set `PHX_HOST=huddlz.com` environment variable on Render
- Migrations now run during build, not on every server restart
- All security improvements are backwards compatible

## Test Plan
- [x] WebSocket connections work on https://huddlz.com
- [x] HTTP traffic redirects to HTTPS
- [x] Page titles display correct branding
- [x] Navbar shows lowercase "huddlz" with custom logo
- [x] Client IPs are properly detected in logs