### PR TITLE
Fix upcoming huddl filter to evaluate timestamp at runtime

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -10,6 +10,8 @@ defmodule Huddlz.Communities.Huddl do
     authorizers: [Ash.Policy.Authorizer],
     primary_read_warning?: false
 
+  require Ash.Query
+
   postgres do
     table "huddlz"
     repo Huddlz.Repo
@@ -74,7 +76,11 @@ defmodule Huddlz.Communities.Huddl do
     end
 
     read :upcoming do
-      filter expr(starts_at > ^DateTime.utc_now())
+      prepare fn query, _ ->
+        now = DateTime.utc_now()
+        Ash.Query.filter(query, expr(starts_at > ^now))
+      end
+
       prepare Huddlz.Communities.Huddl.Preparations.FilterByVisibility
     end
 


### PR DESCRIPTION
## Summary
- Fixed the `:upcoming` action filter to evaluate `DateTime.utc_now()` at runtime instead of compile time
- This ensures past events are properly filtered out when querying for upcoming huddls

## Problem
The `:upcoming` action in the `Huddl` resource was using `^DateTime.utc_now()` in the filter expression, which gets evaluated at compile time. This caused the filter to use a stale timestamp from when the code was compiled, allowing past events to be incorrectly included in the results.

## Solution
Changed the implementation to use a preparation function that evaluates `DateTime.utc_now()` at runtime:

```elixir
read :upcoming do
  prepare fn query, _ ->
    now = DateTime.utc_now()
    Ash.Query.filter(query, expr(starts_at > ^now))
  end
  
  prepare Huddlz.Communities.Huddl.Preparations.FilterByVisibility
end
```

## Test plan
- [x] All existing tests pass
- [x] Specifically verified the huddl search tests that were failing
- [x] Code formatting checked with `mix format`
- [x] Static analysis passed with `mix credo --strict`

🤖 Generated with [Claude Code](https://claude.ai/code)