### PR TITLE
Fix password reset forms to use app layout

### DIFF
--- a/lib/huddlz/accounts/user/senders/send_password_reset_email.ex
+++ b/lib/huddlz/accounts/user/senders/send_password_reset_email.ex
@@ -25,7 +25,7 @@ defmodule Huddlz.Accounts.User.Senders.SendPasswordResetEmail do
   end
 
   defp body(params) do
-    url = url(~p"/password-reset/#{params[:token]}")
+    url = url(~p"/reset/#{params[:token]}")
 
     """
     <p>Click this link to reset your password:</p>

--- a/test/features/step_definitions/password_authentication_steps.exs
+++ b/test/features/step_definitions/password_authentication_steps.exs
@@ -234,7 +234,7 @@ defmodule PasswordAuthenticationSteps do
           # This function needs to return truthy only for the email we want
           if sent_email.to == [{"", email}] && sent_email.subject == "Reset your password" do
             # Extract the reset link if this is the right email
-            case Regex.run(~r{(https?://[^/]+/password-reset/[^\s"'<>]+)}, sent_email.html_body) do
+            case Regex.run(~r{(https?://[^/]+/reset/[^\s"'<>]+)}, sent_email.html_body) do
               [_, url] -> url
               _ -> false
             end
@@ -267,7 +267,7 @@ defmodule PasswordAuthenticationSteps do
     session = context[:session] || context[:conn]
     # Using default Ash Authentication reset page now
     # Just verify we can see the form
-    assert_has(session, "button", text: "Reset password with token")
+    assert_has(session, "button", text: "Reset password")
     {:ok, context}
   end
 


### PR DESCRIPTION
## Summary

This PR fixes the password reset forms to use the custom app layout with proper huddlz branding, matching the registration form's styling.

## Changes

- Updated password reset email sender to link to custom forms at `/reset/*` instead of default Ash forms at `/password-reset/*`
- Enhanced error handling in the password reset confirmation LiveView to properly display invalid token errors
- Updated tests to work within PhoenixTest's limitations for testing LiveView form submissions

## Technical Details

The issue was that while we had custom password reset LiveViews with the app layout, the email sender was still linking to the default Ash Framework routes which showed the unstyled forms. 

The custom forms at `/reset` (request) and `/reset/:token` (confirmation) were already properly wrapped in the `<.app>` component from `layouts.ex`, but weren't being used because emails pointed to `/password-reset/*`.

## Testing

- All existing tests pass
- Password reset flow works end-to-end with proper styling
- Invalid tokens show appropriate error messages

## Screenshots

Before (default Ash UI):
- No app header/footer
- Ash Framework branding

After (custom forms):
- Consistent huddlz branding
- App layout with header/footer
- Matches registration form styling

Closes #54