### PR TITLE
fix(auth): Fix seed by updating user resource actions

### DIFF
--- a/lib/huddlz/accounts.ex
+++ b/lib/huddlz/accounts.ex
@@ -12,6 +12,7 @@ defmodule Huddlz.Accounts do
     resource Huddlz.Accounts.User do
       # Define proper code interfaces for actions
       define :search_by_email, action: :search_by_email, args: [:email]
+      define :update_confirmed_at, action: :update_confirmed_at, args: [:confirmed_at]
       define :update_role, action: :update_role, args: [:role]
       define :get_by_email, action: :get_by_email, args: [:email]
       define :update_display_name, action: :update_display_name, args: [:display_name]

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -108,6 +108,11 @@ defmodule Huddlz.Accounts.User do
       validate string_length(:display_name, min: 1, max: 30)
     end
 
+    update :update_confirmed_at do
+      description "Update a user's confirmed_at"
+      accept [:confirmed_at]
+    end
+
     update :update_role do
       description "Update a user's role"
       accept [:role]
@@ -212,6 +217,10 @@ defmodule Huddlz.Accounts.User do
         allow_nil? false
       end
 
+      argument :display_name, :string do
+        allow_nil? true
+      end
+
       argument :password, :string do
         description "The proposed password for the user, in plain text."
         allow_nil? false
@@ -227,6 +236,9 @@ defmodule Huddlz.Accounts.User do
 
       # Sets the email from the argument
       change set_attribute(:email, arg(:email))
+
+      # Sets the display name from the argument
+      change set_attribute(:display_name, arg(:display_name))
 
       # Generate a random display name if none provided
       change Huddlz.Accounts.User.Changes.SetDefaultDisplayName

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -31,22 +31,24 @@ if Enum.empty?(existing_groups) do
       })
       |> Ash.create(authorize?: false)
 
-    if role != :regular do
-      {:ok, user} =
-        user
-        |> Ash.Changeset.for_update(:update, %{role: role, confirmed_at: DateTime.utc_now()})
-        |> Ash.update(authorize?: false)
+    user =
+      if role != :regular do
+        {:ok, user} =
+          user
+          |> Ash.Changeset.for_update(:update_role, %{role: role})
+          |> Ash.update(authorize?: false)
 
-      user
-    else
-      # Confirm regular users too
-      {:ok, user} =
         user
-        |> Ash.Changeset.for_update(:update, %{confirmed_at: DateTime.utc_now()})
-        |> Ash.update(authorize?: false)
+      else
+        user
+      end
 
+    {:ok, user} =
       user
-    end
+      |> Ash.Changeset.for_update(:update_confirmed_at, %{confirmed_at: DateTime.utc_now()})
+      |> Ash.update(authorize?: false)
+
+    user
   end
 
   # Create admin user

--- a/test/huddlz/accounts/user_test.exs
+++ b/test/huddlz/accounts/user_test.exs
@@ -129,4 +129,34 @@ defmodule Huddlz.Accounts.UserTest do
              end)
     end
   end
+
+  describe "user confirmation" do
+    test "update_role" do
+      email = "test-#{:rand.uniform(99999)}@example.com"
+
+      role = :regular
+      user = Ash.Seed.seed!(User, %{email: email})
+
+      {:ok, user} =
+        user
+        |> Ash.Changeset.for_update(:update_role, %{role: role})
+        |> Ash.update(authorize?: false)
+
+      assert user.role == role
+    end
+
+    test "update_confirmed_at" do
+      email = "test-#{:rand.uniform(99999)}@example.com"
+
+      confirmed_at = DateTime.utc_now()
+      user = Ash.Seed.seed!(User, %{email: email})
+
+      {:ok, user} =
+        user
+        |> Ash.Changeset.for_update(:update_confirmed_at, %{confirmed_at: confirmed_at})
+        |> Ash.update(authorize?: false)
+
+      assert user.confirmed_at == confirmed_at
+    end
+  end
 end


### PR DESCRIPTION
Seed is broken for two reasons:
- `display_name` is not an action argument for `register_with_password`
- `confirmed_at` is not an action argument for `update_role`.

Fixed by updating actions to support these columns.