### PR TITLE
Fix datetime runtime evaluation in huddl filters

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -119,7 +119,7 @@ defmodule Huddlz.Communities.Huddl do
         allow_nil? false
       end
 
-      filter expr(group_id == ^arg(:group_id) and starts_at > ^DateTime.utc_now())
+      filter expr(group_id == ^arg(:group_id) and starts_at > now())
 
       pagination keyset?: true,
                  offset?: true,
@@ -136,7 +136,7 @@ defmodule Huddlz.Communities.Huddl do
         allow_nil? false
       end
 
-      filter expr(group_id == ^arg(:group_id) and ends_at < ^DateTime.utc_now())
+      filter expr(group_id == ^arg(:group_id) and ends_at < now())
 
       pagination keyset?: true,
                  offset?: true,


### PR DESCRIPTION
## Summary
- Fixed compile-time vs runtime datetime evaluation issue in huddl query filters
- Tests were failing because filters were using a fixed timestamp from compile time

## Problem
The `by_group` and `past_by_group` read actions were using `^DateTime.utc_now()` in their filter expressions, which gets evaluated at compile time. This caused the filters to compare against a fixed timestamp from when the code was compiled, not the current time when the query executes.

## Solution
Changed `^DateTime.utc_now()` to `now()` in the filter expressions. The `now()` function is an Ash expression helper that evaluates to the current time at query execution.

## Test Results
All tests now pass:
- Fixed 5 failures in `HuddlzWeb.GroupLive.ShowTabsTest`
- Fixed 2 failures in `ViewPastHuddlzTest` feature tests
- Total: 335 tests, 0 failures

## Changes
- `lib/huddlz/communities/huddl.ex`: Updated `by_group` and `past_by_group` filter expressions