### PR TITLE
Update layout max-width & add placeholder images

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -84,7 +84,7 @@ defmodule HuddlzWeb.Layouts do
     </header>
 
     <main class="px-4 py-20 sm:px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl space-y-4">
+      <div class="mx-auto max-w-screen-2xl space-y-4">
         {render_slot(@inner_block)}
       </div>
     </main>

--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -57,11 +57,13 @@ defmodule HuddlzWeb.GroupLive.Index do
           <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             <%= for group <- @groups do %>
               <div class="card bg-base-100 shadow-xl">
-                <%= if group.image_url do %>
-                  <figure>
+                <figure>
+                  <%= if group.image_url do %>
                     <img src={group.image_url} alt={group.name} class="h-48 w-full object-cover" />
-                  </figure>
-                <% end %>
+                  <% else %>
+                    <img src={"https://placehold.co/600x400/orange/white?text=#{group.name}"} alt={group.name} class="h-48 w-full object-cover" />
+                  <% end %>
+                </figure>
                 <div class="card-body">
                   <h2 class="card-title">
                     {group.name}

--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -61,7 +61,11 @@ defmodule HuddlzWeb.GroupLive.Index do
                   <%= if group.image_url do %>
                     <img src={group.image_url} alt={group.name} class="h-48 w-full object-cover" />
                   <% else %>
-                    <img src={"https://placehold.co/600x400/orange/white?text=#{group.name}"} alt={group.name} class="h-48 w-full object-cover" />
+                    <img
+                      src={"https://placehold.co/600x400/orange/white?text=#{group.name}"}
+                      alt={group.name}
+                      class="h-48 w-full object-cover"
+                    />
                   <% end %>
                 </figure>
                 <div class="card-body">


### PR DESCRIPTION
When visiting the groups page, I noticed that the max width was very constrained.

<img width="1294" alt="Screenshot 2025-07-08 at 17 19 16" src="https://github.com/user-attachments/assets/545fdcba-6315-48d6-a4f1-ee01f55ecabb" />

This PR:
- relaxes the max width to make it a bit cleaner, and allows individual pages to add a tighter constraint if they need
- adds placeholder images for groups on the group discovery page

![CleanShot 2025-07-08 at 20 27 09@2x](https://github.com/user-attachments/assets/33ad3f61-f27b-457c-9950-bf8d2ae49391)
