### PR TITLE
Switch email adapter from SendGrid to Gmail

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -125,19 +125,16 @@ if config_env() == :prod do
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 
-  # Configure SendGrid for production emails (required for magic link authentication)
-  sendgrid_api_key =
-    System.get_env("SENDGRID_API_KEY") ||
+  # Configure Gmail for production emails (required for magic link authentication)
+  gmail_access_token =
+    System.get_env("GMAIL_ACCESS_TOKEN") ||
       raise """
-      environment variable SENDGRID_API_KEY is missing.
+      environment variable GMAIL_ACCESS_TOKEN is missing.
       This is required for magic link authentication to work.
-      Get your API key from https://sendgrid.com/
+      You need an OAuth2 access token with 'gmail.compose' scope.
       """
 
   config :huddlz, Huddlz.Mailer,
-    adapter: Swoosh.Adapters.Sendgrid,
-    api_key: sendgrid_api_key
-
-  # Configure Swoosh API client to use Req (already included in deps)
-  config :swoosh, :api_client, Swoosh.ApiClient.Req
+    adapter: Swoosh.Adapters.Gmail,
+    access_token: gmail_access_token
 end

--- a/mix.exs
+++ b/mix.exs
@@ -75,6 +75,7 @@ defmodule Huddlz.MixProject do
        compile: false,
        depth: 1},
       {:swoosh, "~> 1.16"},
+      {:mail, ">= 0.0.0"},
       {:req, "~> 0.5"},
       {:telemetry_metrics, "~> 1.0"},
       {:telemetry_poller, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -44,6 +44,7 @@
   "joken": {:hex, :joken, "2.6.2", "5daaf82259ca603af4f0b065475099ada1b2b849ff140ccd37f4b6828ca6892a", [:mix], [{:jose, "~> 1.11.10", [hex: :jose, repo: "hexpm", optional: false]}], "hexpm", "5134b5b0a6e37494e46dbf9e4dad53808e5e787904b7c73972651b51cce3d72b"},
   "jose": {:hex, :jose, "1.11.10", "a903f5227417bd2a08c8a00a0cbcc458118be84480955e8d251297a425723f83", [:mix, :rebar3], [], "hexpm", "0d6cd36ff8ba174db29148fc112b5842186b68a90ce9fc2b3ec3afe76593e614"},
   "libgraph": {:hex, :libgraph, "0.16.0", "3936f3eca6ef826e08880230f806bfea13193e49bf153f93edcf0239d4fd1d07", [:mix], [], "hexpm", "41ca92240e8a4138c30a7e06466acc709b0cbb795c643e9e17174a178982d6bf"},
+  "mail": {:hex, :mail, "0.5.1", "6383a61620aea24675c96e34b9019dede1bfc9a37ee10ce5a5cafcc7c5e48743", [:mix], [], "hexpm", "595144340b74f23d651ea2b4a72a896819940478d7425dfa302ea3b5c9041ec9"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "2.0.7", "b8d739037be7cd402aee1ba0306edfdef982687ee7e9859bee6198c1e7e2f128", [:mix], [], "hexpm", "6171188e399ee16023ffc5b76ce445eb6d9672e2e241d2df6050f3c771e80ccd"},
   "mimerl": {:hex, :mimerl, "1.3.0", "d0cd9fc04b9061f82490f6581e0128379830e78535e017f7780f37fea7545726", [:rebar3], [], "hexpm", "a1e15a50d1887217de95f0b9b0793e32853f7c258a5cd227650889b38839fe9d"},


### PR DESCRIPTION
## Summary
- Replaced SendGrid email adapter with Gmail adapter for sending emails
- Added Mail dependency required by the Gmail adapter
- Updated production configuration to use GMAIL_ACCESS_TOKEN instead of SENDGRID_API_KEY

## Changes
1. Added `{:mail, ">= 0.0.0"}` dependency to mix.exs
2. Updated config/runtime.exs to use Swoosh.Adapters.Gmail
3. Changed environment variable from SENDGRID_API_KEY to GMAIL_ACCESS_TOKEN

## Configuration Requirements
- Requires GMAIL_ACCESS_TOKEN environment variable in production
- Token must have OAuth2 'gmail.compose' scope
- See https://hexdocs.pm/swoosh/Swoosh.Adapters.Gmail.html for details

## Testing
All existing email functionality should work the same, just using Gmail as the delivery mechanism instead of SendGrid.