### PR TITLE
Edit Huddlz

### DIFF
--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -1,0 +1,223 @@
+defmodule HuddlzWeb.HuddlLive.Edit do
+  use HuddlzWeb, :live_view
+
+  alias Huddlz.Communities.Huddl
+  alias HuddlzWeb.Layouts
+
+  require Ash.Query
+
+  on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"group_slug" => group_slug, "id" => id}, _, socket) do
+    case get_huddl(id, group_slug, socket.assigns.current_user) do
+      {:ok, huddl} ->
+        form =
+          AshPhoenix.Form.for_update(huddl, :update,
+            domain: Huddlz.Communities,
+            actor: socket.assigns.current_user,
+            forms: [auto?: true]
+          )
+
+        {:noreply,
+         socket
+         |> assign(:page_title, huddl.title)
+         |> assign(:group_slug, group_slug)
+         |> assign(:huddl, huddl)
+         |> assign(:show_physical_location, !!huddl.physical_location)
+         |> assign(:show_virtual_link, !!huddl.virtual_link)
+         |> assign(:form, to_form(form))}
+
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Huddl not found")
+         |> redirect(to: ~p"/groups/#{group_slug}")}
+
+      {:error, :not_authorized} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "You don't have permission to edit this huddl")
+         |> redirect(to: ~p"/groups/#{group_slug}/huddlz/#{id}")}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_user={@current_user}>
+      <.link
+        navigate={~p"/groups/#{@group_slug}"}
+        class="text-sm font-semibold leading-6 hover:underline"
+      >
+        <.icon name="hero-arrow-left" class="h-3 w-3" /> Back to {@huddl.group.name}
+      </.link>
+      <.header>
+        Editing {@huddl.title}
+      </.header>
+
+      <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save" class="space-y-6">
+        <.input field={@form[:title]} type="text" label="Title" required />
+        <.input field={@form[:description]} type="textarea" label="Description" rows="4" />
+
+        <div class="grid gap-4 sm:grid-cols-2">
+          <.input field={@form[:starts_at]} type="datetime-local" label="Start Date & Time" required />
+          <.input field={@form[:ends_at]} type="datetime-local" label="End Date & Time" required />
+        </div>
+
+        <.input
+          field={@form[:event_type]}
+          type="select"
+          label="Event Type"
+          options={[
+            {"In-Person", "in_person"},
+            {"Virtual", "virtual"},
+            {"Hybrid (Both In-Person and Virtual)", "hybrid"}
+          ]}
+          required
+          phx-change="event_type_changed"
+        />
+
+        <%= if @show_physical_location do %>
+          <.input
+            field={@form[:physical_location]}
+            type="text"
+            label="Physical Location"
+            placeholder="e.g., 123 Main St, City, State"
+          />
+        <% end %>
+
+        <%= if @show_virtual_link do %>
+          <.input
+            field={@form[:virtual_link]}
+            type="text"
+            label="Virtual Meeting Link"
+            placeholder="e.g., https://zoom.us/j/123456789"
+          />
+        <% end %>
+
+        <%= if @huddl.group.is_public do %>
+          <.input
+            field={@form[:is_private]}
+            type="checkbox"
+            label="Make this a private event (only visible to group members)"
+          />
+        <% else %>
+          <p class="text-sm text-gray-600">
+            <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
+            This will be a private event (private groups can only create private events)
+          </p>
+        <% end %>
+
+        <div class="flex gap-4">
+          <.button type="submit" phx-disable-with="Creating...">
+            Save Huddl
+          </.button>
+          <.link navigate={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"} class="btn btn-ghost">
+            Cancel
+          </.link>
+        </div>
+      </.form>
+    </Layouts.app>
+    """
+  end
+
+  @impl true
+  def handle_event("validate", %{"form" => params}, socket) do
+    event_type = Map.get(params, "event_type", "in_person")
+
+    # Update visibility based on event type
+    socket =
+      socket
+      |> assign(:show_physical_location, event_type in ["in_person", "hybrid"])
+      |> assign(:show_virtual_link, event_type in ["virtual", "hybrid"])
+
+    form =
+      AshPhoenix.Form.validate(socket.assigns.form, params)
+
+    {:noreply, assign(socket, :form, to_form(form))}
+  end
+
+  def handle_event("event_type_changed", %{"form" => params}, socket) do
+    event_type = params["event_type"]
+
+    # Update visibility based on event type
+    socket =
+      socket
+      |> assign(:show_physical_location, event_type in ["in_person", "hybrid"])
+      |> assign(:show_virtual_link, event_type in ["virtual", "hybrid"])
+
+    # Also run validation
+    form =
+      AshPhoenix.Form.validate(socket.assigns.form, params)
+
+    {:noreply, assign(socket, :form, to_form(form))}
+  end
+
+  def handle_event("save", %{"form" => params}, socket) do
+    # Set is_private to true for private groups
+    params =
+      if socket.assigns.huddl.group.is_public do
+        params
+      else
+        Map.put(params, "is_private", "true")
+      end
+
+    params =
+      case params["event_type"] do
+        "virtual" -> Map.put(params, "physical_location", nil)
+        "in_person" -> Map.put(params, "virtual_link", nil)
+        _ -> params
+      end
+
+    case AshPhoenix.Form.submit(socket.assigns.form,
+           params: params,
+           actor: socket.assigns.current_user
+         ) do
+      {:ok, _huddl} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Huddl updated successfully!")
+         |> redirect(
+           to: ~p"/groups/#{socket.assigns.huddl.group.slug}/huddlz/#{socket.assigns.huddl.id}"
+         )}
+
+      {:error, form} ->
+        {:noreply, assign(socket, :form, to_form(form))}
+    end
+  end
+
+  defp get_huddl(id, group_slug, user) do
+    # Get the huddl and verify it belongs to the group with the given slug
+    case Huddl
+         |> Ash.Query.filter(id == ^id)
+         |> Ash.Query.load([:status, :visible_virtual_link, :group, :creator])
+         |> Ash.read_one(actor: user) do
+      {:ok, nil} ->
+        {:error, :not_found}
+
+      {:ok, huddl} ->
+        verify_group_and_ownership(huddl, user, group_slug)
+
+      {:error, _} ->
+        {:error, :not_authorized}
+    end
+  end
+
+  defp verify_group_and_ownership(huddl, user, group_slug) do
+    if huddl.group.slug == group_slug && huddl.creator_id == user.id do
+      {:ok, huddl}
+    else
+      if huddl.group.slug != group_slug do
+        {:error, :not_found}
+      else
+        {:error, :not_authorized}
+      end
+    end
+  end
+end

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -24,7 +24,8 @@ defmodule HuddlzWeb.HuddlLive.Show do
          socket
          |> assign(:page_title, huddl.title)
          |> assign(:huddl, huddl)
-         |> assign(:has_rsvped, has_rsvped)}
+         |> assign(:has_rsvped, has_rsvped)
+         |> assign(:is_creator, creator?(huddl, socket.assigns.current_user))}
 
       {:error, :not_found} ->
         {:noreply,
@@ -61,6 +62,14 @@ defmodule HuddlzWeb.HuddlLive.Show do
           <% end %>
         </:subtitle>
         <:actions>
+          <%= if @is_creator do %>
+            <.link
+              navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}/edit"}
+              class="btn btn-ghost"
+            >
+              <.icon name="hero-pencil" class="h-4 w-4" /> Edit Huddl
+            </.link>
+          <% end %>
           <%= if @current_user && @huddl.status == :upcoming do %>
             <%= if @has_rsvped do %>
               <div class="flex items-center gap-4">
@@ -253,6 +262,12 @@ defmodule HuddlzWeb.HuddlLive.Show do
       {:error, _} ->
         {:error, :not_authorized}
     end
+  end
+
+  defp creator?(_huddl, nil), do: false
+
+  defp creator?(huddl, user) do
+    huddl.creator_id == user.id
   end
 
   defp check_rsvp(_huddl, nil), do: false

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -47,6 +47,7 @@ defmodule HuddlzWeb.Router do
 
       # Huddl routes
       live "/groups/:group_slug/huddlz/new", HuddlLive.New, :new
+      live "/groups/:group_slug/huddlz/:id/edit", HuddlLive.Edit, :edit
       live "/groups/:group_slug/huddlz/:id", HuddlLive.Show, :show
     end
   end

--- a/test/features/edit_huddl.feature
+++ b/test/features/edit_huddl.feature
@@ -1,0 +1,40 @@
+@conn
+Feature: Edit Huddl
+  As a group owner or organizer
+  I want to edit huddlz for my groups
+  So that members know when and where to meet
+
+  Background:
+    Given the following users exist:
+      | email                 | role     | display_name |
+      | owner@example.com     | verified | Group Owner  |
+      | non_owner@example.com | verified | Other User   |
+    Given the following huddlz exist:
+      | name            | creator_name | group_name
+      | Future Workshop | Group Owner  | Tech Meetup
+
+  Scenario: Owner edits an in-person huddl
+    Given I am signed in as "owner@example.com"
+    When I visit the "Future Workshop" huddl page
+    Then I should see "Edit Huddl"
+    When I click "Edit Huddl"
+    Then I should be on the edit huddl page for "Future Workshop"
+    When I fill in the huddl form with:
+      | Field             | Value                        |
+      | Title             | Monthly Tech Workshop        |
+      | Description       | Discussion about new tech    |
+      | Start Date & Time | tomorrow at 6:00 PM          |
+      | End Date & Time   | tomorrow at 8:00 PM          |
+      | Event Type        | In-Person                    |
+      | Physical Location | 123 Main St, Tech City       |
+    And I save the form
+    Then I should be redirected to the "Monthly Tech Workshop" huddl page
+    And I should see "Huddl updated successfully!"
+
+  Scenario: Non-owner cannot edit a huddl
+    Given I am signed in as "non_owner@example.com"
+    When I visit the "Future Workshop" huddl page
+    Then I should not see "Edit Huddl"
+    When I try to visit the "Future Workshop" edit huddl page
+    Then I should be redirected to the "Future Workshop" huddl page
+    And I should see "You don't have permission to edit this huddl"

--- a/test/features/step_definitions/edit_huddl_steps.exs
+++ b/test/features/step_definitions/edit_huddl_steps.exs
@@ -1,0 +1,106 @@
+defmodule EditHuddlSteps do
+  use Cucumber.StepDefinition
+  import CucumberDatabaseHelper
+  import Huddlz.Generator
+  alias Huddlz.Communities.Huddl
+  import PhoenixTest
+  require Ash.Query
+
+  step "the following huddlz exist:", context do
+    ensure_sandbox()
+
+    huddlz =
+      context.datatable.maps
+      |> Enum.map(fn huddl_data ->
+        host =
+          Enum.find(context.users, fn u ->
+            to_string(u.display_name) == huddl_data["creator_name"]
+          end)
+
+        group =
+          generate(
+            group(owner_id: host.id, name: huddl_data["group_name"], is_public: true, actor: host)
+          )
+
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: host.id,
+            is_private: false,
+            title: huddl_data["name"],
+            actor: host
+          )
+        )
+      end)
+
+    Map.put(context, :huddlz, huddlz)
+  end
+
+  step "I should be on the edit huddl page for {string}", %{args: [huddl_title]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "*", text: "Editing #{huddl_title}")
+    context
+  end
+
+  step "I should be redirected to the {string} huddl page", %{args: [huddl_name]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "*", text: huddl_name)
+    context
+  end
+
+  step "I save the form", context do
+    form_data = Map.get(context, :form_data, %{})
+    session = context[:session] || context[:conn]
+
+    # First, select the event type if provided to ensure proper field visibility
+    session =
+      if form_data["event_type"] do
+        event_type_label =
+          case form_data["event_type"] do
+            "in_person" -> "In-Person"
+            "virtual" -> "Virtual"
+            "hybrid" -> "Hybrid (Both In-Person and Virtual)"
+            _ -> "In-Person"
+          end
+
+        select(session, "Event Type", option: event_type_label, exact: false)
+      else
+        session
+      end
+
+    # Fill in the form data
+    session =
+      Enum.reduce(form_data, session, fn {field, value}, session ->
+        case field do
+          "title" -> fill_in(session, "Title", with: value, exact: false)
+          "description" -> fill_in(session, "Description", with: value, exact: false)
+          "physical_location" -> fill_in(session, "Physical Location", with: value, exact: false)
+          "virtual_link" -> fill_in(session, "Virtual Meeting Link", with: value, exact: false)
+          "starts_at" -> fill_in(session, "Start Date & Time", with: value, exact: false)
+          "ends_at" -> fill_in(session, "End Date & Time", with: value, exact: false)
+          # Already handled above
+          "event_type" -> session
+          _ -> session
+        end
+      end)
+
+    # Submit the form
+    session = click_button(session, "Save Huddl")
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I try to visit the {string} edit huddl page", %{args: [huddl_name]} = context do
+    user = context.current_user
+
+    huddl =
+      Huddl
+      |> Ash.Query.filter(title == ^huddl_name)
+      |> Ash.Query.load(:group)
+      |> Ash.read_one!(actor: user)
+
+    session = context[:session] || context[:conn]
+    session = session |> visit("/groups/#{huddl.group.slug}/huddlz/#{huddl.id}/edit")
+    Map.merge(context, %{session: session, conn: session})
+  end
+end


### PR DESCRIPTION
Add edit huddl page to allow huddl creator to manage it after creation.

- Link to page is accessible from show huddl page.
- User must be creator to edit.
- Changing event type to virtual clears physical location field.
- Changing event type to in-person clears virtual link field.

### Screenshot
<img width="1897" height="888" alt="Screenshot from 2025-08-02 12-55-59" src="https://github.com/user-attachments/assets/5309a15a-9e56-40af-97d4-b3d03be7ebbf" />

### Issues to consider
- Allowing huddl edits opens the ability to change the date/time _after_ it has occurred. One could make a future one past and vice versa. This would be logically confusing to attendees. How should we handle this?
- Editing huddlz is creator scoped for now. This should match the organizer in our current world, as it doesn't look like we support multiple organizers. If we do support multiple organizers in the future, authorization on this should be updated to include them. 