### PR TITLE
Delete Huddlz

### DIFF
--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -69,6 +69,13 @@ defmodule HuddlzWeb.HuddlLive.Show do
             >
               <.icon name="hero-pencil" class="h-4 w-4" /> Edit Huddl
             </.link>
+            <button
+              phx-click="delete_huddl"
+              data-confirm="Are you sure you want to delete this huddl?"
+              class="btn btn-ghost bg-red-500 text-white hover:bg-red-300"
+            >
+              <.icon name="hero-trash" class="h-4 w-4" /> Delete Huddl
+            </button>
           <% end %>
           <%= if @current_user && @huddl.status == :upcoming do %>
             <%= if @has_rsvped do %>
@@ -240,6 +247,15 @@ defmodule HuddlzWeb.HuddlLive.Show do
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to cancel RSVP. Please try again.")}
     end
+  end
+
+  def handle_event("delete_huddl", _, socket) do
+    Ash.destroy!(socket.assigns.huddl, actor: socket.assigns.current_user)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Huddl deleted successfully!")
+     |> redirect(to: ~p"/groups/#{socket.assigns.huddl.group.slug}")}
   end
 
   defp get_huddl(id, group_slug, user) do

--- a/test/features/delete_huddl.feature
+++ b/test/features/delete_huddl.feature
@@ -1,0 +1,27 @@
+@conn
+Feature: Delete Huddl
+  As a group owner or organizer
+  I want to delete huddlz for my groups
+  So that huddlz that are no longer occurring are removed
+
+  Background:
+    Given the following users exist:
+      | email                 | role     | display_name |
+      | owner@example.com     | verified | Group Owner  |
+      | non_owner@example.com | verified | Other User   |
+    Given the following huddlz exist:
+      | name            | creator_name | group_name
+      | Future Workshop | Group Owner  | Tech Meetup
+
+  Scenario: Owner deletes an in-person huddl
+    Given I am signed in as "owner@example.com"
+    When I visit the "Future Workshop" huddl page
+    Then I should see "Delete Huddl"
+    When I click "Delete Huddl"
+    Then I should be redirected to the "Tech Meetup" group page
+    And I should see "Huddl deleted successfully!"
+
+  Scenario: Non-owner cannot delete a huddl
+    Given I am signed in as "non_owner@example.com"
+    When I visit the "Future Workshop" huddl page
+    Then I should not see "Delete Huddl"


### PR DESCRIPTION
Add delete huddl button to show huddl page to allow huddl creator to remove it after creation.

- Button is accessible from show huddl page.
- User must be creator to delete.

### Screenshot
<img width="1920" height="887" alt="Screenshot from 2025-08-16 15-46-42" src="https://github.com/user-attachments/assets/6e831cdb-51b5-4b1b-a6c7-8843ce6f29bb" />
