### PR TITLE
test(harness): reduce setup duplication in test suite

### DIFF
--- a/test/features/step_definitions/create_huddl_steps.exs
+++ b/test/features/step_definitions/create_huddl_steps.exs
@@ -379,9 +379,6 @@ defmodule CreateHuddlSteps do
   end
 
   step "the huddl {string} should be created {int} times", %{args: [text, count]} = context do
-    # Wait a moment for any async operations to complete
-    Process.sleep(100)
-
     huddlz =
       Huddl
       |> Ash.Query.filter(title == ^text)
@@ -393,9 +390,6 @@ defmodule CreateHuddlSteps do
   end
 
   step "the huddl should be created as private", context do
-    # Wait a moment for any async operations to complete
-    Process.sleep(100)
-
     # Find the most recently created huddl using the correct actor
     huddl =
       Huddl

--- a/test/features/step_definitions/location_autocomplete_steps.exs
+++ b/test/features/step_definitions/location_autocomplete_steps.exs
@@ -1,6 +1,6 @@
 defmodule LocationAutocompleteSteps do
   use Cucumber.StepDefinition
-  import Mox
+  import Huddlz.Test.MoxHelpers
   import PhoenixTest
   import Phoenix.LiveViewTest
 
@@ -111,43 +111,15 @@ defmodule LocationAutocompleteSteps do
   end
 
   defp setup_autocomplete_stub(text) do
-    case text do
-      "aus" ->
-        stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts ->
-          {:ok,
-           [
-             %{
-               place_id: "p1",
-               display_text: "Austin, TX, USA",
-               main_text: "Austin",
-               secondary_text: "TX, USA"
-             }
-           ]}
-        end)
+    results =
+      case text do
+        "aus" -> [:austin]
+        "saint" -> [:saint_augustine]
+        _ -> []
+      end
 
-      "saint" ->
-        stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts ->
-          {:ok,
-           [
-             %{
-               place_id: "p2",
-               display_text: "Saint Augustine, FL, USA",
-               main_text: "Saint Augustine",
-               secondary_text: "FL, USA"
-             }
-           ]}
-        end)
-
-      _ ->
-        stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts -> {:ok, []} end)
-    end
+    stub_places_autocomplete(%{text => results})
   end
 
-  defp setup_place_details_stub do
-    stub(Huddlz.MockPlaces, :place_details, fn
-      "p1", _token -> {:ok, %{latitude: 30.27, longitude: -97.74}}
-      "p2", _token -> {:ok, %{latitude: 29.89, longitude: -81.31}}
-      _, _token -> {:error, :not_found}
-    end)
-  end
+  defp setup_place_details_stub, do: stub_place_details(:defaults)
 end

--- a/test/features/step_definitions/password_authentication_steps.exs
+++ b/test/features/step_definitions/password_authentication_steps.exs
@@ -217,9 +217,6 @@ defmodule PasswordAuthenticationSteps do
   end
 
   step "I should receive a password reset email for {string}", %{args: [email]} = context do
-    # Wait a moment for email to be sent
-    Process.sleep(200)
-
     # Debug - let's see what emails were sent
     # First try to assert any email was sent at all
     try do
@@ -258,9 +255,6 @@ defmodule PasswordAuthenticationSteps do
   step "I click the password reset link in the email", context do
     session = context[:session] || context[:conn]
     reset_link = context[:reset_link] || raise "No reset link found in context"
-
-    # Add a small delay to ensure token is fully processed
-    Process.sleep(100)
 
     session = visit(session, reset_link)
     {:ok, Map.merge(context, %{session: session, conn: session})}

--- a/test/huddlz/accounts/profile_picture_test.exs
+++ b/test/huddlz/accounts/profile_picture_test.exs
@@ -75,9 +75,6 @@ defmodule Huddlz.Accounts.ProfilePictureTest do
           actor: user
         )
 
-      # Small delay to ensure different timestamps
-      Process.sleep(10)
-
       # Create second profile picture (most recent)
       {:ok, pic2} =
         Accounts.create_profile_picture(

--- a/test/huddlz/communities/group_image_test.exs
+++ b/test/huddlz/communities/group_image_test.exs
@@ -80,9 +80,6 @@ defmodule Huddlz.Communities.GroupImageTest do
           actor: owner
         )
 
-      # Small delay to ensure different timestamps
-      Process.sleep(10)
-
       # Create second image (most recent)
       {:ok, img2} =
         Communities.create_group_image(

--- a/test/huddlz/communities/huddl_access_control_test.exs
+++ b/test/huddlz/communities/huddl_access_control_test.exs
@@ -14,14 +14,15 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
       non_member = generate(user(role: :user))
       admin = generate(user(role: :admin))
 
-      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
-
-      # Add organizer and member to group
-      generate(
-        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
-      )
-
-      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+      {group, _} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: true],
+          members: [
+            %{user: organizer, role: :organizer},
+            %{user: member, role: :member}
+          ]
+        )
 
       %{
         owner: owner,
@@ -405,13 +406,15 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
       member = generate(user(role: :user))
       admin = generate(user(role: :admin))
 
-      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
-
-      generate(
-        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
-      )
-
-      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+      {group, _} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: true],
+          members: [
+            %{user: organizer, role: :organizer},
+            %{user: member, role: :member}
+          ]
+        )
 
       huddl =
         generate(

--- a/test/huddlz/communities/huddl_image_test.exs
+++ b/test/huddlz/communities/huddl_image_test.exs
@@ -118,8 +118,6 @@ defmodule Huddlz.Communities.HuddlImageTest do
           actor: owner
         )
 
-      Process.sleep(10)
-
       # Create second image (most recent)
       {:ok, img2} =
         Communities.create_huddl_image(

--- a/test/huddlz_web/graphql_test.exs
+++ b/test/huddlz_web/graphql_test.exs
@@ -7,9 +7,7 @@ defmodule HuddlzWeb.GraphqlTest do
 
   describe "GraphQL HTTP authentication" do
     setup do
-      stub(Huddlz.MockGeocoding, :geocode, fn _address ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_geocode(%{latitude: 30.27, longitude: -97.74})
 
       owner = generate(user(role: :user))
       group = generate(group(owner_id: owner.id, is_public: true, actor: owner))

--- a/test/huddlz_web/json_api_test.exs
+++ b/test/huddlz_web/json_api_test.exs
@@ -7,9 +7,7 @@ defmodule HuddlzWeb.JsonApiTest do
 
   describe "JSON:API authentication" do
     setup do
-      stub(Huddlz.MockGeocoding, :geocode, fn _address ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_geocode(%{latitude: 30.27, longitude: -97.74})
 
       owner = generate(user(role: :user))
       group = generate(group(owner_id: owner.id, is_public: true, actor: owner))

--- a/test/huddlz_web/live/group_live_permissions_test.exs
+++ b/test/huddlz_web/live/group_live_permissions_test.exs
@@ -12,82 +12,25 @@ defmodule HuddlzWeb.GroupLivePermissionsTest do
       verified_non_member = generate(user(role: :user))
       regular_non_member = generate(user(role: :user))
 
-      # Groups are automatically created with owner membership
-      public_group =
-        generate(
-          group(
-            is_public: true,
-            owner_id: owner.id,
-            name: "Public Group",
-            actor: owner
-          )
+      members = [
+        %{user: organizer, role: :organizer},
+        %{user: verified_member, role: :member},
+        %{user: regular_member, role: :member}
+      ]
+
+      {public_group, _} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: true, name: "Public Group"],
+          members: members
         )
 
-      private_group =
-        generate(
-          group(
-            is_public: false,
-            owner_id: owner.id,
-            name: "Private Group",
-            actor: owner
-          )
+      {private_group, _} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: false, name: "Private Group"],
+          members: members
         )
-
-      # Add organizer and members to public group
-      generate(
-        group_member(
-          group_id: public_group.id,
-          user_id: organizer.id,
-          role: :organizer,
-          actor: owner
-        )
-      )
-
-      generate(
-        group_member(
-          group_id: public_group.id,
-          user_id: verified_member.id,
-          role: :member,
-          actor: owner
-        )
-      )
-
-      generate(
-        group_member(
-          group_id: public_group.id,
-          user_id: regular_member.id,
-          role: :member,
-          actor: owner
-        )
-      )
-
-      # Add organizer and members to private group
-      generate(
-        group_member(
-          group_id: private_group.id,
-          user_id: organizer.id,
-          role: :organizer,
-          actor: owner
-        )
-      )
-
-      generate(
-        group_member(
-          group_id: private_group.id,
-          user_id: verified_member.id,
-          role: :member,
-          actor: owner
-        )
-      )
-
-      generate(
-        group_member(
-          group_id: private_group.id,
-          user_id: regular_member.id,
-          role: :member,
-          actor: owner
-        )
-      )
 
       %{
         owner: owner,

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -21,14 +21,15 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       regular = generate(user(role: :user))
       non_member = generate(user(role: :user))
 
-      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
-
-      # Add organizer and member to group
-      generate(
-        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
-      )
-
-      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+      {group, _} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: true],
+          members: [
+            %{user: organizer, role: :organizer},
+            %{user: member, role: :member}
+          ]
+        )
 
       %{
         owner: owner,
@@ -528,13 +529,16 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       owner = generate(user(role: :user))
       organizer = generate(user(role: :user))
       member = generate(user(role: :user))
-      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
 
-      generate(
-        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
-      )
-
-      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+      {group, _} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: true],
+          members: [
+            %{user: organizer, role: :organizer},
+            %{user: member, role: :member}
+          ]
+        )
 
       %{
         owner: owner,

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -286,22 +286,8 @@ defmodule HuddlzWeb.HuddlLiveTest do
       host: host,
       public_group: public_group
     } do
-      stub(Huddlz.MockPlaces, :autocomplete, fn
-        _text, _token, _opts ->
-          {:ok,
-           [
-             %{
-               place_id: "p1",
-               display_text: "Austin, TX, USA",
-               main_text: "Austin",
-               secondary_text: "TX, USA"
-             }
-           ]}
-      end)
-
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 30.2672, longitude: -97.7431}}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_place_details(%{"p1" => %{latitude: 30.2672, longitude: -97.7431}})
 
       generate(
         huddl(

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -267,17 +267,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
   describe "location autocomplete" do
     test "shows suggestions when typing a location", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           }
-         ]}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -291,21 +281,8 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "selecting a suggestion activates location filter", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           }
-         ]}
-      end)
-
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_place_details(:defaults)
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -333,9 +310,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "shows no locations found for unmatched queries", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "xyzabc", _token, _opts ->
-        {:ok, []}
-      end)
+      stub_places_autocomplete(%{})
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -349,9 +324,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "handles autocomplete API errors gracefully", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts ->
-        {:error, {:request_failed, :timeout}}
-      end)
+      stub_places_autocomplete_error({:request_failed, :timeout})
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -365,21 +338,8 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "handles place details errors gracefully", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           }
-         ]}
-      end)
-
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:error, {:request_failed, :timeout}}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_place_details_error({:request_failed, :timeout})
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -396,21 +356,8 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "clearing filters clears location", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           }
-         ]}
-      end)
-
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_place_details(:defaults)
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -433,9 +380,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "still shows huddlz when autocomplete returns no results", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts ->
-        {:ok, []}
-      end)
+      stub_places_autocomplete(%{})
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -451,21 +396,8 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "clear location button removes location filter", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           }
-         ]}
-      end)
-
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_place_details(:defaults)
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -489,21 +421,8 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "clear location button doesn't affect other filters", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           }
-         ]}
-      end)
-
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_place_details(:defaults)
 
       {:ok, view, _html} = live(conn, "/")
 
@@ -535,23 +454,17 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
   describe "keyboard navigation" do
     setup %{conn: conn} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "aus", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Austin, TX, USA",
-             main_text: "Austin",
-             secondary_text: "TX, USA"
-           },
-           %{
-             place_id: "p2",
-             display_text: "Austin, MN, USA",
-             main_text: "Austin",
-             secondary_text: "MN, USA"
-           }
-         ]}
-      end)
+      stub_places_autocomplete(%{
+        "aus" => [
+          :austin,
+          %{
+            place_id: "p2",
+            display_text: "Austin, MN, USA",
+            main_text: "Austin",
+            secondary_text: "MN, USA"
+          }
+        ]
+      })
 
       %{conn: conn}
     end
@@ -600,9 +513,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "Enter with highlighted suggestion selects it", %{conn: conn} do
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 30.27, longitude: -97.74}}
-      end)
+      stub_place_details(:defaults)
 
       {:ok, view, _html} = live(conn, "/")
 

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -97,17 +97,10 @@ defmodule HuddlzWeb.ProfileLiveTest do
     end
 
     test "shows suggestions when typing", %{conn: conn, user: user} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "saint", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Saint Augustine, FL, USA",
-             main_text: "Saint Augustine",
-             secondary_text: "FL, USA"
-           }
-         ]}
-      end)
+      # Profile's autocomplete uses place_id "p1" for Saint Augustine
+      stub_places_autocomplete(%{
+        "saint" => [%{known_places().saint_augustine | place_id: "p1"}]
+      })
 
       session = conn |> login(user) |> visit("/profile")
       view = session.view
@@ -122,21 +115,11 @@ defmodule HuddlzWeb.ProfileLiveTest do
     end
 
     test "selecting a suggestion saves location", %{conn: conn, user: user} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn "saint", _token, _opts ->
-        {:ok,
-         [
-           %{
-             place_id: "p1",
-             display_text: "Saint Augustine, FL, USA",
-             main_text: "Saint Augustine",
-             secondary_text: "FL, USA"
-           }
-         ]}
-      end)
+      stub_places_autocomplete(%{
+        "saint" => [%{known_places().saint_augustine | place_id: "p1"}]
+      })
 
-      stub(Huddlz.MockPlaces, :place_details, fn "p1", _token ->
-        {:ok, %{latitude: 29.89, longitude: -81.31}}
-      end)
+      stub_place_details(%{"p1" => %{latitude: 29.89, longitude: -81.31}})
 
       session = conn |> login(user) |> visit("/profile")
       view = session.view
@@ -154,9 +137,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
     end
 
     test "handles autocomplete API errors", %{conn: conn, user: user} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts ->
-        {:error, {:request_failed, :timeout}}
-      end)
+      stub_places_autocomplete_error({:request_failed, :timeout})
 
       session = conn |> login(user) |> visit("/profile")
       view = session.view
@@ -171,9 +152,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
     end
 
     test "clears error when user types in location field", %{conn: conn, user: user} do
-      stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts ->
-        {:error, {:request_failed, :timeout}}
-      end)
+      stub_places_autocomplete_error({:request_failed, :timeout})
 
       session = conn |> login(user) |> visit("/profile")
       view = session.view
@@ -187,7 +166,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
       assert has_element?(view, "p", "Location search is currently unavailable")
 
       # Stub returns ok now — typing clears the error
-      stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts -> {:ok, []} end)
+      stub_places_autocomplete(%{})
 
       view
       |> element("#profile-location-input")

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -30,6 +30,7 @@ defmodule HuddlzWeb.ConnCase do
       import PhoenixTest
       import HuddlzWeb.ConnCase
       import Huddlz.Test.Helpers.Authentication
+      import Huddlz.Test.MoxHelpers
       import Huddlz.Generator
     end
   end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,6 +24,7 @@ defmodule Huddlz.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import Huddlz.DataCase
+      import Huddlz.Test.MoxHelpers
       import Huddlz.Generator
     end
   end

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -83,6 +83,62 @@ defmodule Huddlz.Generator do
   end
 
   @doc """
+  Create a group and add the given members in one call.
+
+  Collapses the common "owner → group → add each member" setup into a single
+  helper. Returns `{group, group_members}` so callers can pattern-match or
+  discard the membership records.
+
+  Options:
+
+    * `:owner` — the `%User{}` that owns the group (acts as actor for group
+      creation and membership additions). Defaults to a freshly generated
+      `:user`-role user.
+    * `:group` — keyword list merged into the underlying `group/1` call
+      (`is_public`, `name`, `description`, etc.). `:owner_id` and `:actor`
+      are derived from `:owner` automatically.
+    * `:members` — list of `%{user: %User{}, role: :member | :organizer | :owner}`
+      maps describing memberships to create. Defaults to `[]`.
+
+  ## Examples
+
+      {public_group, _members} =
+        generate_group_with_members(
+          owner: owner,
+          group: [is_public: true, name: "Public Group"],
+          members: [
+            %{user: organizer, role: :organizer},
+            %{user: regular_member, role: :member}
+          ]
+        )
+  """
+  def generate_group_with_members(opts \\ []) do
+    owner = opts[:owner] || generate(user(role: :user))
+
+    group_opts =
+      (opts[:group] || [])
+      |> Keyword.put_new(:is_public, true)
+      |> Keyword.put(:owner_id, owner.id)
+      |> Keyword.put(:actor, owner)
+
+    group_record = generate(group(group_opts))
+
+    members =
+      for %{user: member_user, role: role} <- opts[:members] || [] do
+        generate(
+          group_member(
+            group_id: group_record.id,
+            user_id: member_user.id,
+            role: role,
+            actor: owner
+          )
+        )
+      end
+
+    {group_record, members}
+  end
+
+  @doc """
   Create a group with given attributes.
   """
   def group(opts \\ []) do

--- a/test/support/mox_helpers.ex
+++ b/test/support/mox_helpers.ex
@@ -1,0 +1,123 @@
+defmodule Huddlz.Test.MoxHelpers do
+  @moduledoc """
+  Thin helpers for stubbing `Huddlz.MockPlaces` and `Huddlz.MockGeocoding`
+  from tests. Each helper takes data (a map) and wires the corresponding
+  `Mox.stub/3`; unknown keys fall through to the existing `PlacesStub` /
+  `GeocodingStub` defaults (empty list or `{:error, :not_found}`).
+
+  Canonical Places fixtures (see `known_places/0`) keep the literal place
+  shape in one spot so changes to the `Huddlz.Places` contract only need
+  to be made here.
+  """
+
+  import Mox
+
+  @known_places %{
+    austin: %{
+      place_id: "p1",
+      display_text: "Austin, TX, USA",
+      main_text: "Austin",
+      secondary_text: "TX, USA"
+    },
+    saint_augustine: %{
+      place_id: "p2",
+      display_text: "Saint Augustine, FL, USA",
+      main_text: "Saint Augustine",
+      secondary_text: "FL, USA"
+    }
+  }
+
+  @known_coords %{
+    "p1" => %{latitude: 30.27, longitude: -97.74},
+    "p2" => %{latitude: 29.89, longitude: -81.31}
+  }
+
+  @doc """
+  Canonical Places fixtures keyed by atom. Extend as tests need new cities.
+  """
+  def known_places, do: @known_places
+
+  @doc """
+  Coordinates matched to known `place_id`s. Convenience default for
+  `stub_place_details/1`.
+  """
+  def known_coords, do: @known_coords
+
+  @doc """
+  Stub `Huddlz.MockPlaces.autocomplete/3` with a map of query-prefix to a
+  list of place entries. Entries may be atoms referring to `known_places/0`
+  or full maps matching the `Huddlz.Places` contract. Unmatched queries
+  return `{:ok, []}`.
+
+      stub_places_autocomplete(%{"aus" => [:austin]})
+      stub_places_autocomplete(%{"saint" => [:saint_augustine]})
+  """
+  def stub_places_autocomplete(results_by_query) when is_map(results_by_query) do
+    normalized =
+      Map.new(results_by_query, fn {query, entries} ->
+        {query, Enum.map(entries, &resolve_place/1)}
+      end)
+
+    stub(Huddlz.MockPlaces, :autocomplete, fn query, _token, _opts ->
+      {:ok, Map.get(normalized, query, [])}
+    end)
+  end
+
+  @doc """
+  Stub `Huddlz.MockPlaces.autocomplete/3` to always return the same error.
+  Useful for `{:error, {:request_failed, :timeout}}` scenarios.
+
+      stub_places_autocomplete_error({:request_failed, :timeout})
+  """
+  def stub_places_autocomplete_error(reason) do
+    stub(Huddlz.MockPlaces, :autocomplete, fn _, _token, _opts -> {:error, reason} end)
+  end
+
+  @doc """
+  Stub `Huddlz.MockPlaces.place_details/2`. Accepts either a map of
+  `place_id => coords` or `:defaults` to use `known_coords/0`. Unknown
+  place ids fall through to `{:error, :not_found}`.
+
+      stub_place_details(:defaults)
+      stub_place_details(%{"p1" => %{latitude: 30.27, longitude: -97.74}})
+  """
+  def stub_place_details(:defaults), do: stub_place_details(@known_coords)
+
+  def stub_place_details(coords_by_place_id) when is_map(coords_by_place_id) do
+    stub(Huddlz.MockPlaces, :place_details, fn place_id, _token ->
+      case Map.get(coords_by_place_id, place_id) do
+        nil -> {:error, :not_found}
+        coords -> {:ok, coords}
+      end
+    end)
+  end
+
+  @doc """
+  Stub `Huddlz.MockPlaces.place_details/2` to always return the same error.
+  """
+  def stub_place_details_error(reason) do
+    stub(Huddlz.MockPlaces, :place_details, fn _place_id, _token -> {:error, reason} end)
+  end
+
+  @doc """
+  Stub `Huddlz.MockGeocoding.geocode/1`. Accepts:
+
+    * a single `%{latitude: _, longitude: _}` map — return it for every address
+    * a map of `address => coords` — per-address responses, unknown → `{:error, :not_found}`
+  """
+  def stub_geocode(%{latitude: _, longitude: _} = coords) do
+    stub(Huddlz.MockGeocoding, :geocode, fn _address -> {:ok, coords} end)
+  end
+
+  def stub_geocode(coords_by_address) when is_map(coords_by_address) do
+    stub(Huddlz.MockGeocoding, :geocode, fn address ->
+      case Map.get(coords_by_address, address) do
+        nil -> {:error, :not_found}
+        coords -> {:ok, coords}
+      end
+    end)
+  end
+
+  defp resolve_place(key) when is_atom(key), do: Map.fetch!(@known_places, key)
+  defp resolve_place(%{} = place), do: place
+end


### PR DESCRIPTION
## Summary
- Added `generate_group_with_members/2` to collapse the owner→group→members triple into one call (biggest win: `group_live_permissions_test.exs`, -59 lines).
- Added `Huddlz.Test.MoxHelpers` (`stub_places_autocomplete`, `stub_place_details`, `stub_geocode`, plus error variants) with canonical Places fixtures, adopted in 6 test files.
- Dropped all 7 `Process.sleep` calls from the test suite:
  - 3 in image tests — verified via tidewave that `inserted_at` is microsecond-precise and rapid inserts are reliably ≥385µs apart.
  - 4 in feature step defs (password reset, huddl creation) — the underlying flows are synchronous (Swoosh `Mailer.deliver!`, no Oban/Task, Ash async disabled in test).

Net: -168 LOC across 18 files. All 616 tests pass; 5 consecutive seeded runs clean.

## Test plan
- [x] \`mix precommit\` (compile --warnings-as-errors, format, full test, credo strict)
- [x] \`mix test\` with seeds 1, 42, 777, 999999 (flakiness check)
- [x] \`grep Process.sleep test/\` returns zero hits
- [ ] Reviewer: sanity-check the \`MoxHelpers\` API shape before broader adoption