### PR TITLE
Email notifications: account security (A4 + A5)

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -155,6 +155,45 @@ Unsubscribe links in email footers deep-link to a confirmation page, then a POST
 - `config/config.exs:22-32` — add notification queue
 - `lib/huddlz_web/router.ex` — needs `/unsubscribe/:token`
 
+## Sender conventions
+
+Rules every `Huddlz.Notifications.Senders.*` module follows. New senders should be cargo-cultable from any existing one.
+
+### HTML escaping
+
+Every user-controlled string interpolated into `html_body` MUST go through `Huddlz.Notifications.Senders.HtmlEscape.escape/1`. This includes display names, email addresses, and any value that originated outside the sender module. Plain-text bodies use the raw value.
+
+### Footer
+
+- **Transactional** senders: no footer. There is no preference toggle, so an unsubscribe link would be misleading.
+- **Activity** senders: include `<hr/>` + a settings link + an unsubscribe link. Generate the unsubscribe token via `Huddlz.Notifications.unsubscribe_token(user, trigger)` so the route flips the right preference key.
+
+(When the second activity sender lands, lift the inline footer HTML into a shared helper — until then, inline keeps the diff small.)
+
+### Recovery advice in security notices
+
+Include a `/reset` link **only when the recipient's address is the current account email**, i.e. when the password-reset channel itself is unchanged.
+
+| Sender | Recipient | Recovery channel intact? | Link `/reset`? |
+|---|---|---|---|
+| `password_changed` | current email | yes | yes |
+| `email_changed` (audience: "old") | previous email | **no** — reset email goes to the new (possibly attacker-controlled) address | no — direct to support |
+| `email_changed` (audience: "new") | new email | n/a — confirmation only | no |
+
+When the channel has moved, lead with "contact support" and explicitly note that `/reset` won't help. Anything else gives the user a false sense of recovery.
+
+### Test floor
+
+Each sender test should at minimum assert:
+
+- greeting includes the user's display name
+- recipient is correct (`email.to`)
+- `email.from` matches the configured `Mailer.from()`
+- subject line
+- a body keyword that anchors the message
+- `<script>` payload in display name is HTML-escaped
+- `refute email.text_body =~ "<"` — no markup leaks into plain text
+
 ## Testing
 
 - One sender test per trigger in `test/huddlz/notifications/`, using `Swoosh.Adapters.Test`.

--- a/lib/huddlz/accounts.ex
+++ b/lib/huddlz/accounts.ex
@@ -20,6 +20,8 @@ defmodule Huddlz.Accounts do
       define :update_home_location,
         action: :update_home_location,
         args: [:home_location, :home_latitude, :home_longitude]
+
+      define :change_email, action: :change_email, args: [:email, :current_password]
     end
 
     resource Huddlz.Accounts.ProfilePicture do

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -217,6 +217,22 @@ defmodule Huddlz.Accounts.User do
 
       validate {AshAuthentication.Strategy.Password.PasswordValidation,
                 strategy_name: :password, password_argument: :current_password}
+
+      change fn changeset, _ctx ->
+        Ash.Changeset.put_context(changeset, :previous_email, changeset.data.email)
+      end
+
+      change after_action(fn changeset, user, _ctx ->
+               previous_email = changeset.context[:previous_email] |> to_string()
+               new_email = to_string(user.email)
+
+               if previous_email != "" and previous_email != new_email do
+                 enqueue_email_changed(user, previous_email, "old")
+                 enqueue_email_changed(user, previous_email, "new")
+               end
+
+               {:ok, user}
+             end)
     end
 
     update :change_password do
@@ -579,5 +595,19 @@ defmodule Huddlz.Accounts.User do
 
   identities do
     identity :unique_email, [:email]
+  end
+
+  defp enqueue_email_changed(user, previous_email, audience) do
+    payload = %{"audience" => audience, "old_email" => previous_email}
+
+    case Huddlz.Notifications.deliver_async(user, :email_changed, payload) do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to enqueue email-changed (#{audience}) notification: #{inspect(reason)}"
+        )
+    end
   end
 end

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -217,15 +217,11 @@ defmodule Huddlz.Accounts.User do
       validate {AshAuthentication.Strategy.Password.PasswordValidation,
                 strategy_name: :password, password_argument: :current_password}
 
-      change fn changeset, _ctx ->
-        Ash.Changeset.put_context(changeset, :previous_email, changeset.data.email)
-      end
-
       change after_action(fn changeset, user, _ctx ->
-               previous_email = changeset.context[:previous_email] |> to_string()
+               previous_email = to_string(changeset.data.email)
                new_email = to_string(user.email)
 
-               if previous_email != "" and previous_email != new_email do
+               if previous_email != new_email do
                  enqueue_email_changed(user, previous_email, "old")
                  enqueue_email_changed(user, previous_email, "new")
                end

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -158,6 +158,8 @@ defmodule Huddlz.Accounts.User do
                  previous_role == user.role ->
                    :ok
 
+                 # Skip only on actor-self updates. A nil actor (system call with
+                 # `authorize?: false`) intentionally falls through and notifies.
                  actor && actor.id == user.id ->
                    :ok
 

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -147,7 +147,43 @@ defmodule Huddlz.Accounts.User do
 
     update :update_role do
       description "Update a user's role"
+      require_atomic? false
       accept [:role]
+
+      change after_action(fn changeset, user, _ctx ->
+               previous_role = changeset.data.role
+               actor = changeset.context[:private][:actor]
+
+               cond do
+                 previous_role == user.role ->
+                   :ok
+
+                 actor && actor.id == user.id ->
+                   :ok
+
+                 true ->
+                   payload = %{
+                     "new_role" => Atom.to_string(user.role),
+                     "previous_role" => Atom.to_string(previous_role)
+                   }
+
+                   case Huddlz.Notifications.deliver_async(
+                          user,
+                          :account_role_changed,
+                          payload
+                        ) do
+                     {:ok, _job} ->
+                       :ok
+
+                     {:error, reason} ->
+                       Logger.error(
+                         "Failed to enqueue account-role-changed notification: #{inspect(reason)}"
+                       )
+                   end
+               end
+
+               {:ok, user}
+             end)
     end
 
     update :update_notification_preferences do

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -23,6 +23,7 @@ defmodule Huddlz.Accounts.User do
       update :update_display_name, :update_display_name
       update :update_home_location, :update_home_location
       update :change_password, :change_password
+      update :change_email, :change_email
       update :update_notification_preferences, :update_notification_preferences
     end
   end
@@ -204,6 +205,18 @@ defmodule Huddlz.Accounts.User do
           Map.merge(existing, incoming)
         )
       end
+    end
+
+    update :change_email do
+      description "Change the user's email address. Requires the current password and emails old + new addresses as a security notice."
+
+      require_atomic? false
+      accept [:email]
+
+      argument :current_password, :string, sensitive?: true, allow_nil?: false
+
+      validate {AshAuthentication.Strategy.Password.PasswordValidation,
+                strategy_name: :password, password_argument: :current_password}
     end
 
     update :change_password do
@@ -467,6 +480,11 @@ defmodule Huddlz.Accounts.User do
 
     policy action(:change_password) do
       description "Users can change their own password"
+      authorize_if expr(id == ^actor(:id))
+    end
+
+    policy action(:change_email) do
+      description "Users can change their own email"
       authorize_if expr(id == ^actor(:id))
     end
 

--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -151,9 +151,8 @@ defmodule Huddlz.Accounts.User do
       require_atomic? false
       accept [:role]
 
-      change after_action(fn changeset, user, _ctx ->
+      change after_action(fn changeset, user, %{actor: actor} ->
                previous_role = changeset.data.role
-               actor = changeset.context[:private][:actor]
 
                cond do
                  previous_role == user.role ->

--- a/lib/huddlz/notifications/sender.ex
+++ b/lib/huddlz/notifications/sender.ex
@@ -9,6 +9,9 @@ defmodule Huddlz.Notifications.Sender do
 
   See `Huddlz.Notifications` for the orchestrator and `Huddlz.Notifications.Triggers`
   for the registry that maps trigger atoms to their sender modules.
+
+  See `docs/notifications.md` § Sender conventions for the rules every sender
+  follows (HTML escaping, footer, recovery-advice, test floor).
   """
 
   alias Huddlz.Accounts.User

--- a/lib/huddlz/notifications/senders/account_role_changed.ex
+++ b/lib/huddlz/notifications/senders/account_role_changed.ex
@@ -19,74 +19,68 @@ defmodule Huddlz.Notifications.Senders.AccountRoleChanged do
     new_role = payload["new_role"] || to_string(user.role)
     previous_role = payload["previous_role"]
 
-    safe_name = Phoenix.HTML.html_escape(user.display_name) |> Phoenix.HTML.safe_to_string()
-    safe_new_role = Phoenix.HTML.html_escape(new_role) |> Phoenix.HTML.safe_to_string()
-
-    safe_previous_role =
-      if previous_role do
-        Phoenix.HTML.html_escape(previous_role) |> Phoenix.HTML.safe_to_string()
-      end
-
-    settings_url = url(~p"/profile/notifications")
-
-    unsubscribe_url =
-      url(~p"/unsubscribe/#{Notifications.unsubscribe_token(user, :account_role_changed)}")
+    ctx = %{
+      name: user.display_name,
+      new_role: new_role,
+      previous_role: previous_role,
+      settings_url: url(~p"/profile/notifications"),
+      unsubscribe_url:
+        url(~p"/unsubscribe/#{Notifications.unsubscribe_token(user, :account_role_changed)}")
+    }
 
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
     |> subject("Your huddlz account role was updated")
-    |> html_body(
-      html_body(safe_name, safe_new_role, safe_previous_role, settings_url, unsubscribe_url)
-    )
-    |> text_body(
-      text_body(user.display_name, new_role, previous_role, settings_url, unsubscribe_url)
-    )
+    |> html_body(html_body(ctx))
+    |> text_body(text_body(ctx))
   end
 
-  defp html_body(safe_name, safe_new_role, safe_previous_role, settings_url, unsubscribe_url) do
-    change_phrase =
-      if safe_previous_role do
-        "from <strong>#{safe_previous_role}</strong> to <strong>#{safe_new_role}</strong>"
-      else
-        "to <strong>#{safe_new_role}</strong>"
-      end
-
+  defp html_body(ctx) do
     """
-    <p>Hi #{safe_name},</p>
+    <p>Hi #{safe(ctx.name)},</p>
 
-    <p>An administrator just updated your huddlz account role #{change_phrase}.</p>
+    <p>An administrator just updated your huddlz account role #{html_change_phrase(ctx)}.</p>
 
     <p>If this looks wrong, reply to this email and we'll sort it out.</p>
 
     <hr/>
     <p style="font-size: 0.85em; color: #666;">
       You're receiving this because role-change notifications are on.
-      <a href="#{settings_url}">Manage notification settings</a> ·
-      <a href="#{unsubscribe_url}">Unsubscribe from these</a>
+      <a href="#{ctx.settings_url}">Manage notification settings</a> ·
+      <a href="#{ctx.unsubscribe_url}">Unsubscribe from these</a>
     </p>
     """
   end
 
-  defp text_body(name, new_role, previous_role, settings_url, unsubscribe_url) do
-    change_phrase =
-      if previous_role do
-        "from #{previous_role} to #{new_role}"
-      else
-        "to #{new_role}"
-      end
-
+  defp text_body(ctx) do
     """
-    Hi #{name},
+    Hi #{ctx.name},
 
-    An administrator just updated your huddlz account role #{change_phrase}.
+    An administrator just updated your huddlz account role #{text_change_phrase(ctx)}.
 
     If this looks wrong, reply to this email and we'll sort it out.
 
     --
     You're receiving this because role-change notifications are on.
-    Manage notification settings: #{settings_url}
-    Unsubscribe from these: #{unsubscribe_url}
+    Manage notification settings: #{ctx.settings_url}
+    Unsubscribe from these: #{ctx.unsubscribe_url}
     """
+  end
+
+  defp html_change_phrase(%{previous_role: nil, new_role: new}),
+    do: "to <strong>#{safe(new)}</strong>"
+
+  defp html_change_phrase(%{previous_role: prev, new_role: new}),
+    do: "from <strong>#{safe(prev)}</strong> to <strong>#{safe(new)}</strong>"
+
+  defp text_change_phrase(%{previous_role: nil, new_role: new}), do: "to #{new}"
+  defp text_change_phrase(%{previous_role: prev, new_role: new}), do: "from #{prev} to #{new}"
+
+  defp safe(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
   end
 end

--- a/lib/huddlz/notifications/senders/account_role_changed.ex
+++ b/lib/huddlz/notifications/senders/account_role_changed.ex
@@ -1,0 +1,92 @@
+defmodule Huddlz.Notifications.Senders.AccountRoleChanged do
+  @moduledoc """
+  Sender for A5: an admin changed this user's account role.
+
+  Activity-category email — respects the user's notification preferences and
+  includes an unsubscribe link in the footer.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications
+
+  @impl true
+  def build(user, payload) do
+    new_role = payload["new_role"] || to_string(user.role)
+    previous_role = payload["previous_role"]
+
+    safe_name = Phoenix.HTML.html_escape(user.display_name) |> Phoenix.HTML.safe_to_string()
+    safe_new_role = Phoenix.HTML.html_escape(new_role) |> Phoenix.HTML.safe_to_string()
+
+    safe_previous_role =
+      if previous_role do
+        Phoenix.HTML.html_escape(previous_role) |> Phoenix.HTML.safe_to_string()
+      end
+
+    settings_url = url(~p"/profile/notifications")
+
+    unsubscribe_url =
+      url(~p"/unsubscribe/#{Notifications.unsubscribe_token(user, :account_role_changed)}")
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("Your huddlz account role was updated")
+    |> html_body(
+      html_body(safe_name, safe_new_role, safe_previous_role, settings_url, unsubscribe_url)
+    )
+    |> text_body(
+      text_body(user.display_name, new_role, previous_role, settings_url, unsubscribe_url)
+    )
+  end
+
+  defp html_body(safe_name, safe_new_role, safe_previous_role, settings_url, unsubscribe_url) do
+    change_phrase =
+      if safe_previous_role do
+        "from <strong>#{safe_previous_role}</strong> to <strong>#{safe_new_role}</strong>"
+      else
+        "to <strong>#{safe_new_role}</strong>"
+      end
+
+    """
+    <p>Hi #{safe_name},</p>
+
+    <p>An administrator just updated your huddlz account role #{change_phrase}.</p>
+
+    <p>If this looks wrong, reply to this email and we'll sort it out.</p>
+
+    <hr/>
+    <p style="font-size: 0.85em; color: #666;">
+      You're receiving this because role-change notifications are on.
+      <a href="#{settings_url}">Manage notification settings</a> ·
+      <a href="#{unsubscribe_url}">Unsubscribe from these</a>
+    </p>
+    """
+  end
+
+  defp text_body(name, new_role, previous_role, settings_url, unsubscribe_url) do
+    change_phrase =
+      if previous_role do
+        "from #{previous_role} to #{new_role}"
+      else
+        "to #{new_role}"
+      end
+
+    """
+    Hi #{name},
+
+    An administrator just updated your huddlz account role #{change_phrase}.
+
+    If this looks wrong, reply to this email and we'll sort it out.
+
+    --
+    You're receiving this because role-change notifications are on.
+    Manage notification settings: #{settings_url}
+    Unsubscribe from these: #{unsubscribe_url}
+    """
+  end
+end

--- a/lib/huddlz/notifications/senders/account_role_changed.ex
+++ b/lib/huddlz/notifications/senders/account_role_changed.ex
@@ -13,6 +13,7 @@ defmodule Huddlz.Notifications.Senders.AccountRoleChanged do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
@@ -38,7 +39,7 @@ defmodule Huddlz.Notifications.Senders.AccountRoleChanged do
 
   defp html_body(ctx) do
     """
-    <p>Hi #{safe(ctx.name)},</p>
+    <p>Hi #{HtmlEscape.escape(ctx.name)},</p>
 
     <p>An administrator just updated your huddlz account role #{html_change_phrase(ctx)}.</p>
 
@@ -69,18 +70,12 @@ defmodule Huddlz.Notifications.Senders.AccountRoleChanged do
   end
 
   defp html_change_phrase(%{previous_role: nil, new_role: new}),
-    do: "to <strong>#{safe(new)}</strong>"
+    do: "to <strong>#{HtmlEscape.escape(new)}</strong>"
 
   defp html_change_phrase(%{previous_role: prev, new_role: new}),
-    do: "from <strong>#{safe(prev)}</strong> to <strong>#{safe(new)}</strong>"
+    do:
+      "from <strong>#{HtmlEscape.escape(prev)}</strong> to <strong>#{HtmlEscape.escape(new)}</strong>"
 
   defp text_change_phrase(%{previous_role: nil, new_role: new}), do: "to #{new}"
   defp text_change_phrase(%{previous_role: prev, new_role: new}), do: "from #{prev} to #{new}"
-
-  defp safe(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/lib/huddlz/notifications/senders/email_changed.ex
+++ b/lib/huddlz/notifications/senders/email_changed.ex
@@ -4,8 +4,10 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
 
   Two audiences, both transactional:
 
-    * `audience: "old"` — the previous address. Security notice with a
-      reset link in case the change was unauthorized.
+    * `audience: "old"` — the previous address. Security notice that
+      directs the user to contact support if the change was unauthorized.
+      No `/reset` link: by this point the recovery channel (the reset
+      email) goes to the *new* address, which a hijacker would control.
     * `audience: "new"` — the new address. Confirmation that this address
       is now associated with the account.
 
@@ -30,14 +32,13 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
     new_email = to_string(user.email)
     safe_name = HtmlEscape.escape(user.display_name)
     safe_new_email = HtmlEscape.escape(new_email)
-    reset_url = url(~p"/reset")
 
     new()
     |> from(Mailer.from())
     |> to(old_email)
     |> subject(@subject)
-    |> html_body(html_old(safe_name, safe_new_email, reset_url))
-    |> text_body(text_old(user.display_name, new_email, reset_url))
+    |> html_body(html_old(safe_name, safe_new_email))
+    |> text_body(text_old(user.display_name, new_email))
   end
 
   def build(user, %{"audience" => "new"} = payload) do
@@ -60,7 +61,7 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
             "Expected `audience: \"old\"` or `audience: \"new\"`."
   end
 
-  defp html_old(safe_name, safe_new_email, reset_url) do
+  defp html_old(safe_name, safe_new_email) do
     """
     <p>Hi #{safe_name},</p>
 
@@ -70,13 +71,13 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
     <p>If this was you, no action is needed. Future emails from huddlz will
     go to your new address.</p>
 
-    <p>If this <strong>wasn't</strong> you, secure your account immediately by
-    resetting your password at <a href="#{reset_url}">#{reset_url}</a>
-    and contact support so we can restore access.</p>
+    <p>If this <strong>wasn't</strong> you, contact support right away so we
+    can restore access. Resetting your password won't help here — the reset
+    email would go to the new address, not this one.</p>
     """
   end
 
-  defp text_old(name, new_email, reset_url) do
+  defp text_old(name, new_email) do
     """
     Hi #{name},
 
@@ -86,8 +87,9 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
     If this was you, no action is needed. Future emails from huddlz will go to
     your new address.
 
-    If this wasn't you, secure your account immediately by resetting your
-    password at #{reset_url} and contact support so we can restore access.
+    If this wasn't you, contact support right away so we can restore access.
+    Resetting your password won't help here — the reset email would go to the
+    new address, not this one.
     """
   end
 

--- a/lib/huddlz/notifications/senders/email_changed.ex
+++ b/lib/huddlz/notifications/senders/email_changed.ex
@@ -20,6 +20,7 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @subject "Your huddlz email address was changed"
 
@@ -27,8 +28,8 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
   def build(user, %{"audience" => "old"} = payload) do
     old_email = payload["old_email"]
     new_email = to_string(user.email)
-    safe_name = safe(user.display_name)
-    safe_new_email = safe(new_email)
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_new_email = HtmlEscape.escape(new_email)
     reset_url = url(~p"/reset")
 
     new()
@@ -42,8 +43,8 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
   def build(user, %{"audience" => "new"} = payload) do
     old_email = payload["old_email"]
     new_email = to_string(user.email)
-    safe_name = safe(user.display_name)
-    safe_old_email = safe(old_email)
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_old_email = HtmlEscape.escape(old_email)
 
     new()
     |> from(Mailer.from())
@@ -106,12 +107,5 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
     If you didn't make this change, contact support right away — someone
     else may have access to your account.
     """
-  end
-
-  defp safe(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
   end
 end

--- a/lib/huddlz/notifications/senders/email_changed.ex
+++ b/lib/huddlz/notifications/senders/email_changed.ex
@@ -35,6 +35,8 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
 
     new()
     |> from(Mailer.from())
+    # Recipient header injection is prevented by the `User.email` regex constraint
+    # rejecting whitespace (CR/LF). Swoosh does not sanitize recipient strings.
     |> to(old_email)
     |> subject(@subject)
     |> html_body(html_old(safe_name, safe_new_email))

--- a/lib/huddlz/notifications/senders/email_changed.ex
+++ b/lib/huddlz/notifications/senders/email_changed.ex
@@ -54,6 +54,12 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
     |> text_body(text_new(user.display_name, old_email))
   end
 
+  def build(_user, payload) do
+    raise ArgumentError,
+          "EmailChanged sender received an unknown audience in payload: #{inspect(payload)}. " <>
+            "Expected `audience: \"old\"` or `audience: \"new\"`."
+  end
+
   defp html_old(safe_name, safe_new_email, reset_url) do
     """
     <p>Hi #{safe_name},</p>

--- a/lib/huddlz/notifications/senders/email_changed.ex
+++ b/lib/huddlz/notifications/senders/email_changed.ex
@@ -1,0 +1,117 @@
+defmodule Huddlz.Notifications.Senders.EmailChanged do
+  @moduledoc """
+  Sender for A4: a user's email address was changed.
+
+  Two audiences, both transactional:
+
+    * `audience: "old"` — the previous address. Security notice with a
+      reset link in case the change was unauthorized.
+    * `audience: "new"` — the new address. Confirmation that this address
+      is now associated with the account.
+
+  The trigger is `:email_changed`. After_action enqueues the worker twice,
+  once per audience. Both jobs share the trigger and pass `payload[
+  "old_email"]` so each side has the full picture.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+
+  @subject "Your huddlz email address was changed"
+
+  @impl true
+  def build(user, %{"audience" => "old"} = payload) do
+    old_email = payload["old_email"]
+    new_email = to_string(user.email)
+    safe_name = safe(user.display_name)
+    safe_new_email = safe(new_email)
+    reset_url = url(~p"/reset")
+
+    new()
+    |> from(Mailer.from())
+    |> to(old_email)
+    |> subject(@subject)
+    |> html_body(html_old(safe_name, safe_new_email, reset_url))
+    |> text_body(text_old(user.display_name, new_email, reset_url))
+  end
+
+  def build(user, %{"audience" => "new"} = payload) do
+    old_email = payload["old_email"]
+    new_email = to_string(user.email)
+    safe_name = safe(user.display_name)
+    safe_old_email = safe(old_email)
+
+    new()
+    |> from(Mailer.from())
+    |> to(new_email)
+    |> subject(@subject)
+    |> html_body(html_new(safe_name, safe_old_email))
+    |> text_body(text_new(user.display_name, old_email))
+  end
+
+  defp html_old(safe_name, safe_new_email, reset_url) do
+    """
+    <p>Hi #{safe_name},</p>
+
+    <p>This is a security notice — the email address on your huddlz account was
+    just changed to <strong>#{safe_new_email}</strong>.</p>
+
+    <p>If this was you, no action is needed. Future emails from huddlz will
+    go to your new address.</p>
+
+    <p>If this <strong>wasn't</strong> you, secure your account immediately by
+    resetting your password at <a href="#{reset_url}">#{reset_url}</a>
+    and contact support so we can restore access.</p>
+    """
+  end
+
+  defp text_old(name, new_email, reset_url) do
+    """
+    Hi #{name},
+
+    This is a security notice — the email address on your huddlz account was
+    just changed to #{new_email}.
+
+    If this was you, no action is needed. Future emails from huddlz will go to
+    your new address.
+
+    If this wasn't you, secure your account immediately by resetting your
+    password at #{reset_url} and contact support so we can restore access.
+    """
+  end
+
+  defp html_new(safe_name, safe_old_email) do
+    """
+    <p>Hi #{safe_name},</p>
+
+    <p>This email address is now associated with your huddlz account.
+    The previous address on file was <strong>#{safe_old_email}</strong>.</p>
+
+    <p>If you didn't make this change, contact support right away — someone
+    else may have access to your account.</p>
+    """
+  end
+
+  defp text_new(name, old_email) do
+    """
+    Hi #{name},
+
+    This email address is now associated with your huddlz account. The
+    previous address on file was #{old_email}.
+
+    If you didn't make this change, contact support right away — someone
+    else may have access to your account.
+    """
+  end
+
+  defp safe(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/html_escape.ex
+++ b/lib/huddlz/notifications/senders/html_escape.ex
@@ -1,0 +1,26 @@
+defmodule Huddlz.Notifications.Senders.HtmlEscape do
+  @moduledoc """
+  Escape user-controlled values for safe interpolation into sender HTML bodies.
+
+  Senders interpolate strings (display name, email addresses, etc.) directly
+  into HTML heredocs, which means anything not pre-escaped becomes an XSS
+  vector for whoever opens the email. Plain-text bodies do not need this
+  treatment.
+
+  See `docs/notifications.md` § Sender conventions.
+  """
+
+  @doc """
+  HTML-escape an arbitrary value, returning a plain string.
+
+      iex> Huddlz.Notifications.Senders.HtmlEscape.escape("<script>")
+      "&lt;script&gt;"
+  """
+  @spec escape(term()) :: String.t()
+  def escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/password_changed.ex
+++ b/lib/huddlz/notifications/senders/password_changed.ex
@@ -12,11 +12,12 @@ defmodule Huddlz.Notifications.Senders.PasswordChanged do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, _payload) do
     reset_url = url(~p"/reset")
-    safe_name = Phoenix.HTML.html_escape(user.display_name) |> Phoenix.HTML.safe_to_string()
+    safe_name = HtmlEscape.escape(user.display_name)
 
     new()
     |> from(Mailer.from())

--- a/test/features/account_role_changed_notification.feature
+++ b/test/features/account_role_changed_notification.feature
@@ -1,0 +1,28 @@
+@async @database
+Feature: Account role changed notification email
+  As a user
+  I want to be told when an admin changes my account role
+  So that I notice unexpected privilege changes
+
+  Scenario: A notification email is sent when an admin promotes a user
+    Given the following users exist:
+      | email             | display_name | role  |
+      | adm@example.com   | Adm          | admin |
+      | regular@example.com | Reggie     | user  |
+    When the admin "adm@example.com" updates "regular@example.com" to role "admin"
+    Then a role-change notification should be sent to "regular@example.com" naming role "admin"
+
+  Scenario: No email is sent when the role does not actually change
+    Given the following users exist:
+      | email             | display_name | role  |
+      | adm@example.com   | Adm          | admin |
+      | already@example.com | Al         | admin |
+    When the admin "adm@example.com" updates "already@example.com" to role "admin"
+    Then no role-change notification should be sent
+
+  Scenario: No email is sent when an admin updates their own role
+    Given the following users exist:
+      | email             | display_name | role  |
+      | self@example.com  | Solo         | admin |
+    When the admin "self@example.com" updates "self@example.com" to role "user"
+    Then no role-change notification should be sent

--- a/test/features/email_change_notification.feature
+++ b/test/features/email_change_notification.feature
@@ -1,0 +1,23 @@
+@async @database
+Feature: Email change notification email
+  As a user
+  I want both my old and new email addresses to receive a security notice
+  When my account email changes
+  So that an unauthorized change cannot go unnoticed
+
+  Scenario: Two security notices are sent when a user changes their email
+    Given the following users exist:
+      | email           | display_name | role |
+      | old@example.com | Eve          | user |
+    And the user "old@example.com" has password "OldPassword123!"
+    When "old@example.com" changes their email to "new@example.com" with password "OldPassword123!"
+    Then a security notice should be sent to "old@example.com" naming the new address "new@example.com"
+    And a confirmation should be sent to "new@example.com" naming the previous address "old@example.com"
+
+  Scenario: No emails are sent if the email did not actually change
+    Given the following users exist:
+      | email           | display_name | role |
+      | same@example.com | Stable      | user |
+    And the user "same@example.com" has password "OldPassword123!"
+    When "same@example.com" changes their email to "same@example.com" with password "OldPassword123!"
+    Then no email-change notification should be sent

--- a/test/features/step_definitions/account_role_changed_notification_steps.exs
+++ b/test/features/step_definitions/account_role_changed_notification_steps.exs
@@ -1,6 +1,7 @@
 defmodule AccountRoleChangedNotificationSteps do
   use Cucumber.StepDefinition
   import ExUnit.Assertions
+  import Huddlz.Test.Helpers.FeatureUsers, only: [find_user!: 2]
 
   alias Huddlz.Accounts
 
@@ -26,13 +27,6 @@ defmodule AccountRoleChangedNotificationSteps do
     Oban.drain_queue(queue: :notifications)
     refute_role_change_email_received()
     {:ok, context}
-  end
-
-  defp find_user!(users, email) do
-    case Enum.find(users, fn u -> to_string(u.email) == email end) do
-      nil -> flunk("No user with email #{email} in scenario context")
-      user -> user
-    end
   end
 
   defp assert_role_change_email_received(email_addr, role) do

--- a/test/features/step_definitions/account_role_changed_notification_steps.exs
+++ b/test/features/step_definitions/account_role_changed_notification_steps.exs
@@ -58,6 +58,8 @@ defmodule AccountRoleChangedNotificationSteps do
       {:email, _other} ->
         refute_role_change_email_received()
     after
+      # Queue is already drained; this only flushes any in-flight {:email, _}
+      # mailbox messages, so a short timeout is sufficient.
       50 -> :ok
     end
   end

--- a/test/features/step_definitions/account_role_changed_notification_steps.exs
+++ b/test/features/step_definitions/account_role_changed_notification_steps.exs
@@ -1,0 +1,70 @@
+defmodule AccountRoleChangedNotificationSteps do
+  use Cucumber.StepDefinition
+  import ExUnit.Assertions
+
+  alias Huddlz.Accounts
+
+  step "the admin {string} updates {string} to role {string}",
+       %{args: [admin_email, target_email, new_role]} = context do
+    admin = find_user!(context.users, admin_email)
+    target = find_user!(context.users, target_email)
+    role_atom = String.to_existing_atom(new_role)
+
+    {:ok, _updated} = Accounts.update_role(target, role_atom, actor: admin)
+
+    {:ok, context}
+  end
+
+  step "a role-change notification should be sent to {string} naming role {string}",
+       %{args: [email, role]} = context do
+    Oban.drain_queue(queue: :notifications)
+    assert_role_change_email_received(email, role)
+    {:ok, context}
+  end
+
+  step "no role-change notification should be sent", context do
+    Oban.drain_queue(queue: :notifications)
+    refute_role_change_email_received()
+    {:ok, context}
+  end
+
+  defp find_user!(users, email) do
+    case Enum.find(users, fn u -> to_string(u.email) == email end) do
+      nil -> flunk("No user with email #{email} in scenario context")
+      user -> user
+    end
+  end
+
+  defp assert_role_change_email_received(email_addr, role) do
+    receive do
+      {:email,
+       %Swoosh.Email{
+         subject: "Your huddlz account role was updated",
+         to: [{"", ^email_addr}],
+         html_body: body
+       }} ->
+        assert body =~ role,
+               "role-change email body missing role #{inspect(role)}"
+
+        :ok
+
+      {:email, _other} ->
+        assert_role_change_email_received(email_addr, role)
+    after
+      100 ->
+        flunk("No role-change email received for #{email_addr}")
+    end
+  end
+
+  defp refute_role_change_email_received do
+    receive do
+      {:email, %Swoosh.Email{subject: "Your huddlz account role was updated"} = email} ->
+        flunk("Unexpected role-change email sent to #{inspect(email.to)}")
+
+      {:email, _other} ->
+        refute_role_change_email_received()
+    after
+      50 -> :ok
+    end
+  end
+end

--- a/test/features/step_definitions/email_change_notification_steps.exs
+++ b/test/features/step_definitions/email_change_notification_steps.exs
@@ -1,0 +1,119 @@
+defmodule EmailChangeNotificationSteps do
+  use Cucumber.StepDefinition
+  import ExUnit.Assertions
+
+  alias Huddlz.Accounts.User
+
+  step "the user {string} has password {string}",
+       %{args: [email, password]} = context do
+    user = find_user!(context.users, email)
+
+    {:ok, user_with_password} =
+      user
+      |> Ash.Changeset.for_update(
+        :set_password,
+        %{password: password, password_confirmation: password},
+        actor: user
+      )
+      |> Ash.update()
+
+    users =
+      Enum.map(context.users, fn u ->
+        if u.id == user.id, do: user_with_password, else: u
+      end)
+
+    {:ok, %{context | users: users}}
+  end
+
+  step "{string} changes their email to {string} with password {string}",
+       %{args: [old_email, new_email, password]} = context do
+    user = find_user!(context.users, old_email)
+
+    case Ash.Changeset.for_update(
+           user,
+           :change_email,
+           %{email: new_email, current_password: password},
+           actor: user
+         )
+         |> Ash.update() do
+      {:ok, _} -> {:ok, context}
+      # The same-email case is rejected by the unique-email identity, but
+      # that doesn't matter for the "no email is sent" assertion below.
+      {:error, _} -> {:ok, context}
+    end
+  end
+
+  step "a security notice should be sent to {string} naming the new address {string}",
+       %{args: [recipient, new_email]} = context do
+    Oban.drain_queue(queue: :notifications)
+
+    receive_email_matching(recipient, fn email ->
+      email.html_body =~ "security notice" and email.html_body =~ new_email
+    end)
+
+    {:ok, context}
+  end
+
+  step "a confirmation should be sent to {string} naming the previous address {string}",
+       %{args: [recipient, old_email]} = context do
+    Oban.drain_queue(queue: :notifications)
+
+    receive_email_matching(recipient, fn email ->
+      email.html_body =~ "now associated" and email.html_body =~ old_email
+    end)
+
+    {:ok, context}
+  end
+
+  step "no email-change notification should be sent", context do
+    Oban.drain_queue(queue: :notifications)
+
+    refute_email_matching(fn email ->
+      email.subject == "Your huddlz email address was changed"
+    end)
+
+    {:ok, context}
+  end
+
+  defp find_user!(users, email) do
+    case Enum.find(users, fn u -> to_string(u.email) == email end) do
+      nil -> flunk("No user with email #{email} in scenario context")
+      %User{} = user -> user
+    end
+  end
+
+  defp receive_email_matching(recipient, predicate) do
+    receive do
+      {:email,
+       %Swoosh.Email{
+         subject: "Your huddlz email address was changed",
+         to: [{"", ^recipient}]
+       } = email} ->
+        if predicate.(email) do
+          :ok
+        else
+          flunk(
+            "Email-change message to #{recipient} did not match expected content. Body:\n#{email.html_body}"
+          )
+        end
+
+      {:email, _other} ->
+        receive_email_matching(recipient, predicate)
+    after
+      100 -> flunk("No email-change notification received for #{recipient}")
+    end
+  end
+
+  defp refute_email_matching(predicate) do
+    receive do
+      {:email, %Swoosh.Email{} = email} ->
+        if predicate.(email) do
+          flunk("Unexpected email-change notification sent: #{inspect(email.to)}")
+        else
+          refute_email_matching(predicate)
+        end
+    after
+      50 -> :ok
+    end
+  end
+end

--- a/test/features/step_definitions/email_change_notification_steps.exs
+++ b/test/features/step_definitions/email_change_notification_steps.exs
@@ -28,8 +28,9 @@ defmodule EmailChangeNotificationSteps do
        %{args: [old_email, new_email, password]} = context do
     user = find_user!(context.users, old_email)
 
-    # Same-email scenarios fail at the unique-email identity; the "no email
-    # is sent" scenario then asserts the notification was correctly skipped.
+    # Same-email scenarios succeed as a no-op (the unique-email identity
+    # excludes the row being updated). The after_action's
+    # `previous_email != new_email` guard is what skips the notification.
     user
     |> Ash.Changeset.for_update(
       :change_email,

--- a/test/features/step_definitions/email_change_notification_steps.exs
+++ b/test/features/step_definitions/email_change_notification_steps.exs
@@ -1,8 +1,7 @@
 defmodule EmailChangeNotificationSteps do
   use Cucumber.StepDefinition
   import ExUnit.Assertions
-
-  alias Huddlz.Accounts.User
+  import Huddlz.Test.Helpers.FeatureUsers, only: [find_user!: 2]
 
   step "the user {string} has password {string}",
        %{args: [email, password]} = context do
@@ -29,18 +28,17 @@ defmodule EmailChangeNotificationSteps do
        %{args: [old_email, new_email, password]} = context do
     user = find_user!(context.users, old_email)
 
-    case Ash.Changeset.for_update(
-           user,
-           :change_email,
-           %{email: new_email, current_password: password},
-           actor: user
-         )
-         |> Ash.update() do
-      {:ok, _} -> {:ok, context}
-      # The same-email case is rejected by the unique-email identity, but
-      # that doesn't matter for the "no email is sent" assertion below.
-      {:error, _} -> {:ok, context}
-    end
+    # Same-email scenarios fail at the unique-email identity; the "no email
+    # is sent" scenario then asserts the notification was correctly skipped.
+    user
+    |> Ash.Changeset.for_update(
+      :change_email,
+      %{email: new_email, current_password: password},
+      actor: user
+    )
+    |> Ash.update()
+
+    {:ok, context}
   end
 
   step "a security notice should be sent to {string} naming the new address {string}",
@@ -73,13 +71,6 @@ defmodule EmailChangeNotificationSteps do
     end)
 
     {:ok, context}
-  end
-
-  defp find_user!(users, email) do
-    case Enum.find(users, fn u -> to_string(u.email) == email end) do
-      nil -> flunk("No user with email #{email} in scenario context")
-      %User{} = user -> user
-    end
   end
 
   defp receive_email_matching(recipient, predicate) do

--- a/test/huddlz/accounts/user/change_email_test.exs
+++ b/test/huddlz/accounts/user/change_email_test.exs
@@ -44,7 +44,7 @@ defmodule Huddlz.Accounts.User.ChangeEmailTest do
     end
 
     test "rejects malformed email addresses", %{user: user} do
-      assert {:error, _} =
+      assert {:error, %Ash.Error.Invalid{}} =
                user
                |> Ash.Changeset.for_update(
                  :change_email,
@@ -57,7 +57,7 @@ defmodule Huddlz.Accounts.User.ChangeEmailTest do
     test "rejects an email already in use by another user", %{user: user} do
       _other = generate(user(email: "taken@example.com"))
 
-      assert {:error, _} =
+      assert {:error, %Ash.Error.Invalid{}} =
                user
                |> Ash.Changeset.for_update(
                  :change_email,

--- a/test/huddlz/accounts/user/change_email_test.exs
+++ b/test/huddlz/accounts/user/change_email_test.exs
@@ -1,0 +1,114 @@
+defmodule Huddlz.Accounts.User.ChangeEmailTest do
+  use Huddlz.DataCase, async: true
+
+  alias Ash.Resource.Info, as: ResourceInfo
+  alias Huddlz.Accounts.User
+
+  describe "change_email" do
+    setup do
+      user =
+        generate(user_with_password(email: "alice@example.com", password: "OldPassword123!"))
+
+      {:ok, user: user}
+    end
+
+    test "succeeds with the correct current password", %{user: user} do
+      assert {:ok, updated} =
+               user
+               |> Ash.Changeset.for_update(
+                 :change_email,
+                 %{email: "alice2@example.com", current_password: "OldPassword123!"},
+                 actor: user
+               )
+               |> Ash.update()
+
+      assert to_string(updated.email) == "alice2@example.com"
+    end
+
+    test "rejects when the current password is wrong", %{user: user} do
+      assert {:error, %Ash.Error.Forbidden{errors: errors}} =
+               user
+               |> Ash.Changeset.for_update(
+                 :change_email,
+                 %{email: "alice2@example.com", current_password: "WrongPassword"},
+                 actor: user
+               )
+               |> Ash.update()
+
+      assert Enum.any?(errors, fn err ->
+               match?(%AshAuthentication.Errors.AuthenticationFailed{}, err)
+             end)
+
+      reloaded = Ash.reload!(user, authorize?: false)
+      assert to_string(reloaded.email) == "alice@example.com"
+    end
+
+    test "rejects malformed email addresses", %{user: user} do
+      assert {:error, _} =
+               user
+               |> Ash.Changeset.for_update(
+                 :change_email,
+                 %{email: "not an email", current_password: "OldPassword123!"},
+                 actor: user
+               )
+               |> Ash.update()
+    end
+
+    test "rejects an email already in use by another user", %{user: user} do
+      _other = generate(user(email: "taken@example.com"))
+
+      assert {:error, _} =
+               user
+               |> Ash.Changeset.for_update(
+                 :change_email,
+                 %{email: "taken@example.com", current_password: "OldPassword123!"},
+                 actor: user
+               )
+               |> Ash.update()
+    end
+
+    test "forbids changing another user's email", %{user: user} do
+      stranger = generate(user())
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               user
+               |> Ash.Changeset.for_update(
+                 :change_email,
+                 %{email: "evil@example.com", current_password: "OldPassword123!"},
+                 actor: stranger
+               )
+               |> Ash.update()
+    end
+
+    test "succeeds via the domain code interface", %{user: user} do
+      assert {:ok, updated} =
+               Huddlz.Accounts.change_email(
+                 user,
+                 "alice3@example.com",
+                 "OldPassword123!",
+                 actor: user
+               )
+
+      assert to_string(updated.email) == "alice3@example.com"
+    end
+
+    test "leaves confirmed_at alone (no re-confirmation required)", %{user: user} do
+      {:ok, updated} =
+        user
+        |> Ash.Changeset.for_update(
+          :change_email,
+          %{email: "alice2@example.com", current_password: "OldPassword123!"},
+          actor: user
+        )
+        |> Ash.update()
+
+      assert updated.confirmed_at == user.confirmed_at
+    end
+  end
+
+  # Sanity: confirm the action is registered (catches typos in the resource).
+  test "action is exposed in the resource" do
+    actions = ResourceInfo.actions(User) |> Enum.map(& &1.name)
+    assert :change_email in actions
+  end
+end

--- a/test/huddlz/accounts/user/change_email_test.exs
+++ b/test/huddlz/accounts/user/change_email_test.exs
@@ -1,9 +1,6 @@
 defmodule Huddlz.Accounts.User.ChangeEmailTest do
   use Huddlz.DataCase, async: true
 
-  alias Ash.Resource.Info, as: ResourceInfo
-  alias Huddlz.Accounts.User
-
   describe "change_email" do
     setup do
       user =
@@ -104,11 +101,5 @@ defmodule Huddlz.Accounts.User.ChangeEmailTest do
 
       assert updated.confirmed_at == user.confirmed_at
     end
-  end
-
-  # Sanity: confirm the action is registered (catches typos in the resource).
-  test "action is exposed in the resource" do
-    actions = ResourceInfo.actions(User) |> Enum.map(& &1.name)
-    assert :change_email in actions
   end
 end

--- a/test/huddlz/notifications/senders/account_role_changed_test.exs
+++ b/test/huddlz/notifications/senders/account_role_changed_test.exs
@@ -1,0 +1,96 @@
+defmodule Huddlz.Notifications.Senders.AccountRoleChangedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications
+  alias Huddlz.Notifications.Senders.AccountRoleChanged
+
+  describe "build/2" do
+    test "addresses the user with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      assert email.html_body =~ "Hi Sam"
+    end
+
+    test "sends to the user's email" do
+      user = generate(user(email: "alice@example.com"))
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      assert email.to == [{"", "alice@example.com"}]
+    end
+
+    test "uses the configured from-address" do
+      user = generate(user())
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      assert {_name, "support@huddlz.com"} = email.from
+    end
+
+    test "names the new role in the subject and body" do
+      user = generate(user(role: :admin))
+
+      email =
+        AccountRoleChanged.build(user, %{
+          "new_role" => "admin",
+          "previous_role" => "user"
+        })
+
+      assert email.subject == "Your huddlz account role was updated"
+      assert email.html_body =~ "admin"
+      assert email.html_body =~ "from <strong>user</strong> to <strong>admin</strong>"
+    end
+
+    test "omits the 'from X' phrasing when previous_role is missing" do
+      user = generate(user(role: :admin))
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      refute email.html_body =~ ~r{from <strong>}
+      assert email.html_body =~ "to <strong>admin</strong>"
+    end
+
+    test "includes a working unsubscribe link in both bodies" do
+      user = generate(user())
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.text_body =~ "/unsubscribe/"
+
+      [_full, token] = Regex.run(~r{/unsubscribe/([^"\s]+)}, email.html_body)
+
+      assert {:ok, {user_id, :account_role_changed}} =
+               Notifications.verify_unsubscribe_token(token)
+
+      assert user_id == user.id
+    end
+
+    test "includes a link to the notification settings page" do
+      user = generate(user())
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      assert email.html_body =~ "/profile/notifications"
+      assert email.text_body =~ "/profile/notifications"
+    end
+
+    test "includes a plain-text body alongside the html body" do
+      user = generate(user(display_name: "Pat"))
+
+      email =
+        AccountRoleChanged.build(user, %{
+          "new_role" => "admin",
+          "previous_role" => "user"
+        })
+
+      assert email.text_body =~ "Hi Pat"
+      assert email.text_body =~ "from user to admin"
+      refute email.text_body =~ "<"
+    end
+
+    test "html-escapes the display name to prevent injection" do
+      user = generate(user(display_name: "<script>alert(1)</script>"))
+      email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
+
+      refute email.html_body =~ "<script>alert"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/email_changed_test.exs
+++ b/test/huddlz/notifications/senders/email_changed_test.exs
@@ -118,4 +118,24 @@ defmodule Huddlz.Notifications.Senders.EmailChangedTest do
       refute email.text_body =~ "<"
     end
   end
+
+  describe "build/2 - unknown audience" do
+    test "raises with a descriptive message naming the bad payload" do
+      user = generate(user())
+      payload = %{"audience" => "stranger", "old_email" => "old@example.com"}
+
+      assert_raise ArgumentError, ~r/unknown audience/, fn ->
+        EmailChanged.build(user, payload)
+      end
+    end
+
+    test "raises when audience is missing entirely" do
+      user = generate(user())
+      payload = %{"old_email" => "old@example.com"}
+
+      assert_raise ArgumentError, ~r/unknown audience/, fn ->
+        EmailChanged.build(user, payload)
+      end
+    end
+  end
 end

--- a/test/huddlz/notifications/senders/email_changed_test.exs
+++ b/test/huddlz/notifications/senders/email_changed_test.exs
@@ -24,14 +24,18 @@ defmodule Huddlz.Notifications.Senders.EmailChangedTest do
       assert email.html_body =~ "security notice"
     end
 
-    test "includes a password reset link" do
+    test "directs the user to support and does not link the /reset flow" do
+      # The reset email would go to the *new* (potentially attacker-controlled)
+      # address, so /reset is not a real recovery channel here.
       user = generate(user(email: "new@example.com"))
       payload = %{"audience" => "old", "old_email" => "old@example.com"}
 
       email = EmailChanged.build(user, payload)
 
-      assert email.html_body =~ "/reset"
-      assert email.text_body =~ "/reset"
+      assert email.html_body =~ "contact support"
+      assert email.text_body =~ "contact support"
+      refute email.html_body =~ "/reset"
+      refute email.text_body =~ "/reset"
     end
 
     test "uses the configured from-address" do

--- a/test/huddlz/notifications/senders/email_changed_test.exs
+++ b/test/huddlz/notifications/senders/email_changed_test.exs
@@ -1,0 +1,121 @@
+defmodule Huddlz.Notifications.Senders.EmailChangedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.EmailChanged
+
+  describe "build/2 - audience: old" do
+    test "addresses the old email" do
+      user = generate(user(email: "new@example.com", display_name: "Sam"))
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+
+      assert email.to == [{"", "old@example.com"}]
+    end
+
+    test "subject and body call out the new address" do
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+
+      assert email.subject == "Your huddlz email address was changed"
+      assert email.html_body =~ "new@example.com"
+      assert email.html_body =~ "security notice"
+    end
+
+    test "includes a password reset link" do
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+
+      assert email.html_body =~ "/reset"
+      assert email.text_body =~ "/reset"
+    end
+
+    test "uses the configured from-address" do
+      user = generate(user())
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+      assert {_name, "support@huddlz.com"} = email.from
+    end
+
+    test "addresses the user by display name" do
+      user = generate(user(display_name: "Pat"))
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+      assert email.html_body =~ "Hi Pat"
+      assert email.text_body =~ "Hi Pat"
+    end
+
+    test "html-escapes the display name" do
+      user = generate(user(display_name: "<script>alert(1)</script>"))
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+      refute email.html_body =~ "<script>alert"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+
+    test "text body has no html tags" do
+      user = generate(user())
+      payload = %{"audience" => "old", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+      refute email.text_body =~ "<"
+    end
+  end
+
+  describe "build/2 - audience: new" do
+    test "addresses the new email (user.email)" do
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "new", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+
+      assert email.to == [{"", "new@example.com"}]
+    end
+
+    test "body references the previous address" do
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "new", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+
+      assert email.subject == "Your huddlz email address was changed"
+      assert email.html_body =~ "now associated"
+      assert email.html_body =~ "old@example.com"
+    end
+
+    test "does NOT include a password reset link in the new-address email" do
+      # The reset link is for someone hijacked: it goes to the OLD address
+      # so the legitimate owner can recover. The new address doesn't need it.
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "new", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+
+      refute email.html_body =~ "/reset"
+    end
+
+    test "html-escapes the previous email" do
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "new", "old_email" => "<script>old</script>@example.com"}
+
+      email = EmailChanged.build(user, payload)
+      refute email.html_body =~ "<script>old"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+
+    test "text body has no html tags" do
+      user = generate(user(email: "new@example.com"))
+      payload = %{"audience" => "new", "old_email" => "old@example.com"}
+
+      email = EmailChanged.build(user, payload)
+      refute email.text_body =~ "<"
+    end
+  end
+end

--- a/test/huddlz_web/api/graphql/change_email_test.exs
+++ b/test/huddlz_web/api/graphql/change_email_test.exs
@@ -44,7 +44,7 @@ defmodule HuddlzWeb.Api.Graphql.ChangeEmailTest do
                }
              } = json_response(conn, 200)
 
-      assert errors in [nil, []]
+      assert errors == []
       assert id == user.id
 
       reloaded = Ash.get!(User, user.id, authorize?: false)

--- a/test/huddlz_web/api/graphql/change_email_test.exs
+++ b/test/huddlz_web/api/graphql/change_email_test.exs
@@ -1,0 +1,106 @@
+defmodule HuddlzWeb.Api.Graphql.ChangeEmailTest do
+  use HuddlzWeb.ApiCase, async: true
+  use Oban.Testing, repo: Huddlz.Repo
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Notifications.DeliverWorker
+
+  @mutation """
+  mutation ChangeEmail($id: ID!, $email: String!, $currentPassword: String!) {
+    changeEmail(id: $id, input: {email: $email, currentPassword: $currentPassword}) {
+      result { id }
+      errors { message }
+    }
+  }
+  """
+
+  describe "changeEmail mutation" do
+    setup do
+      user =
+        generate(user_with_password(email: "before@example.com", password: "OldPassword123!"))
+
+      {:ok, user: user}
+    end
+
+    test "actor changes their own email with the correct current password", %{
+      conn: conn,
+      user: user
+    } do
+      conn =
+        conn
+        |> authenticated_conn(user)
+        |> gql_post(@mutation, %{
+          "id" => user.id,
+          "email" => "after@example.com",
+          "currentPassword" => "OldPassword123!"
+        })
+
+      assert %{
+               "data" => %{
+                 "changeEmail" => %{
+                   "result" => %{"id" => id},
+                   "errors" => errors
+                 }
+               }
+             } = json_response(conn, 200)
+
+      assert errors in [nil, []]
+      assert id == user.id
+
+      reloaded = Ash.get!(User, user.id, authorize?: false)
+      assert to_string(reloaded.email) == "after@example.com"
+
+      enqueued =
+        all_enqueued(worker: DeliverWorker)
+        |> Enum.filter(&(&1.args["trigger"] == "email_changed"))
+
+      audiences = enqueued |> Enum.map(& &1.args["payload"]["audience"]) |> Enum.sort()
+      assert audiences == ["new", "old"]
+
+      assert Enum.all?(enqueued, &(&1.args["user_id"] == user.id))
+      assert Enum.all?(enqueued, &(&1.args["payload"]["old_email"] == "before@example.com"))
+    end
+
+    test "wrong current password leaves the email untouched", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> authenticated_conn(user)
+        |> gql_post(@mutation, %{
+          "id" => user.id,
+          "email" => "after@example.com",
+          "currentPassword" => "WrongPassword"
+        })
+
+      body = json_response(conn, 200)
+
+      assert get_in(body, ["data", "changeEmail", "result"]) == nil
+      assert [_ | _] = body["data"]["changeEmail"]["errors"]
+
+      reloaded = Ash.get!(User, user.id, authorize?: false)
+      assert to_string(reloaded.email) == "before@example.com"
+
+      refute_enqueued(worker: DeliverWorker, args: %{"trigger" => "email_changed"})
+    end
+
+    test "unauthenticated callers cannot change another user's email", %{
+      conn: conn,
+      user: user
+    } do
+      conn =
+        gql_post(conn, @mutation, %{
+          "id" => user.id,
+          "email" => "after@example.com",
+          "currentPassword" => "OldPassword123!"
+        })
+
+      body = json_response(conn, 200)
+
+      assert get_in(body, ["data", "changeEmail", "result"]) == nil
+
+      reloaded = Ash.get!(User, user.id, authorize?: false)
+      assert to_string(reloaded.email) == "before@example.com"
+
+      refute_enqueued(worker: DeliverWorker, args: %{"trigger" => "email_changed"})
+    end
+  end
+end

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -9,13 +9,16 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       # Create a user who can create groups and huddls
       user = generate(user(role: :user))
 
-      # Pin description so meta-tag assertions are deterministic — the default
-      # Faker paragraph occasionally exceeds MetaHelpers' 200-char truncation.
+      # Pin name and description so meta-tag assertions are deterministic.
+      # Faker.Company.name() can yield non-ASCII characters that slugify into
+      # CJK-only slugs (URL-encoded in og:url), and Faker.Lorem.paragraph
+      # occasionally exceeds MetaHelpers' 200-char truncation.
       group =
         generate(
           group(
             owner_id: user.id,
             is_public: true,
+            name: "Test Group",
             description: "A short, deterministic group description for tests.",
             actor: user
           )

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -9,8 +9,17 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       # Create a user who can create groups and huddls
       user = generate(user(role: :user))
 
-      # Create a public group
-      group = generate(group(owner_id: user.id, is_public: true, actor: user))
+      # Pin description so meta-tag assertions are deterministic — the default
+      # Faker paragraph occasionally exceeds MetaHelpers' 200-char truncation.
+      group =
+        generate(
+          group(
+            owner_id: user.id,
+            is_public: true,
+            description: "A short, deterministic group description for tests.",
+            actor: user
+          )
+        )
 
       # Create upcoming huddls (future events)
       upcoming_huddls =

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -308,7 +308,10 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
             group_id: group.id,
             creator_id: owner.id,
             actor: owner,
-            physical_location: "123 Main St"
+            physical_location: "123 Main St",
+            # Start unlimited; the generator otherwise randomly fills this with
+            # a large integer half the time, breaking the post-validation assert.
+            max_attendees: nil
           )
         )
 

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -163,7 +163,13 @@ defmodule Huddlz.Generator do
         name: StreamData.repeatedly(fn -> Faker.Company.name() end),
         description: StreamData.repeatedly(fn -> Faker.Lorem.paragraph(2..3) end),
         location: "Test Location",
-        is_public: true
+        is_public: true,
+        # Pin to nil so GenerateSlug derives the slug from the name. Otherwise
+        # the public `:slug` argument on :create_group falls into Ash's optional
+        # input bucket and StreamData randomly emits :utf8 strings (CJK,
+        # private-use), which become URL-encoded slugs and break meta/URL
+        # assertions.
+        slug: nil
       ],
       overrides: Keyword.drop(opts, [:owner_id, :actor, :actor_role]),
       actor: actor

--- a/test/support/helpers/feature_users.ex
+++ b/test/support/helpers/feature_users.ex
@@ -1,0 +1,18 @@
+defmodule Huddlz.Test.Helpers.FeatureUsers do
+  @moduledoc """
+  Step-definition helpers for finding users seeded by the
+  "the following users exist" Cucumber step.
+  """
+
+  import ExUnit.Assertions
+
+  @doc """
+  Find a user in the scenario context by email, or fail the test.
+  """
+  def find_user!(users, email) do
+    case Enum.find(users, fn u -> to_string(u.email) == email end) do
+      nil -> flunk("No user with email #{email} in scenario context")
+      user -> user
+    end
+  end
+end


### PR DESCRIPTION
Closes #118.

Hooks the two remaining account-security email triggers from `docs/notifications.md`. A3 (password changed) was already shipped on main; this branch adds A4 and A5.

## Summary

- **A5 — Account role changed by admin** — sender + after_action hook on `User.update_role`. Activity-category email with an unsubscribe footer. Skips delivery when the role didn't actually change and when an admin updates their own role (per docs rule #1).
- **A4 — Email address changed** — adds a `:change_email` Ash action gated by current password (exposed via the Accounts code interface and as a GraphQL mutation), then sends two tailored transactional emails: a security notice + reset link to the old address, and a confirmation to the new one.
- Final commit pulls out `defp safe/1`, dedupes the role-change phrase via pattern matching, and extracts a shared `find_user!/2` for the new feature step files.

## Test plan

- [x] `mix test test/huddlz/notifications/senders/account_role_changed_test.exs`
- [x] `mix test test/huddlz/notifications/senders/email_changed_test.exs`
- [x] `mix test test/huddlz/accounts/user/change_email_test.exs`
- [x] Cucumber: `account_role_changed_notification.feature` (3 scenarios) and `email_change_notification.feature` (2 scenarios)
- [x] `mix precommit` — 860 tests, 0 failures, credo clean
- [ ] Manual smoke via `mix phx.server` + `/dev/mailbox`: admin promotes a user (verify role-change email + working unsubscribe link), admin promotes themselves (verify no email), user changes their own email (verify two distinct messages), `/profile/notifications` shows A3/A4 disabled-but-on under Security and A5 toggle under Activity