### PR TITLE
Email notifications: group membership (B1-B7)

### DIFF
--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -69,6 +69,7 @@ defmodule Huddlz.Communities do
     resource Huddlz.Communities.GroupMember do
       define :add_member, action: :add_member, args: [:group_id, :user_id, :role]
       define :remove_member, action: :remove_member, args: [:group_id, :user_id]
+      define :change_member_role, action: :change_role, args: [:role]
       define :get_by_group, action: :get_by_group, args: [:group_id]
       define :get_by_user, action: :get_by_user
     end

--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -42,6 +42,10 @@ defmodule Huddlz.Communities do
       define :update_details,
         action: :update_details,
         args: [:name, :description, :location, :is_public, :slug]
+
+      define :transfer_group_ownership,
+        action: :transfer_ownership,
+        args: [:new_owner_id]
     end
 
     resource Huddlz.Communities.GroupImage do

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -59,7 +59,13 @@ defmodule Huddlz.Communities.Group do
   end
 
   actions do
-    defaults [:create, :read, :update, :destroy]
+    defaults [:create, :read, :update]
+
+    destroy :destroy do
+      primary? true
+      require_atomic? false
+      change Huddlz.Communities.Group.Changes.NotifyArchived
+    end
 
     create :create_group do
       description "Create a new group; the owner is always the current actor."

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -126,6 +126,33 @@ defmodule Huddlz.Communities.Group do
       change Huddlz.Geocoding.ApplyProvidedCoordinates
       change {Huddlz.Geocoding.GeocodeChange, field: :location}
     end
+
+    update :transfer_ownership do
+      description "Transfer the group ownership to another user; demotes the previous owner to organizer."
+      accept []
+      require_atomic? false
+
+      argument :new_owner_id, :uuid do
+        allow_nil? false
+      end
+
+      validate fn changeset, _ctx ->
+        new_owner_id = Ash.Changeset.get_argument(changeset, :new_owner_id)
+
+        cond do
+          is_nil(new_owner_id) ->
+            {:error, field: :new_owner_id, message: "is required"}
+
+          new_owner_id == changeset.data.owner_id ->
+            {:error, field: :new_owner_id, message: "is already the group owner"}
+
+          true ->
+            :ok
+        end
+      end
+
+      change Huddlz.Communities.Group.Changes.TransferOwnership
+    end
   end
 
   policies do
@@ -141,6 +168,11 @@ defmodule Huddlz.Communities.Group do
 
     # Only the owner can update group details
     policy action(:update_details) do
+      authorize_if expr(owner_id == ^actor(:id))
+    end
+
+    # Only the current owner can transfer ownership.
+    policy action(:transfer_ownership) do
       authorize_if expr(owner_id == ^actor(:id))
     end
 

--- a/lib/huddlz/communities/group/changes/add_owner_as_member.ex
+++ b/lib/huddlz/communities/group/changes/add_owner_as_member.ex
@@ -6,14 +6,22 @@ defmodule Huddlz.Communities.Group.Changes.AddOwnerAsMember do
 
   @impl true
   def change(changeset, _opts, _context) do
-    Ash.Changeset.after_action(changeset, fn _changeset, group ->
-      # Automatically add the owner as a member with owner role
+    Ash.Changeset.after_action(changeset, fn cs, group ->
+      # Automatically add the owner as a member with owner role.
+      # Pass the actor (the new owner) through so any add-member side
+      # effects can recognise this as a self-add and skip notifications.
+      actor = cs.context[:private][:actor]
+
       Huddlz.Communities.GroupMember
-      |> Ash.Changeset.for_create(:add_member, %{
-        group_id: group.id,
-        user_id: group.owner_id,
-        role: "owner"
-      })
+      |> Ash.Changeset.for_create(
+        :add_member,
+        %{
+          group_id: group.id,
+          user_id: group.owner_id,
+          role: "owner"
+        },
+        actor: actor
+      )
       |> Ash.create!(authorize?: false)
 
       {:ok, group}

--- a/lib/huddlz/communities/group/changes/notify_archived.ex
+++ b/lib/huddlz/communities/group/changes/notify_archived.ex
@@ -1,0 +1,63 @@
+defmodule Huddlz.Communities.Group.Changes.NotifyArchived do
+  @moduledoc """
+  Enqueues B6 (group_archived) notifications when a group is destroyed.
+
+  Captures member user_ids in `before_action` because the GroupMember
+  rows cascade-delete with the group. The actor (the user destroying
+  the group, typically the owner) is excluded from the recipients.
+  Fans out emails in `after_action` once the destroy commits.
+  """
+
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.GroupMember
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    changeset
+    |> Ash.Changeset.before_action(&capture_members/1)
+    |> Ash.Changeset.after_action(&notify/2)
+  end
+
+  defp capture_members(cs) do
+    user_ids =
+      GroupMember
+      |> Ash.Query.filter(group_id == ^cs.data.id)
+      |> Ash.Query.select([:user_id])
+      |> Ash.read!(authorize?: false)
+      |> Enum.map(& &1.user_id)
+      |> Enum.uniq()
+
+    actor_id =
+      case cs.context[:private][:actor] do
+        %{id: id} -> id
+        _ -> nil
+      end
+
+    recipients = Enum.reject(user_ids, &(&1 == actor_id))
+
+    Ash.Changeset.put_context(cs, :group_archived_recipients, recipients)
+  end
+
+  defp notify(cs, group) do
+    recipients = cs.context[:group_archived_recipients] || []
+
+    payload = %{
+      "group_id" => group.id,
+      "group_name" => to_string(group.name)
+    }
+
+    for user_id <- recipients do
+      case Ash.get(User, user_id, authorize?: false) do
+        {:ok, user} -> Notifications.deliver_async(user, :group_archived, payload)
+        _ -> :noop
+      end
+    end
+
+    {:ok, group}
+  end
+end

--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -6,6 +6,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
     * Demotes the previous owner's GroupMember row to `:organizer`.
     * Promotes the new owner's GroupMember row to `:owner`, creating the
       membership if the new owner is not already in the group.
+    * Enqueues B7 notifications to both the previous and new owners.
 
   Runs as a single `after_action` hook so it lands inside the same Ash
   transaction as the owner_id update.
@@ -15,7 +16,9 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
 
   require Ash.Query
 
+  alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
+  alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
@@ -27,9 +30,48 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
     |> Ash.Changeset.after_action(fn _cs, group ->
       with :ok <- demote(group.id, previous_owner_id),
            :ok <- promote(group.id, new_owner_id) do
+        notify(group, previous_owner_id, new_owner_id)
         {:ok, group}
       end
     end)
+  end
+
+  defp notify(group, previous_owner_id, new_owner_id) do
+    previous_owner =
+      case Ash.get(User, previous_owner_id, authorize?: false) do
+        {:ok, %User{} = u} -> u
+        _ -> nil
+      end
+
+    new_owner =
+      case Ash.get(User, new_owner_id, authorize?: false) do
+        {:ok, %User{} = u} -> u
+        _ -> nil
+      end
+
+    base = %{
+      "group_id" => group.id,
+      "group_name" => to_string(group.name),
+      "group_slug" => group.slug,
+      "previous_owner_display_name" => previous_owner && previous_owner.display_name,
+      "new_owner_display_name" => new_owner && new_owner.display_name
+    }
+
+    if previous_owner do
+      Notifications.deliver_async(
+        previous_owner,
+        :group_ownership_transferred,
+        Map.put(base, "role", "previous_owner")
+      )
+    end
+
+    if new_owner do
+      Notifications.deliver_async(
+        new_owner,
+        :group_ownership_transferred,
+        Map.put(base, "role", "new_owner")
+      )
+    end
   end
 
   defp demote(_group_id, nil), do: :ok

--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -1,0 +1,84 @@
+defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
+  @moduledoc """
+  Implements the side-effects of `Group.:transfer_ownership`:
+
+    * Sets `owner_id` to the new owner.
+    * Demotes the previous owner's GroupMember row to `:organizer`.
+    * Promotes the new owner's GroupMember row to `:owner`, creating the
+      membership if the new owner is not already in the group.
+
+  Runs as a single `after_action` hook so it lands inside the same Ash
+  transaction as the owner_id update.
+  """
+
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Huddlz.Communities.GroupMember
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    new_owner_id = Ash.Changeset.get_argument(changeset, :new_owner_id)
+    previous_owner_id = changeset.data.owner_id
+
+    changeset
+    |> Ash.Changeset.force_change_attribute(:owner_id, new_owner_id)
+    |> Ash.Changeset.after_action(fn _cs, group ->
+      with :ok <- demote(group.id, previous_owner_id),
+           :ok <- promote(group.id, new_owner_id) do
+        {:ok, group}
+      end
+    end)
+  end
+
+  defp demote(_group_id, nil), do: :ok
+
+  defp demote(group_id, user_id) do
+    case fetch_membership(group_id, user_id) do
+      nil ->
+        :ok
+
+      membership ->
+        membership
+        |> Ash.Changeset.for_update(:set_role, %{role: :organizer})
+        |> Ash.update(authorize?: false)
+        |> case do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp promote(group_id, user_id) do
+    case fetch_membership(group_id, user_id) do
+      nil ->
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group_id,
+          user_id: user_id,
+          role: "owner"
+        })
+        |> Ash.create(authorize?: false)
+        |> case do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      membership ->
+        membership
+        |> Ash.Changeset.for_update(:set_role, %{role: :owner})
+        |> Ash.update(authorize?: false)
+        |> case do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp fetch_membership(group_id, user_id) do
+    GroupMember
+    |> Ash.Query.filter(group_id == ^group_id and user_id == ^user_id)
+    |> Ash.read_one!(authorize?: false)
+  end
+end

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -149,6 +149,7 @@ defmodule Huddlz.Communities.GroupMember do
       change manage_relationship(:group_id, :group, type: :append)
       change relate_actor(:user)
       change set_attribute(:role, :member)
+      change Huddlz.Communities.GroupMember.Changes.NotifyJoined
     end
 
     destroy :leave_group do

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -87,6 +87,7 @@ defmodule Huddlz.Communities.GroupMember do
 
     destroy :remove_member do
       description "Remove a user from a group"
+      require_atomic? false
 
       argument :group_id, :uuid do
         allow_nil? false
@@ -98,6 +99,8 @@ defmodule Huddlz.Communities.GroupMember do
 
       filter expr(group_id == ^arg(:group_id))
       filter expr(user_id == ^arg(:user_id))
+
+      change Huddlz.Communities.GroupMember.Changes.NotifyRemoved
     end
 
     action :remove_member_by_ids, :struct do

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -127,6 +127,8 @@ defmodule Huddlz.Communities.GroupMember do
       validate attribute_in(:role, [:member, :organizer]) do
         message "must be :member or :organizer (use transfer_ownership to change the owner)"
       end
+
+      change Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged
     end
 
     update :set_role do

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -23,6 +23,7 @@ defmodule Huddlz.Communities.GroupMember do
       destroy :leave_group, :leave_group
       create :add_member, :add_member
       destroy :remove_member, :remove_member
+      update :change_member_role, :change_role
     end
   end
 
@@ -38,6 +39,7 @@ defmodule Huddlz.Communities.GroupMember do
       delete :leave_group
       post :add_member, route: "/add"
       route :delete, "/remove", :remove_member_by_ids
+      patch :change_role, route: "/role"
     end
   end
 
@@ -113,6 +115,16 @@ defmodule Huddlz.Communities.GroupMember do
       run Huddlz.Communities.GroupMember.Actions.RemoveMemberByIds
     end
 
+    update :change_role do
+      description "Change a member's role within a group (owner only). Cannot promote to :owner — use Group.:transfer_ownership."
+      accept [:role]
+      require_atomic? false
+
+      validate attribute_in(:role, [:member, :organizer]) do
+        message "must be :member or :organizer (use transfer_ownership to change the owner)"
+      end
+    end
+
     create :join_group do
       description "Join a group as a regular member as the current actor"
 
@@ -161,6 +173,12 @@ defmodule Huddlz.Communities.GroupMember do
     # Group owners can remove members
     policy action(:remove_member) do
       authorize_if GroupOwner
+    end
+
+    # Group owners can change a member's role, but never their own.
+    policy action(:change_role) do
+      forbid_if expr(user_id == ^actor(:id))
+      authorize_if expr(group.owner_id == ^actor(:id))
     end
 
     # The remove-by-ids wrapper authorizes by delegating to :remove_member

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -125,6 +125,17 @@ defmodule Huddlz.Communities.GroupMember do
       end
     end
 
+    update :set_role do
+      description """
+      Internal helper used by Group.:transfer_ownership to swap roles
+      without the :change_role validation. Always forbidden by policy —
+      callers must pass `authorize?: false`.
+      """
+
+      accept [:role]
+      require_atomic? false
+    end
+
     create :join_group do
       description "Join a group as a regular member as the current actor"
 
@@ -179,6 +190,11 @@ defmodule Huddlz.Communities.GroupMember do
     policy action(:change_role) do
       forbid_if expr(user_id == ^actor(:id))
       authorize_if expr(group.owner_id == ^actor(:id))
+    end
+
+    # Internal-only — must be called with `authorize?: false`.
+    policy action(:set_role) do
+      forbid_if always()
     end
 
     # The remove-by-ids wrapper authorizes by delegating to :remove_member

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -83,6 +83,7 @@ defmodule Huddlz.Communities.GroupMember do
       change manage_relationship(:group_id, :group, type: :append)
       change manage_relationship(:user_id, :user, type: :append)
       change set_attribute(:role, arg(:role))
+      change Huddlz.Communities.GroupMember.Changes.NotifyAdded
     end
 
     destroy :remove_member do

--- a/lib/huddlz/communities/group_member/changes/notify_added.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_added.ex
@@ -1,0 +1,51 @@
+defmodule Huddlz.Communities.GroupMember.Changes.NotifyAdded do
+  @moduledoc """
+  Enqueues B2 (group_member_added) notifications when a user is added
+  to a *private* group via :add_member. Per spec, additions to public
+  groups do not get a "you were added" email — joins are user-driven
+  there. The actor (typically the owner/organizer doing the adding) is
+  excluded if for any reason they would otherwise be the recipient.
+  """
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.Group
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn cs, member ->
+      actor_id = actor_id(cs)
+      maybe_deliver(member, actor_id)
+      {:ok, member}
+    end)
+  end
+
+  defp maybe_deliver(member, actor_id) do
+    cond do
+      member.user_id == actor_id ->
+        :noop
+
+      true ->
+        with {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false),
+             true <- group.is_public == false,
+             {:ok, recipient} <- Ash.get(User, member.user_id, authorize?: false) do
+          Notifications.deliver_async(recipient, :group_member_added, %{
+            "group_id" => group.id,
+            "group_name" => to_string(group.name),
+            "group_slug" => group.slug
+          })
+        else
+          _ -> :noop
+        end
+    end
+  end
+
+  defp actor_id(%Ash.Changeset{} = cs) do
+    case cs.context[:private][:actor] do
+      %{id: id} -> id
+      _ -> nil
+    end
+  end
+end

--- a/lib/huddlz/communities/group_member/changes/notify_added.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_added.ex
@@ -27,6 +27,12 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyAdded do
       member.user_id == actor_id ->
         :noop
 
+      member.role == :owner ->
+        # :owner additions are internal flows (Group.:create_group's
+        # self-add and Group.:transfer_ownership). Those have their own
+        # notifications (B7) — don't double up with a B2 "you were added".
+        :noop
+
       true ->
         with {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false),
              true <- group.is_public == false,

--- a/lib/huddlz/communities/group_member/changes/notify_joined.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_joined.ex
@@ -35,15 +35,14 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyJoined do
 
       group_id
       |> recipient_user_ids(joiner_id)
-      |> Enum.each(fn user_id ->
-        case Ash.get(User, user_id, authorize?: false) do
-          {:ok, recipient} ->
-            Notifications.deliver_async(recipient, :group_member_joined, payload)
+      |> Enum.each(&deliver_to(&1, payload))
+    end
+  end
 
-          _ ->
-            :noop
-        end
-      end)
+  defp deliver_to(user_id, payload) do
+    case Ash.get(User, user_id, authorize?: false) do
+      {:ok, recipient} -> Notifications.deliver_async(recipient, :group_member_joined, payload)
+      _ -> :noop
     end
   end
 

--- a/lib/huddlz/communities/group_member/changes/notify_joined.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_joined.ex
@@ -1,0 +1,59 @@
+defmodule Huddlz.Communities.GroupMember.Changes.NotifyJoined do
+  @moduledoc """
+  Enqueues B1 (group_member_joined) notifications when a user joins a
+  public group via :join_group. Recipients are the group's owner and
+  organizers, deduplicated and with the actor (the joining user)
+  excluded.
+  """
+
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.Group
+  alias Huddlz.Communities.GroupMember
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn _cs, member ->
+      deliver(member)
+      {:ok, member}
+    end)
+  end
+
+  defp deliver(%GroupMember{group_id: group_id, user_id: joiner_id}) do
+    with {:ok, group} <- Ash.get(Group, group_id, authorize?: false),
+         {:ok, joiner} <- Ash.get(User, joiner_id, authorize?: false) do
+      payload = %{
+        "group_id" => group.id,
+        "group_name" => to_string(group.name),
+        "group_slug" => group.slug,
+        "joiner_display_name" => joiner.display_name
+      }
+
+      group_id
+      |> recipient_user_ids(joiner_id)
+      |> Enum.each(fn user_id ->
+        case Ash.get(User, user_id, authorize?: false) do
+          {:ok, recipient} ->
+            Notifications.deliver_async(recipient, :group_member_joined, payload)
+
+          _ ->
+            :noop
+        end
+      end)
+    end
+  end
+
+  defp recipient_user_ids(group_id, joiner_id) do
+    GroupMember
+    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
+    |> Ash.Query.select([:user_id])
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.user_id)
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == joiner_id))
+  end
+end

--- a/lib/huddlz/communities/group_member/changes/notify_removed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_removed.ex
@@ -1,0 +1,46 @@
+defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
+  @moduledoc """
+  Enqueues the B3 notification (group_member_removed) for the user being
+  removed from a group, after the destroy successfully commits. Skips
+  the notification if the actor is the user being removed (e.g. they
+  left themselves via :remove_member, which the spec treats as B5 → no
+  email).
+  """
+
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Huddlz.Communities.Group
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn cs, member ->
+      actor_id = actor_id(cs)
+
+      if member.user_id != actor_id do
+        deliver(member)
+      end
+
+      {:ok, member}
+    end)
+  end
+
+  defp deliver(member) do
+    with {:ok, user} <- Ash.get(Huddlz.Accounts.User, member.user_id, authorize?: false),
+         {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false) do
+      Notifications.deliver_async(user, :group_member_removed, %{
+        "group_id" => group.id,
+        "group_name" => to_string(group.name)
+      })
+    end
+  end
+
+  defp actor_id(%Ash.Changeset{} = cs) do
+    case cs.context[:private][:actor] do
+      %{id: id} -> id
+      _ -> nil
+    end
+  end
+end

--- a/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
@@ -1,0 +1,39 @@
+defmodule Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged do
+  @moduledoc """
+  Enqueues B4 (group_role_changed) when a member's role changes via
+  :change_role. The recipient is the affected member. No email is sent
+  if the role didn't actually change.
+  """
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.Group
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    previous_role = changeset.data.role
+
+    Ash.Changeset.after_action(changeset, fn _cs, member ->
+      if previous_role != member.role do
+        deliver(member, previous_role)
+      end
+
+      {:ok, member}
+    end)
+  end
+
+  defp deliver(member, previous_role) do
+    with {:ok, user} <- Ash.get(User, member.user_id, authorize?: false),
+         {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false) do
+      Notifications.deliver_async(user, :group_role_changed, %{
+        "group_id" => group.id,
+        "group_name" => to_string(group.name),
+        "group_slug" => group.slug,
+        "previous_role" => to_string(previous_role),
+        "new_role" => to_string(member.role)
+      })
+    end
+  end
+end

--- a/lib/huddlz/notifications/footer.ex
+++ b/lib/huddlz/notifications/footer.ex
@@ -1,0 +1,43 @@
+defmodule Huddlz.Notifications.Footer do
+  @moduledoc """
+  Shared unsubscribe / settings footer markup for Activity emails.
+
+  Builds a per-trigger unsubscribe URL from `Notifications.unsubscribe_token/2`
+  and a link to the notification settings page. Returned as `{html, text}`
+  so senders can splice both bodies.
+  """
+
+  use HuddlzWeb, :verified_routes
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Notifications
+
+  @doc """
+  Returns `{html_footer, text_footer}` for the given user + trigger.
+  """
+  @spec build(User.t(), atom()) :: {String.t(), String.t()}
+  def build(%User{} = user, trigger) when is_atom(trigger) do
+    token = Notifications.unsubscribe_token(user, trigger)
+    unsub_url = url(~p"/unsubscribe/#{token}")
+    settings_url = url(~p"/profile/notifications")
+
+    html = """
+    <hr/>
+    <p style="font-size: 0.85em; color: #666;">
+      You're receiving this email because of your huddlz notification settings.
+      <a href="#{unsub_url}">Unsubscribe from this kind of email</a>
+      or <a href="#{settings_url}">manage all your preferences</a>.
+    </p>
+    """
+
+    text = """
+
+    ---
+    You're receiving this email because of your huddlz notification settings.
+    Unsubscribe from this kind of email: #{unsub_url}
+    Manage all your preferences: #{settings_url}
+    """
+
+    {html, text}
+  end
+end

--- a/lib/huddlz/notifications/senders/group_archived.ex
+++ b/lib/huddlz/notifications/senders/group_archived.ex
@@ -1,0 +1,58 @@
+defmodule Huddlz.Notifications.Senders.GroupArchived do
+  @moduledoc """
+  Sender for B6: a group has been deleted (or archived in the future).
+
+  Sent to every member of the group at the moment of deletion.
+  Transactional — preferences do not apply, no unsubscribe footer.
+
+  Required payload keys:
+
+    * `"group_name"` — display name of the group at the time of removal.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+
+  @impl true
+  def build(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    groups_url = url(~p"/groups")
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("#{group_name(payload)} has been deleted")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>The group <strong>#{safe_group}</strong> has been deleted on
+    huddlz. You no longer have access to its huddlz or member-only
+    content.</p>
+
+    <p>Browse other groups at <a href="#{groups_url}">#{groups_url}</a>.</p>
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    The group "#{group_name(payload)}" has been deleted on huddlz. You no longer
+    have access to its huddlz or member-only content.
+
+    Browse other groups at #{groups_url}.
+    """)
+  end
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "a group"
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/group_archived.ex
+++ b/lib/huddlz/notifications/senders/group_archived.ex
@@ -16,11 +16,12 @@ defmodule Huddlz.Notifications.Senders.GroupArchived do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
     groups_url = url(~p"/groups")
 
     new()
@@ -48,11 +49,4 @@ defmodule Huddlz.Notifications.Senders.GroupArchived do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp escape(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/lib/huddlz/notifications/senders/group_member_added.ex
+++ b/lib/huddlz/notifications/senders/group_member_added.ex
@@ -20,11 +20,12 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
     group_url = group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_member_added)
@@ -56,11 +57,4 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
 
   defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
   defp group_url(_), do: url(~p"/groups")
-
-  defp escape(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/lib/huddlz/notifications/senders/group_member_added.ex
+++ b/lib/huddlz/notifications/senders/group_member_added.ex
@@ -1,0 +1,66 @@
+defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
+  @moduledoc """
+  Sender for B2: a user has been added to a (private) group by an
+  owner or organizer.
+
+  Sent to the added user. Activity category — preferences and the
+  unsubscribe footer apply.
+
+  Required payload keys:
+
+    * `"group_id"` — used for fallback links.
+    * `"group_name"` — display name of the group.
+    * `"group_slug"` — slug for the group page URL.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+
+  @impl true
+  def build(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    group_url = group_url(payload)
+
+    {footer_html, footer_text} = Footer.build(user, :group_member_added)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("You're now a member of #{group_name(payload)}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>You've been added to the group <strong>#{safe_group}</strong> on
+    huddlz. Visit the group page at
+    <a href="#{group_url}">#{group_url}</a> to see upcoming huddlz and
+    say hello.</p>
+    #{footer_html}
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    You've been added to the group "#{group_name(payload)}" on huddlz.
+    Visit the group page at #{group_url} to see upcoming huddlz and say hello.
+    #{footer_text}
+    """)
+  end
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "a group"
+
+  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
+  defp group_url(_), do: url(~p"/groups")
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/group_member_joined.ex
+++ b/lib/huddlz/notifications/senders/group_member_joined.ex
@@ -1,0 +1,70 @@
+defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
+  @moduledoc """
+  Sender for B1: a user joined a public group.
+
+  Sent to each owner/organizer of the group (deduplicated, actor
+  excluded). Activity category — preferences and the unsubscribe footer
+  apply.
+
+  Required payload keys:
+
+    * `"group_id"` — used to render the group page link.
+    * `"group_name"` — display name of the group.
+    * `"group_slug"` — slug used in the group page URL.
+    * `"joiner_display_name"` — name of the user who joined.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+
+  @impl true
+  def build(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    safe_joiner = escape(joiner_display_name(payload))
+    group_url = group_url(payload)
+
+    {footer_html, footer_text} = Footer.build(user, :group_member_joined)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("#{joiner_display_name(payload)} joined #{group_name(payload)}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p><strong>#{safe_joiner}</strong> just joined your group
+    <strong>#{safe_group}</strong>. Say hi or check out the group page
+    at <a href="#{group_url}">#{group_url}</a>.</p>
+    #{footer_html}
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    #{joiner_display_name(payload)} just joined your group "#{group_name(payload)}".
+    Say hi or check out the group page at #{group_url}.
+    #{footer_text}
+    """)
+  end
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "your group"
+
+  defp joiner_display_name(%{"joiner_display_name" => name}) when is_binary(name), do: name
+  defp joiner_display_name(_), do: "Someone"
+
+  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
+  defp group_url(_), do: url(~p"/groups")
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/group_member_joined.ex
+++ b/lib/huddlz/notifications/senders/group_member_joined.ex
@@ -21,12 +21,13 @@ defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
-    safe_joiner = escape(joiner_display_name(payload))
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
+    safe_joiner = HtmlEscape.escape(joiner_display_name(payload))
     group_url = group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_member_joined)
@@ -60,11 +61,4 @@ defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
 
   defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
   defp group_url(_), do: url(~p"/groups")
-
-  defp escape(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/lib/huddlz/notifications/senders/group_member_removed.ex
+++ b/lib/huddlz/notifications/senders/group_member_removed.ex
@@ -16,11 +16,12 @@ defmodule Huddlz.Notifications.Senders.GroupMemberRemoved do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
     groups_url = url(~p"/groups")
 
     new()
@@ -51,11 +52,4 @@ defmodule Huddlz.Notifications.Senders.GroupMemberRemoved do
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(%{group_name: name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp escape(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/lib/huddlz/notifications/senders/group_member_removed.ex
+++ b/lib/huddlz/notifications/senders/group_member_removed.ex
@@ -1,0 +1,61 @@
+defmodule Huddlz.Notifications.Senders.GroupMemberRemoved do
+  @moduledoc """
+  Sender for B3: a user has been removed from a group.
+
+  Sent to the removed user. Transactional — preferences do not apply,
+  no unsubscribe footer.
+
+  Required payload keys:
+
+    * `"group_name"` — display name of the group at the time of removal.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+
+  @impl true
+  def build(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    groups_url = url(~p"/groups")
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("You were removed from #{group_name(payload)}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>You have been removed from the group <strong>#{safe_group}</strong>
+    on huddlz. You no longer have access to its member-only content.</p>
+
+    <p>If you think this was a mistake, reach out to the group's owner
+    directly. You can browse other groups at
+    <a href="#{groups_url}">#{groups_url}</a>.</p>
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    You have been removed from the group "#{group_name(payload)}" on huddlz.
+    You no longer have access to its member-only content.
+
+    If you think this was a mistake, reach out to the group's owner directly.
+    Browse other groups at #{groups_url}.
+    """)
+  end
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(%{group_name: name}) when is_binary(name), do: name
+  defp group_name(_), do: "a group"
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/group_ownership_transferred.ex
+++ b/lib/huddlz/notifications/senders/group_ownership_transferred.ex
@@ -1,0 +1,109 @@
+defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
+  @moduledoc """
+  Sender for B7: ownership of a group was transferred.
+
+  Sent to both the previous owner and the new owner. Transactional —
+  preferences do not apply, no unsubscribe footer.
+
+  Required payload keys:
+
+    * `"group_id"` — used for fallback links.
+    * `"group_name"` — display name of the group.
+    * `"group_slug"` — slug for the group page URL.
+    * `"role"` — `"previous_owner"` or `"new_owner"` — used to pick the
+      correct copy for the recipient.
+    * `"new_owner_display_name"` — name of the new owner (used when
+      addressing the previous owner).
+    * `"previous_owner_display_name"` — name of the previous owner
+      (used when addressing the new owner).
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+
+  @impl true
+  def build(user, payload) do
+    role = payload["role"] || "previous_owner"
+
+    case role do
+      "new_owner" -> build_new_owner(user, payload)
+      _ -> build_previous_owner(user, payload)
+    end
+  end
+
+  defp build_previous_owner(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    safe_new_owner = escape(payload["new_owner_display_name"] || "another member")
+    group_url = group_url(payload)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("You transferred #{group_name(payload)} to a new owner")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>You've transferred ownership of <strong>#{safe_group}</strong> to
+    <strong>#{safe_new_owner}</strong>. You're still part of the group as
+    an organizer and can step away or rejoin anytime.</p>
+
+    <p>The group page is at <a href="#{group_url}">#{group_url}</a>.</p>
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    You've transferred ownership of "#{group_name(payload)}" to #{payload["new_owner_display_name"] || "another member"}.
+    You're still part of the group as an organizer and can step away or rejoin anytime.
+
+    The group page is at #{group_url}.
+    """)
+  end
+
+  defp build_new_owner(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    safe_prev_owner = escape(payload["previous_owner_display_name"] || "the previous owner")
+    group_url = group_url(payload)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("You're the new owner of #{group_name(payload)}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p><strong>#{safe_prev_owner}</strong> has transferred ownership of
+    <strong>#{safe_group}</strong> to you. The group is now yours to
+    manage.</p>
+
+    <p>Open the group page at <a href="#{group_url}">#{group_url}</a> to
+    review members, organizers, and upcoming huddlz.</p>
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    #{payload["previous_owner_display_name"] || "The previous owner"} has transferred ownership of "#{group_name(payload)}" to you.
+    The group is now yours to manage.
+
+    Open the group page at #{group_url} to review members, organizers, and upcoming huddlz.
+    """)
+  end
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "the group"
+
+  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
+  defp group_url(_), do: url(~p"/groups")
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/group_ownership_transferred.ex
+++ b/lib/huddlz/notifications/senders/group_ownership_transferred.ex
@@ -24,6 +24,7 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
@@ -36,9 +37,9 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
   end
 
   defp build_previous_owner(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
-    safe_new_owner = escape(payload["new_owner_display_name"] || "another member")
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
+    safe_new_owner = HtmlEscape.escape(payload["new_owner_display_name"] || "another member")
     group_url = group_url(payload)
 
     new()
@@ -65,9 +66,12 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
   end
 
   defp build_new_owner(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
-    safe_prev_owner = escape(payload["previous_owner_display_name"] || "the previous owner")
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
+
+    safe_prev_owner =
+      HtmlEscape.escape(payload["previous_owner_display_name"] || "the previous owner")
+
     group_url = group_url(payload)
 
     new()
@@ -99,11 +103,4 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
 
   defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
   defp group_url(_), do: url(~p"/groups")
-
-  defp escape(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/lib/huddlz/notifications/senders/group_role_changed.ex
+++ b/lib/huddlz/notifications/senders/group_role_changed.ex
@@ -1,0 +1,81 @@
+defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
+  @moduledoc """
+  Sender for B4: a user's role within a group has changed.
+
+  Sent to the user whose role changed. Activity category — preferences
+  and the unsubscribe footer apply.
+
+  Required payload keys:
+
+    * `"group_id"` — used for fallback links.
+    * `"group_name"` — display name of the group.
+    * `"group_slug"` — slug for the group page URL.
+    * `"previous_role"` — role string the user used to have.
+    * `"new_role"` — role string the user now has.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+
+  @impl true
+  def build(user, payload) do
+    safe_name = escape(user.display_name)
+    safe_group = escape(group_name(payload))
+    safe_prev = escape(humanize_role(role_value(payload, "previous_role")))
+    safe_new = escape(humanize_role(role_value(payload, "new_role")))
+    group_url = group_url(payload)
+
+    {footer_html, footer_text} = Footer.build(user, :group_role_changed)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("Your role in #{group_name(payload)} changed")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>Your role in <strong>#{safe_group}</strong> changed from
+    <strong>#{safe_prev}</strong> to <strong>#{safe_new}</strong>.</p>
+
+    <p>Visit the group at <a href="#{group_url}">#{group_url}</a>.</p>
+    #{footer_html}
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    Your role in "#{group_name(payload)}" changed from #{humanize_role(role_value(payload, "previous_role"))} to #{humanize_role(role_value(payload, "new_role"))}.
+
+    Visit the group at #{group_url}.
+    #{footer_text}
+    """)
+  end
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "the group"
+
+  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
+  defp group_url(_), do: url(~p"/groups")
+
+  defp role_value(payload, key) do
+    case Map.get(payload, key) do
+      value when is_binary(value) -> value
+      value when is_atom(value) -> Atom.to_string(value)
+      _ -> ""
+    end
+  end
+
+  defp humanize_role(""), do: "member"
+  defp humanize_role(role), do: role
+
+  defp escape(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/lib/huddlz/notifications/senders/group_role_changed.ex
+++ b/lib/huddlz/notifications/senders/group_role_changed.ex
@@ -21,13 +21,14 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
   def build(user, payload) do
-    safe_name = escape(user.display_name)
-    safe_group = escape(group_name(payload))
-    safe_prev = escape(humanize_role(role_value(payload, "previous_role")))
-    safe_new = escape(humanize_role(role_value(payload, "new_role")))
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_group = HtmlEscape.escape(group_name(payload))
+    safe_prev = HtmlEscape.escape(humanize_role(role_value(payload, "previous_role")))
+    safe_new = HtmlEscape.escape(humanize_role(role_value(payload, "new_role")))
     group_url = group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_role_changed)
@@ -71,11 +72,4 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
 
   defp humanize_role(""), do: "member"
   defp humanize_role(role), do: role
-
-  defp escape(value) do
-    value
-    |> to_string()
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
 end

--- a/test/huddlz/communities/group_member_test.exs
+++ b/test/huddlz/communities/group_member_test.exs
@@ -113,6 +113,81 @@ defmodule Huddlz.Communities.GroupMemberTest do
       refute Enum.any?(memberships, fn m -> m.user_id == member.id end)
     end
 
+    test "owner can change a member's role to organizer", %{
+      owner: owner,
+      member: member,
+      group: group
+    } do
+      {:ok, membership} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      assert {:ok, updated} =
+               membership
+               |> Ash.Changeset.for_update(:change_role, %{role: :organizer})
+               |> Ash.update(actor: owner)
+
+      assert updated.role == :organizer
+    end
+
+    test "non-owner cannot change a member's role", %{
+      owner: owner,
+      member: member,
+      non_member: non_member,
+      group: group
+    } do
+      {:ok, membership} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               membership
+               |> Ash.Changeset.for_update(:change_role, %{role: :organizer})
+               |> Ash.update(actor: non_member)
+    end
+
+    test "owner cannot change their own role", %{owner: owner, group: group} do
+      owner_membership =
+        GroupMember
+        |> Ash.Query.filter(group_id: group.id, user_id: owner.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               owner_membership
+               |> Ash.Changeset.for_update(:change_role, %{role: :organizer})
+               |> Ash.update(actor: owner)
+    end
+
+    test "change_role rejects :owner — must use transfer_ownership", %{
+      owner: owner,
+      member: member,
+      group: group
+    } do
+      {:ok, membership} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               membership
+               |> Ash.Changeset.for_update(:change_role, %{role: :owner})
+               |> Ash.update(actor: owner)
+    end
+
     test "users can leave groups", %{owner: owner, member: member, group: group} do
       # Add a member first
       {:ok, group_member} =

--- a/test/huddlz/communities/group_test.exs
+++ b/test/huddlz/communities/group_test.exs
@@ -1,6 +1,8 @@
 defmodule Huddlz.Communities.GroupTest do
   use Huddlz.DataCase, async: true
 
+  require Ash.Query
+
   alias Huddlz.Communities
   alias Huddlz.Communities.Group
 
@@ -415,6 +417,101 @@ defmodule Huddlz.Communities.GroupTest do
           name: "Unauthorized Update"
         })
         |> Ash.update(actor: other_user)
+    end
+  end
+
+  describe "transfer_ownership" do
+    setup do
+      owner = generate(user(role: :user))
+      group = generate(group(name: "Transfer Test", owner_id: owner.id, actor: owner))
+      {:ok, %{owner: owner, group: group}}
+    end
+
+    test "owner can transfer ownership to an existing member", %{owner: owner, group: group} do
+      new_owner = generate(user(role: :user))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: new_owner.id,
+          role: :member,
+          actor: owner
+        )
+      )
+
+      assert {:ok, transferred} =
+               group
+               |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: new_owner.id})
+               |> Ash.update(actor: owner)
+
+      assert transferred.owner_id == new_owner.id
+
+      memberships =
+        Huddlz.Communities.GroupMember
+        |> Ash.Query.for_read(:get_by_group, %{group_id: group.id})
+        |> Ash.read!(actor: new_owner)
+
+      assert Enum.any?(memberships, &(&1.user_id == new_owner.id and &1.role == :owner))
+      assert Enum.any?(memberships, &(&1.user_id == owner.id and &1.role == :organizer))
+    end
+
+    test "owner can transfer ownership to a non-member (auto-adds them)", %{
+      owner: owner,
+      group: group
+    } do
+      new_owner = generate(user(role: :user))
+
+      assert {:ok, transferred} =
+               group
+               |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: new_owner.id})
+               |> Ash.update(actor: owner)
+
+      assert transferred.owner_id == new_owner.id
+
+      new_owner_membership =
+        Huddlz.Communities.GroupMember
+        |> Ash.Query.filter(group_id: group.id, user_id: new_owner.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert new_owner_membership.role == :owner
+    end
+
+    test "non-owner cannot transfer ownership", %{group: group} do
+      stranger = generate(user(role: :user))
+      target = generate(user(role: :user))
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               group
+               |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: target.id})
+               |> Ash.update(actor: stranger)
+    end
+
+    test "rejects transferring ownership to the existing owner", %{owner: owner, group: group} do
+      assert {:error, %Ash.Error.Invalid{}} =
+               group
+               |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: owner.id})
+               |> Ash.update(actor: owner)
+    end
+
+    test "set_role action is forbidden through normal authorization", %{
+      group: group,
+      owner: owner
+    } do
+      member = generate(user(role: :user))
+
+      {:ok, membership} =
+        Huddlz.Communities.GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               membership
+               |> Ash.Changeset.for_update(:set_role, %{role: :owner})
+               |> Ash.update(actor: owner)
     end
   end
 

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -234,6 +234,62 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
     end
   end
 
+  describe "B6: group_archived" do
+    test "emails every non-actor member when the group is destroyed" do
+      owner = generate(user(role: :user))
+      member_a = generate(user(display_name: "Alice"))
+      member_b = generate(user(display_name: "Bob"))
+      group = generate(group(name: "Vanishing Group", owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(group_id: group.id, user_id: member_a.id, role: :member, actor: owner)
+      )
+
+      generate(
+        group_member(group_id: group.id, user_id: member_b.id, role: :member, actor: owner)
+      )
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      :ok =
+        group
+        |> Ash.Changeset.for_destroy(:destroy)
+        |> Ash.destroy!(actor: owner)
+
+      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+
+      for member <- [member_a, member_b] do
+        assert_email_sent(fn email ->
+          email.subject == "Vanishing Group has been deleted" and
+            email.to == [{"", to_string(member.email)}]
+        end)
+      end
+    end
+
+    test "does not email the actor (the owner deleting their own group)" do
+      owner = generate(user(role: :user))
+      member = generate(user())
+      group = generate(group(name: "Solo Vanish", owner_id: owner.id, actor: owner))
+
+      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      :ok =
+        group
+        |> Ash.Changeset.for_destroy(:destroy)
+        |> Ash.destroy!(actor: owner)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.to == [{"", to_string(member.email)}]
+      end)
+    end
+  end
+
   describe "B7: group_ownership_transferred" do
     test "emails both the previous and new owner" do
       previous_owner = generate(user(role: :user, display_name: "Old Owner"))

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -1,0 +1,76 @@
+defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
+  @moduledoc """
+  Integration coverage for the B-series group-membership notifications
+  (see `docs/notifications.md`). Exercises each Ash action end-to-end
+  through the Oban worker and asserts the resulting Swoosh email.
+  """
+
+  use Huddlz.DataCase, async: false
+  use Oban.Testing, repo: Huddlz.Repo
+
+  import Swoosh.TestAssertions
+  require Ash.Query
+
+  alias Huddlz.Communities.GroupMember
+  alias Huddlz.Notifications.DeliverWorker
+
+  describe "B3: group_member_removed" do
+    test "emails the removed user when an owner removes them" do
+      owner = generate(user(role: :user))
+      group = generate(group(name: "Synthwave Crew", owner_id: owner.id, actor: owner))
+      member = generate(user(display_name: "Removed Member"))
+
+      {:ok, _} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      membership =
+        GroupMember
+        |> Ash.Query.filter(group_id: group.id, user_id: member.id)
+        |> Ash.read_one!(authorize?: false)
+
+      :ok =
+        membership
+        |> Ash.Changeset.for_destroy(:remove_member, %{
+          group_id: group.id,
+          user_id: member.id
+        })
+        |> Ash.destroy!(actor: owner)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "You were removed from Synthwave Crew" and
+          email.to == [{"", to_string(member.email)}] and
+          email.html_body =~ "Synthwave Crew"
+      end)
+    end
+
+    test ":leave_group does not fire B3 (self-leave is B5: no email)" do
+      owner = generate(user(role: :user))
+      group = generate(group(name: "Self Leave", owner_id: owner.id, actor: owner))
+      member = generate(user())
+
+      {:ok, membership} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      :ok =
+        membership
+        |> Ash.Changeset.for_destroy(:leave_group)
+        |> Ash.destroy!(actor: member)
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+  end
+end

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -14,6 +14,84 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Notifications.DeliverWorker
 
+  describe "B1: group_member_joined" do
+    test "emails the owner and every organizer when a user joins a public group" do
+      owner = generate(user(role: :user, display_name: "Group Owner"))
+      organizer_a = generate(user(display_name: "Org A"))
+      organizer_b = generate(user(display_name: "Org B"))
+      joiner = generate(user(display_name: "New Joiner"))
+
+      group =
+        generate(
+          group(
+            name: "Public Joinable Group",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: organizer_a.id,
+          role: :organizer,
+          actor: owner
+        )
+      )
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: organizer_b.id,
+          role: :organizer,
+          actor: owner
+        )
+      )
+
+      {:ok, _} =
+        GroupMember
+        |> Ash.Changeset.for_create(:join_group, %{group_id: group.id}, actor: joiner)
+        |> Ash.create(actor: joiner)
+
+      assert %{success: 3} = Oban.drain_queue(queue: :notifications)
+
+      for recipient_email <- [owner.email, organizer_a.email, organizer_b.email] do
+        assert_email_sent(fn email ->
+          email.subject == "New Joiner joined Public Joinable Group" and
+            email.to == [{"", to_string(recipient_email)}] and
+            email.html_body =~ "/unsubscribe/"
+        end)
+      end
+    end
+
+    test "skips the joiner themselves even if they are also an organizer of another role" do
+      # If the joiner already had a privileged role somehow (shouldn't happen
+      # via :join_group but worth guarding), they should never be a recipient.
+      owner = generate(user(role: :user))
+
+      group =
+        generate(
+          group(name: "Solo Owner Group", is_public: true, owner_id: owner.id, actor: owner)
+        )
+
+      joiner = generate(user())
+
+      {:ok, _} =
+        GroupMember
+        |> Ash.Changeset.for_create(:join_group, %{group_id: group.id}, actor: joiner)
+        |> Ash.create(actor: joiner)
+
+      # success == 1 already implies the joiner is not enqueued; drain
+      # plus the targeted assert below pins the recipient.
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.to == [{"", to_string(owner.email)}]
+      end)
+    end
+  end
+
   describe "B3: group_member_removed" do
     test "emails the removed user when an owner removes them" do
       owner = generate(user(role: :user))

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -92,6 +92,76 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
     end
   end
 
+  describe "B2: group_member_added" do
+    test "emails the added user when added to a private group" do
+      owner = generate(user(role: :user))
+      added = generate(user(display_name: "Added Pat"))
+
+      group =
+        generate(
+          group(
+            name: "Inner Circle",
+            is_public: false,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      {:ok, _} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: added.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "You're now a member of Inner Circle" and
+          email.to == [{"", to_string(added.email)}] and
+          email.html_body =~ "/unsubscribe/"
+      end)
+    end
+
+    test "does not email when adding to a public group" do
+      owner = generate(user(role: :user))
+      added = generate(user())
+
+      group =
+        generate(
+          group(
+            name: "Open Public",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      {:ok, _} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: added.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+
+    test "does not email the owner when the create_group flow self-adds them" do
+      # Group.:create_group fires AddOwnerAsMember internally, which calls
+      # :add_member with role: "owner". That add_member must not email the
+      # owner about being added to their own group.
+      owner = generate(user(role: :user))
+      _group = generate(group(is_public: false, owner_id: owner.id, actor: owner))
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+  end
+
   describe "B3: group_member_removed" do
     test "emails the removed user when an owner removes them" do
       owner = generate(user(role: :user))

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -162,6 +162,77 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
     end
   end
 
+  describe "B4: group_role_changed" do
+    test "emails the member when an owner changes their role" do
+      owner = generate(user(role: :user))
+      member = generate(user(display_name: "Promoted Pat"))
+      group = generate(group(name: "Promo Group", owner_id: owner.id, actor: owner))
+
+      {:ok, membership} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      # Drain any prior add_member-triggered jobs (none for public groups,
+      # but keep the queue clean).
+      Oban.drain_queue(queue: :notifications)
+      Process.sleep(0)
+      # Flush any leftover test mailbox messages from prior drains.
+      flush_mailbox()
+
+      {:ok, _} =
+        membership
+        |> Ash.Changeset.for_update(:change_role, %{role: :organizer})
+        |> Ash.update(actor: owner)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "Your role in Promo Group changed" and
+          email.to == [{"", to_string(member.email)}] and
+          email.html_body =~ "<strong>member</strong>" and
+          email.html_body =~ "<strong>organizer</strong>" and
+          email.html_body =~ "/unsubscribe/"
+      end)
+    end
+
+    test "does not email when the role change is a no-op" do
+      owner = generate(user(role: :user))
+      member = generate(user())
+      group = generate(group(owner_id: owner.id, actor: owner))
+
+      {:ok, membership} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member
+        })
+        |> Ash.create(actor: owner)
+
+      Oban.drain_queue(queue: :notifications)
+
+      {:ok, _} =
+        membership
+        |> Ash.Changeset.for_update(:change_role, %{role: :member})
+        |> Ash.update(actor: owner)
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+  end
+
+  defp flush_mailbox do
+    receive do
+      {:email, _} -> flush_mailbox()
+    after
+      0 -> :ok
+    end
+  end
+
   describe "B3: group_member_removed" do
     test "emails the removed user when an owner removes them" do
       owner = generate(user(role: :user))

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -11,6 +11,7 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
   import Swoosh.TestAssertions
   require Ash.Query
 
+  alias Huddlz.Communities.Group
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Notifications.DeliverWorker
 
@@ -230,6 +231,39 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
       {:email, _} -> flush_mailbox()
     after
       0 -> :ok
+    end
+  end
+
+  describe "B7: group_ownership_transferred" do
+    test "emails both the previous and new owner" do
+      previous_owner = generate(user(role: :user, display_name: "Old Owner"))
+      new_owner = generate(user(display_name: "New Owner"))
+      group = generate(group(name: "Council", owner_id: previous_owner.id, actor: previous_owner))
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      {:ok, _} =
+        group
+        |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: new_owner.id})
+        |> Ash.update(actor: previous_owner)
+
+      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "You transferred Council to a new owner" and
+          email.to == [{"", to_string(previous_owner.email)}] and
+          email.html_body =~ "New Owner"
+      end)
+
+      assert_email_sent(fn email ->
+        email.subject == "You're the new owner of Council" and
+          email.to == [{"", to_string(new_owner.email)}] and
+          email.html_body =~ "Old Owner"
+      end)
+
+      reloaded = Ash.get!(Group, group.id, authorize?: false)
+      assert reloaded.owner_id == new_owner.id
     end
   end
 

--- a/test/huddlz/notifications/senders/group_archived_test.exs
+++ b/test/huddlz/notifications/senders/group_archived_test.exs
@@ -1,0 +1,48 @@
+defmodule Huddlz.Notifications.Senders.GroupArchivedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.GroupArchived
+
+  describe "build/2" do
+    test "addresses the user with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = GroupArchived.build(user, %{"group_name" => "Doomed Group"})
+
+      assert email.html_body =~ "Hi Sam"
+    end
+
+    test "subject and bodies name the group" do
+      user = generate(user())
+      email = GroupArchived.build(user, %{"group_name" => "Doomed Group"})
+
+      assert email.subject == "Doomed Group has been deleted"
+      assert email.html_body =~ "Doomed Group"
+      assert email.text_body =~ "Doomed Group"
+    end
+
+    test "no unsubscribe footer (transactional)" do
+      user = generate(user())
+      email = GroupArchived.build(user, %{"group_name" => "X"})
+
+      refute email.html_body =~ "unsubscribe"
+      refute email.text_body =~ "unsubscribe"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>x</script>"))
+      email = GroupArchived.build(user, %{"group_name" => "<img src=x>"})
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x"
+      assert email.html_body =~ "&lt;script&gt;"
+      assert email.html_body =~ "&lt;img"
+    end
+
+    test "falls back when group_name is missing" do
+      user = generate(user())
+      email = GroupArchived.build(user, %{})
+
+      assert email.subject == "a group has been deleted"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/group_member_added_test.exs
+++ b/test/huddlz/notifications/senders/group_member_added_test.exs
@@ -1,0 +1,67 @@
+defmodule Huddlz.Notifications.Senders.GroupMemberAddedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.GroupMemberAdded
+
+  defp payload(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "group_id" => "group-1",
+        "group_name" => "Inner Circle",
+        "group_slug" => "inner-circle"
+      },
+      overrides
+    )
+  end
+
+  describe "build/2" do
+    test "addresses the added user with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = GroupMemberAdded.build(user, payload())
+
+      assert email.html_body =~ "Hi Sam"
+      assert email.text_body =~ "Hi Sam"
+    end
+
+    test "subject and bodies name the group" do
+      user = generate(user())
+      email = GroupMemberAdded.build(user, payload())
+
+      assert email.subject == "You're now a member of Inner Circle"
+      assert email.html_body =~ "Inner Circle"
+      assert email.text_body =~ "Inner Circle"
+    end
+
+    test "links to the group page using the slug" do
+      user = generate(user())
+      email = GroupMemberAdded.build(user, payload())
+
+      assert email.html_body =~ "/groups/inner-circle"
+      assert email.text_body =~ "/groups/inner-circle"
+    end
+
+    test "renders an unsubscribe footer (Activity)" do
+      user = generate(user())
+      email = GroupMemberAdded.build(user, payload())
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.text_body =~ "/profile/notifications"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>x</script>"))
+      email = GroupMemberAdded.build(user, payload(%{"group_name" => "<img src=x>"}))
+
+      refute email.html_body =~ "<script>"
+      assert email.html_body =~ "&lt;script&gt;"
+      assert email.html_body =~ "&lt;img"
+    end
+
+    test "falls back when payload is empty" do
+      user = generate(user())
+      email = GroupMemberAdded.build(user, %{})
+
+      assert email.subject == "You're now a member of a group"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/group_member_joined_test.exs
+++ b/test/huddlz/notifications/senders/group_member_joined_test.exs
@@ -1,0 +1,80 @@
+defmodule Huddlz.Notifications.Senders.GroupMemberJoinedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.GroupMemberJoined
+
+  defp payload(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "group_id" => "group-1",
+        "group_name" => "Cyberpunk Book Club",
+        "group_slug" => "cyberpunk-book-club",
+        "joiner_display_name" => "Trinity"
+      },
+      overrides
+    )
+  end
+
+  describe "build/2" do
+    test "addresses the recipient with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = GroupMemberJoined.build(user, payload())
+
+      assert email.html_body =~ "Hi Sam"
+      assert email.text_body =~ "Hi Sam"
+    end
+
+    test "subject names the joiner and the group" do
+      user = generate(user())
+      email = GroupMemberJoined.build(user, payload())
+
+      assert email.subject == "Trinity joined Cyberpunk Book Club"
+      assert email.html_body =~ "Trinity"
+      assert email.html_body =~ "Cyberpunk Book Club"
+    end
+
+    test "links to the group page using the slug" do
+      user = generate(user())
+      email = GroupMemberJoined.build(user, payload())
+
+      assert email.html_body =~ "/groups/cyberpunk-book-club"
+      assert email.text_body =~ "/groups/cyberpunk-book-club"
+    end
+
+    test "renders an unsubscribe footer (Activity)" do
+      user = generate(user())
+      email = GroupMemberJoined.build(user, payload())
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.html_body =~ "/profile/notifications"
+      assert email.text_body =~ "/unsubscribe/"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>alert(1)</script>"))
+
+      email =
+        GroupMemberJoined.build(
+          user,
+          payload(%{
+            "group_name" => "<img src=x>",
+            "joiner_display_name" => "<b>raw</b>"
+          })
+        )
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x"
+      refute email.html_body =~ "<b>raw</b>"
+      assert email.html_body =~ "&lt;script&gt;"
+      assert email.html_body =~ "&lt;img"
+      assert email.html_body =~ "&lt;b&gt;raw"
+    end
+
+    test "falls back when payload fields are missing" do
+      user = generate(user())
+      email = GroupMemberJoined.build(user, %{})
+
+      assert email.subject == "Someone joined your group"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/group_member_removed_test.exs
+++ b/test/huddlz/notifications/senders/group_member_removed_test.exs
@@ -1,0 +1,65 @@
+defmodule Huddlz.Notifications.Senders.GroupMemberRemovedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.GroupMemberRemoved
+
+  describe "build/2" do
+    test "addresses the removed user with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = GroupMemberRemoved.build(user, %{"group_name" => "Cyberpunk Book Club"})
+
+      assert email.html_body =~ "Hi Sam"
+      assert email.text_body =~ "Hi Sam"
+    end
+
+    test "names the group in the subject and bodies" do
+      user = generate(user())
+      email = GroupMemberRemoved.build(user, %{"group_name" => "Cyberpunk Book Club"})
+
+      assert email.subject == "You were removed from Cyberpunk Book Club"
+      assert email.html_body =~ "Cyberpunk Book Club"
+      assert email.text_body =~ "Cyberpunk Book Club"
+    end
+
+    test "sends to the user's email" do
+      user = generate(user(email: "removed@example.com"))
+      email = GroupMemberRemoved.build(user, %{"group_name" => "X"})
+
+      assert email.to == [{"", "removed@example.com"}]
+    end
+
+    test "uses the configured from-address" do
+      user = generate(user())
+      email = GroupMemberRemoved.build(user, %{"group_name" => "X"})
+
+      assert {_name, "support@huddlz.com"} = email.from
+    end
+
+    test "does not include an unsubscribe footer (transactional)" do
+      user = generate(user())
+      email = GroupMemberRemoved.build(user, %{"group_name" => "X"})
+
+      refute email.html_body =~ "unsubscribe"
+      refute email.text_body =~ "unsubscribe"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>x</script>"))
+
+      email =
+        GroupMemberRemoved.build(user, %{"group_name" => "<img src=x onerror=alert(1)>"})
+
+      refute email.html_body =~ "<script>"
+      assert email.html_body =~ "&lt;script&gt;"
+      refute email.html_body =~ "<img src=x"
+      assert email.html_body =~ "&lt;img"
+    end
+
+    test "falls back gracefully when group_name is missing from the payload" do
+      user = generate(user())
+      email = GroupMemberRemoved.build(user, %{})
+
+      assert email.subject == "You were removed from a group"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/group_ownership_transferred_test.exs
+++ b/test/huddlz/notifications/senders/group_ownership_transferred_test.exs
@@ -1,0 +1,85 @@
+defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferredTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.GroupOwnershipTransferred
+
+  defp base_payload(overrides) do
+    Map.merge(
+      %{
+        "group_id" => "g-1",
+        "group_name" => "The Council",
+        "group_slug" => "the-council",
+        "previous_owner_display_name" => "Old Owner",
+        "new_owner_display_name" => "New Owner"
+      },
+      overrides
+    )
+  end
+
+  describe "previous_owner variant" do
+    test "subject and copy describe the transfer to the new owner" do
+      user = generate(user(display_name: "Sam"))
+      email = GroupOwnershipTransferred.build(user, base_payload(%{"role" => "previous_owner"}))
+
+      assert email.subject == "You transferred The Council to a new owner"
+      assert email.html_body =~ "Hi Sam"
+      assert email.html_body =~ "transferred ownership"
+      assert email.html_body =~ "New Owner"
+      assert email.text_body =~ "New Owner"
+    end
+
+    test "links to the group page" do
+      user = generate(user())
+      email = GroupOwnershipTransferred.build(user, base_payload(%{"role" => "previous_owner"}))
+
+      assert email.html_body =~ "/groups/the-council"
+    end
+
+    test "no unsubscribe footer (transactional)" do
+      user = generate(user())
+      email = GroupOwnershipTransferred.build(user, base_payload(%{"role" => "previous_owner"}))
+
+      refute email.html_body =~ "unsubscribe"
+      refute email.text_body =~ "unsubscribe"
+    end
+  end
+
+  describe "new_owner variant" do
+    test "subject and copy welcome the new owner and credit the previous owner" do
+      user = generate(user(display_name: "Pat"))
+      email = GroupOwnershipTransferred.build(user, base_payload(%{"role" => "new_owner"}))
+
+      assert email.subject == "You're the new owner of The Council"
+      assert email.html_body =~ "Hi Pat"
+      assert email.html_body =~ "Old Owner"
+      assert email.html_body =~ "transferred ownership"
+    end
+
+    test "no unsubscribe footer (transactional)" do
+      user = generate(user())
+      email = GroupOwnershipTransferred.build(user, base_payload(%{"role" => "new_owner"}))
+
+      refute email.html_body =~ "unsubscribe"
+    end
+  end
+
+  describe "html escape" do
+    test "escapes user-controlled fields in both variants" do
+      user = generate(user(display_name: "<script>alert(1)</script>"))
+
+      payload =
+        base_payload(%{
+          "role" => "new_owner",
+          "group_name" => "<img src=x>",
+          "previous_owner_display_name" => "<b>x</b>"
+        })
+
+      email = GroupOwnershipTransferred.build(user, payload)
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x>"
+      refute email.html_body =~ "<b>x</b>"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/group_role_changed_test.exs
+++ b/test/huddlz/notifications/senders/group_role_changed_test.exs
@@ -1,0 +1,82 @@
+defmodule Huddlz.Notifications.Senders.GroupRoleChangedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.GroupRoleChanged
+
+  defp payload(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "group_id" => "group-1",
+        "group_name" => "Inner Circle",
+        "group_slug" => "inner-circle",
+        "previous_role" => "member",
+        "new_role" => "organizer"
+      },
+      overrides
+    )
+  end
+
+  describe "build/2" do
+    test "addresses the user with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = GroupRoleChanged.build(user, payload())
+
+      assert email.html_body =~ "Hi Sam"
+    end
+
+    test "subject names the group; bodies state the role transition" do
+      user = generate(user())
+      email = GroupRoleChanged.build(user, payload())
+
+      assert email.subject == "Your role in Inner Circle changed"
+      assert email.html_body =~ "<strong>member</strong>"
+      assert email.html_body =~ "<strong>organizer</strong>"
+      assert email.text_body =~ "from member to organizer"
+    end
+
+    test "links to the group page using the slug" do
+      user = generate(user())
+      email = GroupRoleChanged.build(user, payload())
+
+      assert email.html_body =~ "/groups/inner-circle"
+    end
+
+    test "renders an unsubscribe footer (Activity)" do
+      user = generate(user())
+      email = GroupRoleChanged.build(user, payload())
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.text_body =~ "/profile/notifications"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>x</script>"))
+
+      email =
+        GroupRoleChanged.build(
+          user,
+          payload(%{"group_name" => "<img src=x>", "new_role" => "<b>boss</b>"})
+        )
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x"
+      refute email.html_body =~ "<b>boss</b>"
+      assert email.html_body =~ "&lt;script&gt;"
+      assert email.html_body =~ "&lt;img"
+      assert email.html_body =~ "&lt;b&gt;boss"
+    end
+
+    test "accepts atom roles in the payload" do
+      user = generate(user())
+
+      email =
+        GroupRoleChanged.build(
+          user,
+          payload(%{"previous_role" => :member, "new_role" => :organizer})
+        )
+
+      assert email.html_body =~ "<strong>member</strong>"
+      assert email.html_body =~ "<strong>organizer</strong>"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements all of issue #117 — six group-membership lifecycle emails (B1–B7, B5 intentionally skipped per spec) plus the two new resource actions they hang off of.

Each B-trigger gets its own commit with a sender, sender unit tests, an after_action change module, and an integration test that drives the full action → Oban → mailer path.

| Trigger | Action | Category | Recipient |
|---|---|---|---|
| B1 `group_member_joined` | `GroupMember.:join_group` | Activity | owner + organizers (deduped, joiner excluded) |
| B2 `group_member_added` | `GroupMember.:add_member` | Activity | added user (private groups only) |
| B3 `group_member_removed` | `GroupMember.:remove_member` | Transactional | removed user |
| B4 `group_role_changed` | `GroupMember.:change_role` (new) | Activity | the user |
| B6 `group_archived` | `Group.:destroy` | Transactional | every member at delete time |
| B7 `group_ownership_transferred` | `Group.:transfer_ownership` (new) | Transactional | old + new owner |

### New resource actions
- `GroupMember.:change_role` — owner-only, accepts `:member`/`:organizer`. `:owner` is rejected (use transfer_ownership). Owners can't change their own role.
- `Group.:transfer_ownership` — owner-only, swaps `owner_id` and reconciles GroupMember roles atomically (old owner → :organizer, new owner → :owner, auto-joining if not already a member).
- `GroupMember.:set_role` — internal-only escape hatch used by transfer_ownership; always forbidden by policy, callers must pass `authorize?: false`.

### Notes on the `Ash.Notifier` hint in the issue
The issue suggested `Ash.Notifier`. I used `after_action` changes instead because the Ash docs themselves ([notifiers.html#when-you-really-need-an-event-to-happen](https://hexdocs.pm/ash/notifiers.html#when-you-really-need-an-event-to-happen)) explicitly recommend committing Oban jobs in-transaction for events that must happen — which is what `after_action` does and `Ash.Notifier` does not (it fires after the transaction closes). Also matches the existing `User.change_password` pattern.

### Out of scope
- B6 currently fires on hard `:destroy`. A soft-delete `:archive` action is tracked separately in #128.
- Daily cap on B1 for viral public groups — explicitly v2 per `docs/notifications.md`.

## Test plan

- [x] All 6 sender unit tests (subject/body/escape/footer presence)
- [x] Integration tests per trigger using `Oban.drain_queue/1` + `Swoosh.TestAssertions`
- [x] New action tests (`:change_role`, `:transfer_ownership`, `:set_role` policy)
- [x] No regressions in existing GroupMember/Group tests (107 total, all green)
- [x] Full suite green (`mix precommit`: 883 tests, credo --strict clean, formatter clean)
- [ ] Manual smoke in `/dev/mailbox`: trigger each action and confirm the email renders correctly