### PR TITLE
chore(notifications): B-series follow-up cleanups

### DIFF
--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -85,10 +85,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
         membership
         |> Ash.Changeset.for_update(:set_role, %{role: :organizer})
         |> Ash.update(authorize?: false)
-        |> case do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+        |> ok_or_error()
     end
   end
 
@@ -102,21 +99,18 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
           role: "owner"
         })
         |> Ash.create(authorize?: false)
-        |> case do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+        |> ok_or_error()
 
       membership ->
         membership
         |> Ash.Changeset.for_update(:set_role, %{role: :owner})
         |> Ash.update(authorize?: false)
-        |> case do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+        |> ok_or_error()
     end
   end
+
+  defp ok_or_error({:ok, _}), do: :ok
+  defp ok_or_error({:error, reason}), do: {:error, reason}
 
   defp fetch_membership(group_id, user_id) do
     GroupMember

--- a/lib/huddlz/notifications.ex
+++ b/lib/huddlz/notifications.ex
@@ -12,6 +12,8 @@ defmodule Huddlz.Notifications do
   for the registry of trigger codes.
   """
 
+  require Logger
+
   alias Huddlz.Accounts.User
   alias Huddlz.Mailer
   alias Huddlz.Notifications.DeliverWorker
@@ -70,6 +72,17 @@ defmodule Huddlz.Notifications do
     %{user_id: user_id, trigger: Atom.to_string(trigger), payload: payload}
     |> DeliverWorker.new()
     |> Oban.insert()
+    |> case do
+      {:ok, job} ->
+        {:ok, job}
+
+      {:error, reason} = err ->
+        Logger.warning(
+          "Failed to enqueue #{inspect(trigger)} notification for user #{user_id}: #{inspect(reason)}"
+        )
+
+        err
+    end
   end
 
   # The registry references sender modules for triggers whose phases haven't

--- a/lib/huddlz/notifications/senders/group_role_changed.ex
+++ b/lib/huddlz/notifications/senders/group_role_changed.ex
@@ -27,8 +27,8 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
   def build(user, payload) do
     safe_name = HtmlEscape.escape(user.display_name)
     safe_group = HtmlEscape.escape(group_name(payload))
-    safe_prev = HtmlEscape.escape(humanize_role(role_value(payload, "previous_role")))
-    safe_new = HtmlEscape.escape(humanize_role(role_value(payload, "new_role")))
+    safe_prev = HtmlEscape.escape(role_label(role_value(payload, "previous_role")))
+    safe_new = HtmlEscape.escape(role_label(role_value(payload, "new_role")))
     group_url = group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_role_changed)
@@ -49,7 +49,7 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
     |> text_body("""
     Hi #{user.display_name},
 
-    Your role in "#{group_name(payload)}" changed from #{humanize_role(role_value(payload, "previous_role"))} to #{humanize_role(role_value(payload, "new_role"))}.
+    Your role in "#{group_name(payload)}" changed from #{role_label(role_value(payload, "previous_role"))} to #{role_label(role_value(payload, "new_role"))}.
 
     Visit the group at #{group_url}.
     #{footer_text}
@@ -70,6 +70,6 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
     end
   end
 
-  defp humanize_role(""), do: "member"
-  defp humanize_role(role), do: role
+  defp role_label(""), do: "member"
+  defp role_label(role), do: role
 end

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -179,10 +179,9 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
         |> Ash.create(actor: owner)
 
       # Drain any prior add_member-triggered jobs (none for public groups,
-      # but keep the queue clean).
+      # but keep the queue clean) and flush any leftover test mailbox
+      # messages from prior drains.
       Oban.drain_queue(queue: :notifications)
-      Process.sleep(0)
-      # Flush any leftover test mailbox messages from prior drains.
       flush_mailbox()
 
       {:ok, _} =
@@ -223,14 +222,6 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
         |> Ash.update(actor: owner)
 
       refute_enqueued(worker: DeliverWorker)
-    end
-  end
-
-  defp flush_mailbox do
-    receive do
-      {:email, _} -> flush_mailbox()
-    after
-      0 -> :ok
     end
   end
 
@@ -380,6 +371,14 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
         |> Ash.destroy!(actor: member)
 
       refute_enqueued(worker: DeliverWorker)
+    end
+  end
+
+  defp flush_mailbox do
+    receive do
+      {:email, _} -> flush_mailbox()
+    after
+      0 -> :ok
     end
   end
 end


### PR DESCRIPTION
## Summary

Four small follow-ups on the B-series notifications work merged in #129. None of them are functionally novel; they're cleanups that should have shipped with #129. Splitting into a separate PR rather than carrying them onto the upcoming C/D-series branch keeps that diff focused.

- **`feat(notifications): log Oban enqueue failures in deliver_async`** — only behavior change. Adds a `Logger.warning` when `Oban.insert/1` rejects the enqueue. Caller still gets `{:error, reason}` back; this is purely additive instrumentation.
- **`refactor(group): extract ok_or_error helper in transfer_ownership`** — three branches of the role-swap repeated the same `case` clauses; pulled into a private helper.
- **`refactor(notifications): rename humanize_role to role_label`** — the helper didn't actually humanize anything, just labelled. Pure rename in `Senders.GroupRoleChanged`.
- **`refactor(test): tidy flush_mailbox placement and drop dead sleep`** — moves the private helper to the bottom of the module and drops a `Process.sleep(0)` that was decorating an already-synchronous `Oban.drain_queue/1`.

## Test plan

- [x] `mix precommit` clean (921 tests, credo clean)
- [ ] CI green