### PR TITLE
feat(notifications): RSVP emails (E1, E2, E3) — closes #116

### DIFF
--- a/lib/huddlz/communities/group_member/changes/notify_joined.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_joined.ex
@@ -8,12 +8,10 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyJoined do
 
   use Ash.Resource.Change
 
-  require Ash.Query
-
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.Group
   alias Huddlz.Communities.GroupMember
-  alias Huddlz.Notifications
+  alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
 
   @impl true
   def change(changeset, _opts, _context) do
@@ -34,25 +32,8 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyJoined do
       }
 
       group_id
-      |> recipient_user_ids(joiner_id)
-      |> Enum.each(&deliver_to(&1, payload))
+      |> RecipientHelpers.group_organizer_user_ids(exclude: joiner_id)
+      |> RecipientHelpers.deliver_each(:group_member_joined, payload)
     end
-  end
-
-  defp deliver_to(user_id, payload) do
-    case Ash.get(User, user_id, authorize?: false) do
-      {:ok, recipient} -> Notifications.deliver_async(recipient, :group_member_joined, payload)
-      _ -> :noop
-    end
-  end
-
-  defp recipient_user_ids(group_id, joiner_id) do
-    GroupMember
-    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
-    |> Ash.Query.select([:user_id])
-    |> Ash.read!(authorize?: false)
-    |> Enum.map(& &1.user_id)
-    |> Enum.uniq()
-    |> Enum.reject(&(&1 == joiner_id))
   end
 end

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -300,6 +300,7 @@ defmodule Huddlz.Communities.Huddl do
       require_atomic? false
 
       change Huddlz.Communities.Huddl.Changes.CancelRsvp
+      change Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled
     end
 
     read :due_for_24h_reminder do

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -291,6 +291,7 @@ defmodule Huddlz.Communities.Huddl do
       require_atomic? false
 
       change Huddlz.Communities.Huddl.Changes.Rsvp
+      change Huddlz.Communities.Huddl.Changes.NotifyRsvpConfirmation
     end
 
     update :cancel_rsvp do

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -291,6 +291,7 @@ defmodule Huddlz.Communities.Huddl do
       require_atomic? false
 
       change Huddlz.Communities.Huddl.Changes.Rsvp
+      change Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived
       change Huddlz.Communities.Huddl.Changes.NotifyRsvpConfirmation
     end
 

--- a/lib/huddlz/communities/huddl/changes/cancel_rsvp.ex
+++ b/lib/huddlz/communities/huddl/changes/cancel_rsvp.ex
@@ -21,7 +21,7 @@ defmodule Huddlz.Communities.Huddl.Changes.CancelRsvp do
 
       {:ok, attendee} ->
         Ash.destroy!(attendee, authorize?: false)
-        changeset
+        Ash.Changeset.put_context(changeset, :rsvp_cancelled, true)
 
       {:error, error} ->
         Ash.Changeset.add_error(changeset, error)

--- a/lib/huddlz/communities/huddl/changes/notify_cancelled.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_cancelled.ex
@@ -12,9 +12,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyCancelled do
 
   use Ash.Resource.Change
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
-  alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
@@ -45,12 +43,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyCancelled do
     recipients = cs.context[:huddl_cancelled_recipients] || []
     payload = cs.context[:huddl_cancelled_payload] || %{}
 
-    for user_id <- recipients do
-      case Ash.get(User, user_id, authorize?: false) do
-        {:ok, user} -> Notifications.deliver_async(user, :huddl_cancelled, payload)
-        _ -> :noop
-      end
-    end
+    RecipientHelpers.deliver_each(recipients, :huddl_cancelled, payload)
 
     {:ok, huddl}
   end

--- a/lib/huddlz/communities/huddl/changes/notify_meaningful_update.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_meaningful_update.ex
@@ -23,10 +23,8 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
 
   require Ash.Query
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
-  alias Huddlz.Notifications
 
   @meaningful_attrs [:title, :starts_at, :ends_at, :physical_location, :virtual_link]
 
@@ -60,7 +58,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
 
     payload = base_payload(huddl, changed_fields)
 
-    deliver_each(recipients, :huddl_updated, payload)
+    RecipientHelpers.deliver_each(recipients, :huddl_updated, payload)
 
     {:ok, huddl}
   end
@@ -79,7 +77,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
 
         payload = base_payload(next, changed_fields)
 
-        deliver_each(recipients, :huddl_series_updated, payload)
+        RecipientHelpers.deliver_each(recipients, :huddl_series_updated, payload)
 
         {:ok, huddl}
     end
@@ -104,14 +102,5 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
       "group_slug" => to_string(huddl.group.slug),
       "changed_fields" => Enum.map(changed_fields, &Atom.to_string/1)
     }
-  end
-
-  defp deliver_each(user_ids, trigger, payload) do
-    for user_id <- user_ids do
-      case Ash.get(User, user_id, authorize?: false) do
-        {:ok, user} -> Notifications.deliver_async(user, trigger, payload)
-        _ -> :noop
-      end
-    end
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_new_in_group.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_new_in_group.ex
@@ -19,10 +19,8 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyNewInGroup do
 
   require Ash.Query
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
-  alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
@@ -56,12 +54,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyNewInGroup do
       "group_slug" => to_string(huddl.group.slug)
     }
 
-    for user_id <- user_ids do
-      case Ash.get(User, user_id, authorize?: false) do
-        {:ok, user} -> Notifications.deliver_async(user, :huddl_new, payload)
-        _ -> :noop
-      end
-    end
+    RecipientHelpers.deliver_each(user_ids, :huddl_new, payload)
 
     {:ok, huddl}
   end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
@@ -1,0 +1,80 @@
+defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
+  @moduledoc """
+  Enqueues E2 (rsvp_cancelled) emails when a user cancels their RSVP
+  to a huddl. Sent to the group's owner and organizers, deduplicated,
+  with the actor (the rsvper) excluded.
+
+  No-ops when there was no actual RSVP to cancel: `Huddl.Changes.CancelRsvp`
+  only sets `cs.context[:rsvp_cancelled]` on the destroy path. If no
+  attendee row existed, the action still succeeds but no email fires.
+  """
+
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.GroupMember
+  alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, &notify/2)
+  end
+
+  defp notify(cs, huddl) do
+    cond do
+      cs.context[:rsvp_cancelled] != true ->
+        {:ok, huddl}
+
+      is_nil(RecipientHelpers.actor_id(cs)) ->
+        {:ok, huddl}
+
+      true ->
+        deliver(huddl, RecipientHelpers.actor_id(cs))
+        {:ok, huddl}
+    end
+  end
+
+  defp deliver(huddl, actor_id) do
+    huddl = Ash.load!(huddl, [:group], authorize?: false)
+
+    payload = %{
+      "huddl_id" => huddl.id,
+      "huddl_title" => to_string(huddl.title),
+      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
+      "group_name" => to_string(huddl.group.name),
+      "group_slug" => to_string(huddl.group.slug),
+      "rsvper_display_name" => rsvper_display_name(actor_id)
+    }
+
+    huddl.group_id
+    |> recipient_user_ids(actor_id)
+    |> Enum.each(&deliver_to(&1, payload))
+  end
+
+  defp deliver_to(user_id, payload) do
+    case Ash.get(User, user_id, authorize?: false) do
+      {:ok, recipient} -> Notifications.deliver_async(recipient, :rsvp_cancelled, payload)
+      _ -> :noop
+    end
+  end
+
+  defp recipient_user_ids(group_id, actor_id) do
+    GroupMember
+    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
+    |> Ash.Query.select([:user_id])
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.user_id)
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == actor_id))
+  end
+
+  defp rsvper_display_name(actor_id) do
+    case Ash.get(User, actor_id, authorize?: false) do
+      {:ok, user} -> to_string(user.display_name)
+      _ -> "Someone"
+    end
+  end
+end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
@@ -11,9 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
 
   use Ash.Resource.Change
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
-  alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
@@ -21,40 +19,28 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
   end
 
   defp notify(cs, huddl) do
-    cond do
-      cs.context[:rsvp_cancelled] != true ->
-        {:ok, huddl}
-
-      is_nil(RecipientHelpers.actor_id(cs)) ->
-        {:ok, huddl}
-
-      true ->
-        deliver(huddl, RecipientHelpers.actor_id(cs))
-        {:ok, huddl}
+    with true <- cs.context[:rsvp_cancelled] == true,
+         %{id: _} = actor <- cs.context[:private][:actor] do
+      deliver(huddl, actor)
+      {:ok, huddl}
+    else
+      _ -> {:ok, huddl}
     end
   end
 
-  defp deliver(huddl, actor_id) do
+  defp deliver(huddl, actor) do
     huddl = Ash.load!(huddl, [:group], authorize?: false)
 
     payload = %{
       "huddl_id" => huddl.id,
       "huddl_title" => to_string(huddl.title),
-      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
       "group_name" => to_string(huddl.group.name),
       "group_slug" => to_string(huddl.group.slug),
-      "rsvper_display_name" => RecipientHelpers.user_display_name(actor_id, "Someone")
+      "rsvper_display_name" => to_string(actor.display_name)
     }
 
     huddl.group_id
-    |> RecipientHelpers.group_organizer_user_ids(exclude: actor_id)
-    |> Enum.each(&deliver_to(&1, payload))
-  end
-
-  defp deliver_to(user_id, payload) do
-    case Ash.get(User, user_id, authorize?: false) do
-      {:ok, recipient} -> Notifications.deliver_async(recipient, :rsvp_cancelled, payload)
-      _ -> :noop
-    end
+    |> RecipientHelpers.group_organizer_user_ids(exclude: actor.id)
+    |> RecipientHelpers.deliver_each(:rsvp_cancelled, payload)
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
@@ -11,10 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
 
   use Ash.Resource.Change
 
-  require Ash.Query
-
   alias Huddlz.Accounts.User
-  alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
   alias Huddlz.Notifications
 
@@ -46,11 +43,11 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
       "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
       "group_name" => to_string(huddl.group.name),
       "group_slug" => to_string(huddl.group.slug),
-      "rsvper_display_name" => rsvper_display_name(actor_id)
+      "rsvper_display_name" => RecipientHelpers.user_display_name(actor_id, "Someone")
     }
 
     huddl.group_id
-    |> recipient_user_ids(actor_id)
+    |> RecipientHelpers.group_organizer_user_ids(exclude: actor_id)
     |> Enum.each(&deliver_to(&1, payload))
   end
 
@@ -58,23 +55,6 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
     case Ash.get(User, user_id, authorize?: false) do
       {:ok, recipient} -> Notifications.deliver_async(recipient, :rsvp_cancelled, payload)
       _ -> :noop
-    end
-  end
-
-  defp recipient_user_ids(group_id, actor_id) do
-    GroupMember
-    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
-    |> Ash.Query.select([:user_id])
-    |> Ash.read!(authorize?: false)
-    |> Enum.map(& &1.user_id)
-    |> Enum.uniq()
-    |> Enum.reject(&(&1 == actor_id))
-  end
-
-  defp rsvper_display_name(actor_id) do
-    case Ash.get(User, actor_id, authorize?: false) do
-      {:ok, user} -> to_string(user.display_name)
-      _ -> "Someone"
     end
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_confirmation.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_confirmation.ex
@@ -1,0 +1,46 @@
+defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpConfirmation do
+  @moduledoc """
+  Enqueues E3 (rsvp_confirmation) email when a user RSVPs to a huddl.
+  Sent to the actor (the rsvper) themselves, not to organizers — that's
+  E1's job.
+
+  No-ops on duplicate RSVPs: `Huddl.Changes.Rsvp` only sets
+  `cs.context[:rsvp_created]` on the create path. If the attendee row
+  already existed, the action still succeeds but no email fires.
+  """
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, &notify/2)
+  end
+
+  defp notify(cs, huddl) do
+    cond do
+      cs.context[:rsvp_created] != true ->
+        {:ok, huddl}
+
+      is_nil(RecipientHelpers.actor_id(cs)) ->
+        {:ok, huddl}
+
+      true ->
+        deliver(huddl, RecipientHelpers.actor_id(cs))
+        {:ok, huddl}
+    end
+  end
+
+  defp deliver(huddl, actor_id) do
+    case Ash.get(User, actor_id, authorize?: false) do
+      {:ok, user} ->
+        Notifications.deliver_async(user, :rsvp_confirmation, %{"huddl_id" => huddl.id})
+
+      _ ->
+        :noop
+    end
+  end
+end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_confirmation.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_confirmation.ex
@@ -11,8 +11,6 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpConfirmation do
 
   use Ash.Resource.Change
 
-  alias Huddlz.Accounts.User
-  alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
   alias Huddlz.Notifications
 
   @impl true
@@ -21,26 +19,12 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpConfirmation do
   end
 
   defp notify(cs, huddl) do
-    cond do
-      cs.context[:rsvp_created] != true ->
-        {:ok, huddl}
-
-      is_nil(RecipientHelpers.actor_id(cs)) ->
-        {:ok, huddl}
-
-      true ->
-        deliver(huddl, RecipientHelpers.actor_id(cs))
-        {:ok, huddl}
-    end
-  end
-
-  defp deliver(huddl, actor_id) do
-    case Ash.get(User, actor_id, authorize?: false) do
-      {:ok, user} ->
-        Notifications.deliver_async(user, :rsvp_confirmation, %{"huddl_id" => huddl.id})
-
-      _ ->
-        :noop
+    with true <- cs.context[:rsvp_created] == true,
+         %{id: _} = actor <- cs.context[:private][:actor] do
+      Notifications.deliver_async(actor, :rsvp_confirmation, %{"huddl_id" => huddl.id})
+      {:ok, huddl}
+    else
+      _ -> {:ok, huddl}
     end
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
@@ -11,9 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
 
   use Ash.Resource.Change
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
-  alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
@@ -21,40 +19,28 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
   end
 
   defp notify(cs, huddl) do
-    cond do
-      cs.context[:rsvp_created] != true ->
-        {:ok, huddl}
-
-      is_nil(RecipientHelpers.actor_id(cs)) ->
-        {:ok, huddl}
-
-      true ->
-        deliver(huddl, RecipientHelpers.actor_id(cs))
-        {:ok, huddl}
+    with true <- cs.context[:rsvp_created] == true,
+         %{id: _} = actor <- cs.context[:private][:actor] do
+      deliver(huddl, actor)
+      {:ok, huddl}
+    else
+      _ -> {:ok, huddl}
     end
   end
 
-  defp deliver(huddl, actor_id) do
+  defp deliver(huddl, actor) do
     huddl = Ash.load!(huddl, [:group], authorize?: false)
 
     payload = %{
       "huddl_id" => huddl.id,
       "huddl_title" => to_string(huddl.title),
-      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
       "group_name" => to_string(huddl.group.name),
       "group_slug" => to_string(huddl.group.slug),
-      "rsvper_display_name" => RecipientHelpers.user_display_name(actor_id, "Someone")
+      "rsvper_display_name" => to_string(actor.display_name)
     }
 
     huddl.group_id
-    |> RecipientHelpers.group_organizer_user_ids(exclude: actor_id)
-    |> Enum.each(&deliver_to(&1, payload))
-  end
-
-  defp deliver_to(user_id, payload) do
-    case Ash.get(User, user_id, authorize?: false) do
-      {:ok, recipient} -> Notifications.deliver_async(recipient, :rsvp_received, payload)
-      _ -> :noop
-    end
+    |> RecipientHelpers.group_organizer_user_ids(exclude: actor.id)
+    |> RecipientHelpers.deliver_each(:rsvp_received, payload)
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
@@ -11,10 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
 
   use Ash.Resource.Change
 
-  require Ash.Query
-
   alias Huddlz.Accounts.User
-  alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
   alias Huddlz.Notifications
 
@@ -46,11 +43,11 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
       "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
       "group_name" => to_string(huddl.group.name),
       "group_slug" => to_string(huddl.group.slug),
-      "rsvper_display_name" => rsvper_display_name(actor_id)
+      "rsvper_display_name" => RecipientHelpers.user_display_name(actor_id, "Someone")
     }
 
     huddl.group_id
-    |> recipient_user_ids(actor_id)
+    |> RecipientHelpers.group_organizer_user_ids(exclude: actor_id)
     |> Enum.each(&deliver_to(&1, payload))
   end
 
@@ -58,23 +55,6 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
     case Ash.get(User, user_id, authorize?: false) do
       {:ok, recipient} -> Notifications.deliver_async(recipient, :rsvp_received, payload)
       _ -> :noop
-    end
-  end
-
-  defp recipient_user_ids(group_id, actor_id) do
-    GroupMember
-    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
-    |> Ash.Query.select([:user_id])
-    |> Ash.read!(authorize?: false)
-    |> Enum.map(& &1.user_id)
-    |> Enum.uniq()
-    |> Enum.reject(&(&1 == actor_id))
-  end
-
-  defp rsvper_display_name(actor_id) do
-    case Ash.get(User, actor_id, authorize?: false) do
-      {:ok, user} -> to_string(user.display_name)
-      _ -> "Someone"
     end
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
@@ -1,0 +1,80 @@
+defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
+  @moduledoc """
+  Enqueues E1 (rsvp_received) emails when a user RSVPs to a huddl.
+  Sent to the group's owner and organizers, deduplicated, with the
+  actor (the rsvper) excluded.
+
+  No-ops on duplicate RSVPs: `Huddl.Changes.Rsvp` only sets
+  `cs.context[:rsvp_created]` on the create path. If the attendee row
+  already existed, the action still succeeds but no email fires.
+  """
+
+  use Ash.Resource.Change
+
+  require Ash.Query
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.GroupMember
+  alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
+  alias Huddlz.Notifications
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, &notify/2)
+  end
+
+  defp notify(cs, huddl) do
+    cond do
+      cs.context[:rsvp_created] != true ->
+        {:ok, huddl}
+
+      is_nil(RecipientHelpers.actor_id(cs)) ->
+        {:ok, huddl}
+
+      true ->
+        deliver(huddl, RecipientHelpers.actor_id(cs))
+        {:ok, huddl}
+    end
+  end
+
+  defp deliver(huddl, actor_id) do
+    huddl = Ash.load!(huddl, [:group], authorize?: false)
+
+    payload = %{
+      "huddl_id" => huddl.id,
+      "huddl_title" => to_string(huddl.title),
+      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
+      "group_name" => to_string(huddl.group.name),
+      "group_slug" => to_string(huddl.group.slug),
+      "rsvper_display_name" => rsvper_display_name(actor_id)
+    }
+
+    huddl.group_id
+    |> recipient_user_ids(actor_id)
+    |> Enum.each(&deliver_to(&1, payload))
+  end
+
+  defp deliver_to(user_id, payload) do
+    case Ash.get(User, user_id, authorize?: false) do
+      {:ok, recipient} -> Notifications.deliver_async(recipient, :rsvp_received, payload)
+      _ -> :noop
+    end
+  end
+
+  defp recipient_user_ids(group_id, actor_id) do
+    GroupMember
+    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
+    |> Ash.Query.select([:user_id])
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.user_id)
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == actor_id))
+  end
+
+  defp rsvper_display_name(actor_id) do
+    case Ash.get(User, actor_id, authorize?: false) do
+      {:ok, user} -> to_string(user.display_name)
+      _ -> "Someone"
+    end
+  end
+end

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -10,6 +10,7 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.HuddlAttendee
+  alias Huddlz.Notifications
 
   @doc """
   Returns the user_ids of every RSVP on the given huddl, optionally
@@ -61,17 +62,19 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   end
 
   @doc """
-  Look up a user's `display_name` by id, falling back to the given
-  string if the user can't be loaded. Used to render the rsvper's name
-  in E1/E2 fanout payloads.
+  Fan a notification trigger out to a list of user_ids, fetching each
+  user with `authorize?: false` and skipping any that no longer exist
+  (e.g. raced deletion). Used by the C/E-series fanout notifiers.
   """
-  @spec user_display_name(Ecto.UUID.t() | nil, String.t()) :: String.t()
-  def user_display_name(nil, fallback), do: fallback
-
-  def user_display_name(user_id, fallback) do
-    case Ash.get(User, user_id, authorize?: false) do
-      {:ok, user} -> to_string(user.display_name)
-      _ -> fallback
+  @spec deliver_each([Ecto.UUID.t()], atom(), map()) :: :ok
+  def deliver_each(user_ids, trigger, payload) do
+    for user_id <- user_ids do
+      case Ash.get(User, user_id, authorize?: false) do
+        {:ok, user} -> Notifications.deliver_async(user, trigger, payload)
+        _ -> :noop
+      end
     end
+
+    :ok
   end
 end

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -7,6 +7,8 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
 
   require Ash.Query
 
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.HuddlAttendee
 
   @doc """
@@ -29,6 +31,24 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   end
 
   @doc """
+  Returns the user_ids of every owner and organizer of the given group,
+  deduplicated, optionally excluding the actor. Used by the E1/E2 RSVP
+  fanout notifiers.
+  """
+  @spec group_organizer_user_ids(Ecto.UUID.t(), keyword()) :: [Ecto.UUID.t()]
+  def group_organizer_user_ids(group_id, opts \\ []) do
+    actor_id = Keyword.get(opts, :exclude)
+
+    GroupMember
+    |> Ash.Query.filter(group_id == ^group_id and role in [:owner, :organizer])
+    |> Ash.Query.select([:user_id])
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.user_id)
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == actor_id))
+  end
+
+  @doc """
   Pull the actor id out of an Ash.Changeset's private context. Returns
   `nil` when no actor is present (e.g. system-driven actions).
   """
@@ -37,6 +57,21 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
     case changeset.context[:private][:actor] do
       %{id: id} -> id
       _ -> nil
+    end
+  end
+
+  @doc """
+  Look up a user's `display_name` by id, falling back to the given
+  string if the user can't be loaded. Used to render the rsvper's name
+  in E1/E2 fanout payloads.
+  """
+  @spec user_display_name(Ecto.UUID.t() | nil, String.t()) :: String.t()
+  def user_display_name(nil, fallback), do: fallback
+
+  def user_display_name(user_id, fallback) do
+    case Ash.get(User, user_id, authorize?: false) do
+      {:ok, user} -> to_string(user.display_name)
+      _ -> fallback
     end
   end
 end

--- a/lib/huddlz/communities/huddl/changes/rsvp.ex
+++ b/lib/huddlz/communities/huddl/changes/rsvp.ex
@@ -35,7 +35,7 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
       Ash.Changeset.add_error(cs, "This huddl is full")
     else
       create_rsvp!(huddl.id, user_id)
-      cs
+      Ash.Changeset.put_context(cs, :rsvp_created, true)
     end
   end
 

--- a/lib/huddlz/communities/huddl/changes/send_reminder.ex
+++ b/lib/huddlz/communities/huddl/changes/send_reminder.ex
@@ -14,9 +14,7 @@ defmodule Huddlz.Communities.Huddl.Changes.SendReminder do
 
   use Ash.Resource.Change
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
-  alias Huddlz.Notifications
 
   @impl true
   def change(changeset, opts, _context) do
@@ -34,12 +32,7 @@ defmodule Huddlz.Communities.Huddl.Changes.SendReminder do
 
     payload = %{"huddl_id" => huddl.id}
 
-    for user_id <- user_ids do
-      case Ash.get(User, user_id, authorize?: false) do
-        {:ok, user} -> Notifications.deliver_async(user, trigger, payload)
-        _ -> :noop
-      end
-    end
+    RecipientHelpers.deliver_each(user_ids, trigger, payload)
 
     {:ok, huddl}
   end

--- a/lib/huddlz/notifications/senders/group_archived.ex
+++ b/lib/huddlz/notifications/senders/group_archived.ex
@@ -16,6 +16,7 @@ defmodule Huddlz.Notifications.Senders.GroupArchived do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -27,7 +28,7 @@ defmodule Huddlz.Notifications.Senders.GroupArchived do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("#{group_name(payload)} has been deleted")
+    |> subject(HeaderSafe.safe("#{group_name(payload)} has been deleted"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/group_member_added.ex
+++ b/lib/huddlz/notifications/senders/group_member_added.ex
@@ -20,6 +20,7 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -33,7 +34,7 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("You're now a member of #{group_name(payload)}")
+    |> subject(HeaderSafe.safe("You're now a member of #{group_name(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/group_member_joined.ex
+++ b/lib/huddlz/notifications/senders/group_member_joined.ex
@@ -21,6 +21,7 @@ defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -35,7 +36,7 @@ defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("#{joiner_display_name(payload)} joined #{group_name(payload)}")
+    |> subject(HeaderSafe.safe("#{joiner_display_name(payload)} joined #{group_name(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/group_member_removed.ex
+++ b/lib/huddlz/notifications/senders/group_member_removed.ex
@@ -16,6 +16,7 @@ defmodule Huddlz.Notifications.Senders.GroupMemberRemoved do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -27,7 +28,7 @@ defmodule Huddlz.Notifications.Senders.GroupMemberRemoved do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("You were removed from #{group_name(payload)}")
+    |> subject(HeaderSafe.safe("You were removed from #{group_name(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/group_ownership_transferred.ex
+++ b/lib/huddlz/notifications/senders/group_ownership_transferred.ex
@@ -24,6 +24,7 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -45,7 +46,7 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("You transferred #{group_name(payload)} to a new owner")
+    |> subject(HeaderSafe.safe("You transferred #{group_name(payload)} to a new owner"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 
@@ -77,7 +78,7 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("You're the new owner of #{group_name(payload)}")
+    |> subject(HeaderSafe.safe("You're the new owner of #{group_name(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/group_role_changed.ex
+++ b/lib/huddlz/notifications/senders/group_role_changed.ex
@@ -21,6 +21,7 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -36,7 +37,7 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("Your role in #{group_name(payload)} changed")
+    |> subject(HeaderSafe.safe("Your role in #{group_name(payload)} changed"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/header_safe.ex
+++ b/lib/huddlz/notifications/senders/header_safe.ex
@@ -1,0 +1,31 @@
+defmodule Huddlz.Notifications.Senders.HeaderSafe do
+  @moduledoc """
+  Strip control characters from values that get interpolated into email
+  header fields (Subject, etc.). User-controlled fields like
+  `display_name`, `Group.name`, and `Huddl.title` have no format
+  constraints preventing CR/LF, which on a poorly-behaved transport
+  could fold or inject headers. Swoosh's mail layer handles most of
+  this defensively, but explicit sanitization at the boundary is
+  cheaper than auditing every transport.
+
+  Plain-text and HTML bodies do not need this treatment; HTML bodies
+  use `HtmlEscape`.
+  """
+
+  @doc """
+  Replace any control character (CR, LF, tab, NUL, DEL, etc.) with a
+  single space, then collapse whitespace runs and trim. Returns a
+  plain string.
+
+      iex> Huddlz.Notifications.Senders.HeaderSafe.safe("Alice\\r\\nBcc: x")
+      "Alice Bcc: x"
+  """
+  @spec safe(term()) :: String.t()
+  def safe(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[[:cntrl:]]/u, " ")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+end

--- a/lib/huddlz/notifications/senders/huddl_cancelled.ex
+++ b/lib/huddlz/notifications/senders/huddl_cancelled.ex
@@ -21,6 +21,7 @@ defmodule Huddlz.Notifications.Senders.HuddlCancelled do
   import Swoosh.Email
 
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -35,7 +36,7 @@ defmodule Huddlz.Notifications.Senders.HuddlCancelled do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("Cancelled: #{huddl_title(payload)}")
+    |> subject(HeaderSafe.safe("Cancelled: #{huddl_title(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/huddl_new.ex
+++ b/lib/huddlz/notifications/senders/huddl_new.ex
@@ -23,6 +23,7 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -39,7 +40,7 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("New huddl in #{group_name(payload)}: #{huddl_title(payload)}")
+    |> subject(HeaderSafe.safe("New huddl in #{group_name(payload)}: #{huddl_title(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/huddl_reminder_1h.ex
+++ b/lib/huddlz/notifications/senders/huddl_reminder_1h.ex
@@ -22,6 +22,7 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder1h do
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.ICS
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -41,7 +42,7 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder1h do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("Starting soon: #{huddl.title}")
+    |> subject(HeaderSafe.safe("Starting soon: #{huddl.title}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/huddl_reminder_24h.ex
+++ b/lib/huddlz/notifications/senders/huddl_reminder_24h.ex
@@ -25,6 +25,7 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder24h do
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.ICS
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -44,7 +45,7 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder24h do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("Tomorrow: #{huddl.title}")
+    |> subject(HeaderSafe.safe("Tomorrow: #{huddl.title}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/huddl_series_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_series_updated.ex
@@ -21,6 +21,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -38,7 +39,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("Recurring series updated: #{huddl_title(payload)}")
+    |> subject(HeaderSafe.safe("Recurring series updated: #{huddl_title(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/huddl_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_updated.ex
@@ -21,6 +21,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -38,7 +39,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("Updated: #{huddl_title(payload)}")
+    |> subject(HeaderSafe.safe("Updated: #{huddl_title(payload)}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/rsvp_cancelled.ex
+++ b/lib/huddlz/notifications/senders/rsvp_cancelled.ex
@@ -1,0 +1,73 @@
+defmodule Huddlz.Notifications.Senders.RsvpCancelled do
+  @moduledoc """
+  Sender for E2: someone cancelled their RSVP to a huddl in a group I
+  organize.
+
+  Sent to each owner/organizer of the group (deduplicated, actor
+  excluded). Activity category — preferences and the unsubscribe footer
+  apply.
+
+  Required payload keys:
+
+    * `"huddl_id"` — used to render the huddl page link.
+    * `"huddl_title"` — display name of the huddl.
+    * `"group_name"` — display name of the group.
+    * `"group_slug"` — slug used in the huddl page URL.
+    * `"rsvper_display_name"` — name of the user who cancelled.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HtmlEscape
+
+  @impl true
+  def build(user, payload) do
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_title = HtmlEscape.escape(huddl_title(payload))
+    safe_group = HtmlEscape.escape(group_name(payload))
+    safe_rsvper = HtmlEscape.escape(rsvper_display_name(payload))
+    huddl_url = huddl_url(payload)
+
+    {footer_html, footer_text} = Footer.build(user, :rsvp_cancelled)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("#{rsvper_display_name(payload)} cancelled their RSVP to #{huddl_title(payload)}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p><strong>#{safe_rsvper}</strong> cancelled their RSVP to
+    <strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>.
+    See the current attendee list at <a href="#{huddl_url}">#{huddl_url}</a>.</p>
+    #{footer_html}
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    #{rsvper_display_name(payload)} cancelled their RSVP to "#{huddl_title(payload)}" in "#{group_name(payload)}".
+    See the current attendee list at #{huddl_url}.
+    #{footer_text}
+    """)
+  end
+
+  defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title
+  defp huddl_title(_), do: "your huddl"
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "your group"
+
+  defp rsvper_display_name(%{"rsvper_display_name" => name}) when is_binary(name), do: name
+  defp rsvper_display_name(_), do: "Someone"
+
+  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
+       when is_binary(slug) and is_binary(id),
+       do: url(~p"/groups/#{slug}/huddlz/#{id}")
+
+  defp huddl_url(_), do: url(~p"/")
+end

--- a/lib/huddlz/notifications/senders/rsvp_cancelled.ex
+++ b/lib/huddlz/notifications/senders/rsvp_cancelled.ex
@@ -23,6 +23,7 @@ defmodule Huddlz.Notifications.Senders.RsvpCancelled do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -38,7 +39,11 @@ defmodule Huddlz.Notifications.Senders.RsvpCancelled do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("#{rsvper_display_name(payload)} cancelled their RSVP to #{huddl_title(payload)}")
+    |> subject(
+      HeaderSafe.safe(
+        "#{rsvper_display_name(payload)} cancelled their RSVP to #{huddl_title(payload)}"
+      )
+    )
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/rsvp_confirmation.ex
+++ b/lib/huddlz/notifications/senders/rsvp_confirmation.ex
@@ -23,6 +23,7 @@ defmodule Huddlz.Notifications.Senders.RsvpConfirmation do
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.ICS
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -42,7 +43,7 @@ defmodule Huddlz.Notifications.Senders.RsvpConfirmation do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("You're going to #{huddl.title}")
+    |> subject(HeaderSafe.safe("You're going to #{huddl.title}"))
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/lib/huddlz/notifications/senders/rsvp_confirmation.ex
+++ b/lib/huddlz/notifications/senders/rsvp_confirmation.ex
@@ -1,0 +1,79 @@
+defmodule Huddlz.Notifications.Senders.RsvpConfirmation do
+  @moduledoc """
+  Sender for E3: confirmation to a user that their RSVP was recorded.
+
+  Sent to the user themselves at RSVP time. Activity category —
+  preferences and the unsubscribe footer apply. Includes an `.ics`
+  calendar attachment so the recipient can save the huddl to their
+  calendar.
+
+  Required payload keys:
+
+    * `"huddl_id"` — UUID of the huddl. The sender re-reads the row
+      to construct the email body and attach the live `.ics`. Same
+      pattern as the D1/D2 reminder senders.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Communities.Huddl
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.ICS
+  alias Huddlz.Notifications.Senders.HtmlEscape
+
+  @impl true
+  def build(user, payload) do
+    huddl = fetch_huddl!(payload)
+
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_title = HtmlEscape.escape(huddl.title)
+    safe_group = HtmlEscape.escape(huddl.group.name)
+    when_text = format_starts_at(huddl.starts_at)
+    safe_when = HtmlEscape.escape(when_text)
+    huddl_url = url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}")
+
+    {footer_html, footer_text} = Footer.build(user, :rsvp_confirmation)
+    {ics_filename, ics_content} = ICS.event_for(huddl)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("You're going to #{huddl.title}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>You're confirmed for <strong>#{safe_title}</strong> in
+    <strong>#{safe_group}</strong> on #{safe_when}.</p>
+
+    <p>The calendar event is attached. Or open the huddl page at
+    <a href="#{huddl_url}">#{huddl_url}</a>.</p>
+    #{footer_html}
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    You're confirmed for "#{huddl.title}" in "#{huddl.group.name}" on #{when_text}.
+
+    The calendar event is attached. Or open the huddl page at #{huddl_url}.
+    #{footer_text}
+    """)
+    |> attachment(
+      Swoosh.Attachment.new({:data, ics_content},
+        filename: ics_filename,
+        content_type: "text/calendar"
+      )
+    )
+  end
+
+  defp fetch_huddl!(%{"huddl_id" => id}) when is_binary(id) do
+    Ash.get!(Huddl, id, authorize?: false, load: [:group])
+  end
+
+  defp format_starts_at(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%a %b %-d, %Y at %-I:%M %p UTC")
+  end
+end

--- a/lib/huddlz/notifications/senders/rsvp_received.ex
+++ b/lib/huddlz/notifications/senders/rsvp_received.ex
@@ -1,0 +1,72 @@
+defmodule Huddlz.Notifications.Senders.RsvpReceived do
+  @moduledoc """
+  Sender for E1: someone RSVPd to a huddl in a group I organize.
+
+  Sent to each owner/organizer of the group (deduplicated, actor
+  excluded). Activity category — preferences and the unsubscribe footer
+  apply.
+
+  Required payload keys:
+
+    * `"huddl_id"` — used to render the huddl page link.
+    * `"huddl_title"` — display name of the huddl.
+    * `"group_name"` — display name of the group.
+    * `"group_slug"` — slug used in the huddl page URL.
+    * `"rsvper_display_name"` — name of the user who RSVPd.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  use HuddlzWeb, :verified_routes
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HtmlEscape
+
+  @impl true
+  def build(user, payload) do
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_title = HtmlEscape.escape(huddl_title(payload))
+    safe_group = HtmlEscape.escape(group_name(payload))
+    safe_rsvper = HtmlEscape.escape(rsvper_display_name(payload))
+    huddl_url = huddl_url(payload)
+
+    {footer_html, footer_text} = Footer.build(user, :rsvp_received)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject("#{rsvper_display_name(payload)} RSVPd to #{huddl_title(payload)}")
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p><strong>#{safe_rsvper}</strong> just RSVPd to
+    <strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>.
+    See the full attendee list at <a href="#{huddl_url}">#{huddl_url}</a>.</p>
+    #{footer_html}
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    #{rsvper_display_name(payload)} just RSVPd to "#{huddl_title(payload)}" in "#{group_name(payload)}".
+    See the full attendee list at #{huddl_url}.
+    #{footer_text}
+    """)
+  end
+
+  defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title
+  defp huddl_title(_), do: "your huddl"
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "your group"
+
+  defp rsvper_display_name(%{"rsvper_display_name" => name}) when is_binary(name), do: name
+  defp rsvper_display_name(_), do: "Someone"
+
+  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
+       when is_binary(slug) and is_binary(id),
+       do: url(~p"/groups/#{slug}/huddlz/#{id}")
+
+  defp huddl_url(_), do: url(~p"/")
+end

--- a/lib/huddlz/notifications/senders/rsvp_received.ex
+++ b/lib/huddlz/notifications/senders/rsvp_received.ex
@@ -22,6 +22,7 @@ defmodule Huddlz.Notifications.Senders.RsvpReceived do
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
   @impl true
@@ -37,7 +38,9 @@ defmodule Huddlz.Notifications.Senders.RsvpReceived do
     new()
     |> from(Mailer.from())
     |> to(to_string(user.email))
-    |> subject("#{rsvper_display_name(payload)} RSVPd to #{huddl_title(payload)}")
+    |> subject(
+      HeaderSafe.safe("#{rsvper_display_name(payload)} RSVPd to #{huddl_title(payload)}")
+    )
     |> html_body("""
     <p>Hi #{safe_name},</p>
 

--- a/test/huddlz/notifications/rsvp_notifications_test.exs
+++ b/test/huddlz/notifications/rsvp_notifications_test.exs
@@ -1,0 +1,125 @@
+defmodule Huddlz.Notifications.RsvpNotificationsTest do
+  @moduledoc """
+  Integration coverage for the E-series RSVP notifications (see
+  `docs/notifications.md` § E). Exercises the `Huddl.:rsvp` and
+  `Huddl.:cancel_rsvp` actions end-to-end through the Oban worker
+  and asserts the resulting Swoosh email.
+  """
+
+  use Huddlz.DataCase, async: false
+  use Oban.Testing, repo: Huddlz.Repo
+
+  import Swoosh.TestAssertions
+  require Ash.Query
+
+  alias Huddlz.Notifications.DeliverWorker
+
+  describe "E3: rsvp_confirmation" do
+    test "emails the rsvper themselves with an .ics attachment" do
+      owner = generate(user(role: :user))
+      attendee = generate(user(display_name: "Attendee"))
+
+      group =
+        generate(
+          group(
+            name: "Pickup Sports",
+            slug: "pickup-sports",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner
+          )
+        )
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "You're going to Saturday Soccer" and
+          email.to == [{"", to_string(attendee.email)}] and
+          Enum.any?(email.attachments, &(&1.content_type == "text/calendar"))
+      end)
+    end
+
+    test "does not fire on duplicate RSVP" do
+      owner = generate(user(role: :user))
+      attendee = generate(user())
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+
+    test "does not fire when capacity is rejected" do
+      owner = generate(user(role: :user))
+      first = generate(user())
+      second = generate(user())
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            max_attendees: 1
+          )
+        )
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: first)
+      |> Ash.update!()
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      assert_raise Ash.Error.Invalid, ~r/full/, fn ->
+        huddl
+        |> Ash.Changeset.for_update(:rsvp, %{}, actor: second)
+        |> Ash.update!()
+      end
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+  end
+
+  defp flush_mailbox do
+    receive do
+      {:email, _} -> flush_mailbox()
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/test/huddlz/notifications/rsvp_notifications_test.exs
+++ b/test/huddlz/notifications/rsvp_notifications_test.exs
@@ -159,8 +159,6 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
       |> Ash.update!()
 
-      # Per-recipient assertions below cover what was sent. Drain
-      # asserts no jobs failed.
       assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       for recipient <- [owner, organizer_a, organizer_b] do

--- a/test/huddlz/notifications/rsvp_notifications_test.exs
+++ b/test/huddlz/notifications/rsvp_notifications_test.exs
@@ -239,6 +239,125 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
     end
   end
 
+  describe "E2: rsvp_cancelled" do
+    test "emails the group owner and every organizer (deduped, actor excluded)" do
+      owner = generate(user(role: :user, display_name: "Owner"))
+      organizer = generate(user(display_name: "Organizer"))
+      attendee = generate(user(display_name: "Attendee"))
+
+      group =
+        generate(
+          group(
+            name: "Pickup Sports",
+            slug: "pickup-sports",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      generate(
+        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
+      )
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner
+          )
+        )
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      # Owner + organizer get E2. There is no E4 confirmation to the
+      # actor (the spec explicitly skips it).
+      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+
+      for recipient <- [owner, organizer] do
+        assert_email_sent(fn email ->
+          email.subject == "Attendee cancelled their RSVP to Saturday Soccer" and
+            email.to == [{"", to_string(recipient.email)}] and
+            email.html_body =~ "/groups/pickup-sports/huddlz/#{huddl.id}"
+        end)
+      end
+    end
+
+    test "does not fire when cancelling a nonexistent RSVP" do
+      owner = generate(user(role: :user))
+      attendee = generate(user())
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      # Attendee never RSVPd. cancel_rsvp is a no-op but the action still
+      # succeeds; no email should fire.
+      huddl
+      |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      refute_enqueued(worker: DeliverWorker)
+    end
+
+    test "actor who is also an organizer is excluded from E2" do
+      owner = generate(user(role: :user))
+      organizer = generate(user(display_name: "Self-cancelling Organizer"))
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
+      )
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner
+          )
+        )
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: organizer)
+      |> Ash.update!()
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: organizer)
+      |> Ash.update!()
+
+      # Only owner gets E2. Organizer is the actor — excluded.
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.to == [{"", to_string(owner.email)}] and
+          email.subject == "Self-cancelling Organizer cancelled their RSVP to Saturday Soccer"
+      end)
+    end
+  end
+
   defp flush_mailbox do
     receive do
       {:email, _} -> flush_mailbox()

--- a/test/huddlz/notifications/rsvp_notifications_test.exs
+++ b/test/huddlz/notifications/rsvp_notifications_test.exs
@@ -50,7 +50,7 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: owner)
       |> Ash.update!()
 
-      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
         email.subject == "You're going to Saturday Soccer" and
@@ -159,8 +159,9 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
       |> Ash.update!()
 
-      # Owner + 2 organizers receive E1, attendee receives E3.
-      assert %{success: 4} = Oban.drain_queue(queue: :notifications)
+      # Per-recipient assertions below cover what was sent. Drain
+      # asserts no jobs failed.
+      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       for recipient <- [owner, organizer_a, organizer_b] do
         assert_email_sent(fn email ->
@@ -199,8 +200,7 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: organizer)
       |> Ash.update!()
 
-      # Owner gets E1, organizer gets E3 only (excluded from E1).
-      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
         email.subject == "Self-RSVPing Organizer RSVPd to Saturday Soccer" and
@@ -230,7 +230,7 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       |> Ash.update!()
 
       # Only E3 to the owner. No E1 since owner is the actor.
-      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
         email.subject == "You're going to #{huddl.title}" and
@@ -283,7 +283,7 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
 
       # Owner + organizer get E2. There is no E4 confirmation to the
       # actor (the spec explicitly skips it).
-      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       for recipient <- [owner, organizer] do
         assert_email_sent(fn email ->
@@ -349,7 +349,7 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       |> Ash.update!()
 
       # Only owner gets E2. Organizer is the actor — excluded.
-      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
         email.to == [{"", to_string(owner.email)}] and

--- a/test/huddlz/notifications/rsvp_notifications_test.exs
+++ b/test/huddlz/notifications/rsvp_notifications_test.exs
@@ -16,8 +16,11 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
 
   describe "E3: rsvp_confirmation" do
     test "emails the rsvper themselves with an .ics attachment" do
-      owner = generate(user(role: :user))
-      attendee = generate(user(display_name: "Attendee"))
+      # Setup: actor IS the sole owner of the group, so E1's recipient
+      # set (owner+organizers minus actor) is empty and only E3 fires.
+      # This keeps the test focused on E3's distinguishing properties
+      # (subject + .ics attachment).
+      owner = generate(user(role: :user, display_name: "Owner"))
 
       group =
         generate(
@@ -44,14 +47,14 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       flush_mailbox()
 
       huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: owner)
       |> Ash.update!()
 
       assert %{success: 1} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
         email.subject == "You're going to Saturday Soccer" and
-          email.to == [{"", to_string(attendee.email)}] and
+          email.to == [{"", to_string(owner.email)}] and
           Enum.any?(email.attachments, &(&1.content_type == "text/calendar"))
       end)
     end
@@ -112,6 +115,127 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       end
 
       refute_enqueued(worker: DeliverWorker)
+    end
+  end
+
+  describe "E1: rsvp_received" do
+    test "emails the group owner and every organizer (deduped, actor excluded)" do
+      owner = generate(user(role: :user, display_name: "Owner"))
+      organizer_a = generate(user(display_name: "Org A"))
+      organizer_b = generate(user(display_name: "Org B"))
+      attendee = generate(user(display_name: "Attendee"))
+
+      group =
+        generate(
+          group(
+            name: "Pickup Sports",
+            slug: "pickup-sports",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      for org <- [organizer_a, organizer_b] do
+        generate(
+          group_member(group_id: group.id, user_id: org.id, role: :organizer, actor: owner)
+        )
+      end
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner
+          )
+        )
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      # Owner + 2 organizers receive E1, attendee receives E3.
+      assert %{success: 4} = Oban.drain_queue(queue: :notifications)
+
+      for recipient <- [owner, organizer_a, organizer_b] do
+        assert_email_sent(fn email ->
+          email.subject == "Attendee RSVPd to Saturday Soccer" and
+            email.to == [{"", to_string(recipient.email)}] and
+            email.html_body =~ "/groups/pickup-sports/huddlz/#{huddl.id}"
+        end)
+      end
+    end
+
+    test "actor who is also an organizer is excluded from E1 but still receives E3" do
+      owner = generate(user(role: :user))
+      organizer = generate(user(display_name: "Self-RSVPing Organizer"))
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(group_id: group.id, user_id: organizer.id, role: :organizer, actor: owner)
+      )
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner
+          )
+        )
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: organizer)
+      |> Ash.update!()
+
+      # Owner gets E1, organizer gets E3 only (excluded from E1).
+      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "Self-RSVPing Organizer RSVPd to Saturday Soccer" and
+          email.to == [{"", to_string(owner.email)}]
+      end)
+
+      assert_email_sent(fn email ->
+        email.subject == "You're going to Saturday Soccer" and
+          email.to == [{"", to_string(organizer.email)}]
+      end)
+    end
+
+    test "does not fire when the actor is the only owner/organizer (recipient set is empty)" do
+      owner = generate(user(role: :user))
+
+      group =
+        generate(group(name: "Solo Group", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: owner)
+      |> Ash.update!()
+
+      # Only E3 to the owner. No E1 since owner is the actor.
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "You're going to #{huddl.title}" and
+          email.to == [{"", to_string(owner.email)}]
+      end)
     end
   end
 

--- a/test/huddlz/notifications/senders/header_safe_test.exs
+++ b/test/huddlz/notifications/senders/header_safe_test.exs
@@ -1,0 +1,32 @@
+defmodule Huddlz.Notifications.Senders.HeaderSafeTest do
+  use ExUnit.Case, async: true
+
+  alias Huddlz.Notifications.Senders.HeaderSafe
+
+  doctest HeaderSafe
+
+  test "replaces CR and LF with spaces (header injection vector)" do
+    assert HeaderSafe.safe("Alice\r\nBcc: x@evil.com") == "Alice Bcc: x@evil.com"
+  end
+
+  test "replaces NUL, tab, vertical tab, and DEL" do
+    assert HeaderSafe.safe("a\x00b\tc\vd\x7fe") == "a b c d e"
+  end
+
+  test "collapses runs of whitespace to a single space" do
+    assert HeaderSafe.safe("hello   world") == "hello world"
+  end
+
+  test "trims leading and trailing whitespace" do
+    assert HeaderSafe.safe("  padded  ") == "padded"
+  end
+
+  test "preserves non-ASCII unicode" do
+    assert HeaderSafe.safe("Café résumé 🎉") == "Café résumé 🎉"
+  end
+
+  test "coerces non-string input via to_string/1" do
+    assert HeaderSafe.safe(42) == "42"
+    assert HeaderSafe.safe(nil) == ""
+  end
+end

--- a/test/huddlz/notifications/senders/rsvp_cancelled_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_cancelled_test.exs
@@ -1,22 +1,10 @@
 defmodule Huddlz.Notifications.Senders.RsvpCancelledTest do
   use Huddlz.DataCase, async: true
 
+  import Huddlz.Test.Helpers.RsvpFanoutPayload, only: [payload: 0, payload: 1]
+
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Senders.RsvpCancelled
-
-  defp payload(overrides \\ %{}) do
-    Map.merge(
-      %{
-        "huddl_id" => "00000000-0000-0000-0000-000000000001",
-        "huddl_title" => "Saturday Soccer",
-        "starts_at_iso" => "2026-05-10T15:00:00Z",
-        "group_name" => "Pickup Sports",
-        "group_slug" => "pickup-sports",
-        "rsvper_display_name" => "Trinity"
-      },
-      overrides
-    )
-  end
 
   describe "build/2" do
     test "addresses the recipient with their display name" do

--- a/test/huddlz/notifications/senders/rsvp_cancelled_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_cancelled_test.exs
@@ -1,0 +1,111 @@
+defmodule Huddlz.Notifications.Senders.RsvpCancelledTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.RsvpCancelled
+
+  defp payload(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "huddl_id" => "00000000-0000-0000-0000-000000000001",
+        "huddl_title" => "Saturday Soccer",
+        "starts_at_iso" => "2026-05-10T15:00:00Z",
+        "group_name" => "Pickup Sports",
+        "group_slug" => "pickup-sports",
+        "rsvper_display_name" => "Trinity"
+      },
+      overrides
+    )
+  end
+
+  describe "build/2" do
+    test "addresses the recipient with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = RsvpCancelled.build(user, payload())
+
+      assert email.html_body =~ "Hi Sam"
+      assert email.text_body =~ "Hi Sam"
+    end
+
+    test "to and from are correct" do
+      user = generate(user())
+      email = RsvpCancelled.build(user, payload())
+
+      assert email.to == [{"", to_string(user.email)}]
+      assert email.from == Mailer.from()
+    end
+
+    test "subject names the rsvper, frames the action as a cancellation, and names the huddl" do
+      user = generate(user())
+      email = RsvpCancelled.build(user, payload())
+
+      assert email.subject == "Trinity cancelled their RSVP to Saturday Soccer"
+      assert email.html_body =~ "Trinity"
+      assert email.html_body =~ "cancelled their RSVP"
+      assert email.html_body =~ "Saturday Soccer"
+      assert email.html_body =~ "Pickup Sports"
+    end
+
+    test "links to the huddl page using the slug + id" do
+      user = generate(user())
+
+      email =
+        RsvpCancelled.build(
+          user,
+          payload(%{
+            "group_slug" => "pickup-sports",
+            "huddl_id" => "abc123"
+          })
+        )
+
+      assert email.html_body =~ "/groups/pickup-sports/huddlz/abc123"
+      assert email.text_body =~ "/groups/pickup-sports/huddlz/abc123"
+    end
+
+    test "renders an unsubscribe footer (Activity)" do
+      user = generate(user())
+      email = RsvpCancelled.build(user, payload())
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.html_body =~ "/profile/notifications"
+      assert email.text_body =~ "/unsubscribe/"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>alert(1)</script>"))
+
+      email =
+        RsvpCancelled.build(
+          user,
+          payload(%{
+            "huddl_title" => "<img src=x>",
+            "group_name" => "<b>boom</b>",
+            "rsvper_display_name" => "<u>raw</u>"
+          })
+        )
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x"
+      refute email.html_body =~ "<b>boom"
+      refute email.html_body =~ "<u>raw"
+      assert email.html_body =~ "&lt;script&gt;"
+      assert email.html_body =~ "&lt;img"
+    end
+
+    test "leaves user-controlled strings raw in text_body" do
+      user = generate(user(display_name: "Sam"))
+
+      email = RsvpCancelled.build(user, payload(%{"huddl_title" => "Sat & Sun"}))
+
+      assert email.text_body =~ "Sat & Sun"
+      refute email.text_body =~ "<"
+    end
+
+    test "falls back when payload fields are missing" do
+      user = generate(user())
+      email = RsvpCancelled.build(user, %{})
+
+      assert email.subject == "Someone cancelled their RSVP to your huddl"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/rsvp_confirmation_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_confirmation_test.exs
@@ -1,0 +1,124 @@
+defmodule Huddlz.Notifications.Senders.RsvpConfirmationTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.RsvpConfirmation
+
+  defp setup_huddl(attrs \\ %{}) do
+    owner = generate(user(role: :user))
+
+    group =
+      generate(
+        group(
+          name: attrs[:group_name] || "Pickup Sports",
+          slug: attrs[:group_slug] || "pickup-sports",
+          is_public: true,
+          owner_id: owner.id,
+          actor: owner
+        )
+      )
+
+    generate(
+      huddl(
+        title: attrs[:title] || "Saturday Soccer",
+        group_id: group.id,
+        creator_id: owner.id,
+        actor: owner
+      )
+    )
+  end
+
+  describe "build/2" do
+    test "addresses the user with their display name" do
+      user = generate(user(display_name: "Sam"))
+      huddl = setup_huddl()
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert email.html_body =~ "Hi Sam"
+      assert email.text_body =~ "Hi Sam"
+    end
+
+    test "to and from are correct" do
+      user = generate(user())
+      huddl = setup_huddl()
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert email.to == [{"", to_string(user.email)}]
+      assert email.from == Mailer.from()
+    end
+
+    test "subject confirms the rsvp and names the huddl" do
+      user = generate(user())
+      huddl = setup_huddl(%{title: "Saturday Soccer"})
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert email.subject == "You're going to Saturday Soccer"
+    end
+
+    test "body links to the huddl page using slug + id" do
+      user = generate(user())
+
+      huddl =
+        setup_huddl(%{
+          title: "Saturday Soccer",
+          group_name: "Pickup Sports",
+          group_slug: "pickup-sports"
+        })
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert email.html_body =~ "Saturday Soccer"
+      assert email.html_body =~ "Pickup Sports"
+      assert email.html_body =~ "/groups/pickup-sports/huddlz/#{huddl.id}"
+      assert email.text_body =~ "/groups/pickup-sports/huddlz/#{huddl.id}"
+    end
+
+    test "attaches an .ics calendar event" do
+      user = generate(user())
+      huddl = setup_huddl()
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert [attachment] = email.attachments
+      assert attachment.filename == "huddl.ics"
+      assert attachment.content_type == "text/calendar"
+      assert attachment.data =~ "BEGIN:VCALENDAR"
+    end
+
+    test "includes the unsubscribe footer (activity)" do
+      user = generate(user())
+      huddl = setup_huddl()
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.html_body =~ "/profile/notifications"
+      assert email.text_body =~ "Unsubscribe"
+    end
+
+    test "html-escapes user-controlled strings in html_body" do
+      user = generate(user(display_name: "<script>x</script>"))
+      huddl = setup_huddl(%{title: "<img src=x>", group_name: "<b>Boom</b>"})
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x"
+      refute email.html_body =~ "<b>Boom"
+      assert email.html_body =~ "&lt;script&gt;"
+    end
+
+    test "leaves user-controlled strings raw in text_body" do
+      user = generate(user(display_name: "Sam"))
+      huddl = setup_huddl(%{title: "Sat & Sun"})
+
+      email = RsvpConfirmation.build(user, %{"huddl_id" => huddl.id})
+
+      assert email.text_body =~ "Sat & Sun"
+      refute email.text_body =~ "<"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/rsvp_received_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_received_test.exs
@@ -107,5 +107,19 @@ defmodule Huddlz.Notifications.Senders.RsvpReceivedTest do
 
       assert email.subject == "Someone RSVPd to your huddl"
     end
+
+    test "strips control characters from the subject (header injection guard)" do
+      user = generate(user())
+
+      email =
+        RsvpReceived.build(
+          user,
+          payload(%{"rsvper_display_name" => "Eve\r\nBcc: x@evil.com"})
+        )
+
+      refute email.subject =~ "\r"
+      refute email.subject =~ "\n"
+      assert email.subject =~ "Eve Bcc: x@evil.com"
+    end
   end
 end

--- a/test/huddlz/notifications/senders/rsvp_received_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_received_test.exs
@@ -1,0 +1,111 @@
+defmodule Huddlz.Notifications.Senders.RsvpReceivedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.RsvpReceived
+
+  defp payload(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "huddl_id" => "00000000-0000-0000-0000-000000000001",
+        "huddl_title" => "Saturday Soccer",
+        "starts_at_iso" => "2026-05-10T15:00:00Z",
+        "group_name" => "Pickup Sports",
+        "group_slug" => "pickup-sports",
+        "rsvper_display_name" => "Trinity"
+      },
+      overrides
+    )
+  end
+
+  describe "build/2" do
+    test "addresses the recipient with their display name" do
+      user = generate(user(display_name: "Sam"))
+      email = RsvpReceived.build(user, payload())
+
+      assert email.html_body =~ "Hi Sam"
+      assert email.text_body =~ "Hi Sam"
+    end
+
+    test "to and from are correct" do
+      user = generate(user())
+      email = RsvpReceived.build(user, payload())
+
+      assert email.to == [{"", to_string(user.email)}]
+      assert email.from == Mailer.from()
+    end
+
+    test "subject names the rsvper and the huddl" do
+      user = generate(user())
+      email = RsvpReceived.build(user, payload())
+
+      assert email.subject == "Trinity RSVPd to Saturday Soccer"
+      assert email.html_body =~ "Trinity"
+      assert email.html_body =~ "Saturday Soccer"
+      assert email.html_body =~ "Pickup Sports"
+    end
+
+    test "links to the huddl page using the slug + id" do
+      user = generate(user())
+
+      email =
+        RsvpReceived.build(
+          user,
+          payload(%{
+            "group_slug" => "pickup-sports",
+            "huddl_id" => "abc123"
+          })
+        )
+
+      assert email.html_body =~ "/groups/pickup-sports/huddlz/abc123"
+      assert email.text_body =~ "/groups/pickup-sports/huddlz/abc123"
+    end
+
+    test "renders an unsubscribe footer (Activity)" do
+      user = generate(user())
+      email = RsvpReceived.build(user, payload())
+
+      assert email.html_body =~ "/unsubscribe/"
+      assert email.html_body =~ "/profile/notifications"
+      assert email.text_body =~ "/unsubscribe/"
+    end
+
+    test "html-escapes user-controlled strings" do
+      user = generate(user(display_name: "<script>alert(1)</script>"))
+
+      email =
+        RsvpReceived.build(
+          user,
+          payload(%{
+            "huddl_title" => "<img src=x>",
+            "group_name" => "<b>boom</b>",
+            "rsvper_display_name" => "<u>raw</u>"
+          })
+        )
+
+      refute email.html_body =~ "<script>"
+      refute email.html_body =~ "<img src=x"
+      refute email.html_body =~ "<b>boom"
+      refute email.html_body =~ "<u>raw"
+      assert email.html_body =~ "&lt;script&gt;"
+      assert email.html_body =~ "&lt;img"
+    end
+
+    test "leaves user-controlled strings raw in text_body" do
+      user = generate(user(display_name: "Sam"))
+
+      email =
+        RsvpReceived.build(user, payload(%{"huddl_title" => "Sat & Sun"}))
+
+      assert email.text_body =~ "Sat & Sun"
+      refute email.text_body =~ "<"
+    end
+
+    test "falls back when payload fields are missing" do
+      user = generate(user())
+      email = RsvpReceived.build(user, %{})
+
+      assert email.subject == "Someone RSVPd to your huddl"
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/rsvp_received_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_received_test.exs
@@ -1,22 +1,10 @@
 defmodule Huddlz.Notifications.Senders.RsvpReceivedTest do
   use Huddlz.DataCase, async: true
 
+  import Huddlz.Test.Helpers.RsvpFanoutPayload, only: [payload: 0, payload: 1]
+
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Senders.RsvpReceived
-
-  defp payload(overrides \\ %{}) do
-    Map.merge(
-      %{
-        "huddl_id" => "00000000-0000-0000-0000-000000000001",
-        "huddl_title" => "Saturday Soccer",
-        "starts_at_iso" => "2026-05-10T15:00:00Z",
-        "group_name" => "Pickup Sports",
-        "group_slug" => "pickup-sports",
-        "rsvper_display_name" => "Trinity"
-      },
-      overrides
-    )
-  end
 
   describe "build/2" do
     test "addresses the recipient with their display name" do

--- a/test/huddlz/notifications_test.exs
+++ b/test/huddlz/notifications_test.exs
@@ -42,8 +42,6 @@ defmodule Huddlz.NotificationsTest do
 
     test "skips when the user has opted out of an activity trigger" do
       user = generate_user_with_prefs(%{"rsvp_received" => false})
-      # The sender module for :rsvp_received does not exist yet — the
-      # orchestrator must short-circuit before invoking it.
       assert :skipped == Notifications.deliver(user, :rsvp_received, %{})
       refute_email_sent()
     end
@@ -55,13 +53,14 @@ defmodule Huddlz.NotificationsTest do
     end
 
     test "raises a clear error when the registered sender isn't implemented" do
-      # :rsvp_received is registered with a sender module that doesn't exist
-      # yet. With the trigger enabled and the user eligible, deliver/3 must
-      # surface this loudly rather than producing an UndefinedFunctionError.
-      user = generate_user_with_prefs(%{"rsvp_received" => true})
+      # :weekly_digest is registered with a sender module (Senders.WeeklyDigest)
+      # that doesn't exist yet — F-series digests are deferred to v2. With
+      # the trigger enabled and the user eligible, deliver/3 must surface
+      # this loudly rather than producing an UndefinedFunctionError.
+      user = generate_user_with_prefs(%{"weekly_digest" => true})
 
       assert_raise ArgumentError, ~r/not yet implemented/, fn ->
-        Notifications.deliver(user, :rsvp_received, %{})
+        Notifications.deliver(user, :weekly_digest, %{})
       end
 
       refute_email_sent()

--- a/test/support/helpers/rsvp_fanout_payload.ex
+++ b/test/support/helpers/rsvp_fanout_payload.ex
@@ -1,0 +1,22 @@
+defmodule Huddlz.Test.Helpers.RsvpFanoutPayload do
+  @moduledoc """
+  Shared payload builder for the RSVP fanout sender tests
+  (`RsvpReceivedTest`, `RsvpCancelledTest`). Both senders consume the
+  same shape of payload built by `NotifyRsvpReceived` /
+  `NotifyRsvpCancelled`; centralizing the fixture here keeps the two
+  test files focused on the behavioral differences (subject string,
+  fallback text).
+  """
+
+  @defaults %{
+    "huddl_id" => "00000000-0000-0000-0000-000000000001",
+    "huddl_title" => "Saturday Soccer",
+    "group_name" => "Pickup Sports",
+    "group_slug" => "pickup-sports",
+    "rsvper_display_name" => "Trinity"
+  }
+
+  @doc "Returns a complete payload, with `overrides` merged on top."
+  @spec payload(map()) :: map()
+  def payload(overrides \\ %{}), do: Map.merge(@defaults, overrides)
+end


### PR DESCRIPTION
## Summary

Ships the E-series RSVP email notifications, completing the trigger set from `docs/notifications.md` § E.

- **E3 `rsvp_confirmation`** — confirmation email to the user who RSVPd, with an `.ics` calendar attachment. Mirrors the D1/D2 reminder sender pattern (re-reads the huddl row at send time so the `.ics` is live).
- **E1 `rsvp_received`** — fanout to the group's owner + organizers when someone RSVPs. Deduped, actor excluded.
- **E2 `rsvp_cancelled`** — same fanout when someone cancels their RSVP. Per spec, no E4 confirmation to the cancelling user.

Three small atomic commits, one trigger each, each `mix precommit` clean.

### Implementation notes

- Notifications are wired as Ash change modules attached to `Huddl.:rsvp` and `Huddl.:cancel_rsvp` (`lib/huddlz/communities/huddl.ex:289-302`), matching the established `NotifyCancelled` / `NotifyMeaningfulUpdate` / `NotifyJoined` pattern. The issue's `Ash.Notifier on HuddlAttendee` framing predates that pattern.
- The `Rsvp` and `CancelRsvp` changes return the changeset unchanged on the duplicate-RSVP / no-op-cancel paths, which would otherwise trigger spurious emails. Each now sets a one-off `cs.context[:rsvp_created]` / `:rsvp_cancelled` flag only on the actual create/destroy path; the notify-changes skip when the flag is absent. Capacity rejection already short-circuits via a `before_action` error, so no extra guard is needed there.
- The orchestrator's "raises when sender not implemented" test moved from `:rsvp_received` to `:weekly_digest`, since the former is now implemented and the latter (F-series digest) remains stubbed for v2.

Closes #116.

## Test plan

- [x] `mix precommit` clean on every commit (1014 tests, credo clean)
- [x] Sender unit tests assert greeting, subject, body link, footer, HTML escaping, missing-payload fallback (and `.ics` attachment for E3)
- [x] Integration tests in `test/huddlz/notifications/rsvp_notifications_test.exs` cover:
  - E3 happy path with `.ics` attachment
  - E3 does not fire on duplicate RSVP
  - E3 does not fire on capacity-rejected RSVP
  - E1 fans out to owner + every organizer, deduped
  - E1: actor who is also an organizer is excluded but still receives E3
  - E1 does not fire when the actor is the only owner/organizer
  - E2 fans out to owner + every organizer
  - E2 does not fire when cancelling a nonexistent RSVP
  - E2: actor who is also an organizer is excluded
- [x] Tidewave check: registry resolves all three new sender modules
- [ ] Manual smoke in `/dev/mailbox` once the branch is reviewed