### PR TITLE
Fix N+1 recipient user fetches

### DIFF
--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -62,18 +62,18 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   end
 
   @doc """
-  Fan a notification trigger out to a list of user_ids, fetching each
-  user with `authorize?: false` and skipping any that no longer exist
+  Fan a notification trigger out to a list of user_ids, fetching users
+  with `authorize?: false` and skipping any that no longer exist
   (e.g. raced deletion). Used by the C/E-series fanout notifiers.
   """
   @spec deliver_each([Ecto.UUID.t()], atom(), map()) :: :ok
+  def deliver_each([], _trigger, _payload), do: :ok
+
   def deliver_each(user_ids, trigger, payload) do
-    for user_id <- user_ids do
-      case Ash.get(User, user_id, authorize?: false) do
-        {:ok, user} -> Notifications.deliver_async(user, trigger, payload)
-        _ -> :noop
-      end
-    end
+    User
+    |> Ash.Query.filter(id in ^user_ids)
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(&Notifications.deliver_async(&1, trigger, payload))
 
     :ok
   end

--- a/test/huddlz/notifications/senders/huddl_reminder_1h_test.exs
+++ b/test/huddlz/notifications/senders/huddl_reminder_1h_test.exs
@@ -22,6 +22,9 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder1hTest do
       title: attrs[:title] || "Morning Standup",
       group_id: group.id,
       creator_id: owner.id,
+      event_type: :in_person,
+      physical_location: "123 Main St, Anytown, USA",
+      virtual_link: nil,
       actor: owner
     ]
 


### PR DESCRIPTION
## Summary
- Batch user lookup in RecipientHelpers.deliver_each/3 with a single Ash read
- Keep missing/stale recipient IDs skipped by only delivering to returned users
- Avoid querying users for empty recipient lists

Closes #138

## Tests
- mix format lib/huddlz/communities/huddl/changes/recipient_helpers.ex
- mix test test/huddlz/notifications/huddl_lifecycle_notifications_test.exs test/huddlz/notifications/rsvp_notifications_test.exs test/huddlz/notifications/group_membership_notifications_test.exs