### PR TITLE
Handle missing RSVP confirmation huddl id

### DIFF
--- a/lib/huddlz/notifications/senders/rsvp_confirmation.ex
+++ b/lib/huddlz/notifications/senders/rsvp_confirmation.ex
@@ -74,6 +74,10 @@ defmodule Huddlz.Notifications.Senders.RsvpConfirmation do
     Ash.get!(Huddl, id, authorize?: false, load: [:group])
   end
 
+  defp fetch_huddl!(_) do
+    raise ArgumentError, "RsvpConfirmation requires payload key \"huddl_id\" with a binary UUID"
+  end
+
   defp format_starts_at(%DateTime{} = dt) do
     Calendar.strftime(dt, "%a %b %-d, %Y at %-I:%M %p UTC")
   end

--- a/test/huddlz/notifications/senders/rsvp_confirmation_test.exs
+++ b/test/huddlz/notifications/senders/rsvp_confirmation_test.exs
@@ -120,5 +120,21 @@ defmodule Huddlz.Notifications.Senders.RsvpConfirmationTest do
       assert email.text_body =~ "Sat & Sun"
       refute email.text_body =~ "<"
     end
+
+    test "raises a clear error when huddl_id is missing" do
+      user = generate(user())
+
+      assert_raise ArgumentError, ~r/requires payload key "huddl_id"/, fn ->
+        RsvpConfirmation.build(user, %{})
+      end
+    end
+
+    test "raises a clear error when huddl_id is not binary" do
+      user = generate(user())
+
+      assert_raise ArgumentError, ~r/requires payload key "huddl_id"/, fn ->
+        RsvpConfirmation.build(user, %{"huddl_id" => 123})
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- raise a clear ArgumentError when RsvpConfirmation receives a payload without a binary huddl_id
- add regression tests for missing and non-binary huddl_id payloads

Fixes #133

## Tests
- mix test test/huddlz/notifications/senders/rsvp_confirmation_test.exs