### PR TITLE
Use actor helper for RSVP notifications

### DIFF
--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
@@ -20,7 +20,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpCancelled do
 
   defp notify(cs, huddl) do
     with true <- cs.context[:rsvp_cancelled] == true,
-         %{id: _} = actor <- cs.context[:private][:actor] do
+         %{id: _} = actor <- RecipientHelpers.actor(cs) do
       deliver(huddl, actor)
       {:ok, huddl}
     else

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex
@@ -20,7 +20,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpReceived do
 
   defp notify(cs, huddl) do
     with true <- cs.context[:rsvp_created] == true,
-         %{id: _} = actor <- cs.context[:private][:actor] do
+         %{id: _} = actor <- RecipientHelpers.actor(cs) do
       deliver(huddl, actor)
       {:ok, huddl}
     else

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -55,10 +55,19 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   """
   @spec actor_id(Ash.Changeset.t()) :: Ecto.UUID.t() | nil
   def actor_id(changeset) do
-    case changeset.context[:private][:actor] do
+    case actor(changeset) do
       %{id: id} -> id
       _ -> nil
     end
+  end
+
+  @doc """
+  Pull the actor out of an Ash.Changeset's private context. Returns
+  `nil` when no actor is present (e.g. system-driven actions).
+  """
+  @spec actor(Ash.Changeset.t()) :: struct() | nil
+  def actor(changeset) do
+    changeset.context[:private][:actor]
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- add RecipientHelpers.actor/1 for retrieving the full changeset actor
- update RSVP received/cancelled notifiers to use the shared helper
- route actor_id/1 through the new actor helper

## Testing
- mix format lib/huddlz/communities/huddl/changes/recipient_helpers.ex lib/huddlz/communities/huddl/changes/notify_rsvp_received.ex lib/huddlz/communities/huddl/changes/notify_rsvp_cancelled.ex
- mix test test/huddlz/notifications/rsvp_notifications_test.exs (blocked: DATABASE_URL is not set during AshPostgres setup)

Fixes #134