### PR TITLE
Gate Fly deploy on CI success

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -2,16 +2,20 @@
 
 name: Fly Deploy
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Elixir CI"]
+    branches: [main]
+    types: [completed]
 jobs:
   deploy:
     name: Deploy app
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:


### PR DESCRIPTION
## Summary
- trigger Fly deploy from the completed Elixir CI workflow instead of direct pushes
- deploy only after successful push-based CI runs on main
- pin checkout to the tested workflow_run commit SHA

## Testing
- not run; GitHub Actions config-only change