### PR TITLE
fix(groups): disable browser autocomplete on Group Name field

### DIFF
--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -149,7 +149,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
         phx-change="validate"
         class="space-y-6 mt-6"
       >
-        <.input field={@form[:name]} type="text" label="Group Name" required />
+        <.input field={@form[:name]} type="text" label="Group Name" autocomplete="off" required />
 
         <div>
           <.input

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -224,7 +224,7 @@ defmodule HuddlzWeb.GroupLive.New do
       </.header>
 
       <form id="group-form" phx-change="validate" phx-submit="save" class="space-y-6">
-        <.input field={@form[:name]} type="text" label="Group Name" required />
+        <.input field={@form[:name]} type="text" label="Group Name" autocomplete="off" required />
 
         <div class="border border-base-300 p-4 bg-base-200/50">
           <p class="text-sm text-base-content/60">


### PR DESCRIPTION
## Summary
- Browsers were autofilling the Group Name input from the user's address book because the field name (`name`) is interpreted as a person's name.
- Setting `autocomplete="off"` on both the create and edit forms keeps the field empty until the user types a group name.

Closes #30

## Test plan
- [ ] Open `/groups/new` in a browser with autofill profiles configured — Group Name field stays empty on focus
- [ ] Open `/groups/<slug>/edit` — Group Name field shows the existing name and does not get overridden by autofill