### PR TITLE
chore(github): add bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report something that isn't working
+title: ""
+labels: bug
+---
+
+### Description
+<!-- What's broken? -->
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Expected behavior
+<!-- What should happen? -->
+
+### Actual behavior
+<!-- What actually happens? -->
+
+### Environment
+<!-- Browser, OS, anything else relevant -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: ""
+labels: enhancement
+---
+
+### Problem
+<!-- What problem are you trying to solve? -->
+
+### Proposal
+<!-- What should we build? -->
+
+### Acceptance
+<!-- How will we know this is done? -->
+
+### Notes
+<!-- Anything else: alternatives considered, links, screenshots -->


### PR DESCRIPTION
## Summary
- The repo had no issue templates, so new issues were free-form.
- Adds two minimal markdown templates (`bug_report.md`, `feature_request.md`) under `.github/ISSUE_TEMPLATE/`.

Closes #55

## Test plan
- [ ] Visit https://github.com/huddlz-hq/huddlz/issues/new/choose after merge — both templates appear with the right labels (`bug`, `enhancement`)