### PR TITLE
fix(ui): square corners on image-upload progress bars

### DIFF
--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -314,9 +314,9 @@ defmodule HuddlzWeb.GroupLive.Edit do
               <.live_img_preview entry={entry} class="w-32 aspect-video object-cover" />
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-medium truncate">{entry.client_name}</p>
-                <div class="w-full bg-base-300 rounded-full h-1.5 mt-1">
+                <div class="w-full bg-base-300 h-1.5 mt-1">
                   <div
-                    class="bg-primary h-1.5 rounded-full transition-all"
+                    class="bg-primary h-1.5 transition-all"
                     style={"width: #{entry.progress}%"}
                   >
                   </div>

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -329,9 +329,9 @@ defmodule HuddlzWeb.GroupLive.New do
                 <.live_img_preview entry={entry} class="w-32 aspect-video object-cover" />
                 <div class="flex-1 min-w-0">
                   <p class="text-sm font-medium truncate">{entry.client_name}</p>
-                  <div class="w-full bg-base-300 rounded-full h-1.5 mt-1">
+                  <div class="w-full bg-base-300 h-1.5 mt-1">
                     <div
-                      class="bg-primary h-1.5 rounded-full transition-all"
+                      class="bg-primary h-1.5 transition-all"
                       style={"width: #{entry.progress}%"}
                     >
                     </div>

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -299,9 +299,9 @@ defmodule HuddlzWeb.HuddlLive.Edit do
                   <.live_img_preview entry={entry} class="w-32 aspect-video object-cover" />
                   <div class="flex-1 min-w-0">
                     <p class="text-sm font-medium truncate">{entry.client_name}</p>
-                    <div class="w-full bg-base-300 rounded-full h-1.5 mt-1">
+                    <div class="w-full bg-base-300 h-1.5 mt-1">
                       <div
-                        class="bg-primary h-1.5 rounded-full transition-all"
+                        class="bg-primary h-1.5 transition-all"
                         style={"width: #{entry.progress}%"}
                       >
                       </div>

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -232,9 +232,9 @@ defmodule HuddlzWeb.HuddlLive.New do
                     <.live_img_preview entry={entry} class="w-32 aspect-video object-cover" />
                     <div class="flex-1 min-w-0">
                       <p class="text-sm font-medium truncate">{entry.client_name}</p>
-                      <div class="w-full bg-base-300 rounded-full h-1.5 mt-1">
+                      <div class="w-full bg-base-300 h-1.5 mt-1">
                         <div
-                          class="bg-primary h-1.5 rounded-full transition-all"
+                          class="bg-primary h-1.5 transition-all"
                           style={"width: #{entry.progress}%"}
                         >
                         </div>


### PR DESCRIPTION
## Summary
- Drops \`rounded-full\` from the image-upload progress track and fill across huddl + group create/edit forms.
- Sharp edges match the cyberpunk-brutalist design system.

Closes #148

## Test plan
- [ ] Visit \`/huddlz/new\`, \`/huddlz/<slug>/edit\`, \`/groups/new\`, \`/groups/<slug>/edit\`
- [ ] Upload an image; the progress bar shows square corners while filling