### PR TITLE
refactor(ui): drop daisyUI from checkbox and user-menu dropdown

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -108,3 +108,46 @@ html {
   text-transform: uppercase;
 }
 
+/* Sharp-edged checkbox in cyberpunk-brutalist style. */
+@utility checkbox-cyber {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  border: 1px solid var(--color-base-300);
+  background-color: transparent;
+  cursor: pointer;
+  position: relative;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+
+  &:hover {
+    border-color: var(--color-primary);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 1px var(--color-primary);
+  }
+
+  &:checked {
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+
+  &:checked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3.5,8.5 6.5,11.5 12.5,5'/%3E%3C/svg%3E");
+    background-size: 0.85rem 0.85rem;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+

--- a/lib/huddlz_web/components/core_components.ex
+++ b/lib/huddlz_web/components/core_components.ex
@@ -218,7 +218,7 @@ defmodule HuddlzWeb.CoreComponents do
           name={@name}
           value="true"
           checked={@checked}
-          class={@class || "checkbox checkbox-sm checkbox-primary"}
+          class={@class || "checkbox-cyber"}
           {@rest}
         />
         <span class="text-sm font-medium">{@label}</span>

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -34,15 +34,26 @@ defmodule HuddlzWeb.Layouts do
           <%!-- Right side --%>
           <div class="flex items-center gap-3">
             <%= if @current_user do %>
-              <div class="dropdown dropdown-end">
-                <label tabindex="0" class="cursor-pointer">
+              <div class="relative">
+                <button
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-controls="user-menu"
+                  phx-click={JS.toggle(to: "#user-menu")}
+                  class="cursor-pointer"
+                >
                   <div class="ring-1 ring-base-300 hover:ring-primary transition-colors">
                     <.avatar user={@current_user} size={:sm} />
                   </div>
-                </label>
+                </button>
                 <ul
-                  tabindex="0"
-                  class="dropdown-content mt-3 z-[1] p-1 border border-primary/20 bg-base-200 w-56 shadow-xl shadow-primary/5"
+                  id="user-menu"
+                  role="menu"
+                  hidden
+                  phx-click-away={JS.hide(to: "#user-menu")}
+                  phx-window-keydown={JS.hide(to: "#user-menu")}
+                  phx-key="escape"
+                  class="absolute right-0 mt-3 z-50 p-1 border border-primary/20 bg-base-200 w-56 shadow-xl shadow-primary/5"
                 >
                   <li class="px-3 py-2.5 border-b border-base-300">
                     <span class="mono-label text-primary/60">


### PR DESCRIPTION
## Summary
- Adds a \`checkbox-cyber\` utility (sharp-edged, primary-cyan fill, native check icon) and swaps it in for daisyUI's \`checkbox checkbox-sm checkbox-primary\` inside \`<.input type=\"checkbox\">\`.
- Reimplements the header user menu as a relative-positioned panel toggled by \`phx-click\`, dismissed by \`phx-click-away\` and Escape — replaces daisyUI's \`dropdown\` / \`dropdown-content\`.

Closes #149

## Test plan
- [ ] Visit \`/profile/notifications\` and toggle a checkbox — square edges, primary-cyan fill with check, focus ring on tab
- [ ] Sign in and click the avatar in the header — menu opens; clicking outside or pressing Escape closes it
- [ ] Verify keyboard tab order still reaches the avatar trigger (now a real \`<button>\`)