### PR TITLE
refactor(ui): extend <.button> with danger/ghost variants and migrate primary action sites

### DIFF
--- a/lib/huddlz_web/components/core_components.ex
+++ b/lib/huddlz_web/components/core_components.ex
@@ -102,22 +102,45 @@ defmodule HuddlzWeb.CoreComponents do
       <.button navigate={~p"/"}>Home</.button>
   """
   attr :rest, :global, include: ~w(href navigate patch method disabled)
-  attr :variant, :string, values: ~w(primary)
+  attr :variant, :string, values: ~w(primary danger ghost)
+  attr :size, :string, values: ~w(sm md), default: "md"
+  attr :class, :any, default: nil, doc: "extra classes appended to the variant defaults"
   slot :inner_block, required: true
 
   def button(%{rest: rest} = assigns) do
     variants = %{
       "primary" => "bg-primary text-primary-content border border-primary btn-neon",
+      "danger" => "bg-error text-error-content border border-error btn-neon",
+      "ghost" =>
+        "bg-transparent text-primary border-0 hover:underline normal-case tracking-normal font-body",
       nil => "bg-transparent text-primary border border-primary/40 btn-neon hover:bg-primary/10"
     }
 
-    assigns = assign(assigns, :class, Map.fetch!(variants, assigns[:variant]))
+    sizes = %{
+      "sm" => "px-3 py-1 text-xs",
+      "md" => "px-5 py-2 text-sm"
+    }
+
+    ghost_sizes = %{"sm" => "text-xs", "md" => "text-sm"}
+
+    size_class =
+      case assigns[:variant] do
+        "ghost" -> Map.fetch!(ghost_sizes, assigns.size)
+        _ -> Map.fetch!(sizes, assigns.size)
+      end
+
+    assigns =
+      assigns
+      |> assign(:variant_class, Map.fetch!(variants, assigns[:variant]))
+      |> assign(:size_class, size_class)
 
     if rest[:href] || rest[:navigate] || rest[:patch] do
       ~H"""
       <.link
         class={[
-          "inline-flex items-center justify-center gap-2 px-5 py-2 text-sm font-medium tracking-wide uppercase font-display",
+          "inline-flex items-center justify-center gap-2 font-medium tracking-wide uppercase font-display",
+          @size_class,
+          @variant_class,
           @class
         ]}
         {@rest}
@@ -129,7 +152,9 @@ defmodule HuddlzWeb.CoreComponents do
       ~H"""
       <button
         class={[
-          "inline-flex items-center justify-center gap-2 px-5 py-2 text-sm font-medium tracking-wide uppercase font-display",
+          "inline-flex items-center justify-center gap-2 font-medium tracking-wide uppercase font-display",
+          @size_class,
+          @variant_class,
           @class
         ]}
         {@rest}

--- a/lib/huddlz_web/live/admin_live.ex
+++ b/lib/huddlz_web/live/admin_live.ex
@@ -94,19 +94,12 @@ defmodule HuddlzWeb.AdminLive do
                   placeholder="Search users by email..."
                   class="flex-1 border border-base-300 px-4 py-2.5 bg-base-100 text-sm focus:border-primary focus:ring-1 focus:ring-primary/30 transition-colors"
                 />
-                <button
-                  type="submit"
-                  class="px-5 py-2.5 bg-primary text-primary-content text-sm font-medium btn-neon"
-                >
+                <.button type="submit" variant="primary">
                   Search
-                </button>
-                <button
-                  type="button"
-                  phx-click="clear_search"
-                  class="px-5 py-2.5 border border-base-300 text-sm font-medium hover:border-primary/30 transition-colors"
-                >
+                </.button>
+                <.button type="button" phx-click="clear_search">
                   Clear
-                </button>
+                </.button>
               </div>
             </form>
 
@@ -150,12 +143,9 @@ defmodule HuddlzWeb.AdminLive do
                                 <option value="user" selected={user.role == :user}>User</option>
                                 <option value="admin" selected={user.role == :admin}>Admin</option>
                               </select>
-                              <button
-                                type="submit"
-                                class="px-3 py-1 bg-primary text-primary-content text-xs font-medium btn-neon transition-all"
-                              >
+                              <.button type="submit" variant="primary" size="sm">
                                 Update
-                              </button>
+                              </.button>
                             </form>
                           </td>
                         </tr>

--- a/lib/huddlz_web/live/auth_live/register.ex
+++ b/lib/huddlz_web/live/auth_live/register.ex
@@ -73,13 +73,15 @@ defmodule HuddlzWeb.AuthLive.Register do
                 placeholder="First and Last Name"
                 autocomplete="name"
               />
-              <button
+              <.button
                 type="button"
                 phx-click="generate_display_name"
-                class="text-xs text-primary hover:underline font-medium inline-flex items-center gap-1 mt-1"
+                variant="ghost"
+                size="sm"
+                class="mt-1"
               >
                 <.icon name="hero-arrow-path" class="h-4 w-4" /> Generate Random Name
-              </button>
+              </.button>
             </div>
 
             <div>

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -277,12 +277,9 @@ defmodule HuddlzWeb.HuddlLive do
                   This Month
                 </option>
               </select>
-              <button
-                type="submit"
-                class="h-12 px-6 bg-primary text-primary-content font-medium btn-neon active:scale-[0.98] transition-all"
-              >
+              <.button type="submit" variant="primary" class="h-12 px-6">
                 Search
-              </button>
+              </.button>
             </div>
             <div class="flex flex-wrap items-end gap-2 mt-2">
               <div class="flex-grow min-w-[200px]">
@@ -343,12 +340,9 @@ defmodule HuddlzWeb.HuddlLive do
                   {@location_text} · {@distance_miles} mi
                 </span>
               <% end %>
-              <button
-                phx-click="clear_filters"
-                class="text-xs text-primary hover:underline font-medium"
-              >
+              <.button phx-click="clear_filters" variant="ghost" size="sm">
                 Clear all
-              </button>
+              </.button>
             </div>
           <% end %>
         </div>

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -68,13 +68,13 @@ defmodule HuddlzWeb.HuddlLive.Show do
             >
               <.icon name="hero-pencil" class="h-4 w-4" /> Edit Huddl
             </.link>
-            <button
+            <.button
               phx-click="delete_huddl"
               data-confirm="Are you sure you want to delete this huddl?"
-              class="px-4 py-2 text-sm font-medium bg-error text-error-content btn-neon transition-all inline-flex items-center gap-1.5"
+              variant="danger"
             >
               <.icon name="hero-trash" class="h-4 w-4" /> Delete Huddl
-            </button>
+            </.button>
           <% end %>
           <%= if @current_user && @huddl.status == :upcoming do %>
             <%= if @has_rsvped do %>


### PR DESCRIPTION
## Summary
Extends \`<.button>\` and migrates the most prominent raw \`<button>\` tags. Closes the highest-leverage portion of #150 and splits the rest off into #154.

### \`<.button>\` additions
- \`:class\` attr — callsites can append classes (e.g., \`class=\"h-12 px-6\"\` for a button matching an adjacent search input height).
- \`variant=\"danger\"\` — filled red, for destructive primary actions like \"Delete Huddl\".
- \`variant=\"ghost\"\` — text-link style (no border, no uppercase, no font-display, hover underline) for inline actions like \"Clear all\" or \"Generate Random Name\".
- \`size=\"sm\"\` / \`size=\"md\"\` — compact vs default; ghost ignores horizontal padding so it stays inline-flush.

### Migrated callsites (7)
- \`admin_live.ex\` — Search, Clear, Update (3 buttons)
- \`huddl_live.ex\` — Search, Clear all (2 buttons)
- \`huddl_live/show.ex\` — Delete Huddl (1 button)
- \`auth_live/register.ex\` — Generate Random Name (1 button)

### Out of scope (intentional)
- **Tab-style buttons** in \`group_live/show.ex:150,163\` — different pattern (border-b active indicator), not a button.
- **Icon-only cancel/edit buttons** across upload widgets (~13 sites) — split into #154 as \`<.icon_button>\` extraction.
- **Full-width menu/list-row items** in \`location_autocomplete.ex\`, \`saved_location_picker.ex\`, \`profile_live.ex\` avatar menu — different pattern (selectable rows), would become \`<.menu_item>\` if extracted.
- **Cancel RSVP** in \`huddl_live/show.ex:85\` and **Save/Cancel** in \`group_live/locations.ex:114,120\` — one-off subtle styles that don't match any current variant; left raw rather than introducing single-use variants.

Refs #150 (kept open for further migration as patterns extract).

## Test plan
- [ ] \`/admin\` — search, clear, role update buttons render and trigger correctly
- [ ] \`/huddlz\` — search button matches input height; \"Clear all\" filter pill renders inline
- [ ] \`/groups/<slug>/huddlz/<id>\` as huddl owner — \"Delete Huddl\" button is filled red
- [ ] \`/register\` — \"Generate Random Name\" link-style button still triggers the action
- [ ] All variants render with sharp corners, no daisyUI fallbacks