### PR TITLE
feat(groups): personal sections + search on /groups

### DIFF
--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -37,6 +37,7 @@ defmodule Huddlz.Communities do
 
       define :search_groups, action: :search, args: [:query]
       define :get_by_owner, action: :get_by_owner
+      define :get_joined_groups, action: :get_joined
       define :get_by_slug, action: :get_by_slug, args: [:slug]
 
       define :update_details,

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -18,6 +18,7 @@ defmodule Huddlz.Communities.Group do
       list :list_groups, :read
       list :search_groups, :search
       list :my_groups, :get_by_owner
+      list :joined_groups, :get_joined
     end
 
     mutations do
@@ -37,6 +38,7 @@ defmodule Huddlz.Communities.Group do
       index :read
       index :search, route: "/search"
       index :get_by_owner, route: "/mine"
+      index :get_joined, route: "/joined"
       get :get_by_slug, route: "/by_slug/:slug"
       post :create_group
       patch :update_details
@@ -108,6 +110,15 @@ defmodule Huddlz.Communities.Group do
     read :get_by_owner do
       description "Get groups owned by the current actor"
       filter expr(owner_id == ^actor(:id))
+    end
+
+    read :get_joined do
+      description "Get groups the current actor has joined but does not own"
+
+      filter expr(
+               exists(group_members, user_id == ^actor(:id)) and
+                 owner_id != ^actor(:id)
+             )
     end
 
     read :get_by_slug do

--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -8,6 +8,7 @@ defmodule HuddlzWeb.GroupLive.Index do
   alias Huddlz.Communities.Group
   alias HuddlzWeb.Layouts
   require Ash.Query
+  require Logger
 
   @section_limit 6
 
@@ -62,7 +63,7 @@ defmodule HuddlzWeb.GroupLive.Index do
 
   defp normalize_query(nil), do: nil
   defp normalize_query(""), do: nil
-  defp normalize_query(q) when is_binary(q), do: String.trim(q) |> nilify_blank()
+  defp normalize_query(q) when is_binary(q), do: q |> String.trim() |> nilify_blank()
 
   defp nilify_blank(""), do: nil
   defp nilify_blank(q), do: q
@@ -73,9 +74,8 @@ defmodule HuddlzWeb.GroupLive.Index do
 
   defp scoped_path(scope, query) do
     params =
-      []
-      |> maybe_put(:yours, scope_param(scope))
-      |> maybe_put(:q, query)
+      [yours: scope_param(scope), q: query]
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
 
     case params do
       [] -> ~p"/groups"
@@ -86,9 +86,6 @@ defmodule HuddlzWeb.GroupLive.Index do
   defp scope_param(:hosting), do: "hosting"
   defp scope_param(:joined), do: "joined"
   defp scope_param(:all), do: nil
-
-  defp maybe_put(list, _key, nil), do: list
-  defp maybe_put(list, key, value), do: [{key, value} | list]
 
   defp load_groups(socket) do
     user = socket.assigns.current_user
@@ -130,6 +127,9 @@ defmodule HuddlzWeb.GroupLive.Index do
     |> read_groups(actor: user)
   end
 
+  # The main directory stays public-only on purpose: a user's private groups
+  # already surface in the // JOINED section above, so re-listing them here
+  # would just duplicate. Anonymous users can only ever see public groups.
   defp list_all(query) do
     Group
     |> Ash.Query.for_read(:read, %{}, actor: nil)
@@ -139,12 +139,12 @@ defmodule HuddlzWeb.GroupLive.Index do
     |> read_groups(actor: nil)
   end
 
-  defp apply_search(query, nil) do
-    Ash.Query.sort(query, name: :asc)
+  defp apply_search(ash_query, nil) do
+    Ash.Query.sort(ash_query, name: :asc)
   end
 
-  defp apply_search(query, search_text) do
-    query
+  defp apply_search(ash_query, search_text) do
+    ash_query
     |> Ash.Query.filter(
       trigram_similarity(name, ^search_text) > 0.1 or
         trigram_similarity(description, ^search_text) > 0.1
@@ -156,10 +156,14 @@ defmodule HuddlzWeb.GroupLive.Index do
     )
   end
 
-  defp read_groups(query, opts) do
-    case Ash.read(query, opts) do
-      {:ok, groups} -> groups
-      {:error, _} -> []
+  defp read_groups(ash_query, opts) do
+    case Ash.read(ash_query, opts) do
+      {:ok, groups} ->
+        groups
+
+      {:error, reason} ->
+        Logger.warning("GroupLive.Index group read failed: #{inspect(reason)}")
+        []
     end
   end
 

--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -312,8 +312,8 @@ defmodule HuddlzWeb.GroupLive.Index do
 
   defp show_all_heading?(_), do: false
 
+  defp empty_message(_scope, query) when not is_nil(query), do: "No groups match your search."
   defp empty_message(:hosting, _), do: "You aren't hosting any groups yet."
   defp empty_message(:joined, _), do: "You haven't joined any groups yet."
-  defp empty_message(:all, nil), do: "No groups found."
-  defp empty_message(:all, _query), do: "No groups match your search."
+  defp empty_message(:all, _), do: "No groups found."
 end

--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -1,6 +1,7 @@
 defmodule HuddlzWeb.GroupLive.Index do
   @moduledoc """
-  LiveView for listing and searching groups.
+  LiveView for listing and searching groups, with personal sections for
+  authenticated users (Hosting, Joined) and a public directory.
   """
   use HuddlzWeb, :live_view
 
@@ -8,27 +9,158 @@ defmodule HuddlzWeb.GroupLive.Index do
   alias HuddlzWeb.Layouts
   require Ash.Query
 
+  @section_limit 6
+
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
 
   @impl true
   def mount(_params, _session, socket) do
-    groups = list_groups()
-
     {:ok,
      socket
-     |> assign(:groups, groups)
-     |> assign(:can_create_group, Ash.can?({Group, :create_group}, socket.assigns.current_user))}
+     |> assign(:can_create_group, Ash.can?({Group, :create_group}, socket.assigns.current_user))
+     |> assign(:query, nil)
+     |> assign(:scope, :all)
+     |> assign(:section_limit, @section_limit)
+     |> assign(:hosting, [])
+     |> assign(:joined, [])
+     |> assign(:hosting_total, 0)
+     |> assign(:joined_total, 0)
+     |> assign(:groups, [])}
   end
 
   @impl true
   def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+    scope = parse_scope(params["yours"])
+    query = params["q"] |> normalize_query()
+
+    socket =
+      socket
+      |> assign(:page_title, page_title(scope))
+      |> assign(:scope, scope)
+      |> assign(:query, query)
+      |> load_groups()
+
+    {:noreply, socket}
   end
 
-  defp apply_action(socket, :index, _params) do
-    socket
-    |> assign(:page_title, "Groups")
-    |> assign(:group, nil)
+  @impl true
+  def handle_event("filter_change", %{"query" => query}, socket) do
+    {:noreply, push_patch(socket, to: scoped_path(socket.assigns.scope, query))}
+  end
+
+  def handle_event("search", %{"query" => query}, socket) do
+    {:noreply, push_patch(socket, to: scoped_path(socket.assigns.scope, query))}
+  end
+
+  def handle_event("clear_search", _params, socket) do
+    {:noreply, push_patch(socket, to: scoped_path(socket.assigns.scope, nil))}
+  end
+
+  defp parse_scope("hosting"), do: :hosting
+  defp parse_scope("joined"), do: :joined
+  defp parse_scope(_), do: :all
+
+  defp normalize_query(nil), do: nil
+  defp normalize_query(""), do: nil
+  defp normalize_query(q) when is_binary(q), do: String.trim(q) |> nilify_blank()
+
+  defp nilify_blank(""), do: nil
+  defp nilify_blank(q), do: q
+
+  defp page_title(:hosting), do: "Groups You Host"
+  defp page_title(:joined), do: "Groups You've Joined"
+  defp page_title(:all), do: "Groups"
+
+  defp scoped_path(scope, query) do
+    params =
+      []
+      |> maybe_put(:yours, scope_param(scope))
+      |> maybe_put(:q, query)
+
+    case params do
+      [] -> ~p"/groups"
+      params -> ~p"/groups?#{params}"
+    end
+  end
+
+  defp scope_param(:hosting), do: "hosting"
+  defp scope_param(:joined), do: "joined"
+  defp scope_param(:all), do: nil
+
+  defp maybe_put(list, _key, nil), do: list
+  defp maybe_put(list, key, value), do: [{key, value} | list]
+
+  defp load_groups(socket) do
+    user = socket.assigns.current_user
+    query = socket.assigns.query
+
+    case socket.assigns.scope do
+      :hosting ->
+        assign(socket, :groups, list_hosting(user, query))
+
+      :joined ->
+        assign(socket, :groups, list_joined(user, query))
+
+      :all ->
+        hosting = if user, do: list_hosting(user, query), else: []
+        joined = if user, do: list_joined(user, query), else: []
+
+        socket
+        |> assign(:hosting, Enum.take(hosting, @section_limit))
+        |> assign(:hosting_total, length(hosting))
+        |> assign(:joined, Enum.take(joined, @section_limit))
+        |> assign(:joined_total, length(joined))
+        |> assign(:groups, list_all(query))
+    end
+  end
+
+  defp list_hosting(user, query) do
+    Group
+    |> Ash.Query.for_read(:get_by_owner, %{}, actor: user)
+    |> apply_search(query)
+    |> Ash.Query.load(:current_image_url)
+    |> read_groups(actor: user)
+  end
+
+  defp list_joined(user, query) do
+    Group
+    |> Ash.Query.for_read(:get_joined, %{}, actor: user)
+    |> apply_search(query)
+    |> Ash.Query.load(:current_image_url)
+    |> read_groups(actor: user)
+  end
+
+  defp list_all(query) do
+    Group
+    |> Ash.Query.for_read(:read, %{}, actor: nil)
+    |> Ash.Query.filter(is_public == true)
+    |> apply_search(query)
+    |> Ash.Query.load(:current_image_url)
+    |> read_groups(actor: nil)
+  end
+
+  defp apply_search(query, nil) do
+    Ash.Query.sort(query, name: :asc)
+  end
+
+  defp apply_search(query, search_text) do
+    query
+    |> Ash.Query.filter(
+      trigram_similarity(name, ^search_text) > 0.1 or
+        trigram_similarity(description, ^search_text) > 0.1
+    )
+    |> Ash.Query.load(search_relevance: [query: search_text])
+    |> Ash.Query.sort(
+      search_relevance: {%{query: search_text}, :desc},
+      name: :asc
+    )
+  end
+
+  defp read_groups(query, opts) do
+    case Ash.read(query, opts) do
+      {:ok, groups} -> groups
+      {:error, _} -> []
+    end
   end
 
   @impl true
@@ -36,19 +168,74 @@ defmodule HuddlzWeb.GroupLive.Index do
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user}>
       <.header>
-        Groups
+        {page_title(@scope)}
         <:actions :if={@can_create_group}>
-          <.link navigate={~p"/groups/new"}>
-            <.button>New Group</.button>
-          </.link>
+          <.button navigate={~p"/groups/new"}>New Group</.button>
         </:actions>
       </.header>
 
-      <div class="mt-8">
+      <form phx-change="filter_change" phx-submit="search" class="mt-6">
+        <div class="flex items-end gap-2">
+          <div class="flex-grow">
+            <label for="group-search" class="sr-only">Search groups</label>
+            <input
+              id="group-search"
+              type="text"
+              name="query"
+              value={@query}
+              placeholder="Search groups"
+              phx-debounce="300"
+              class="w-full h-12 pl-0 pr-4 border-0 border-b border-base-300 bg-transparent text-base focus:outline-none focus:ring-0 focus:border-primary transition-colors placeholder:text-base-content/30"
+            />
+          </div>
+          <%= if @query do %>
+            <button
+              type="button"
+              phx-click="clear_search"
+              class="text-xs text-primary hover:underline font-medium"
+            >
+              Clear
+            </button>
+          <% end %>
+        </div>
+      </form>
+
+      <%= if @scope == :all and @current_user do %>
+        <.personal_section
+          :if={@hosting_total > 0}
+          title="Hosting"
+          count={@hosting_total}
+          groups={@hosting}
+          limit={@section_limit}
+          query={@query}
+          yours="hosting"
+        />
+        <.personal_section
+          :if={@joined_total > 0}
+          title="Joined"
+          count={@joined_total}
+          groups={@joined}
+          limit={@section_limit}
+          query={@query}
+          yours="joined"
+        />
+      <% end %>
+
+      <div class="mt-10">
+        <h2
+          :if={show_all_heading?(assigns)}
+          class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3"
+        >
+          <span class="mono-label text-primary/70">// {scope_heading(@scope)}</span>
+          <span class="text-sm font-body font-normal text-base-content/40">
+            ({length(@groups)})
+          </span>
+        </h2>
+
         <%= if @groups == [] do %>
-          <div class="border border-dashed border-base-300 p-12 text-center">
-            <p class="text-lg text-base-content/40">No groups found.</p>
-            <%= if @can_create_group do %>
+          <div class="border border-dashed border-base-300 p-12 text-center mt-4">
+            <p class="text-lg text-base-content/40">{empty_message(@scope, @query)}</p>
+            <%= if @scope == :all and @can_create_group and is_nil(@query) do %>
               <p class="mt-4">
                 <.link navigate={~p"/groups/new"} class="text-primary hover:underline font-medium">
                   Create the first group
@@ -57,24 +244,76 @@ defmodule HuddlzWeb.GroupLive.Index do
             <% end %>
           </div>
         <% else %>
-          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <div class={[
+            "grid gap-6 sm:grid-cols-2 lg:grid-cols-3",
+            show_all_heading?(assigns) && "mt-4"
+          ]}>
             <%= for group <- @groups do %>
               <.group_card group={group} />
             <% end %>
           </div>
         <% end %>
+
+        <div :if={@scope != :all} class="mt-6">
+          <.link navigate={~p"/groups"} class="text-sm text-primary hover:underline font-medium">
+            ← All groups
+          </.link>
+        </div>
       </div>
     </Layouts.app>
     """
   end
 
-  defp list_groups do
-    case Group
-         |> Ash.Query.filter(is_public: true)
-         |> Ash.Query.load(:current_image_url)
-         |> Ash.read() do
-      {:ok, groups} -> groups
-      {:error, _} -> []
-    end
+  attr :title, :string, required: true
+  attr :count, :integer, required: true
+  attr :groups, :list, required: true
+  attr :limit, :integer, required: true
+  attr :query, :string, default: nil
+  attr :yours, :string, required: true
+
+  defp personal_section(assigns) do
+    ~H"""
+    <div class="mt-10">
+      <div class="flex items-baseline justify-between gap-2">
+        <h2 class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3">
+          <span class="mono-label text-primary/70">// {@title}</span>
+          <span class="text-sm font-body font-normal text-base-content/40">
+            ({@count})
+          </span>
+        </h2>
+        <.link
+          :if={@count > @limit}
+          navigate={view_all_path(@yours, @query)}
+          class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+        >
+          View all →
+        </.link>
+      </div>
+
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 mt-4">
+        <%= for group <- @groups do %>
+          <.group_card group={group} />
+        <% end %>
+      </div>
+    </div>
+    """
   end
+
+  defp view_all_path(yours, nil), do: ~p"/groups?#{[yours: yours]}"
+  defp view_all_path(yours, query), do: ~p"/groups?#{[yours: yours, q: query]}"
+
+  defp scope_heading(:hosting), do: "Hosting"
+  defp scope_heading(:joined), do: "Joined"
+  defp scope_heading(:all), do: "All Groups"
+
+  defp show_all_heading?(%{scope: :all, current_user: user, hosting_total: h, joined_total: j})
+       when not is_nil(user) and (h > 0 or j > 0),
+       do: true
+
+  defp show_all_heading?(_), do: false
+
+  defp empty_message(:hosting, _), do: "You aren't hosting any groups yet."
+  defp empty_message(:joined, _), do: "You haven't joined any groups yet."
+  defp empty_message(:all, nil), do: "No groups found."
+  defp empty_message(:all, _query), do: "No groups match your search."
 end

--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -34,15 +34,25 @@ defmodule HuddlzWeb.GroupLive.Index do
     scope = parse_scope(params["yours"])
     query = params["q"] |> normalize_query()
 
-    socket =
-      socket
-      |> assign(:page_title, page_title(scope))
-      |> assign(:scope, scope)
-      |> assign(:query, query)
-      |> load_groups()
+    if scope != :all and is_nil(socket.assigns.current_user) do
+      {:noreply,
+       socket
+       |> put_flash(:error, "Sign in to view #{sign_in_prompt(scope)}.")
+       |> push_navigate(to: ~p"/sign-in")}
+    else
+      socket =
+        socket
+        |> assign(:page_title, page_title(scope))
+        |> assign(:scope, scope)
+        |> assign(:query, query)
+        |> load_groups()
 
-    {:noreply, socket}
+      {:noreply, socket}
+    end
   end
+
+  defp sign_in_prompt(:hosting), do: "groups you host"
+  defp sign_in_prompt(:joined), do: "groups you've joined"
 
   @impl true
   def handle_event("filter_change", %{"query" => query}, socket) do

--- a/test/features/groups_personal_sections.feature
+++ b/test/features/groups_personal_sections.feature
@@ -1,0 +1,55 @@
+@async @database @conn
+Feature: Groups Personal Sections
+  As a logged-in user browsing the groups directory
+  I want to see groups I host or have joined surfaced at the top
+  So that I can find my own groups without scanning the full list
+
+  Background:
+    Given the following users exist:
+      | email                    | role     | display_name |
+      | owner@example.com        | verified | Group Owner  |
+      | member@example.com       | verified | Member User  |
+      | stranger@example.com     | verified | Stranger     |
+
+  Scenario: Owner sees their group in the Hosting section
+    Given a public group "Cyberpunk Builders" exists with owner "owner@example.com"
+    And I am signed in as "owner@example.com"
+    When I visit the groups page
+    Then I should see "// Hosting"
+    And I should see "Cyberpunk Builders"
+    And I should not see "// Joined"
+
+  Scenario: Member sees groups they joined in the Joined section
+    Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
+    And "member@example.com" has joined the group "Phoenix Devs"
+    And I am signed in as "member@example.com"
+    When I visit the groups page
+    Then I should see "// Joined"
+    And I should see "Phoenix Devs"
+    And I should not see "// Hosting"
+
+  Scenario: Anonymous user sees no personal sections
+    Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
+    When I visit the groups page
+    Then I should not see "// Hosting"
+    And I should not see "// Joined"
+    And I should see "Phoenix Devs"
+
+  Scenario: View all link navigates to the scoped view and shows all hosted groups
+    Given "owner@example.com" hosts 7 public groups named "Heavy Group"
+    And I am signed in as "owner@example.com"
+    When I visit the groups page
+    Then I should see "// Hosting"
+    And I should see "View all"
+    When I click "View all"
+    Then I should see "Groups You Host"
+    And I should see "Heavy Group 7"
+    And I should not see "// Hosting"
+
+  Scenario: Search filters sections and main grid together
+    Given a public group "Cyberpunk Builders" exists with owner "owner@example.com"
+    And a public group "Knitting Circle" exists with owner "stranger@example.com"
+    And I am signed in as "owner@example.com"
+    When I visit "/groups?q=cyberpunk"
+    Then I should see "Cyberpunk Builders"
+    And I should not see "Knitting Circle"

--- a/test/features/step_definitions/groups_personal_sections_steps.exs
+++ b/test/features/step_definitions/groups_personal_sections_steps.exs
@@ -1,0 +1,52 @@
+defmodule GroupsPersonalSectionsSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+
+  alias Huddlz.Accounts.User
+
+  require Ash.Query
+
+  step "{string} has joined the group {string}",
+       %{args: [email, name]} = context do
+    user = lookup_user(email)
+    group = lookup_group(name)
+    owner = lookup_user_by_id(group.owner_id)
+
+    generate(group_member(group_id: group.id, user_id: user.id, actor: owner))
+
+    context
+  end
+
+  step "{string} hosts {int} public groups named {string}",
+       %{args: [email, count, prefix]} = context do
+    owner = lookup_user(email)
+
+    for i <- 1..count do
+      generate(
+        group(
+          name: "#{prefix} #{i}",
+          actor: owner,
+          is_public: true,
+          location: "Test Location"
+        )
+      )
+    end
+
+    context
+  end
+
+  defp lookup_user(email) do
+    User
+    |> Ash.Query.filter(email: email)
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp lookup_user_by_id(id), do: Ash.get!(User, id, authorize?: false)
+
+  defp lookup_group(name) do
+    Huddlz.Communities.Group
+    |> Ash.Query.filter(name: name)
+    |> Ash.read_one!(authorize?: false)
+  end
+end

--- a/test/huddlz/communities/group_test.exs
+++ b/test/huddlz/communities/group_test.exs
@@ -574,4 +574,54 @@ defmodule Huddlz.Communities.GroupTest do
       assert MapSet.member?(group_ids, group3.id)
     end
   end
+
+  describe ":get_joined action" do
+    setup do
+      member = generate(user(role: :user))
+      stranger = generate(user(role: :user))
+
+      owned = generate(group(name: "Owned by member", actor: member, is_public: true))
+
+      joined =
+        generate(group(name: "Joined by member", actor: stranger, is_public: true))
+
+      generate(group_member(group_id: joined.id, user_id: member.id, actor: stranger))
+
+      _untouched =
+        generate(group(name: "Unrelated", actor: stranger, is_public: true))
+
+      %{member: member, stranger: stranger, owned: owned, joined: joined}
+    end
+
+    test "returns groups the actor has joined", %{member: member, joined: joined} do
+      result = Communities.get_joined_groups!(actor: member)
+
+      assert Enum.map(result, & &1.id) == [joined.id]
+    end
+
+    test "excludes groups the actor owns", %{member: member, owned: owned} do
+      result = Communities.get_joined_groups!(actor: member)
+
+      refute Enum.any?(result, &(&1.id == owned.id))
+    end
+
+    test "excludes groups the actor has no relationship to", %{
+      member: member,
+      stranger: stranger
+    } do
+      # The "Unrelated" group is owned by stranger and member is not a member.
+      member_results = Communities.get_joined_groups!(actor: member)
+      stranger_results = Communities.get_joined_groups!(actor: stranger)
+
+      refute Enum.any?(member_results, &(&1.name |> to_string() == "Unrelated"))
+      # Stranger owns Unrelated, so it's also excluded from THEIR joined list
+      refute Enum.any?(stranger_results, &(&1.name |> to_string() == "Unrelated"))
+    end
+
+    test "returns nothing for an actor with no memberships" do
+      lonely = generate(user(role: :user))
+
+      assert Communities.get_joined_groups!(actor: lonely) == []
+    end
+  end
 end

--- a/test/huddlz_web/api/graphql/group_test.exs
+++ b/test/huddlz_web/api/graphql/group_test.exs
@@ -49,4 +49,41 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
       assert id == g.id
     end
   end
+
+  describe "joinedGroups query" do
+    test "returns groups the actor has joined but does not own", %{conn: conn} do
+      member = generate(user())
+      stranger = generate(user())
+
+      owned = generate(group(name: "Owned by member", actor: member, is_public: true))
+
+      joined =
+        generate(group(name: "Joined by member", actor: stranger, is_public: true))
+
+      generate(group_member(group_id: joined.id, user_id: member.id, actor: stranger))
+
+      conn =
+        conn
+        |> authenticated_conn(member)
+        |> gql_post("{ joinedGroups { id name } }")
+
+      assert %{"data" => %{"joinedGroups" => results}} = json_response(conn, 200)
+
+      ids = Enum.map(results, & &1["id"])
+      assert joined.id in ids
+      refute owned.id in ids
+    end
+
+    test "returns empty list for user with no memberships beyond ownership", %{conn: conn} do
+      lonely = generate(user())
+      _owned = generate(group(actor: lonely, is_public: true))
+
+      conn =
+        conn
+        |> authenticated_conn(lonely)
+        |> gql_post("{ joinedGroups { id } }")
+
+      assert %{"data" => %{"joinedGroups" => []}} = json_response(conn, 200)
+    end
+  end
 end

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -197,6 +197,20 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> assert_has("h2", text: to_string(joined.name))
     end
 
+    test "anonymous user is redirected to sign-in from ?yours= scopes", %{conn: conn} do
+      session = conn |> visit(~p"/groups?yours=hosting")
+      assert_path(session, ~p"/sign-in")
+
+      assert Phoenix.Flash.get(session.conn.assigns.flash, :error) =~
+               "Sign in to view groups you host"
+
+      session = conn |> visit(~p"/groups?yours=joined")
+      assert_path(session, ~p"/sign-in")
+
+      assert Phoenix.Flash.get(session.conn.assigns.flash, :error) =~
+               "Sign in to view groups you've joined"
+    end
+
     test "scoped view with non-matching search shows search-aware empty copy", %{
       conn: conn,
       owner: owner

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -82,6 +82,135 @@ defmodule HuddlzWeb.GroupLiveTest do
     end
   end
 
+  describe "Index personal sections" do
+    setup do
+      owner = generate(user(role: :user))
+      member = generate(user(role: :user))
+      stranger = generate(user(role: :user))
+
+      hosted = generate(group(name: "Cyberpunk Builders", actor: owner, is_public: true))
+
+      joined =
+        generate(group(name: "Phoenix Devs", actor: stranger, is_public: true))
+
+      generate(group_member(group_id: joined.id, user_id: member.id, actor: stranger))
+
+      %{owner: owner, member: member, stranger: stranger, hosted: hosted, joined: joined}
+    end
+
+    test "anonymous users see no personal sections", %{conn: conn} do
+      conn
+      |> visit(~p"/groups")
+      |> refute_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Joined")
+    end
+
+    test "logged-in user with no relationships sees no personal sections", %{conn: conn} do
+      disconnected = generate(user(role: :user))
+
+      conn
+      |> login(disconnected)
+      |> visit(~p"/groups")
+      |> refute_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Joined")
+    end
+
+    test "owner sees Hosting section with their group", %{
+      conn: conn,
+      owner: owner,
+      hosted: hosted
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups")
+      |> assert_has("span", text: "// Hosting")
+      |> assert_has("h2", text: to_string(hosted.name))
+    end
+
+    test "member sees Joined section with the joined group, not Hosting", %{
+      conn: conn,
+      member: member,
+      joined: joined
+    } do
+      conn
+      |> login(member)
+      |> visit(~p"/groups")
+      |> assert_has("span", text: "// Joined")
+      |> refute_has("span", text: "// Hosting")
+      |> assert_has("h2", text: to_string(joined.name))
+    end
+
+    test "owner is not double-counted in Joined section", %{conn: conn, owner: owner} do
+      # Owner is auto-added as member of their own group. The Joined section
+      # filter must exclude groups they own so they only appear under Hosting.
+      conn
+      |> login(owner)
+      |> visit(~p"/groups")
+      |> assert_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Joined")
+    end
+
+    test "search filters sections and main grid together", %{
+      conn: conn,
+      owner: owner,
+      hosted: hosted
+    } do
+      _other =
+        generate(
+          group(name: "Knitting Circle", actor: generate(user(role: :user)), is_public: true)
+        )
+
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups?q=cyberpunk")
+
+      session
+      |> assert_has("h2", text: to_string(hosted.name))
+      |> refute_has("h2", text: "Knitting Circle")
+    end
+
+    test "?yours=hosting scope shows only hosted, hides sections", %{
+      conn: conn,
+      owner: owner,
+      hosted: hosted
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups?yours=hosting")
+      |> assert_has("h1", text: "Groups You Host")
+      |> assert_has("h2", text: to_string(hosted.name))
+      |> refute_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Joined")
+      |> assert_has("a", text: "All groups")
+    end
+
+    test "?yours=joined scope shows only joined", %{
+      conn: conn,
+      member: member,
+      joined: joined
+    } do
+      conn
+      |> login(member)
+      |> visit(~p"/groups?yours=joined")
+      |> assert_has("h1", text: "Groups You've Joined")
+      |> assert_has("h2", text: to_string(joined.name))
+    end
+
+    test "View all link appears when section count exceeds limit", %{conn: conn} do
+      heavy_owner = generate(user(role: :user))
+
+      for i <- 1..7 do
+        generate(group(name: "Heavy Group #{i}", actor: heavy_owner, is_public: true))
+      end
+
+      conn
+      |> login(heavy_owner)
+      |> visit(~p"/groups")
+      |> assert_has("a", text: "View all →")
+    end
+  end
+
   describe "New" do
     setup do
       admin = generate(user(role: :admin))

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -197,6 +197,19 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> assert_has("h2", text: to_string(joined.name))
     end
 
+    test "scoped view with non-matching search shows search-aware empty copy", %{
+      conn: conn,
+      owner: owner
+    } do
+      # Owner DOES host groups, but the search matches none of them. The empty
+      # state must reflect the search, not falsely claim they host nothing.
+      conn
+      |> login(owner)
+      |> visit(~p"/groups?yours=hosting&q=zzznomatch")
+      |> assert_has("p", text: "No groups match your search.")
+      |> refute_has("p", text: "You aren't hosting any groups yet.")
+    end
+
     test "View all link points to scoped path and preserves search", %{conn: conn} do
       heavy_owner = generate(user(role: :user))
 

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -197,17 +197,42 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> assert_has("h2", text: to_string(joined.name))
     end
 
-    test "View all link appears when section count exceeds limit", %{conn: conn} do
+    test "View all link points to scoped path and preserves search", %{conn: conn} do
       heavy_owner = generate(user(role: :user))
 
       for i <- 1..7 do
         generate(group(name: "Heavy Group #{i}", actor: heavy_owner, is_public: true))
       end
 
+      # No search active — link should point at the scope only
       conn
       |> login(heavy_owner)
       |> visit(~p"/groups")
-      |> assert_has("a", text: "View all →")
+      |> assert_has(~s|a[href="/groups?yours=hosting"]|, text: "View all →")
+
+      # Search active — link should preserve the query
+      conn
+      |> login(heavy_owner)
+      |> visit(~p"/groups?q=heavy")
+      |> assert_has(~s|a[href="/groups?yours=hosting&q=heavy"]|, text: "View all →")
+    end
+
+    test "search with no matches collapses both personal sections", %{
+      conn: conn,
+      owner: owner
+    } do
+      # Owner has hosting; also make them a member of an unrelated group so we
+      # can prove BOTH sections collapse when the search matches nothing.
+      stranger = generate(user(role: :user))
+      other_group = generate(group(name: "Knitting Circle", actor: stranger, is_public: true))
+      generate(group_member(group_id: other_group.id, user_id: owner.id, actor: stranger))
+
+      conn
+      |> login(owner)
+      |> visit(~p"/groups?q=zzzznosuchgroupzzzz")
+      |> refute_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Joined")
+      |> assert_has("p", text: "No groups match your search.")
     end
   end
 


### PR DESCRIPTION
## Summary

Reworks `/groups` so authenticated users can find their own groups without scanning the full directory, and adds the search bar that was missing.

### What's new on `/groups`

- **`// HOSTING (n)`** section — groups you own
- **`// JOINED (n)`** section — groups you belong to but don't own (owners are filtered out so they don't double-count, since owners are auto-added as members on creation)
- Each section **caps at 6 cards** and shows `View all →` when count > 6, deep-linking to `/groups?yours=hosting` or `/groups?yours=joined`
- **Search input** (trigram similarity, matching the `:search` action's behavior) filters all three queries in unison
- Empty sections are **hidden entirely** — anonymous users and users with no relationships see the original directory layout
- The `View all` link **preserves the active search** via `&q=`
- Scoped views (`?yours=...`) render a single full grid with an `← All groups` back link and a context-appropriate page title

### API surface

Per the API-first principle: the new behavior is reachable as a real action.

- `:get_joined` read action on `Group` — filters by `exists(group_members, user_id == ^actor(:id)) and owner_id != ^actor(:id)`
- `Communities.get_joined_groups`
- GraphQL: `joined_groups`
- JSON API: `/groups/joined`

### Trade-offs worth flagging

- **Cards appear in two places** — a group you host shows up in `// HOSTING` *and* the `// All Groups` grid below. Standard pattern (Meetup, GitHub) and intentional: sections are a shortcut, not a filter.
- **Three queries per render** when logged in (hosting, joined, all). Trigram + actor-scoped filters are cheap; revisit if it shows up in metrics.
- **No pagination on the scoped views** yet. Most users won't have hundreds of groups owned/joined; can add if needed.

### Out of scope

- The same treatment for `/huddlz` — natural follow-up, would mirror this structure with "Hosting upcoming" and "Attending upcoming" sections. Time-bounded data so the sections cap themselves.

## Test plan

- [ ] `/groups` as anonymous — no personal sections, full directory grid, search input visible
- [ ] `/groups` logged in with no relationships — same as anonymous (no `// Hosting` / `// Joined` headings)
- [ ] `/groups` logged in as owner — `// Hosting` section appears with your group; not duplicated under `// Joined`
- [ ] `/groups` logged in as member of someone else's group — `// Joined` section appears with that group
- [ ] Type a search query — sections and main grid filter together; non-matching sections disappear; clear button appears
- [ ] `/groups?yours=hosting` — single grid, page title "Groups You Host", back link works
- [ ] `/groups?yours=joined` — single grid, page title "Groups You've Joined"
- [ ] Create 7+ owned groups, visit `/groups` — `View all →` link visible in `// Hosting`, navigates to `/groups?yours=hosting`
- [ ] Search active + click `View all` — destination URL preserves `&q=`