### PR TITLE
feat(huddlz): personal sections + URL-driven filters on /huddlz

### DIFF
--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -19,7 +19,8 @@ defmodule Huddlz.Communities do
           {:optional, :event_type},
           {:optional, :search_latitude},
           {:optional, :search_longitude},
-          {:optional, :distance_miles}
+          {:optional, :distance_miles},
+          {:optional, :relationship}
         ],
         get?: false
 

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -241,6 +241,12 @@ defmodule Huddlz.Communities.Huddl do
         constraints min: 5, max: 100
       end
 
+      argument :relationship, :atom do
+        description "Restrict results to huddlz the actor hosts (creator) or is attending (RSVPed)."
+        allow_nil? true
+        constraints one_of: [:hosting, :attending]
+      end
+
       pagination keyset?: true,
                  offset?: true,
                  countable: true,

--- a/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
+++ b/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
@@ -7,12 +7,13 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
 
   @meters_per_mile 1609.344
 
-  def prepare(query, _opts, _context) do
+  def prepare(query, _opts, context) do
     query
     |> apply_text_filter()
     |> apply_date_filter()
     |> apply_event_type_filter()
     |> apply_location_filter()
+    |> apply_relationship_filter(context)
   end
 
   defp apply_text_filter(query) do
@@ -87,6 +88,35 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
       )
     else
       query
+    end
+  end
+
+  defp apply_relationship_filter(query, %{actor: nil}) do
+    # An anonymous actor cannot host or attend anything; force an empty result
+    # rather than ignoring the relationship filter (which would silently broaden
+    # the query and leak unrelated huddlz to API consumers).
+    case Ash.Query.get_argument(query, :relationship) do
+      relationship when relationship in [:hosting, :attending] ->
+        Ash.Query.filter(query, false)
+
+      _ ->
+        query
+    end
+  end
+
+  defp apply_relationship_filter(query, %{actor: actor}) do
+    case Ash.Query.get_argument(query, :relationship) do
+      :hosting ->
+        Ash.Query.filter(query, creator_id == ^actor.id)
+
+      :attending ->
+        Ash.Query.filter(
+          query,
+          exists(attendees, user_id == ^actor.id) and creator_id != ^actor.id
+        )
+
+      _ ->
+        query
     end
   end
 end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -1,57 +1,162 @@
 defmodule HuddlzWeb.HuddlLive do
   @moduledoc """
-  LiveView for searching and filtering huddlz across all groups.
+  LiveView for searching and filtering huddlz across all groups, with personal
+  sections (Hosting, Attending) for authenticated users.
   """
   use HuddlzWeb, :live_view
 
-  alias Huddlz.Communities
   alias Huddlz.Communities.Group
   alias HuddlzWeb.Layouts
   require Ash.Query
   require Logger
 
-  # Authentication is optional - show cards to all but require auth for joining
+  @section_limit 6
+
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
 
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns[:current_user]
 
-    # Pre-fill location from user profile if available
-    {location_text, location_lat, location_lng} =
-      if user && user.home_location do
-        {user.home_location, user.home_latitude, user.home_longitude}
-      else
-        {nil, nil, nil}
-      end
+    {:ok,
+     socket
+     |> assign(:default_location_text, user && user.home_location)
+     |> assign(:default_location_lat, user && user.home_latitude)
+     |> assign(:default_location_lng, user && user.home_longitude)
+     |> assign(:section_limit, @section_limit)
+     |> assign_search_defaults()}
+  end
 
-    location_active = not is_nil(location_lat) and not is_nil(location_lng)
-
-    socket =
-      assign(socket,
-        search_query: nil,
-        event_type_filter: nil,
-        date_filter: "upcoming",
-        location_text: location_text,
-        location_lat: location_lat,
-        location_lng: location_lng,
-        location_active: location_active,
-        distance_miles: 25,
-        groups: []
-      )
-
-    socket = perform_search(socket)
-
-    {:ok, socket}
+  defp assign_search_defaults(socket) do
+    assign(socket,
+      search_query: nil,
+      event_type_filter: nil,
+      date_filter: "upcoming",
+      distance_miles: 25,
+      location_text: socket.assigns.default_location_text,
+      location_lat: socket.assigns.default_location_lat,
+      location_lng: socket.assigns.default_location_lng,
+      location_active:
+        not is_nil(socket.assigns.default_location_lat) and
+          not is_nil(socket.assigns.default_location_lng),
+      scope: :all,
+      hosting: [],
+      attending: [],
+      hosting_total: 0,
+      attending_total: 0,
+      huddls: [],
+      groups: [],
+      page_info: %{total_pages: 1, current_page: 1, total_count: 0}
+    )
   end
 
   @impl true
+  def handle_params(params, _url, socket) do
+    scope = parse_scope(params["yours"])
+
+    if scope != :all and is_nil(socket.assigns.current_user) do
+      {:noreply,
+       socket
+       |> put_flash(:error, "Sign in to view #{sign_in_prompt(scope)}.")
+       |> push_navigate(to: ~p"/sign-in")}
+    else
+      socket =
+        socket
+        |> assign(:scope, scope)
+        |> assign(:page_title, page_title(scope))
+        |> assign_filters_from_params(params)
+        |> perform_search()
+
+      {:noreply, socket}
+    end
+  end
+
+  defp assign_filters_from_params(socket, params) do
+    {location_text, location_lat, location_lng, location_active} =
+      parse_location_params(params, socket)
+
+    socket
+    |> assign(:search_query, normalize_string(params["q"]))
+    |> assign(:event_type_filter, normalize_event_type(params["event_type"]))
+    |> assign(:date_filter, normalize_date_filter(params["date_filter"]))
+    |> assign(:distance_miles, parse_distance(params["distance"] || params["distance_miles"]))
+    |> assign(:location_text, location_text)
+    |> assign(:location_lat, location_lat)
+    |> assign(:location_lng, location_lng)
+    |> assign(:location_active, location_active)
+  end
+
+  defp parse_location_params(params, socket) do
+    case {params["lat"], params["lng"]} do
+      {lat_str, lng_str} when is_binary(lat_str) and is_binary(lng_str) ->
+        with {lat, ""} <- Float.parse(lat_str),
+             {lng, ""} <- Float.parse(lng_str) do
+          {params["location"], lat, lng, true}
+        else
+          _ -> {nil, nil, nil, false}
+        end
+
+      _ ->
+        # Honor the user's home_location pre-fill ONLY when no lat/lng are in the
+        # URL — once they explicitly clear, don't auto-resurrect.
+        if params["lat"] == nil and params["lng"] == nil and
+             not Map.has_key?(params, "cleared") do
+          {socket.assigns.default_location_text, socket.assigns.default_location_lat,
+           socket.assigns.default_location_lng,
+           not is_nil(socket.assigns.default_location_lat) and
+             not is_nil(socket.assigns.default_location_lng)}
+        else
+          {nil, nil, nil, false}
+        end
+    end
+  end
+
+  defp parse_scope("hosting"), do: :hosting
+  defp parse_scope("attending"), do: :attending
+  defp parse_scope(_), do: :all
+
+  defp normalize_string(nil), do: nil
+  defp normalize_string(""), do: nil
+  defp normalize_string(s) when is_binary(s), do: s |> String.trim() |> nilify_blank()
+
+  defp nilify_blank(""), do: nil
+  defp nilify_blank(s), do: s
+
+  defp normalize_event_type(s) when s in ["in_person", "virtual", "hybrid"], do: s
+  defp normalize_event_type(_), do: nil
+
+  defp normalize_date_filter(s) when s in ["upcoming", "this_week", "this_month", "past", "all"],
+    do: s
+
+  defp normalize_date_filter(_), do: "upcoming"
+
+  defp parse_distance(nil), do: 25
+  defp parse_distance(""), do: 25
+
+  defp parse_distance(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n in 5..100 -> n
+      _ -> 25
+    end
+  end
+
+  defp parse_distance(val) when is_integer(val) and val in 5..100, do: val
+  defp parse_distance(_), do: 25
+
+  defp page_title(:hosting), do: "Huddlz You're Hosting"
+  defp page_title(:attending), do: "Huddlz You're Attending"
+  defp page_title(:all), do: "Huddlz"
+
+  defp sign_in_prompt(:hosting), do: "huddlz you're hosting"
+  defp sign_in_prompt(:attending), do: "huddlz you're attending"
+
+  @impl true
   def handle_event("filter_change", params, socket) do
-    {:noreply, apply_search_params(params, socket)}
+    {:noreply, push_patch(socket, to: build_path(socket, params))}
   end
 
   def handle_event("search", params, socket) do
-    {:noreply, apply_search_params(params, socket)}
+    {:noreply, push_patch(socket, to: build_path(socket, params))}
   end
 
   def handle_event("clear_filters", _params, socket) do
@@ -62,21 +167,10 @@ defmodule HuddlzWeb.HuddlLive do
       longitude: nil
     )
 
-    socket =
-      socket
-      |> assign(
-        search_query: nil,
-        event_type_filter: nil,
-        date_filter: "upcoming",
-        location_text: nil,
-        location_lat: nil,
-        location_lng: nil,
-        location_active: false,
-        distance_miles: 25
-      )
-      |> perform_search()
-
-    {:noreply, socket}
+    {:noreply,
+     push_patch(socket,
+       to: scoped_path(socket.assigns.scope, %{}, override_location_with_cleared: true)
+     )}
   end
 
   def handle_event("change_page", %{"page" => page_str}, socket) do
@@ -85,52 +179,104 @@ defmodule HuddlzWeb.HuddlLive do
     {:noreply, socket}
   end
 
-  defp apply_search_params(params, socket) do
-    query = if params["query"] != "", do: params["query"], else: nil
-    event_type = if params["event_type"] != "", do: params["event_type"], else: nil
-    date_filter = params["date_filter"] || "upcoming"
-    distance_miles = parse_distance(params["distance_miles"])
+  @impl true
+  def handle_info(
+        {:location_selected, "location-autocomplete",
+         %{display_text: text, latitude: lat, longitude: lng}},
+        socket
+      ) do
+    merged =
+      socket
+      |> form_params_from_assigns()
+      |> Map.merge(%{
+        "location" => text,
+        "lat" => Float.to_string(lat),
+        "lng" => Float.to_string(lng)
+      })
 
-    socket
-    |> assign(search_query: query)
-    |> assign(event_type_filter: event_type)
-    |> assign(date_filter: date_filter)
-    |> assign(distance_miles: distance_miles)
-    |> perform_search()
+    {:noreply, push_patch(socket, to: scoped_path(socket.assigns.scope, merged))}
   end
+
+  def handle_info({:location_cleared, "location-autocomplete"}, socket) do
+    if socket.assigns.location_active do
+      merged = form_params_from_assigns(socket)
+
+      {:noreply,
+       push_patch(socket,
+         to: scoped_path(socket.assigns.scope, merged, override_location_with_cleared: true)
+       )}
+    else
+      # Component fires :location_cleared on its own initial mount when its
+      # value is nil. Ignoring that no-op so the URL doesn't pick up `cleared=1`
+      # spuriously.
+      {:noreply, socket}
+    end
+  end
+
+  defp build_path(socket, params) do
+    scoped_path(socket.assigns.scope, params)
+  end
+
+  defp scoped_path(scope, form_params, opts \\ []) do
+    cleared? = Keyword.get(opts, :override_location_with_cleared, false)
+
+    base = current_filter_params(form_params, cleared?)
+    params = put_scope(scope, base)
+
+    case params do
+      [] -> ~p"/"
+      params -> ~p"/?#{params}"
+    end
+  end
+
+  defp current_filter_params(form_params, cleared?) do
+    location =
+      cond do
+        cleared? ->
+          [{"cleared", "1"}]
+
+        form_params["lat"] && form_params["lng"] ->
+          [
+            {"location", form_params["location"] || ""},
+            {"lat", form_params["lat"]},
+            {"lng", form_params["lng"]}
+          ]
+
+        true ->
+          []
+      end
+
+    [
+      {"q", form_params["query"]},
+      {"event_type", form_params["event_type"]},
+      {"date_filter", form_params["date_filter"] || "upcoming"},
+      {"distance", form_params["distance_miles"]}
+    ]
+    |> Enum.reject(fn
+      {_, ""} -> true
+      {_, nil} -> true
+      {"date_filter", "upcoming"} -> true
+      _ -> false
+    end)
+    |> Kernel.++(location)
+  end
+
+  defp put_scope(:all, params), do: params
+  defp put_scope(scope, params), do: [{"yours", Atom.to_string(scope)} | params]
 
   defp perform_search(socket, opts \\ []) do
     offset = Keyword.get(opts, :offset, 0)
 
-    event_type_atom =
-      if socket.assigns.event_type_filter && socket.assigns.event_type_filter != "",
-        do: String.to_existing_atom(socket.assigns.event_type_filter),
-        else: nil
+    base_args = build_search_args(socket)
 
-    date_filter_atom = String.to_existing_atom(socket.assigns.date_filter)
-
-    {search_lat, search_lng, distance} =
-      if socket.assigns.location_active do
-        {socket.assigns.location_lat, socket.assigns.location_lng, socket.assigns.distance_miles}
-      else
-        {nil, nil, nil}
-      end
-
-    page =
-      Communities.search_huddlz(
-        socket.assigns.search_query,
-        date_filter_atom,
-        event_type_atom,
-        search_lat,
-        search_lng,
-        distance,
-        actor: socket.assigns[:current_user],
+    main_page =
+      run_search(base_args, socket.assigns[:current_user],
+        relationship: scope_to_relationship(socket.assigns.scope),
         page: [limit: 20, offset: offset, count: true]
       )
 
-    {huddls, distances} = load_results_with_distances(page, socket)
-
-    page_info = extract_page_info(page)
+    {huddls, distances} = load_results_with_distances(main_page, socket)
+    page_info = extract_page_info(main_page)
 
     page_info =
       if offset > 0, do: Map.put(page_info, :current_page, div(offset, 20) + 1), else: page_info
@@ -138,40 +284,93 @@ defmodule HuddlzWeb.HuddlLive do
     socket
     |> assign(huddls: Enum.zip(huddls, distances))
     |> assign(page_info: page_info)
+    |> maybe_load_personal_sections(base_args)
     |> maybe_load_groups(huddls)
   end
 
-  @impl true
-  def handle_info(
-        {:location_selected, "location-autocomplete",
-         %{display_text: text, latitude: lat, longitude: lng}},
-        socket
-      ) do
-    socket =
-      socket
-      |> assign(
-        location_text: text,
-        location_lat: lat,
-        location_lng: lng,
-        location_active: true
-      )
-      |> perform_search()
+  defp build_search_args(socket) do
+    {search_lat, search_lng, distance} =
+      if socket.assigns.location_active do
+        {socket.assigns.location_lat, socket.assigns.location_lng, socket.assigns.distance_miles}
+      else
+        {nil, nil, nil}
+      end
 
-    {:noreply, socket}
+    event_type_atom =
+      if socket.assigns.event_type_filter && socket.assigns.event_type_filter != "",
+        do: String.to_existing_atom(socket.assigns.event_type_filter),
+        else: nil
+
+    %{
+      query: socket.assigns.search_query,
+      date_filter: String.to_existing_atom(socket.assigns.date_filter),
+      event_type: event_type_atom,
+      search_latitude: search_lat,
+      search_longitude: search_lng,
+      distance_miles: distance
+    }
   end
 
-  def handle_info({:location_cleared, "location-autocomplete"}, socket) do
-    socket =
-      socket
-      |> assign(
-        location_text: nil,
-        location_lat: nil,
-        location_lng: nil,
-        location_active: false
-      )
-      |> perform_search()
+  defp scope_to_relationship(:hosting), do: :hosting
+  defp scope_to_relationship(:attending), do: :attending
+  defp scope_to_relationship(:all), do: nil
 
-    {:noreply, socket}
+  defp run_search(args, actor, opts) do
+    relationship = Keyword.get(opts, :relationship)
+    page_opts = Keyword.get(opts, :page, [])
+
+    args_with_relationship = Map.put(args, :relationship, relationship)
+
+    Huddlz.Communities.Huddl
+    |> Ash.Query.for_read(:search, args_with_relationship, actor: actor)
+    |> Ash.read(actor: actor, page: page_opts)
+  end
+
+  defp maybe_load_personal_sections(socket, _base_args)
+       when is_nil(socket.assigns.current_user) do
+    assign(socket, hosting: [], attending: [], hosting_total: 0, attending_total: 0)
+  end
+
+  defp maybe_load_personal_sections(socket, _base_args)
+       when socket.assigns.scope != :all do
+    # On a scoped view, we only render the main grid — sections are hidden.
+    assign(socket, hosting: [], attending: [], hosting_total: 0, attending_total: 0)
+  end
+
+  defp maybe_load_personal_sections(socket, base_args) do
+    user = socket.assigns.current_user
+
+    {hosting, hosting_total} = load_section(base_args, user, :hosting)
+    {attending, attending_total} = load_section(base_args, user, :attending)
+
+    socket
+    |> assign(:hosting, hosting)
+    |> assign(:hosting_total, hosting_total)
+    |> assign(:attending, attending)
+    |> assign(:attending_total, attending_total)
+  end
+
+  defp load_section(base_args, user, relationship) do
+    page =
+      run_search(base_args, user,
+        relationship: relationship,
+        page: [limit: @section_limit, offset: 0, count: true]
+      )
+
+    case page do
+      {:ok, %{results: results, count: count}} ->
+        loaded =
+          Ash.load!(
+            results,
+            [:status, :rsvp_count, :visible_virtual_link, :display_image_url, :group],
+            actor: user
+          )
+
+        {loaded, count || length(loaded)}
+
+      _ ->
+        {[], 0}
+    end
   end
 
   defp maybe_load_groups(socket, [_ | _]), do: assign(socket, :groups, [])
@@ -183,7 +382,11 @@ defmodule HuddlzWeb.HuddlLive do
         socket.assigns.date_filter != "upcoming" or
         socket.assigns.location_active
 
-    if has_filters, do: socket, else: assign(socket, :groups, list_public_groups())
+    if has_filters or socket.assigns.scope != :all do
+      assign(socket, :groups, [])
+    else
+      assign(socket, :groups, list_public_groups())
+    end
   end
 
   defp load_results_with_distances({:ok, %{results: results}}, socket) do
@@ -219,16 +422,55 @@ defmodule HuddlzWeb.HuddlLive do
     end)
   end
 
-  defp parse_distance(nil), do: 25
-  defp parse_distance(""), do: 25
-  defp parse_distance(val) when is_binary(val), do: String.to_integer(val)
-  defp parse_distance(val) when is_integer(val), do: val
+  defp extract_page_info({:ok, %Ash.Page.Offset{count: count, limit: limit, offset: offset}}) do
+    total_pages = if count && count > 0, do: ceil(count / limit), else: 1
+    current_page = if offset && limit > 0, do: div(offset, limit) + 1, else: 1
+
+    %{
+      total_pages: total_pages,
+      current_page: current_page,
+      total_count: count || 0
+    }
+  end
+
+  defp extract_page_info({:ok, %Ash.Page.Keyset{count: count, limit: limit}}) do
+    total_pages = if count && count > 0, do: ceil(count / limit), else: 1
+
+    %{
+      total_pages: total_pages,
+      current_page: 1,
+      total_count: count || 0
+    }
+  end
+
+  defp extract_page_info(_) do
+    %{
+      total_pages: 1,
+      current_page: 1,
+      total_count: 0
+    }
+  end
+
+  defp list_public_groups do
+    case Group
+         |> Ash.Query.filter(is_public: true)
+         |> Ash.Query.load(:current_image_url)
+         |> Ash.Query.limit(6)
+         |> Ash.read() do
+      {:ok, groups} -> groups
+      {:error, _} -> []
+    end
+  end
 
   @impl true
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user}>
       <div>
+        <h1 :if={@scope != :all} class="font-display text-2xl tracking-tight text-glow mb-4">
+          {page_title(@scope)}
+        </h1>
+
         <div class="mb-8">
           <form phx-change="filter_change" phx-submit="search">
             <div class="flex flex-wrap items-end gap-2">
@@ -277,9 +519,12 @@ defmodule HuddlzWeb.HuddlLive do
                   This Month
                 </option>
               </select>
-              <.button type="submit" variant="primary" class="h-12 px-6">
+              <button
+                type="submit"
+                class="h-12 px-6 bg-primary text-primary-content font-medium btn-neon active:scale-[0.98] transition-all"
+              >
                 Search
-              </.button>
+              </button>
             </div>
             <div class="flex flex-wrap items-end gap-2 mt-2">
               <div class="flex-grow min-w-[200px]">
@@ -313,7 +558,7 @@ defmodule HuddlzWeb.HuddlLive do
             </div>
           </form>
 
-          <%= if @search_query || @event_type_filter || @date_filter != "upcoming" || @location_active do %>
+          <%= if any_filter_active?(assigns) do %>
             <div class="mt-3 flex flex-wrap items-center gap-2">
               <span class="text-sm text-base-content/40">Filters:</span>
               <%= if @search_query do %>
@@ -340,20 +585,40 @@ defmodule HuddlzWeb.HuddlLive do
                   {@location_text} · {@distance_miles} mi
                 </span>
               <% end %>
-              <.button phx-click="clear_filters" variant="ghost" size="sm">
+              <button
+                phx-click="clear_filters"
+                class="text-xs text-primary hover:underline font-medium"
+              >
                 Clear all
-              </.button>
+              </button>
             </div>
           <% end %>
         </div>
 
+        <%= if @scope == :all and @current_user do %>
+          <.personal_section
+            :if={@hosting_total > 0}
+            title="Hosting"
+            count={@hosting_total}
+            huddls={@hosting}
+            limit={@section_limit}
+            view_all_path={view_all_path(:hosting, assigns)}
+          />
+          <.personal_section
+            :if={@attending_total > 0}
+            title="Attending"
+            count={@attending_total}
+            huddls={@attending}
+            limit={@section_limit}
+            view_all_path={view_all_path(:attending, assigns)}
+          />
+        <% end %>
+
         <div class="w-full">
           <%= if Enum.empty?(@huddls) do %>
-            <%= if @search_query || @event_type_filter || @date_filter != "upcoming" || @location_active do %>
+            <%= if any_filter_active?(assigns) or @scope != :all do %>
               <div class="border border-dashed border-base-300 p-12 text-center">
-                <p class="text-lg text-base-content/50">
-                  No huddlz found matching your filters. Try adjusting your search criteria.
-                </p>
+                <p class="text-lg text-base-content/50">{empty_message(assigns)}</p>
               </div>
             <% else %>
               <div class="text-center py-8">
@@ -382,7 +647,16 @@ defmodule HuddlzWeb.HuddlLive do
               <% end %>
             <% end %>
           <% else %>
-            <div class="mb-4 text-sm text-base-content/40">
+            <h2
+              :if={show_main_heading?(assigns)}
+              class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3 mb-4"
+            >
+              <span class="mono-label text-primary/70">// {main_heading(@scope)}</span>
+              <span class="text-sm font-body font-normal text-base-content/40">
+                ({@page_info.total_count})
+              </span>
+            </h2>
+            <div :if={!show_main_heading?(assigns)} class="mb-4 text-sm text-base-content/40">
               Found {@page_info.total_count} {if @page_info.total_count == 1,
                 do: "huddl",
                 else: "huddlz"}
@@ -402,10 +676,108 @@ defmodule HuddlzWeb.HuddlLive do
             <% end %>
           <% end %>
         </div>
+
+        <div :if={@scope != :all} class="mt-6">
+          <.link navigate={~p"/"} class="text-sm text-primary hover:underline font-medium">
+            ← All huddlz
+          </.link>
+        </div>
       </div>
     </Layouts.app>
     """
   end
+
+  attr :title, :string, required: true
+  attr :count, :integer, required: true
+  attr :huddls, :list, required: true
+  attr :limit, :integer, required: true
+  attr :view_all_path, :string, required: true
+
+  defp personal_section(assigns) do
+    ~H"""
+    <div class="mt-10">
+      <div class="flex items-baseline justify-between gap-2">
+        <h2 class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3">
+          <span class="mono-label text-primary/70">// {@title}</span>
+          <span class="text-sm font-body font-normal text-base-content/40">
+            ({@count})
+          </span>
+        </h2>
+        <.link
+          :if={@count > @limit}
+          navigate={@view_all_path}
+          class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+        >
+          View all →
+        </.link>
+      </div>
+
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 mt-4">
+        <%= for huddl <- @huddls do %>
+          <.huddl_card huddl={huddl} show_group={true} />
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp view_all_path(scope, assigns) do
+    params = current_filter_params(form_params_from_assigns(assigns), false)
+    params = put_scope(scope, params)
+
+    case params do
+      [] -> ~p"/"
+      params -> ~p"/?#{params}"
+    end
+  end
+
+  defp form_params_from_assigns(%Phoenix.LiveView.Socket{assigns: assigns}),
+    do: form_params_from_assigns(assigns)
+
+  defp form_params_from_assigns(assigns) do
+    base = %{
+      "query" => assigns.search_query,
+      "event_type" => assigns.event_type_filter,
+      "date_filter" => assigns.date_filter
+    }
+
+    if assigns.location_active do
+      Map.merge(base, %{
+        "location" => assigns.location_text,
+        "lat" => Float.to_string(assigns.location_lat),
+        "lng" => Float.to_string(assigns.location_lng),
+        "distance_miles" => Integer.to_string(assigns.distance_miles)
+      })
+    else
+      base
+    end
+  end
+
+  defp any_filter_active?(assigns) do
+    not is_nil(assigns.search_query) or not is_nil(assigns.event_type_filter) or
+      assigns.date_filter != "upcoming" or assigns.location_active
+  end
+
+  defp show_main_heading?(%{
+         scope: scope,
+         current_user: user,
+         hosting_total: h,
+         attending_total: a
+       })
+       when scope == :all and not is_nil(user) and (h > 0 or a > 0),
+       do: true
+
+  defp show_main_heading?(_), do: false
+
+  defp main_heading(:hosting), do: "Hosting"
+  defp main_heading(:attending), do: "Attending"
+  defp main_heading(:all), do: "All Huddlz"
+
+  defp empty_message(%{scope: :hosting}), do: "You aren't hosting any huddlz that match."
+  defp empty_message(%{scope: :attending}), do: "You aren't attending any huddlz that match."
+
+  defp empty_message(%{scope: :all}),
+    do: "No huddlz found matching your filters. Try adjusting your search criteria."
 
   defp humanize_filter(filter) do
     filter
@@ -413,45 +785,5 @@ defmodule HuddlzWeb.HuddlLive do
     |> String.replace("_", " ")
     |> String.split(" ")
     |> Enum.map_join(" ", &String.capitalize/1)
-  end
-
-  defp extract_page_info({:ok, %Ash.Page.Offset{count: count, limit: limit, offset: offset}}) do
-    total_pages = if count && count > 0, do: ceil(count / limit), else: 1
-    current_page = if offset && limit > 0, do: div(offset, limit) + 1, else: 1
-
-    %{
-      total_pages: total_pages,
-      current_page: current_page,
-      total_count: count || 0
-    }
-  end
-
-  defp extract_page_info({:ok, %Ash.Page.Keyset{count: count, limit: limit}}) do
-    total_pages = if count && count > 0, do: ceil(count / limit), else: 1
-
-    %{
-      total_pages: total_pages,
-      current_page: 1,
-      total_count: count || 0
-    }
-  end
-
-  defp extract_page_info(_) do
-    %{
-      total_pages: 1,
-      current_page: 1,
-      total_count: 0
-    }
-  end
-
-  defp list_public_groups do
-    case Group
-         |> Ash.Query.filter(is_public: true)
-         |> Ash.Query.load(:current_image_url)
-         |> Ash.Query.limit(6)
-         |> Ash.read() do
-      {:ok, groups} -> groups
-      {:error, _} -> []
-    end
   end
 end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -230,36 +230,38 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   defp current_filter_params(form_params, cleared?) do
-    location =
-      cond do
-        cleared? ->
-          [{"cleared", "1"}]
+    non_location_params(form_params)
+    |> Kernel.++(location_params(form_params, cleared?))
+    |> Enum.reject(&drop_param?/1)
+  end
 
-        form_params["lat"] && form_params["lng"] ->
-          [
-            {"location", form_params["location"] || ""},
-            {"lat", form_params["lat"]},
-            {"lng", form_params["lng"]}
-          ]
-
-        true ->
-          []
-      end
-
+  defp non_location_params(form_params) do
     [
       {"q", form_params["query"]},
       {"event_type", form_params["event_type"]},
-      {"date_filter", form_params["date_filter"] || "upcoming"},
-      {"distance", form_params["distance_miles"]}
+      {"date_filter", form_params["date_filter"] || "upcoming"}
     ]
-    |> Enum.reject(fn
-      {_, ""} -> true
-      {_, nil} -> true
-      {"date_filter", "upcoming"} -> true
-      _ -> false
-    end)
-    |> Kernel.++(location)
   end
+
+  defp location_params(_form_params, true), do: [{"cleared", "1"}]
+
+  defp location_params(form_params, false) do
+    if form_params["lat"] && form_params["lng"] do
+      [
+        {"location", form_params["location"] || ""},
+        {"lat", form_params["lat"]},
+        {"lng", form_params["lng"]},
+        {"distance", form_params["distance_miles"]}
+      ]
+    else
+      []
+    end
+  end
+
+  defp drop_param?({_, ""}), do: true
+  defp drop_param?({_, nil}), do: true
+  defp drop_param?({"date_filter", "upcoming"}), do: true
+  defp drop_param?(_), do: false
 
   defp put_scope(:all, params), do: params
   defp put_scope(scope, params), do: [{"yours", Atom.to_string(scope)} | params]
@@ -722,13 +724,20 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   defp view_all_path(scope, assigns) do
-    params = current_filter_params(form_params_from_assigns(assigns), false)
+    cleared? = location_explicitly_cleared?(assigns)
+    params = current_filter_params(form_params_from_assigns(assigns), cleared?)
     params = put_scope(scope, params)
 
     case params do
       [] -> ~p"/"
       params -> ~p"/?#{params}"
     end
+  end
+
+  defp location_explicitly_cleared?(assigns) do
+    not assigns.location_active and
+      not is_nil(assigns.default_location_lat) and
+      not is_nil(assigns.default_location_lng)
   end
 
   defp form_params_from_assigns(%Phoenix.LiveView.Socket{assigns: assigns}),

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -207,9 +207,8 @@ defmodule HuddlzWeb.HuddlLive do
          to: scoped_path(socket.assigns.scope, merged, override_location_with_cleared: true)
        )}
     else
-      # Component fires :location_cleared on its own initial mount when its
-      # value is nil. Ignoring that no-op so the URL doesn't pick up `cleared=1`
-      # spuriously.
+      # No-op when there was nothing to clear, so the URL doesn't pick up
+      # `cleared=1` spuriously.
       {:noreply, socket}
     end
   end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -214,7 +214,26 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   defp build_path(socket, params) do
-    scoped_path(socket.assigns.scope, params)
+    scoped_path(socket.assigns.scope, merge_active_location(socket, params))
+  end
+
+  # The autocomplete component only emits a hidden `location` text input on the
+  # form; lat/lng live in component state and reach the parent via :location_selected.
+  # Plain form events (typing search, changing date, etc.) therefore don't carry
+  # lat/lng — merge them in from socket assigns so the URL doesn't silently drop
+  # an active location filter.
+  defp merge_active_location(%{assigns: %{location_active: false}}, params), do: params
+
+  defp merge_active_location(%{assigns: assigns}, params) do
+    if params["lat"] && params["lng"] do
+      params
+    else
+      Map.merge(params, %{
+        "location" => params["location"] || assigns.location_text,
+        "lat" => Float.to_string(assigns.location_lat),
+        "lng" => Float.to_string(assigns.location_lng)
+      })
+    end
   end
 
   defp scoped_path(scope, form_params, opts \\ []) do

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -144,9 +144,9 @@ defmodule HuddlzWeb.HuddlLive do
   defp parse_distance(val) when is_integer(val) and val in 5..100, do: val
   defp parse_distance(_), do: 25
 
-  defp page_title(:hosting), do: "Huddlz You're Hosting"
-  defp page_title(:attending), do: "Huddlz You're Attending"
-  defp page_title(:all), do: "Huddlz"
+  defp page_title(:hosting), do: "huddlz you're hosting"
+  defp page_title(:attending), do: "huddlz you're attending"
+  defp page_title(:all), do: "huddlz"
 
   defp sign_in_prompt(:hosting), do: "huddlz you're hosting"
   defp sign_in_prompt(:attending), do: "huddlz you're attending"

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -699,7 +699,10 @@ defmodule HuddlzWeb.HuddlLive do
         </div>
 
         <div :if={@scope != :all} class="mt-6">
-          <.link navigate={~p"/"} class="text-sm text-primary hover:underline font-medium">
+          <.link
+            navigate={view_all_path(:all, assigns)}
+            class="text-sm text-primary hover:underline font-medium"
+          >
             ← All huddlz
           </.link>
         </div>

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive do
   """
   use HuddlzWeb, :live_view
 
+  alias Huddlz.Communities
   alias Huddlz.Communities.Group
   alias HuddlzWeb.Layouts
   require Ash.Query
@@ -337,14 +338,17 @@ defmodule HuddlzWeb.HuddlLive do
   defp scope_to_relationship(:all), do: nil
 
   defp run_search(args, actor, opts) do
-    relationship = Keyword.get(opts, :relationship)
-    page_opts = Keyword.get(opts, :page, [])
-
-    args_with_relationship = Map.put(args, :relationship, relationship)
-
-    Huddlz.Communities.Huddl
-    |> Ash.Query.for_read(:search, args_with_relationship, actor: actor)
-    |> Ash.read(actor: actor, page: page_opts)
+    Communities.search_huddlz(
+      args.query,
+      args.date_filter,
+      args.event_type,
+      args.search_latitude,
+      args.search_longitude,
+      args.distance_miles,
+      Keyword.get(opts, :relationship),
+      actor: actor,
+      page: Keyword.get(opts, :page, [])
+    )
   end
 
   defp maybe_load_personal_sections(socket, _base_args)

--- a/test/features/huddlz_personal_sections.feature
+++ b/test/features/huddlz_personal_sections.feature
@@ -1,0 +1,42 @@
+@async @database @conn
+Feature: Huddlz Personal Sections
+  As a logged-in user browsing huddlz
+  I want to see huddlz I'm hosting or attending surfaced at the top
+  So that I can find my own huddlz without scanning the full discovery feed
+
+  Background:
+    Given the following users exist:
+      | email                | role     | display_name |
+      | host@example.com     | verified | Host User    |
+      | attendee@example.com | verified | Attendee     |
+      | stranger@example.com | verified | Stranger     |
+
+  Scenario: Anonymous users see no personal sections
+    Given a public group "Phoenix Devs" exists with owner "host@example.com"
+    And the huddl "Elixir Workshop" exists in group "Phoenix Devs" hosted by "host@example.com"
+    When I visit the landing page
+    Then I should not see "// Hosting"
+    And I should not see "// Attending"
+
+  Scenario: Host sees their huddl in the Hosting section
+    Given a public group "Phoenix Devs" exists with owner "host@example.com"
+    And the huddl "Elixir Workshop" exists in group "Phoenix Devs" hosted by "host@example.com"
+    And I am signed in as "host@example.com"
+    When I visit the landing page
+    Then I should see "// Hosting"
+    And I should see "Elixir Workshop"
+    And I should not see "// Attending"
+
+  Scenario: RSVPed user sees the huddl in the Attending section
+    Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
+    And the huddl "Elixir Workshop" exists in group "Phoenix Devs" hosted by "stranger@example.com"
+    And "attendee@example.com" has RSVPed to "Elixir Workshop"
+    And I am signed in as "attendee@example.com"
+    When I visit the landing page
+    Then I should see "// Attending"
+    And I should not see "// Hosting"
+
+  Scenario: Anonymous user is redirected from a scoped view to sign-in
+    When I visit "/?yours=hosting"
+    Then I should be redirected to "/sign-in"
+    And I should see "Sign in to view huddlz you're hosting"

--- a/test/features/step_definitions/huddlz_personal_sections_steps.exs
+++ b/test/features/step_definitions/huddlz_personal_sections_steps.exs
@@ -1,0 +1,42 @@
+defmodule HuddlzPersonalSectionsSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.Group
+
+  require Ash.Query
+
+  step "the huddl {string} exists in group {string} hosted by {string}",
+       %{args: [title, group_name, host_email]} = context do
+    host = lookup_user(host_email)
+    group = lookup_group(group_name)
+
+    huddl =
+      generate(
+        huddl(
+          title: title,
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          actor: host
+        )
+      )
+
+    huddls = Map.get(context, :huddls, [])
+    Map.put(context, :huddls, [huddl | huddls])
+  end
+
+  defp lookup_user(email) do
+    User
+    |> Ash.Query.filter(email: email)
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp lookup_group(name) do
+    Group
+    |> Ash.Query.filter(name: name)
+    |> Ash.read_one!(authorize?: false)
+  end
+end

--- a/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
+++ b/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
@@ -79,6 +79,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           30.2672,
           -97.7431,
           50,
+          nil,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -100,6 +101,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           30.2672,
           -97.7431,
           10,
+          nil,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -120,6 +122,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           30.2672,
           -97.7431,
           100,
+          nil,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -139,6 +142,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
         Huddlz.Communities.search_huddlz(
           nil,
           :upcoming,
+          nil,
           nil,
           nil,
           nil,
@@ -163,6 +167,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           30.2672,
           -97.7431,
           10,
+          nil,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -175,6 +180,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           30.2672,
           -97.7431,
           100,
+          nil,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )

--- a/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
+++ b/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
@@ -182,4 +182,118 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
       assert length(far_results) >= length(near_results)
     end
   end
+
+  describe "relationship filter" do
+    setup %{group: host_group, owner: owner} do
+      attendee = generate(user(role: :user))
+      stranger = generate(user(role: :user))
+      stranger_group = generate(group(owner_id: stranger.id, is_public: true, actor: stranger))
+
+      hosted_by_owner =
+        generate(
+          huddl_at_location(
+            title: "Owner hosts",
+            latitude: nil,
+            longitude: nil,
+            group_id: host_group.id,
+            creator_id: owner.id
+          )
+        )
+
+      hosted_by_stranger =
+        generate(
+          huddl_at_location(
+            title: "Stranger hosts",
+            latitude: nil,
+            longitude: nil,
+            group_id: stranger_group.id,
+            creator_id: stranger.id
+          )
+        )
+
+      hosted_by_stranger
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      %{
+        attendee: attendee,
+        stranger: stranger,
+        hosted_by_owner: hosted_by_owner,
+        hosted_by_stranger: hosted_by_stranger
+      }
+    end
+
+    test ":hosting returns only huddlz the actor created", %{
+      owner: owner,
+      hosted_by_owner: hosted
+    } do
+      {:ok, %{results: results}} =
+        Huddlz.Communities.Huddl
+        |> Ash.Query.for_read(:search, %{relationship: :hosting, date_filter: :all}, actor: owner)
+        |> Ash.read(actor: owner, page: [limit: 50, count: true])
+
+      ids = Enum.map(results, & &1.id)
+      assert hosted.id in ids
+      assert Enum.all?(results, &(&1.creator_id == owner.id))
+    end
+
+    test ":attending returns huddlz the actor RSVPed but did not create", %{
+      attendee: attendee,
+      hosted_by_stranger: hosted
+    } do
+      {:ok, %{results: results}} =
+        Huddlz.Communities.Huddl
+        |> Ash.Query.for_read(:search, %{relationship: :attending, date_filter: :all},
+          actor: attendee
+        )
+        |> Ash.read(actor: attendee, page: [limit: 50, count: true])
+
+      ids = Enum.map(results, & &1.id)
+      assert hosted.id in ids
+    end
+
+    test ":attending excludes huddlz the actor created (even if they RSVPed)", %{
+      owner: owner,
+      hosted_by_owner: hosted
+    } do
+      hosted
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: owner)
+      |> Ash.update!()
+
+      {:ok, %{results: results}} =
+        Huddlz.Communities.Huddl
+        |> Ash.Query.for_read(:search, %{relationship: :attending, date_filter: :all},
+          actor: owner
+        )
+        |> Ash.read(actor: owner, page: [limit: 50, count: true])
+
+      refute hosted.id in Enum.map(results, & &1.id)
+    end
+
+    test "anonymous actor with relationship filter returns []", %{} do
+      require Ash.Query
+
+      {:ok, %{results: results}} =
+        Huddlz.Communities.Huddl
+        |> Ash.Query.for_read(:search, %{relationship: :hosting, date_filter: :all}, actor: nil)
+        |> Ash.read(actor: nil, page: [limit: 50, count: true])
+
+      assert results == []
+    end
+
+    test "no relationship filter returns the broader public set", %{
+      hosted_by_owner: a,
+      hosted_by_stranger: b,
+      attendee: attendee
+    } do
+      {:ok, %{results: results}} =
+        Huddlz.Communities.Huddl
+        |> Ash.Query.for_read(:search, %{date_filter: :all}, actor: attendee)
+        |> Ash.read(actor: attendee, page: [limit: 50, count: true])
+
+      ids = Enum.map(results, & &1.id)
+      assert a.id in ids
+      assert b.id in ids
+    end
+  end
 end

--- a/test/huddlz_web/api/graphql/huddl_test.exs
+++ b/test/huddlz_web/api/graphql/huddl_test.exs
@@ -153,4 +153,79 @@ defmodule HuddlzWeb.Api.Graphql.HuddlTest do
       assert h.id in ids
     end
   end
+
+  describe "searchHuddlz query — relationship arg" do
+    setup do
+      host = generate(user())
+      attendee = generate(user())
+      stranger = generate(user())
+
+      host_group = generate(group(owner_id: host.id, is_public: true, actor: host))
+      stranger_group = generate(group(owner_id: stranger.id, is_public: true, actor: stranger))
+
+      hosted =
+        generate(huddl(group_id: host_group.id, creator_id: host.id, actor: host))
+
+      foreign =
+        generate(huddl(group_id: stranger_group.id, creator_id: stranger.id, actor: stranger))
+
+      foreign
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      %{host: host, attendee: attendee, hosted: hosted, foreign: foreign}
+    end
+
+    test "relationship hosting returns only huddlz the actor created", %{
+      conn: conn,
+      host: host,
+      hosted: hosted,
+      foreign: foreign
+    } do
+      conn =
+        conn
+        |> authenticated_conn(host)
+        |> gql_post(~s|{ searchHuddlz(query: null, relationship: "hosting") { results { id } } }|)
+
+      assert %{"data" => %{"searchHuddlz" => %{"results" => results}}} =
+               json_response(conn, 200)
+
+      ids = Enum.map(results, & &1["id"])
+
+      assert hosted.id in ids
+      refute foreign.id in ids
+    end
+
+    test "relationship attending returns RSVPed huddlz the actor did not create", %{
+      conn: conn,
+      attendee: attendee,
+      foreign: foreign,
+      hosted: hosted
+    } do
+      conn =
+        conn
+        |> authenticated_conn(attendee)
+        |> gql_post(
+          ~s|{ searchHuddlz(query: null, relationship: "attending") { results { id } } }|
+        )
+
+      assert %{"data" => %{"searchHuddlz" => %{"results" => results}}} =
+               json_response(conn, 200)
+
+      ids = Enum.map(results, & &1["id"])
+
+      assert foreign.id in ids
+      refute hosted.id in ids
+    end
+
+    test "anonymous actor with relationship filter returns []", %{conn: conn} do
+      conn =
+        gql_post(
+          conn,
+          ~s|{ searchHuddlz(query: null, relationship: "hosting") { results { id } } }|
+        )
+
+      assert %{"data" => %{"searchHuddlz" => %{"results" => []}}} = json_response(conn, 200)
+    end
+  end
 end

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -491,7 +491,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
       conn
       |> login(host)
       |> visit("/?yours=hosting")
-      |> assert_has("h1", text: "Huddlz You're Hosting")
+      |> assert_has("h1", text: "huddlz you're hosting")
       |> assert_has("h3", text: hosted.title)
       |> refute_has("span", text: "// Hosting")
       |> assert_has("a", text: "All huddlz")
@@ -505,7 +505,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
       conn
       |> login(attendee)
       |> visit("/?yours=attending")
-      |> assert_has("h1", text: "Huddlz You're Attending")
+      |> assert_has("h1", text: "huddlz you're attending")
       |> assert_has("h3", text: foreign.title)
     end
 

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -509,6 +509,13 @@ defmodule HuddlzWeb.HuddlLiveTest do
       |> assert_has("h3", text: foreign.title)
     end
 
+    test "← All huddlz back link preserves active filters", %{conn: conn, host: host} do
+      conn
+      |> login(host)
+      |> visit("/?yours=hosting&q=elixir&date_filter=this_week")
+      |> assert_has(~s|a[href="/?q=elixir&date_filter=this_week"]|, text: "All huddlz")
+    end
+
     test "anonymous users redirected from ?yours= scopes to sign-in", %{conn: conn} do
       session = conn |> visit("/?yours=hosting")
       assert_path(session, ~p"/sign-in")

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -373,4 +373,166 @@ defmodule HuddlzWeb.HuddlLiveTest do
              end)
     end
   end
+
+  describe "Personal sections" do
+    setup do
+      host = generate(user(role: :user))
+      attendee = generate(user(role: :user))
+      stranger = generate(user(role: :user))
+
+      host_group = generate(group(is_public: true, owner_id: host.id, actor: host))
+      stranger_group = generate(group(is_public: true, owner_id: stranger.id, actor: stranger))
+
+      hosted =
+        generate(
+          huddl(
+            group_id: host_group.id,
+            creator_id: host.id,
+            is_private: false,
+            title: "Hosted by host",
+            actor: host
+          )
+        )
+
+      foreign =
+        generate(
+          huddl(
+            group_id: stranger_group.id,
+            creator_id: stranger.id,
+            is_private: false,
+            title: "Hosted by stranger",
+            actor: stranger
+          )
+        )
+
+      foreign
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      %{
+        host: host,
+        attendee: attendee,
+        stranger: stranger,
+        host_group: host_group,
+        stranger_group: stranger_group,
+        hosted: hosted,
+        foreign: foreign
+      }
+    end
+
+    test "anonymous users see no personal sections", %{conn: conn} do
+      conn
+      |> visit("/")
+      |> refute_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Attending")
+    end
+
+    test "host sees Hosting section", %{conn: conn, host: host, hosted: hosted} do
+      conn
+      |> login(host)
+      |> visit("/")
+      |> assert_has("span", text: "// Hosting")
+      |> assert_has("h3", text: hosted.title)
+    end
+
+    test "RSVPed attendee sees Attending section, not Hosting", %{
+      conn: conn,
+      attendee: attendee,
+      foreign: foreign
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/")
+      |> assert_has("span", text: "// Attending")
+      |> refute_has("span", text: "// Hosting")
+      |> assert_has("h3", text: foreign.title)
+    end
+
+    test "host who also RSVPed to their own huddl is not double-counted", %{
+      conn: conn,
+      host: host,
+      hosted: hosted
+    } do
+      hosted
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: host)
+      |> Ash.update!()
+
+      conn
+      |> login(host)
+      |> visit("/")
+      |> assert_has("span", text: "// Hosting")
+      |> refute_has("span", text: "// Attending")
+    end
+
+    test "?yours=hosting scope shows only hosted, hides sections", %{
+      conn: conn,
+      host: host,
+      hosted: hosted
+    } do
+      conn
+      |> login(host)
+      |> visit("/?yours=hosting")
+      |> assert_has("h1", text: "Huddlz You're Hosting")
+      |> assert_has("h3", text: hosted.title)
+      |> refute_has("span", text: "// Hosting")
+      |> assert_has("a", text: "All huddlz")
+    end
+
+    test "?yours=attending scope shows only attending", %{
+      conn: conn,
+      attendee: attendee,
+      foreign: foreign
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/?yours=attending")
+      |> assert_has("h1", text: "Huddlz You're Attending")
+      |> assert_has("h3", text: foreign.title)
+    end
+
+    test "anonymous users redirected from ?yours= scopes to sign-in", %{conn: conn} do
+      session = conn |> visit("/?yours=hosting")
+      assert_path(session, ~p"/sign-in")
+
+      assert Phoenix.Flash.get(session.conn.assigns.flash, :error) =~
+               "Sign in to view huddlz you're hosting"
+
+      session = conn |> visit("/?yours=attending")
+      assert_path(session, ~p"/sign-in")
+    end
+
+    test "View all link appears when hosting count exceeds limit", %{
+      conn: conn,
+      host: host
+    } do
+      group2 = generate(group(is_public: true, owner_id: host.id, actor: host))
+
+      for i <- 1..7 do
+        generate(
+          huddl(
+            group_id: group2.id,
+            creator_id: host.id,
+            is_private: false,
+            title: "Heavy Hosting #{i}",
+            actor: host
+          )
+        )
+      end
+
+      conn
+      |> login(host)
+      |> visit("/")
+      |> assert_has(~s|a[href="/?yours=hosting"]|, text: "View all →")
+    end
+
+    test "scoped view with non-matching search shows search-aware empty copy", %{
+      conn: conn,
+      host: host
+    } do
+      conn
+      |> login(host)
+      |> visit("/?yours=hosting&q=zzznomatch")
+      |> assert_has("p", text: "You aren't hosting any huddlz that match.")
+    end
+  end
 end

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -535,4 +535,67 @@ defmodule HuddlzWeb.HuddlLiveTest do
       |> assert_has("p", text: "You aren't hosting any huddlz that match.")
     end
   end
+
+  describe "Cleared location pre-fill" do
+    test "View all link preserves cleared=1 when home_location was cleared", %{conn: conn} do
+      user = generate(user(role: :user))
+
+      user
+      |> Ash.Changeset.for_update(
+        :update_home_location,
+        %{home_location: "Austin, TX", home_latitude: 30.2672, home_longitude: -97.7431},
+        actor: user
+      )
+      |> Ash.update!()
+
+      group = generate(group(is_public: true, owner_id: user.id, actor: user))
+
+      for i <- 1..7 do
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: user.id,
+            is_private: false,
+            title: "Hosted #{i}",
+            actor: user
+          )
+        )
+      end
+
+      session =
+        conn
+        |> login(user)
+        |> visit("/?cleared=1")
+
+      assert_has(session, ~s|a[href="/?yours=hosting&cleared=1"]|, text: "View all →")
+    end
+
+    test "anonymous visit to / does not produce ?cleared=1 in resulting URL", %{conn: conn} do
+      session = conn |> visit("/")
+      assert_path(session, ~p"/")
+    end
+
+    test "clearing location while pre-fill is active drops distance and lat/lng from URL", %{
+      conn: conn
+    } do
+      user = generate(user(role: :user))
+
+      user
+      |> Ash.Changeset.for_update(
+        :update_home_location,
+        %{home_location: "Austin, TX", home_latitude: 30.2672, home_longitude: -97.7431},
+        actor: user
+      )
+      |> Ash.update!()
+
+      conn = login(conn, user)
+      {:ok, view, _html} = Phoenix.LiveViewTest.live(conn, "/")
+
+      view
+      |> element(~s|button[aria-label="Clear location"]|)
+      |> render_click()
+
+      assert_patch(view, "/?cleared=1")
+    end
+  end
 end

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -320,6 +320,25 @@ defmodule HuddlzWeb.HuddlLiveTest do
       session |> click_button("Search")
       refute has_element?(view, "[role='option']")
     end
+
+    test "typing in search after picking a location preserves lat/lng in URL", %{
+      conn: conn
+    } do
+      conn
+      |> visit("/?location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=25")
+      |> assert_has("span", text: "Austin, TX · 25 mi")
+      |> fill_in("Search huddlz", with: "elixir")
+      |> assert_path(~p"/",
+        query_params: %{
+          "q" => "elixir",
+          "location" => "Austin, TX",
+          "lat" => "30.2672",
+          "lng" => "-97.7431",
+          "distance" => "25"
+        }
+      )
+      |> assert_has("span", text: "Austin, TX · 25 mi")
+    end
   end
 
   describe "Groups fallback" do


### PR DESCRIPTION
## Summary

Mirrors the /groups personal-sections treatment on the huddlz discovery page (#157 was the precedent), and migrates the page's filter state into the URL so deep links and back/forward navigation work properly.

### What's new

- **\`// HOSTING (n)\`** section — huddlz where the actor is the creator
- **\`// ATTENDING (n)\`** section — huddlz the actor RSVPed to but did not create (so a host who RSVPed to their own huddl isn't double-counted)
- Sections **inherit every filter**: search, event type, date range, location/distance — they scope alongside the main grid, not orthogonally
- Each section **caps at 6 cards** with a \`View all →\` link to \`/?yours=hosting\` or \`/?yours=attending\` that **preserves all active filters**
- \`?yours=hosting\` and \`?yours=attending\` render a full scoped grid with an \`← All huddlz\` back link
- **Anonymous users** hitting a scoped URL are redirected to \`/sign-in\` with a flash; the unscoped \`/\` is unchanged for anonymous

### URL-driven filter state

The page previously kept search/type/date/location in socket assigns only. Now it's URL-driven (via \`handle_params\` + \`push_patch\`), so:

- Deep links like \`/?q=elixir&date_filter=this_week&yours=attending\` reproduce state
- Back/forward navigation works as expected
- Sharing a URL preserves the filters

### Resource & API surface

Per the API-first principle:

- New optional \`:relationship\` argument on the existing \`Huddl.search\` action (\`:hosting | :attending\`)
- Anonymous actor + relationship filter returns \`[]\` (rather than silently broadening scope)
- Exposed in GraphQL as \`searchHuddlz(relationship: \"hosting\" | \"attending\")\`
- The new filter composes with all existing search filters in a single query — no fan-out to additional actions

### Trade-offs worth flagging

- **Same-card-twice trade-off** as /groups: a huddl you host appears in \`// HOSTING\` and (if it matches the broader filter) in the main grid below. Standard pattern; intentional.
- **Three queries when authenticated**: hosting + attending + main grid. Single trigram + actor-scoped query each; cheap. Revisit if metrics show pressure.
- **Section sort is \`starts_at\` ascending** — soonest first, which matches the existing main-grid sort.

### Out of scope

- The \`Huddl.search\` action's existing free-form \`:query\` arg uses \`contains/2\`; converting it to trigram + relevance ranking (matching /groups) is a separate change.
- A unified \`prepare\` helper that both /groups and /huddlz could share — defer until we have a third caller.

## Test plan

- [ ] \`/\` as anonymous — no personal sections
- [ ] \`/\` logged in with no relationships — no personal sections, page unchanged
- [ ] \`/\` logged in as host — \`// Hosting\` section appears
- [ ] \`/\` logged in as RSVPed user — \`// Attending\` section appears
- [ ] Host who also RSVPed their own huddl — appears in Hosting only, not Attending
- [ ] Type a search query — sections and main grid filter together; non-matching sections disappear
- [ ] Apply event type or date filter — same: sections and main grid scope together
- [ ] Pick a location with distance — sections and main grid both filter by location
- [ ] \`?yours=hosting\` / \`?yours=attending\` — single grid, scoped page title, back link
- [ ] Click \`View all →\` with active filters — destination URL preserves \`q\`, \`event_type\`, \`date_filter\`, \`location\`/\`lat\`/\`lng\`/\`distance_miles\`
- [ ] Anonymous → \`/?yours=hosting\` → redirected to \`/sign-in\` with flash
- [ ] Browser back/forward — filter state restored from URL