### PR TITLE
feat: URL-driven pagination on /huddlz and /groups discovery pages

### DIFF
--- a/lib/huddlz_web/live/group_live/index.ex
+++ b/lib/huddlz_web/live/group_live/index.ex
@@ -11,6 +11,7 @@ defmodule HuddlzWeb.GroupLive.Index do
   require Logger
 
   @section_limit 6
+  @page_size 20
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
 
@@ -26,7 +27,8 @@ defmodule HuddlzWeb.GroupLive.Index do
      |> assign(:joined, [])
      |> assign(:hosting_total, 0)
      |> assign(:joined_total, 0)
-     |> assign(:groups, [])}
+     |> assign(:groups, [])
+     |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})}
   end
 
   @impl true
@@ -40,14 +42,24 @@ defmodule HuddlzWeb.GroupLive.Index do
        |> put_flash(:error, "Sign in to view #{sign_in_prompt(scope)}.")
        |> push_navigate(to: ~p"/sign-in")}
     else
+      page = parse_page(params["page"])
+
       socket =
         socket
         |> assign(:page_title, page_title(scope))
         |> assign(:scope, scope)
         |> assign(:query, query)
-        |> load_groups()
+        |> load_groups(page)
 
-      {:noreply, socket}
+      total_pages = socket.assigns.page_info.total_pages
+
+      if page > total_pages do
+        # Out-of-range page: clamp by patching to the last valid page so the URL
+        # reflects what the user actually sees.
+        {:noreply, push_patch(socket, to: scoped_path(scope, query, page: total_pages))}
+      else
+        {:noreply, socket}
+      end
     end
   end
 
@@ -67,6 +79,14 @@ defmodule HuddlzWeb.GroupLive.Index do
     {:noreply, push_patch(socket, to: scoped_path(socket.assigns.scope, nil))}
   end
 
+  def handle_event("change_page", %{"page" => page_str}, socket) do
+    page = parse_page(page_str)
+
+    path = scoped_path(socket.assigns.scope, socket.assigns.query, page: page)
+
+    {:noreply, push_patch(socket, to: path)}
+  end
+
   defp parse_scope("hosting"), do: :hosting
   defp parse_scope("joined"), do: :joined
   defp parse_scope(_), do: :all
@@ -78,13 +98,28 @@ defmodule HuddlzWeb.GroupLive.Index do
   defp nilify_blank(""), do: nil
   defp nilify_blank(q), do: q
 
+  defp parse_page(nil), do: 1
+  defp parse_page(""), do: 1
+
+  defp parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_page(val) when is_integer(val) and val >= 1, do: val
+  defp parse_page(_), do: 1
+
   defp page_title(:hosting), do: "Groups You Host"
   defp page_title(:joined), do: "Groups You've Joined"
   defp page_title(:all), do: "Groups"
 
-  defp scoped_path(scope, query) do
+  defp scoped_path(scope, query, opts \\ []) do
+    page = Keyword.get(opts, :page, 1)
+
     params =
-      [yours: scope_param(scope), q: query]
+      [yours: scope_param(scope), q: query, page: page_param(page)]
       |> Enum.reject(fn {_, v} -> is_nil(v) end)
 
     case params do
@@ -93,35 +128,50 @@ defmodule HuddlzWeb.GroupLive.Index do
     end
   end
 
+  defp page_param(page) when is_integer(page) and page > 1, do: Integer.to_string(page)
+  defp page_param(_), do: nil
+
   defp scope_param(:hosting), do: "hosting"
   defp scope_param(:joined), do: "joined"
   defp scope_param(:all), do: nil
 
-  defp load_groups(socket) do
+  defp load_groups(socket, page) do
     user = socket.assigns.current_user
     query = socket.assigns.query
 
     case socket.assigns.scope do
       :hosting ->
-        assign(socket, :groups, list_hosting(user, query))
+        {groups, total} = list_hosting(user, query, page)
+
+        socket
+        |> assign(:groups, groups)
+        |> assign(:page_info, page_info(total, page))
 
       :joined ->
-        assign(socket, :groups, list_joined(user, query))
+        {groups, total} = list_joined(user, query, page)
+
+        socket
+        |> assign(:groups, groups)
+        |> assign(:page_info, page_info(total, page))
 
       :all ->
-        hosting = if user, do: list_hosting(user, query), else: []
-        joined = if user, do: list_joined(user, query), else: []
+        hosting = if user, do: list_hosting_section(user, query), else: []
+        joined = if user, do: list_joined_section(user, query), else: []
+        {groups, total} = list_all(query, page)
 
         socket
         |> assign(:hosting, Enum.take(hosting, @section_limit))
         |> assign(:hosting_total, length(hosting))
         |> assign(:joined, Enum.take(joined, @section_limit))
         |> assign(:joined_total, length(joined))
-        |> assign(:groups, list_all(query))
+        |> assign(:groups, groups)
+        |> assign(:page_info, page_info(total, page))
     end
   end
 
-  defp list_hosting(user, query) do
+  # Personal sections aren't paginated — they show up to @section_limit and
+  # link out to the scoped (paginated) view via "View all".
+  defp list_hosting_section(user, query) do
     Group
     |> Ash.Query.for_read(:get_by_owner, %{}, actor: user)
     |> apply_search(query)
@@ -129,7 +179,7 @@ defmodule HuddlzWeb.GroupLive.Index do
     |> read_groups(actor: user)
   end
 
-  defp list_joined(user, query) do
+  defp list_joined_section(user, query) do
     Group
     |> Ash.Query.for_read(:get_joined, %{}, actor: user)
     |> apply_search(query)
@@ -137,16 +187,58 @@ defmodule HuddlzWeb.GroupLive.Index do
     |> read_groups(actor: user)
   end
 
+  defp list_hosting(user, query, page) do
+    Group
+    |> Ash.Query.for_read(:get_by_owner, %{}, actor: user)
+    |> apply_search(query)
+    |> paginate_with_count(page, actor: user)
+  end
+
+  defp list_joined(user, query, page) do
+    Group
+    |> Ash.Query.for_read(:get_joined, %{}, actor: user)
+    |> apply_search(query)
+    |> paginate_with_count(page, actor: user)
+  end
+
   # The main directory stays public-only on purpose: a user's private groups
   # already surface in the // JOINED section above, so re-listing them here
   # would just duplicate. Anonymous users can only ever see public groups.
-  defp list_all(query) do
+  defp list_all(query, page) do
     Group
     |> Ash.Query.for_read(:read, %{}, actor: nil)
     |> Ash.Query.filter(is_public == true)
     |> apply_search(query)
-    |> Ash.Query.load(:current_image_url)
-    |> read_groups(actor: nil)
+    |> paginate_with_count(page, actor: nil)
+  end
+
+  defp paginate_with_count(ash_query, page, opts) do
+    total =
+      case Ash.count(ash_query, opts) do
+        {:ok, n} ->
+          n
+
+        {:error, reason} ->
+          Logger.warning("GroupLive.Index group count failed: #{inspect(reason)}")
+          0
+      end
+
+    paginated =
+      ash_query
+      |> Ash.Query.load(:current_image_url)
+      |> Ash.Query.limit(@page_size)
+      |> Ash.Query.offset((page - 1) * @page_size)
+      |> read_groups(opts)
+
+    {paginated, total}
+  end
+
+  defp page_info(0, _page),
+    do: %{total_pages: 1, current_page: 1, total_count: 0}
+
+  defp page_info(total, page) when total > 0 do
+    total_pages = ceil(total / @page_size)
+    %{total_pages: total_pages, current_page: page, total_count: total}
   end
 
   defp apply_search(ash_query, nil) do
@@ -238,7 +330,7 @@ defmodule HuddlzWeb.GroupLive.Index do
         >
           <span class="mono-label text-primary/70">// {scope_heading(@scope)}</span>
           <span class="text-sm font-body font-normal text-base-content/40">
-            ({length(@groups)})
+            ({@page_info.total_count})
           </span>
         </h2>
 
@@ -262,6 +354,14 @@ defmodule HuddlzWeb.GroupLive.Index do
               <.group_card group={group} />
             <% end %>
           </div>
+
+          <%= if @page_info.total_pages > 1 do %>
+            <.pagination
+              current_page={@page_info.current_page}
+              total_pages={@page_info.total_pages}
+              event_name="change_page"
+            />
+          <% end %>
         <% end %>
 
         <div :if={@scope != :all} class="mt-6">

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -61,14 +61,32 @@ defmodule HuddlzWeb.HuddlLive do
        |> put_flash(:error, "Sign in to view #{sign_in_prompt(scope)}.")
        |> push_navigate(to: ~p"/sign-in")}
     else
+      page = parse_page(params["page"])
+
       socket =
         socket
         |> assign(:scope, scope)
         |> assign(:page_title, page_title(scope))
         |> assign_filters_from_params(params)
-        |> perform_search()
+        |> perform_search(offset: (page - 1) * 20)
 
-      {:noreply, socket}
+      total_pages = socket.assigns.page_info.total_pages
+
+      if page > total_pages do
+        # Out-of-range page: clamp by patching to the last valid page so the URL
+        # reflects what the user actually sees.
+        cleared? = location_explicitly_cleared?(socket.assigns)
+
+        path =
+          scoped_path(scope, form_params_from_assigns(socket),
+            override_location_with_cleared: cleared?,
+            page: total_pages
+          )
+
+        {:noreply, push_patch(socket, to: path)}
+      else
+        {:noreply, socket}
+      end
     end
   end
 
@@ -144,6 +162,19 @@ defmodule HuddlzWeb.HuddlLive do
   defp parse_distance(val) when is_integer(val) and val in 5..100, do: val
   defp parse_distance(_), do: 25
 
+  defp parse_page(nil), do: 1
+  defp parse_page(""), do: 1
+
+  defp parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_page(val) when is_integer(val) and val >= 1, do: val
+  defp parse_page(_), do: 1
+
   defp page_title(:hosting), do: "huddlz you're hosting"
   defp page_title(:attending), do: "huddlz you're attending"
   defp page_title(:all), do: "huddlz"
@@ -175,9 +206,16 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   def handle_event("change_page", %{"page" => page_str}, socket) do
-    page_num = String.to_integer(page_str)
-    socket = perform_search(socket, offset: (page_num - 1) * 20)
-    {:noreply, socket}
+    page = parse_page(page_str)
+    cleared? = location_explicitly_cleared?(socket.assigns)
+
+    path =
+      scoped_path(socket.assigns.scope, form_params_from_assigns(socket),
+        override_location_with_cleared: cleared?,
+        page: page
+      )
+
+    {:noreply, push_patch(socket, to: path)}
   end
 
   @impl true
@@ -238,8 +276,9 @@ defmodule HuddlzWeb.HuddlLive do
 
   defp scoped_path(scope, form_params, opts \\ []) do
     cleared? = Keyword.get(opts, :override_location_with_cleared, false)
+    page = Keyword.get(opts, :page, 1)
 
-    base = current_filter_params(form_params, cleared?)
+    base = current_filter_params(form_params, cleared?) ++ page_params(page)
     params = put_scope(scope, base)
 
     case params do
@@ -247,6 +286,11 @@ defmodule HuddlzWeb.HuddlLive do
       params -> ~p"/?#{params}"
     end
   end
+
+  defp page_params(page) when is_integer(page) and page > 1,
+    do: [{"page", Integer.to_string(page)}]
+
+  defp page_params(_), do: []
 
   defp current_filter_params(form_params, cleared?) do
     non_location_params(form_params)
@@ -285,7 +329,7 @@ defmodule HuddlzWeb.HuddlLive do
   defp put_scope(:all, params), do: params
   defp put_scope(scope, params), do: [{"yours", Atom.to_string(scope)} | params]
 
-  defp perform_search(socket, opts \\ []) do
+  defp perform_search(socket, opts) do
     offset = Keyword.get(opts, :offset, 0)
 
     base_args = build_search_args(socket)

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -2,6 +2,7 @@ defmodule HuddlzWeb.GroupLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Phoenix.LiveViewTest
 
   alias Huddlz.Communities.Group
 
@@ -260,6 +261,94 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> refute_has("span", text: "// Hosting")
       |> refute_has("span", text: "// Joined")
       |> assert_has("p", text: "No groups match your search.")
+    end
+  end
+
+  describe "Index pagination" do
+    setup do
+      owner = generate(user(role: :user))
+
+      # 22 public groups → 2 pages at 20/page
+      for i <- 1..22 do
+        generate(group(is_public: true, owner_id: owner.id, actor: owner, name: "Group #{i}"))
+      end
+
+      %{owner: owner}
+    end
+
+    test "shows pagination when more than 20 groups", %{conn: conn} do
+      conn
+      |> visit(~p"/groups")
+      |> assert_has("button[phx-click=change_page]")
+      |> assert_has("button.w-8", text: "2")
+    end
+
+    test "direct visit to ?page=2 renders page 2", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/groups?page=2")
+      # Page 2 has only 2 of the 22 groups; page 1 has 20.
+      group_card_count =
+        html
+        |> Floki.parse_document!()
+        |> Floki.find(".grid > a")
+        |> length()
+
+      assert group_card_count == 2
+    end
+
+    test "clicking page 2 button updates the URL via push_patch", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/groups")
+
+      view
+      |> element("button.w-8[phx-value-page='2']")
+      |> render_click()
+
+      assert_patch(view, "/groups?page=2")
+    end
+
+    test "page=1 is omitted from the URL", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/groups?page=2")
+
+      view
+      |> element("button.w-8[phx-value-page='1']")
+      |> render_click()
+
+      assert_patch(view, "/groups")
+    end
+
+    test "filter change drops ?page from the URL", %{conn: conn} do
+      conn
+      |> visit(~p"/groups?page=2")
+      |> fill_in("Search groups", with: "Group 1")
+      |> assert_path(~p"/groups", query_params: %{"q" => "Group 1"})
+    end
+
+    test "out-of-range ?page= clamps to the last valid page", %{conn: conn} do
+      conn
+      |> visit(~p"/groups?page=999")
+      |> assert_path(~p"/groups", query_params: %{"page" => "2"})
+    end
+
+    test "non-integer ?page= falls back to page 1", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/groups?page=abc")
+
+      group_card_count =
+        html
+        |> Floki.parse_document!()
+        |> Floki.find(".grid > a")
+        |> length()
+
+      # Page 1 has 20 of the 22 groups
+      assert group_card_count == 20
+    end
+
+    test "pagination preserves active query in the URL", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/groups?q=Group")
+
+      view
+      |> element("button.w-8[phx-value-page='2']")
+      |> render_click()
+
+      assert_patch(view, "/groups?q=Group&page=2")
     end
   end
 

--- a/test/huddlz_web/live/huddl_search_pagination_test.exs
+++ b/test/huddlz_web/live/huddl_search_pagination_test.exs
@@ -1,6 +1,8 @@
 defmodule HuddlzWeb.HuddlSearchPaginationTest do
   use HuddlzWeb.ConnCase, async: true
 
+  import Phoenix.LiveViewTest
+
   setup do
     user = generate(user(role: :user))
     group = generate(group(owner_id: user.id, is_public: true, actor: user))
@@ -232,6 +234,78 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       # No pagination should be shown for exactly 20 results
       |> refute_has("button", text: "2")
       |> refute_has("button[phx-click=change_page]")
+    end
+  end
+
+  describe "URL-driven pagination" do
+    test "direct visit to ?page=2 renders page 2", %{conn: conn} do
+      conn
+      |> visit("/?page=2")
+      |> assert_has("h3", text: "Test Huddl 21")
+      |> assert_has("h3", text: "Test Huddl 22")
+      |> refute_has("h3", text: "Test Huddl 1")
+      |> refute_has("h3", text: "Test Huddl 20")
+    end
+
+    test "clicking a page button updates the URL via push_patch", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+
+      view
+      |> element("button.w-8[phx-value-page='2']")
+      |> render_click()
+
+      assert_patch(view, "/?page=2")
+    end
+
+    test "page=1 is omitted from the URL", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/?page=2")
+
+      view
+      |> element("button.w-8[phx-value-page='1']")
+      |> render_click()
+
+      assert_patch(view, "/")
+    end
+
+    test "changing a filter while on page 2 drops ?page from the URL", %{conn: conn} do
+      conn
+      |> visit("/?page=2")
+      |> fill_in("Search huddlz", with: "Test")
+      |> assert_path(~p"/", query_params: %{"q" => "Test"})
+      |> assert_has("h3", text: "Test Huddl 1")
+    end
+
+    test "out-of-range ?page= clamps to the last valid page", %{conn: conn} do
+      conn
+      |> visit("/?page=999")
+      |> assert_path(~p"/", query_params: %{"page" => "2"})
+      |> assert_has("h3", text: "Test Huddl 21")
+    end
+
+    test "?page=0 is treated as page 1 and dropped from URL", %{conn: conn} do
+      conn
+      |> visit("/?page=0")
+      |> assert_has("h3", text: "Test Huddl 1")
+      |> assert_has("h3", text: "Test Huddl 20")
+    end
+
+    test "non-integer ?page= falls back to page 1", %{conn: conn} do
+      conn
+      |> visit("/?page=abc")
+      |> assert_has("h3", text: "Test Huddl 1")
+      |> assert_has("h3", text: "Test Huddl 20")
+      |> refute_has("h3", text: "Test Huddl 21")
+    end
+
+    test "pagination preserves active filters in the URL", %{conn: conn} do
+      # Use a term that matches all 22 huddlz to keep multiple pages
+      {:ok, view, _html} = live(conn, "/?q=Test")
+
+      view
+      |> element("button.w-8[phx-value-page='2']")
+      |> render_click()
+
+      assert_patch(view, "/?q=Test&page=2")
     end
   end
 end


### PR DESCRIPTION
## Summary

- Promote the page index to a `?page=N` URL param on `/huddlz` and `/groups` so paginated views are linkable, refresh-safe, and back/forward-restorable.
- Add offset pagination (20/page) to `/groups` (which previously had none) using `Ash.Query.limit/offset` + `Ash.count`, scoped to the directory grid and `?yours=hosting` / `?yours=joined` views — personal sections stay unpaginated and link out via "View all".
- Same URL semantics on both pages: `?page=1` omitted, out-of-range clamps to the last valid page via `push_patch`, non-integer values fall back to 1, and any filter change (search / event_type / date / location / scope) drops `?page`.

Closes #164.

## Test plan

- [x] `mix precommit` passes (1096 tests, credo clean)
- [x] Direct visit to `/huddlz?page=2` and `/groups?page=2` renders page 2
- [x] Clicking Next/Prev on both pages updates the URL via `push_patch`
- [x] Changing a filter while on page 2 drops `?page` from the URL
- [x] `?page=999` clamps to the last valid page
- [x] `?page=abc` falls back to page 1
- [x] Pagination preserves active filters in the URL