### PR TITLE
refactor(notifications): make deliver/3 the async public API

### DIFF
--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -169,7 +169,7 @@ defmodule Huddlz.Accounts.User do
                      "previous_role" => Atom.to_string(previous_role)
                    }
 
-                   case Huddlz.Notifications.deliver_async(
+                   case Huddlz.Notifications.deliver(
                           user,
                           :account_role_changed,
                           payload
@@ -255,7 +255,7 @@ defmodule Huddlz.Accounts.User do
       change {AshAuthentication.Strategy.Password.HashPasswordChange, strategy_name: :password}
 
       change after_action(fn _changeset, user, _ctx ->
-               case Huddlz.Notifications.deliver_async(user, :password_changed) do
+               case Huddlz.Notifications.deliver(user, :password_changed) do
                  {:ok, _job} ->
                    :ok
 
@@ -597,7 +597,7 @@ defmodule Huddlz.Accounts.User do
   defp enqueue_email_changed(user, previous_email, audience) do
     payload = %{"audience" => audience, "old_email" => previous_email}
 
-    case Huddlz.Notifications.deliver_async(user, :email_changed, payload) do
+    case Huddlz.Notifications.deliver(user, :email_changed, payload) do
       {:ok, _job} ->
         :ok
 

--- a/lib/huddlz/communities/group/changes/notify_archived.ex
+++ b/lib/huddlz/communities/group/changes/notify_archived.ex
@@ -53,7 +53,7 @@ defmodule Huddlz.Communities.Group.Changes.NotifyArchived do
 
     for user_id <- recipients do
       case Ash.get(User, user_id, authorize?: false) do
-        {:ok, user} -> Notifications.deliver_async(user, :group_archived, payload)
+        {:ok, user} -> Notifications.deliver(user, :group_archived, payload)
         _ -> :noop
       end
     end

--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -58,7 +58,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
     }
 
     if previous_owner do
-      Notifications.deliver_async(
+      Notifications.deliver(
         previous_owner,
         :group_ownership_transferred,
         Map.put(base, "role", "previous_owner")
@@ -66,7 +66,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
     end
 
     if new_owner do
-      Notifications.deliver_async(
+      Notifications.deliver(
         new_owner,
         :group_ownership_transferred,
         Map.put(base, "role", "new_owner")

--- a/lib/huddlz/communities/group_member/changes/notify_added.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_added.ex
@@ -37,7 +37,7 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyAdded do
         with {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false),
              true <- group.is_public == false,
              {:ok, recipient} <- Ash.get(User, member.user_id, authorize?: false) do
-          Notifications.deliver_async(recipient, :group_member_added, %{
+          Notifications.deliver(recipient, :group_member_added, %{
             "group_id" => group.id,
             "group_name" => to_string(group.name),
             "group_slug" => group.slug

--- a/lib/huddlz/communities/group_member/changes/notify_removed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_removed.ex
@@ -30,7 +30,7 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
   defp deliver(member) do
     with {:ok, user} <- Ash.get(Huddlz.Accounts.User, member.user_id, authorize?: false),
          {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false) do
-      Notifications.deliver_async(user, :group_member_removed, %{
+      Notifications.deliver(user, :group_member_removed, %{
         "group_id" => group.id,
         "group_name" => to_string(group.name)
       })

--- a/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
@@ -27,7 +27,7 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged do
   defp deliver(member, previous_role) do
     with {:ok, user} <- Ash.get(User, member.user_id, authorize?: false),
          {:ok, group} <- Ash.get(Group, member.group_id, authorize?: false) do
-      Notifications.deliver_async(user, :group_role_changed, %{
+      Notifications.deliver(user, :group_role_changed, %{
         "group_id" => group.id,
         "group_name" => to_string(group.name),
         "group_slug" => group.slug,

--- a/lib/huddlz/communities/huddl/changes/notify_rsvp_confirmation.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_rsvp_confirmation.ex
@@ -21,7 +21,7 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyRsvpConfirmation do
   defp notify(cs, huddl) do
     with true <- cs.context[:rsvp_created] == true,
          %{id: _} = actor <- cs.context[:private][:actor] do
-      Notifications.deliver_async(actor, :rsvp_confirmation, %{"huddl_id" => huddl.id})
+      Notifications.deliver(actor, :rsvp_confirmation, %{"huddl_id" => huddl.id})
       {:ok, huddl}
     else
       _ -> {:ok, huddl}

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -82,7 +82,7 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
     User
     |> Ash.Query.filter(id in ^user_ids)
     |> Ash.read!(authorize?: false)
-    |> Enum.each(&Notifications.deliver_async(&1, trigger, payload))
+    |> Enum.each(&Notifications.deliver(&1, trigger, payload))
 
     :ok
   end

--- a/lib/huddlz/notifications.ex
+++ b/lib/huddlz/notifications.ex
@@ -2,11 +2,13 @@ defmodule Huddlz.Notifications do
   @moduledoc """
   Email notifications orchestrator.
 
-  Single entry point for sending a notification email. Resolves the user's
-  preferences, decides whether to send, and dispatches to the right sender
-  module.
+  Public entry point for sending a notification email. `deliver/3`
+  enqueues an Oban job; the `Huddlz.Notifications.DeliverWorker` then
+  resolves the user's preferences, decides whether to send, and
+  dispatches to the right sender module.
 
       Huddlz.Notifications.deliver(user, :password_changed, %{...})
+      #=> {:ok, %Oban.Job{}}
 
   See `docs/notifications.md` for the system spec and `Huddlz.Notifications.Triggers`
   for the registry of trigger codes.
@@ -27,46 +29,19 @@ defmodule Huddlz.Notifications do
   @type deliver_result :: :sent | :skipped | {:error, term()}
 
   @doc """
-  Build and deliver the email for `trigger` to `user`.
-
-  Returns `:sent` if the mailer accepted the email, `:skipped` if the user is
-  not eligible (preferences off, unconfirmed, etc.), or `{:error, reason}` if
-  the mailer rejected.
-
-  Raises if `trigger` is not in the registry — callers should use known atoms.
-  """
-  @spec deliver(User.t(), atom(), map()) :: deliver_result()
-  def deliver(user, trigger, payload \\ %{}) do
-    entry = Triggers.fetch!(trigger)
-
-    if should_deliver?(user, trigger, entry) do
-      ensure_sender_implemented!(trigger, entry.sender)
-      email = entry.sender.build(user, payload)
-
-      case Mailer.deliver(email) do
-        {:ok, _result} -> :sent
-        {:error, reason} -> {:error, reason}
-      end
-    else
-      :skipped
-    end
-  end
-
-  @doc """
   Enqueue an Oban job that will deliver the email asynchronously.
 
   Returns `{:ok, %Oban.Job{}}` when the job is inserted, `{:error, reason}`
   if Oban refuses it. The trigger is validated up front so callers find out
   about typos at enqueue time rather than after a job is already scheduled.
 
-  This is the preferred entry point from request-handling code paths
-  (Ash actions, controllers, LiveViews) — it avoids holding the request
-  open while SMTP completes and keeps Swoosh test-adapter messages out of
-  the LV's `$callers` chain.
+  This is the only entry point app code should use. It avoids holding
+  request handlers open while SMTP completes and lets failed deliveries
+  retry on the worker's backoff schedule.
   """
-  @spec deliver_async(User.t(), atom(), map()) ::
+  @spec deliver(User.t(), atom(), map()) ::
           {:ok, Oban.Job.t()} | {:error, term()}
-  def deliver_async(%User{id: user_id}, trigger, payload \\ %{}) when is_atom(trigger) do
+  def deliver(%User{id: user_id}, trigger, payload \\ %{}) when is_atom(trigger) do
     _ = Triggers.fetch!(trigger)
 
     %{user_id: user_id, trigger: Atom.to_string(trigger), payload: payload}
@@ -82,6 +57,27 @@ defmodule Huddlz.Notifications do
         )
 
         err
+    end
+  end
+
+  @doc false
+  # Synchronous delivery. Internal to the notifications pipeline — only
+  # `Huddlz.Notifications.DeliverWorker` should call this. App code uses
+  # `deliver/3` so that delivery happens off the request path with retry.
+  @spec deliver_now(User.t(), atom(), map()) :: deliver_result()
+  def deliver_now(user, trigger, payload \\ %{}) do
+    entry = Triggers.fetch!(trigger)
+
+    if should_deliver?(user, trigger, entry) do
+      ensure_sender_implemented!(trigger, entry.sender)
+      email = entry.sender.build(user, payload)
+
+      case Mailer.deliver(email) do
+        {:ok, _result} -> :sent
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      :skipped
     end
   end
 
@@ -101,7 +97,7 @@ defmodule Huddlz.Notifications do
   @doc """
   Pure decision function: should this email be sent?
 
-  Used by `deliver/3` and useful directly in tests for asserting the
+  Used by `deliver_now/3` and useful directly in tests for asserting the
   preference matrix without going through the mailer.
   """
   @spec should_deliver?(User.t(), atom(), map()) :: boolean()

--- a/lib/huddlz/notifications/deliver_worker.ex
+++ b/lib/huddlz/notifications/deliver_worker.ex
@@ -6,9 +6,9 @@ defmodule Huddlz.Notifications.DeliverWorker do
 
       %{"user_id" => "...", "trigger" => "password_changed", "payload" => %{}}
 
-  Looks up the user, then calls `Huddlz.Notifications.deliver/3` — the same
-  synchronous code path that direct callers use. Eligibility, preferences,
-  and sender dispatch live there; the worker is just the async wrapper.
+  Looks up the user, then calls `Huddlz.Notifications.deliver_now/3` —
+  the synchronous internal code path. Eligibility, preferences, and
+  sender dispatch live there; the worker is the only legitimate caller.
 
   Delivery failures retry with the worker's default exponential backoff.
   Skipped or unknown-user jobs return `{:cancel, reason}` so they don't
@@ -27,7 +27,7 @@ defmodule Huddlz.Notifications.DeliverWorker do
          {:ok, user} <- fetch_user(user_id) do
       payload = Map.get(args, "payload", %{})
 
-      case Notifications.deliver(user, trigger, payload) do
+      case Notifications.deliver_now(user, trigger, payload) do
         :sent -> :ok
         :skipped -> :ok
         {:error, reason} -> {:error, reason}

--- a/test/huddlz/notifications/deliver_worker_test.exs
+++ b/test/huddlz/notifications/deliver_worker_test.exs
@@ -6,11 +6,11 @@ defmodule Huddlz.Notifications.DeliverWorkerTest do
   alias Huddlz.Notifications
   alias Huddlz.Notifications.DeliverWorker
 
-  describe "deliver_async/3" do
+  describe "deliver/3" do
     test "enqueues a job in the :notifications queue with string-keyed args" do
       user = generate(user(confirmed_at: DateTime.utc_now()))
 
-      assert {:ok, _job} = Notifications.deliver_async(user, :password_changed)
+      assert {:ok, _job} = Notifications.deliver(user, :password_changed)
 
       assert_enqueued(
         worker: DeliverWorker,
@@ -27,7 +27,7 @@ defmodule Huddlz.Notifications.DeliverWorkerTest do
       user = generate(user())
 
       assert_raise KeyError, fn ->
-        Notifications.deliver_async(user, :totally_made_up)
+        Notifications.deliver(user, :totally_made_up)
       end
 
       refute_enqueued(worker: DeliverWorker)

--- a/test/huddlz/notifications_test.exs
+++ b/test/huddlz/notifications_test.exs
@@ -11,10 +11,10 @@ defmodule Huddlz.NotificationsTest do
     def deliver(_email, _config), do: {:error, :smtp_unavailable}
   end
 
-  describe "deliver/3 with a real sender" do
+  describe "deliver_now/3 with a real sender" do
     test "sends for a transactional trigger with the live PasswordChanged sender" do
       user = generate(user(confirmed_at: DateTime.utc_now()))
-      assert :sent == Notifications.deliver(user, :password_changed, %{})
+      assert :sent == Notifications.deliver_now(user, :password_changed, %{})
 
       assert_email_sent(fn email ->
         email.subject == "Your huddlz password was changed" and
@@ -36,31 +36,34 @@ defmodule Huddlz.NotificationsTest do
       Application.put_env(:huddlz, Huddlz.Mailer, adapter: FailingMailerAdapter)
 
       user = generate(user(confirmed_at: DateTime.utc_now()))
-      assert {:error, :smtp_unavailable} == Notifications.deliver(user, :password_changed, %{})
+
+      assert {:error, :smtp_unavailable} ==
+               Notifications.deliver_now(user, :password_changed, %{})
+
       refute_email_sent()
     end
 
     test "skips when the user has opted out of an activity trigger" do
       user = generate_user_with_prefs(%{"rsvp_received" => false})
-      assert :skipped == Notifications.deliver(user, :rsvp_received, %{})
+      assert :skipped == Notifications.deliver_now(user, :rsvp_received, %{})
       refute_email_sent()
     end
 
     test "skips activity triggers for unconfirmed users" do
       user = generate(user(confirmed_at: nil))
-      assert :skipped == Notifications.deliver(user, :rsvp_received, %{})
+      assert :skipped == Notifications.deliver_now(user, :rsvp_received, %{})
       refute_email_sent()
     end
 
     test "raises a clear error when the registered sender isn't implemented" do
       # :weekly_digest is registered with a sender module (Senders.WeeklyDigest)
       # that doesn't exist yet — F-series digests are deferred to v2. With
-      # the trigger enabled and the user eligible, deliver/3 must surface
+      # the trigger enabled and the user eligible, deliver_now/3 must surface
       # this loudly rather than producing an UndefinedFunctionError.
       user = generate_user_with_prefs(%{"weekly_digest" => true})
 
       assert_raise ArgumentError, ~r/not yet implemented/, fn ->
-        Notifications.deliver(user, :weekly_digest, %{})
+        Notifications.deliver_now(user, :weekly_digest, %{})
       end
 
       refute_email_sent()


### PR DESCRIPTION
Closes #126.

## Summary

- Swap the names of the two delivery entry points so `Notifications.deliver/3` is the public async API and `Notifications.deliver_now/3` is the internal sync helper.
- `deliver/3` now enqueues an Oban job and returns `{:ok, %Oban.Job{}} | {:error, term()}` (the "or similar" the issue's acceptance criterion allows). The trigger is validated up front so typos surface at enqueue time.
- `deliver_now/3` is `@doc false`. Only `Huddlz.Notifications.DeliverWorker.perform/1` and the synchronous-pipeline tests should call it.
- All nine `deliver_async(...)` call sites in `lib/` (groups, group members, huddl changes, accounts/user) become `deliver/3`. The `notifications_test.exs` tests of the synchronous pipeline target `deliver_now/3`; the worker enqueue test targets `deliver/3`.

## Why

The async-via-Oban infrastructure already shipped with the foundation work — but the public entry point was named `deliver_async/3` and `deliver/3` was the worker-internal sync path. A caller reaching for the obvious name (`deliver`) would have ended up on the sync path and blocked the request on SMTP. This finishes the rename so the public API matches what #126 asked for.

The other acceptance items were already in place on main:
- Failures retry with backoff (`max_attempts: 5` in `DeliverWorker`).
- Tests use `Oban.Testing` / `Oban.drain_queue` to assert enqueue.
- The `handle_info({:email, _}, _)` LiveView workarounds are gone.

## Test plan

- [x] `mix precommit` clean (1 doctest, 1080 tests, 0 failures, no Credo issues)
- [x] `grep deliver_async lib/ test/` returns nothing