### PR TITLE
Reconcile theme with search-organize prototype

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -18,35 +18,51 @@
   themes: false;
 }
 
-/* ===== CYBERPUNK BRUTALIST DARK THEME ===== */
+/* ===== HUDDLZ DARK THEME =====
+   Reconciled with docs/design/search-organize-prototype.html.
+   Calmer than the previous cyberpunk-brutalist theme: single cyan accent,
+   neutral panels, slightly larger radii, no neon glow by default.
+   Glow utilities are still defined below for opt-in use. */
 @plugin "../vendor/daisyui-theme" {
   name: "dark";
   default: true;
   prefersdark: true;
   color-scheme: "dark";
-  --color-base-100: oklch(8% 0.01 270);
-  --color-base-200: oklch(11% 0.012 270);
-  --color-base-300: oklch(18% 0.015 270);
-  --color-base-content: oklch(93% 0.005 270);
-  --color-primary: oklch(75% 0.18 195);
-  --color-primary-content: oklch(8% 0.01 270);
-  --color-secondary: oklch(65% 0.25 340);
-  --color-secondary-content: oklch(8% 0.01 270);
-  --color-accent: oklch(93% 0.005 270);
-  --color-accent-content: oklch(8% 0.01 270);
-  --color-neutral: oklch(22% 0.01 270);
-  --color-neutral-content: oklch(85% 0.005 270);
-  --color-info: oklch(70% 0.15 230);
-  --color-info-content: oklch(8% 0.01 270);
-  --color-success: oklch(72% 0.2 155);
-  --color-success-content: oklch(8% 0.01 270);
-  --color-warning: oklch(78% 0.18 80);
-  --color-warning-content: oklch(8% 0.01 270);
-  --color-error: oklch(65% 0.25 25);
-  --color-error-content: oklch(95% 0.01 25);
-  --radius-selector: 0rem;
-  --radius-field: 0.125rem;
-  --radius-box: 0.125rem;
+
+  /* Surfaces — match prototype --bg / --panel / --panel-2.
+     Translated to OKLCH for daisyUI consistency. */
+  --color-base-100: oklch(13% 0.005 200);  /* canvas (#020404-ish) */
+  --color-base-200: oklch(16% 0.008 200);  /* cards, dropdowns */
+  --color-base-300: oklch(22% 0.012 200);  /* form fields, segmented borders */
+  --color-base-content: oklch(97% 0.005 200);
+
+  /* Brand cyan — matches prototype --cyan (#18cbd4) */
+  --color-primary: oklch(78% 0.13 195);
+  --color-primary-content: oklch(13% 0.01 200);
+
+  /* Secondary kept restrained (not magenta). Used sparingly. */
+  --color-secondary: oklch(70% 0.10 195);
+  --color-secondary-content: oklch(13% 0.01 200);
+
+  --color-accent: oklch(78% 0.13 195);
+  --color-accent-content: oklch(13% 0.01 200);
+
+  --color-neutral: oklch(20% 0.01 200);
+  --color-neutral-content: oklch(85% 0.005 200);
+
+  --color-info: oklch(72% 0.12 220);
+  --color-info-content: oklch(13% 0.01 200);
+  --color-success: oklch(72% 0.18 155);
+  --color-success-content: oklch(13% 0.01 200);
+  --color-warning: oklch(78% 0.16 80);
+  --color-warning-content: oklch(13% 0.01 200);
+  --color-error: oklch(72% 0.18 25);   /* prototype --danger #ff896f */
+  --color-error-content: oklch(13% 0.01 200);
+
+  /* Radii — prototype: --radius 7px (cards), --radius-sm 5px (fields/chips) */
+  --radius-selector: 0.3125rem;  /* 5px — chips, toggles */
+  --radius-field:    0.3125rem;  /* 5px — inputs, buttons */
+  --radius-box:      0.4375rem;  /* 7px — cards, modals */
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
   --border: 1px;
@@ -62,53 +78,73 @@
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session] { display: contents }
 
-/* ===== CYBERPUNK BRUTALIST GLOBAL STYLES ===== */
+/* ===== HUDDLZ GLOBAL STYLES ===== */
 
-/* Typography */
+html {
+  font-family: 'Inter', system-ui, sans-serif;
+  /* Inter heavy-weight stylistic sets used in the prototype */
+  font-feature-settings: "ss01", "cv11";
+}
+
+/* Typography — display is now Inter heavy, not Space Mono.
+   Keep Space Mono only for mono-labels (eyebrows, KPI captions). */
 @utility font-display {
-  font-family: 'Space Mono', 'Courier New', monospace;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 900;
+  letter-spacing: -0.01em;
 }
 
 @utility font-body {
   font-family: 'Inter', system-ui, sans-serif;
 }
 
-html {
-  font-family: 'Inter', system-ui, sans-serif;
-}
-
-/* Neon glow effect for containers */
-@utility neon-glow {
-  box-shadow: 0 0 8px oklch(75% 0.18 195 / 0.4), 0 0 20px oklch(75% 0.18 195 / 0.1);
-}
-
-/* Neon text glow */
-@utility text-glow {
-  text-shadow: 0 0 10px oklch(75% 0.18 195 / 0.4);
-}
-
-/* Button hover: neon border glow */
-@utility btn-neon {
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
-  &:hover {
-    box-shadow: 0 0 12px oklch(75% 0.18 195 / 0.4);
-    border-color: oklch(75% 0.18 195);
-  }
-  &:active {
-    box-shadow: 0 0 4px oklch(75% 0.18 195 / 0.2);
-  }
-}
-
-/* Monospace label utility */
+/* Mono kicker / eyebrow / KPI label — Space Mono survives here only */
 @utility mono-label {
   font-family: 'Space Mono', monospace;
-  font-size: 0.65rem;
+  font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
-/* Sharp-edged checkbox in cyberpunk-brutalist style. */
+/* ===== Soft elevation (replaces neon-glow as the default) =====
+   Use --shadow-pop on modals and floating panels. */
+@utility shadow-pop {
+  box-shadow: 0 28px 80px oklch(0% 0 0 / 0.56);
+}
+
+/* Sticky form-actions backdrop. */
+@utility blur-bg {
+  background: oklch(13% 0.01 200 / 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+/* ===== Glow utilities — kept for opt-in use only =====
+   Previously applied by default on every button via btn-neon.
+   The prototype doesn't use them, so the new core_components don't either.
+   Leave them defined so existing screens that rely on them still render. */
+@utility neon-glow {
+  box-shadow: 0 0 8px oklch(78% 0.13 195 / 0.3),
+              0 0 20px oklch(78% 0.13 195 / 0.08);
+}
+
+@utility text-glow {
+  /* Down from a 10px halo to a subtle 4px lift — matches prototype's
+     restrained type treatment without breaking screens that reference it. */
+  text-shadow: 0 0 4px oklch(78% 0.13 195 / 0.25);
+}
+
+/* btn-neon was the cyberpunk default. Kept for backward compat but
+   neutralised: a small border-colour transition on hover, no glow. */
+@utility btn-neon {
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+  &:hover {
+    border-color: oklch(78% 0.13 195);
+  }
+}
+
+/* Sharp-edged checkbox in prototype style. */
 @utility checkbox-cyber {
   appearance: none;
   width: 1rem;
@@ -118,6 +154,7 @@ html {
   background-color: transparent;
   cursor: pointer;
   position: relative;
+  border-radius: 0.1875rem;
   transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 
   &:hover {
@@ -150,4 +187,3 @@ html {
     opacity: 0.5;
   }
 }
-

--- a/lib/huddlz_web/components/community_components.ex
+++ b/lib/huddlz_web/components/community_components.ex
@@ -1,6 +1,10 @@
 defmodule HuddlzWeb.CommunityComponents do
   @moduledoc """
   Reusable UI components for communities domain (groups and huddlz).
+
+  Reconciled with the search-organize prototype: rounded corners use the
+  theme `--radius-box` (7px), titles use Inter heavy weights instead of
+  Space Mono, status pills use the prototype's uppercase-mono badge.
   """
   use Phoenix.Component
   use HuddlzWeb, :verified_routes
@@ -12,11 +16,6 @@ defmodule HuddlzWeb.CommunityComponents do
 
   @doc """
   Renders a list of huddlz with empty state handling.
-
-  ## Examples
-
-      <.huddl_list huddlz={@upcoming_huddlz} empty_message="No upcoming huddlz scheduled." />
-      <.huddl_list huddlz={@huddlz} show_group={true} empty_message="No huddlz found." />
   """
   attr :huddlz, :list, required: true
   attr :empty_message, :string, default: "No huddlz found."
@@ -38,10 +37,6 @@ defmodule HuddlzWeb.CommunityComponents do
 
   @doc """
   Renders a group card with 16:9 banner image and content below.
-
-  ## Examples
-
-      <.group_card group={group} />
   """
   attr :group, :map, required: true
   attr :class, :string, default: nil
@@ -52,12 +47,12 @@ defmodule HuddlzWeb.CommunityComponents do
     <.link
       navigate={~p"/groups/#{@group.slug}"}
       class={[
-        "border border-base-300 overflow-hidden hover:border-primary/30 transition-colors group flex flex-col",
+        "border border-base-300 rounded overflow-hidden bg-base-200 hover:border-primary/50 transition-colors group flex flex-col",
         @class
       ]}
       {@rest}
     >
-      <div class="aspect-video overflow-hidden relative bg-base-200 flex-shrink-0">
+      <div class="aspect-video overflow-hidden relative bg-base-300 flex-shrink-0">
         <%= if @group.current_image_url do %>
           <img
             src={GroupImages.url(@group.current_image_url)}
@@ -66,18 +61,18 @@ defmodule HuddlzWeb.CommunityComponents do
           />
         <% else %>
           <div class="w-full h-full bg-base-100 flex items-center justify-center">
-            <span class="text-2xl font-bold text-base-content/30 text-center px-4 line-clamp-2">
+            <span class="text-2xl font-extrabold text-base-content/30 text-center px-4 line-clamp-2">
               {@group.name}
             </span>
           </div>
         <% end %>
       </div>
       <div class="p-4 flex-1">
-        <h2 class="font-display tracking-tight">{@group.name}</h2>
-        <p class="text-sm text-base-content/40 line-clamp-2 mt-1">
+        <h2 class="text-base font-extrabold leading-snug text-base-content">{@group.name}</h2>
+        <p class="text-sm text-base-content/50 line-clamp-2 mt-1.5 leading-relaxed">
           {@group.description || "No description provided."}
         </p>
-        <p :if={@group.location} class="text-xs text-base-content/50 mt-2 flex items-center gap-1">
+        <p :if={@group.location} class="text-xs text-base-content/50 mt-3 flex items-center gap-1">
           <.icon name="hero-map-pin" class="h-3 w-3" /> {@group.location}
         </p>
       </div>
@@ -87,10 +82,6 @@ defmodule HuddlzWeb.CommunityComponents do
 
   @doc """
   Renders a grid of group cards with empty state handling.
-
-  ## Examples
-
-      <.group_list groups={@groups} empty_message="No groups found." />
   """
   attr :groups, :list, required: true
   attr :empty_message, :string, default: "No groups found."
@@ -111,10 +102,6 @@ defmodule HuddlzWeb.CommunityComponents do
 
   @doc """
   Renders a huddl card with 16:9 banner image and content below.
-
-  ## Examples
-
-      <.huddl_card huddl={@huddl} />
   """
   attr :huddl, :map, required: true
   attr :show_group, :boolean, default: false
@@ -127,12 +114,12 @@ defmodule HuddlzWeb.CommunityComponents do
     <.link
       navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}
       class={[
-        "border border-base-300 overflow-hidden hover:border-primary/30 transition-colors group flex flex-col",
+        "border border-base-300 rounded overflow-hidden bg-base-200 hover:border-primary/50 transition-colors group flex flex-col",
         @class
       ]}
       {@rest}
     >
-      <div class="aspect-video overflow-hidden relative bg-base-200 flex-shrink-0">
+      <div class="aspect-video overflow-hidden relative bg-base-300 flex-shrink-0">
         <%= if @huddl.display_image_url do %>
           <img
             src={HuddlImages.url(@huddl.display_image_url)}
@@ -141,7 +128,7 @@ defmodule HuddlzWeb.CommunityComponents do
           />
         <% else %>
           <div class="w-full h-full flex items-center justify-center bg-base-100">
-            <span class="text-base-content/30 font-display text-lg text-center px-3 line-clamp-2">
+            <span class="text-base-content/30 text-lg font-extrabold text-center px-3 line-clamp-2">
               {@huddl.title}
             </span>
           </div>
@@ -150,20 +137,18 @@ defmodule HuddlzWeb.CommunityComponents do
           <.huddl_status_badge status={@huddl.status} />
         </div>
         <div :if={@huddl.is_private} class="absolute top-2 left-2">
-          <span class="text-xs px-2 py-0.5 bg-base-300/80 text-base-content/50">
-            Private
-          </span>
+          <.huddl_badge>Private</.huddl_badge>
         </div>
       </div>
       <div class="p-4 flex-1 flex flex-col">
-        <h3 class="font-display tracking-tight">{@huddl.title}</h3>
+        <h3 class="text-base font-extrabold leading-snug text-base-content">{@huddl.title}</h3>
         <%= if @show_group && Map.has_key?(@huddl, :group) do %>
-          <p class="text-xs text-base-content/50 mt-0.5 flex items-center gap-1">
+          <p class="text-xs text-base-content/50 mt-1 flex items-center gap-1">
             <.icon name="hero-user-group" class="h-3 w-3" />
             {@huddl.group.name}
           </p>
         <% end %>
-        <p class="text-sm text-base-content/40 mt-1 line-clamp-2">
+        <p class="text-sm text-base-content/50 mt-1.5 line-clamp-2 leading-relaxed">
           {truncate(@huddl.description || "No description provided", 150)}
         </p>
         <div class="flex flex-wrap gap-x-3 gap-y-1 mt-3 text-xs text-base-content/50">
@@ -192,7 +177,7 @@ defmodule HuddlzWeb.CommunityComponents do
             </span>
           <% end %>
           <%= if @distance do %>
-            <span class="flex items-center gap-1 text-primary/70">
+            <span class="flex items-center gap-1 text-primary/80">
               <.icon name="hero-map-pin" class="h-3.5 w-3.5" />
               {format_distance(@distance)}
             </span>
@@ -203,7 +188,7 @@ defmodule HuddlzWeb.CommunityComponents do
             <div class="flex items-center justify-between text-xs">
               <span class={capacity_status_class(@huddl)}>{capacity_status(@huddl)}</span>
             </div>
-            <div class="mt-1.5 h-1.5 bg-base-200 overflow-hidden">
+            <div class="mt-1.5 h-1.5 bg-base-300 rounded-sm overflow-hidden">
               <div class="h-full bg-primary" style={"width: #{capacity_percent(@huddl)}%"}></div>
             </div>
           </div>
@@ -214,6 +199,33 @@ defmodule HuddlzWeb.CommunityComponents do
   end
 
   @doc """
+  Renders a small uppercase-mono pill — the prototype's badge vocabulary.
+  Use directly, or via `huddl_status_badge` / `huddl_type_badge`.
+  """
+  attr :variant, :string, default: "default", values: ~w(default cyan outline danger)
+  attr :class, :string, default: nil
+  slot :inner_block, required: true
+
+  def huddl_badge(assigns) do
+    ~H"""
+    <span class={[
+      "inline-flex items-center min-h-[22px] px-2 rounded-sm text-[10px] font-extrabold uppercase tracking-wider leading-none",
+      huddl_badge_classes(@variant),
+      @class
+    ]}>
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  defp huddl_badge_classes("default"),
+    do: "border border-base-300 text-base-content/70 bg-base-200"
+
+  defp huddl_badge_classes("cyan"), do: "border border-primary text-primary bg-primary/10"
+  defp huddl_badge_classes("outline"), do: "border border-base-300 text-base-content/60"
+  defp huddl_badge_classes("danger"), do: "border border-error text-error"
+
+  @doc """
   Renders a huddl status badge.
   """
   attr :status, :atom, required: true
@@ -221,13 +233,9 @@ defmodule HuddlzWeb.CommunityComponents do
 
   def huddl_status_badge(assigns) do
     ~H"""
-    <span class={[
-      "text-xs px-2 py-0.5 font-medium border border-current/20",
-      status_badge_class(@status),
-      @class
-    ]}>
+    <.huddl_badge variant={status_badge_variant(@status)} class={@class}>
       {humanize(@status)}
-    </span>
+    </.huddl_badge>
     """
   end
 
@@ -239,23 +247,15 @@ defmodule HuddlzWeb.CommunityComponents do
 
   def huddl_type_badge(assigns) do
     ~H"""
-    <span class={[
-      "text-xs px-2 py-0.5 font-medium inline-flex items-center gap-1 border border-current/20",
-      type_badge_class(@type),
-      @class
-    ]}>
-      <.icon name={type_icon(@type)} class="h-3 w-3" />
+    <.huddl_badge variant="outline" class={@class}>
+      <.icon name={type_icon(@type)} class="h-3 w-3 mr-1" />
       {humanize(@type)}
-    </span>
+    </.huddl_badge>
     """
   end
 
   @doc """
   Renders a member card showing user display name and optional owner badge.
-
-  ## Examples
-
-      <.member_card member={member} is_owner={member.id == @group.owner_id} />
   """
   attr :member, :map, required: true
   attr :is_owner, :boolean, default: false
@@ -265,7 +265,7 @@ defmodule HuddlzWeb.CommunityComponents do
     <div class="flex items-center gap-3 py-2">
       <.avatar user={@member} size={:sm} />
       <div class="flex-1 min-w-0">
-        <p class="font-medium text-sm truncate">
+        <p class="font-bold text-sm truncate">
           {@member.display_name || "User"}
         </p>
       </div>
@@ -280,15 +280,6 @@ defmodule HuddlzWeb.CommunityComponents do
 
   @doc """
   Renders a grid of group members with permission-based visibility.
-
-  ## Examples
-
-      <.member_list
-        members={@members}
-        member_count={@member_count}
-        owner_id={@group.owner_id}
-        current_user={@current_user}
-      />
   """
   attr :members, :list, default: nil
   attr :member_count, :integer, required: true
@@ -298,9 +289,9 @@ defmodule HuddlzWeb.CommunityComponents do
   def member_list(assigns) do
     ~H"""
     <div class="mt-10">
-      <h3 class="font-display text-lg tracking-tight text-glow flex items-center gap-2">
+      <h3 class="text-lg font-extrabold tracking-tight text-base-content flex items-center gap-2">
         <.icon name="hero-users" class="w-5 h-5 text-base-content/40" /> Members
-        <span class="text-sm font-body font-normal text-base-content/50">({@member_count})</span>
+        <span class="text-sm font-normal text-base-content/50">({@member_count})</span>
       </h3>
       <%= if @members do %>
         <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -321,17 +312,12 @@ defmodule HuddlzWeb.CommunityComponents do
     """
   end
 
-  # Huddl helper functions
+  # Helper functions
 
-  defp status_badge_class(:upcoming), do: "bg-primary/10 text-primary"
-  defp status_badge_class(:in_progress), do: "bg-success/10 text-success"
-  defp status_badge_class(:completed), do: "bg-base-200 text-base-content/50"
-  defp status_badge_class(_), do: "bg-base-200 text-base-content/50"
-
-  defp type_badge_class(:in_person), do: "bg-info/10 text-info"
-  defp type_badge_class(:virtual), do: "bg-warning/10 text-warning"
-  defp type_badge_class(:hybrid), do: "bg-secondary/10 text-secondary"
-  defp type_badge_class(_), do: "bg-base-200 text-base-content/50"
+  defp status_badge_variant(:upcoming), do: "cyan"
+  defp status_badge_variant(:in_progress), do: "cyan"
+  defp status_badge_variant(:completed), do: "default"
+  defp status_badge_variant(_), do: "default"
 
   defp type_icon(:in_person), do: "hero-map-pin"
   defp type_icon(:virtual), do: "hero-video-camera"
@@ -366,9 +352,9 @@ defmodule HuddlzWeb.CommunityComponents do
   defp capacity_status_for_tier(:filling_up), do: "Filling up"
   defp capacity_status_for_tier(:plenty), do: "Plenty of space"
 
-  defp capacity_status_class_for_tier(:full), do: "font-semibold text-error"
-  defp capacity_status_class_for_tier(:almost_full), do: "font-semibold text-warning"
-  defp capacity_status_class_for_tier(_), do: "font-semibold text-success"
+  defp capacity_status_class_for_tier(:full), do: "font-bold text-error"
+  defp capacity_status_class_for_tier(:almost_full), do: "font-bold text-warning"
+  defp capacity_status_class_for_tier(_), do: "font-bold text-success"
 
   defp truncate(text, max_length) when is_binary(text) and byte_size(text) > max_length do
     String.slice(text, 0, max_length) <> "..."

--- a/lib/huddlz_web/components/core_components.ex
+++ b/lib/huddlz_web/components/core_components.ex
@@ -2,29 +2,15 @@ defmodule HuddlzWeb.CoreComponents do
   @moduledoc """
   Provides core UI components.
 
-  At first glance, this module may seem daunting, but its goal is to provide
-  core building blocks for your application, such as tables, forms, and
-  inputs. The components consist mostly of markup and are well-documented
-  with doc strings and declarative assigns. You may customize and style
-  them in any way you want, based on your application growth and needs.
+  Reconciled with the huddlz search-organize prototype:
+  buttons use Inter heavy weights instead of uppercase Space Mono;
+  inputs are bordered fields on a panel surface; modal uses a soft
+  shadow-pop instead of the cyan-glow halo.
 
-  The foundation for styling is Tailwind CSS, a utility-first CSS framework,
-  augmented with daisyUI, a Tailwind CSS plugin that provides UI components
-  and themes. Here are useful references:
-
-    * [daisyUI](https://daisyui.com/docs/intro/) - a good place to get
-      started and see the available components.
-
-    * [Tailwind CSS](https://tailwindcss.com) - the foundational framework
-      we build on. You will use it for layout, sizing, flexbox, grid, and
-      spacing.
-
-    * [Heroicons](https://heroicons.com) - see `icon/1` for usage.
-
-    * [Phoenix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html) -
-      the component system used by Phoenix. Some components, such as `<.link>`
-      and `<.form>`, are defined there.
-
+    * [daisyUI](https://daisyui.com/docs/intro/)
+    * [Tailwind CSS](https://tailwindcss.com)
+    * [Heroicons](https://heroicons.com) — see `icon/1`
+    * [Phoenix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html)
   """
   use Phoenix.Component
   use Gettext, backend: HuddlzWeb.Gettext
@@ -34,16 +20,10 @@ defmodule HuddlzWeb.CoreComponents do
   alias Phoenix.HTML.Form
   alias Phoenix.LiveView.JS
 
-  # Import verified routes for ~p sigil
   use HuddlzWeb, :verified_routes
 
   @doc """
   Renders flash notices.
-
-  ## Examples
-
-      <.flash kind={:info} flash={@flash} />
-      <.flash kind={:info} phx-mounted={show("#flash")}>Welcome Back!</.flash>
   """
   attr :id, :string, doc: "the optional id of flash container"
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
@@ -66,7 +46,7 @@ defmodule HuddlzWeb.CoreComponents do
       {@rest}
     >
       <div class={[
-        "flex items-center gap-3 border px-4 py-3 text-sm",
+        "flex items-center gap-3 border rounded px-4 py-3 text-sm",
         @kind == :info && "border-primary/30 bg-primary/5 text-primary",
         @kind == :error && "border-error/30 bg-error/5 text-error"
       ]}>
@@ -95,11 +75,12 @@ defmodule HuddlzWeb.CoreComponents do
   @doc """
   Renders a button with navigation support.
 
-  ## Examples
+  Variants follow the prototype:
 
-      <.button>Send!</.button>
-      <.button phx-click="go" variant="primary">Send!</.button>
-      <.button navigate={~p"/"}>Home</.button>
+    * `nil` (default) — outline: panel surface, line-strong border
+    * `"primary"` — cyan fill (one per surface; the headline action)
+    * `"danger"` — destructive outline (or fill with `solid` size combo)
+    * `"ghost"` — transparent, used in dense headers/menus
   """
   attr :rest, :global, include: ~w(href navigate patch method disabled)
   attr :variant, :string, values: ~w(primary danger ghost)
@@ -109,15 +90,18 @@ defmodule HuddlzWeb.CoreComponents do
 
   def button(%{rest: rest} = assigns) do
     variants = %{
-      "primary" => "bg-primary text-primary-content border border-primary btn-neon",
-      "danger" => "bg-error text-error-content border border-error btn-neon",
-      "ghost" => "bg-transparent text-primary border-0 hover:underline font-body",
-      nil => "bg-transparent text-primary border border-primary/40 btn-neon hover:bg-primary/10"
+      "primary" =>
+        "bg-primary text-primary-content border border-primary font-extrabold hover:brightness-110",
+      "danger" =>
+        "bg-transparent text-error border border-error font-extrabold hover:bg-error/10",
+      "ghost" =>
+        "bg-transparent text-base-content/70 border border-transparent hover:bg-base-200 hover:text-base-content",
+      nil => "bg-base-200 text-base-content border border-base-300 hover:bg-base-300 font-bold"
     }
 
     sizes = %{
       "sm" => "px-3 py-1 text-xs",
-      "md" => "px-5 py-2 text-sm"
+      "md" => "px-4 h-[42px] text-sm"
     }
 
     ghost_sizes = %{"sm" => "text-xs", "md" => "text-sm"}
@@ -131,21 +115,13 @@ defmodule HuddlzWeb.CoreComponents do
     assigns =
       assigns
       |> assign(:variant_class, Map.fetch!(variants, assigns[:variant]))
-      |> assign(
-        :text_style_class,
-        if(assigns[:variant] == "ghost",
-          do: "tracking-normal normal-case",
-          else: "tracking-wide uppercase font-display"
-        )
-      )
       |> assign(:size_class, size_class)
 
     if rest[:href] || rest[:navigate] || rest[:patch] do
       ~H"""
       <.link
         class={[
-          "inline-flex items-center justify-center gap-2 font-medium",
-          @text_style_class,
+          "inline-flex items-center justify-center gap-2 rounded-sm transition",
           @size_class,
           @variant_class,
           @class
@@ -159,8 +135,7 @@ defmodule HuddlzWeb.CoreComponents do
       ~H"""
       <button
         class={[
-          "inline-flex items-center justify-center gap-2 font-medium",
-          @text_style_class,
+          "inline-flex items-center justify-center gap-2 rounded-sm transition",
           @size_class,
           @variant_class,
           @class
@@ -176,28 +151,8 @@ defmodule HuddlzWeb.CoreComponents do
   @doc """
   Renders an input with label and error messages.
 
-  A `Phoenix.HTML.FormField` may be passed as argument,
-  which is used to retrieve the input name, id, and values.
-  Otherwise all attributes may be passed explicitly.
-
-  ## Types
-
-  This function accepts all HTML input types, considering that:
-
-    * You may also set `type="select"` to render a `<select>` tag
-
-    * `type="checkbox"` is used exclusively to render boolean values
-
-    * For live file uploads, see `Phoenix.Component.live_file_input/1`
-
-  See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
-  for more information. Unsupported types, such as hidden and radio,
-  are best written directly in your templates.
-
-  ## Examples
-
-      <.input field={@form[:email]} type="email" />
-      <.input name="my-input" errors={["oh no!"]} />
+  Bordered fields on a panel surface (matches the prototype). Pass either
+  a `Phoenix.HTML.FormField` via `:field` or raw `:name`/`:value`.
   """
   attr :id, :any, default: nil
   attr :name, :any
@@ -267,7 +222,7 @@ defmodule HuddlzWeb.CoreComponents do
       <label
         :if={@label}
         for={@id}
-        class="mono-label text-primary/70 mb-1.5 block"
+        class="mono-label text-base-content/60 mb-2 block"
       >
         {@label}
       </label>
@@ -276,7 +231,7 @@ defmodule HuddlzWeb.CoreComponents do
         name={@name}
         class={[
           @class ||
-            "w-full h-10 border-0 border-b border-base-300 bg-transparent focus:border-primary focus:ring-0 focus:outline-none text-base-content text-sm",
+            "w-full h-11 px-3 rounded-sm bg-base-200 text-base-content text-sm border border-base-300 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none transition",
           @errors != [] && (@error_class || "border-error")
         ]}
         multiple={@multiple}
@@ -296,7 +251,7 @@ defmodule HuddlzWeb.CoreComponents do
       <label
         :if={@label}
         for={@id}
-        class="mono-label text-primary/70 mb-1.5 block"
+        class="mono-label text-base-content/60 mb-2 block"
       >
         {@label}
       </label>
@@ -305,7 +260,7 @@ defmodule HuddlzWeb.CoreComponents do
         name={@name}
         class={[
           @class ||
-            "w-full py-2 border-0 border-b border-base-300 bg-transparent focus:border-primary focus:ring-0 focus:outline-none text-base-content text-sm",
+            "w-full px-3 py-2.5 rounded-sm bg-base-200 text-base-content text-sm leading-relaxed border border-base-300 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none transition resize-y",
           @errors != [] && (@error_class || "border-error")
         ]}
         {@rest}
@@ -322,7 +277,7 @@ defmodule HuddlzWeb.CoreComponents do
       <label
         :if={@label}
         for={@id}
-        class="mono-label text-primary/70 mb-1.5 block"
+        class="mono-label text-base-content/60 mb-2 block"
       >
         {@label}
       </label>
@@ -333,7 +288,7 @@ defmodule HuddlzWeb.CoreComponents do
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
           @class ||
-            "w-full h-10 border-0 border-b border-base-300 bg-transparent focus:border-primary focus:ring-0 focus:outline-none text-base-content text-sm",
+            "w-full h-11 px-3 rounded-sm bg-base-200 text-base-content text-sm border border-base-300 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none transition placeholder:text-base-content/40",
           @errors != [] && (@error_class || "border-error")
         ]}
         {@rest}
@@ -343,7 +298,6 @@ defmodule HuddlzWeb.CoreComponents do
     """
   end
 
-  # Helper used by inputs to generate form errors
   defp error(assigns) do
     ~H"""
     <p class="mt-1.5 flex gap-2 items-center text-sm text-error">
@@ -366,10 +320,10 @@ defmodule HuddlzWeb.CoreComponents do
     ~H"""
     <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-6", @class]}>
       <div>
-        <h1 class="font-display text-2xl md:text-3xl tracking-tight text-base-content text-glow">
+        <h1 class="text-2xl md:text-3xl font-extrabold tracking-tight text-base-content">
           {render_slot(@inner_block)}
         </h1>
-        <p :if={@subtitle != []} class="mt-1 text-sm text-base-content/40">
+        <p :if={@subtitle != []} class="mt-1 text-sm text-base-content/50">
           {render_slot(@subtitle)}
         </p>
       </div>
@@ -380,13 +334,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc ~S"""
   Renders a table with generic styling.
-
-  ## Examples
-
-      <.table id="users" rows={@users}>
-        <:col :let={user} label="id">{user.id}</:col>
-        <:col :let={user} label="username">{user.username}</:col>
-      </.table>
   """
   attr :id, :string, required: true
   attr :rows, :list, required: true
@@ -410,13 +357,13 @@ defmodule HuddlzWeb.CoreComponents do
       end
 
     ~H"""
-    <div class="overflow-x-auto border border-base-300">
+    <div class="overflow-x-auto border border-base-300 rounded">
       <table class="table">
         <thead>
           <tr class="border-b border-base-300">
             <th
               :for={col <- @col}
-              class="mono-label text-primary/60 bg-base-200/30"
+              class="mono-label text-base-content/50 bg-base-200/30"
             >
               {col[:label]}
             </th>
@@ -454,13 +401,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a data list.
-
-  ## Examples
-
-      <.list>
-        <:item title="Title">{@post.title}</:item>
-        <:item title="Views">{@post.views}</:item>
-      </.list>
   """
   slot :item, required: true do
     attr :title, :string, required: true
@@ -481,21 +421,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a [Heroicon](https://heroicons.com).
-
-  Heroicons come in three styles – outline, solid, and mini.
-  By default, the outline style is used, but solid and mini may
-  be applied by using the `-solid` and `-mini` suffix.
-
-  You can customize the size and colors of the icons by setting
-  width, height, and background color classes.
-
-  Icons are extracted from the `deps/heroicons` directory and bundled within
-  your compiled app.css by the plugin in `assets/vendor/heroicons.js`.
-
-  ## Examples
-
-      <.icon name="hero-x-mark-solid" />
-      <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
   """
   attr :name, :string, required: true
   attr :class, :string, default: "size-4"
@@ -508,12 +433,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a user avatar with fallback to initials or icon.
-
-  ## Examples
-
-      <.avatar user={@current_user} />
-      <.avatar user={@member} size={:sm} />
-      <.avatar user={nil} size={:lg} />
   """
   attr :user, :map,
     default: nil,
@@ -548,7 +467,7 @@ defmodule HuddlzWeb.CoreComponents do
 
     ~H"""
     <div class={[
-      "flex items-center justify-center flex-shrink-0 overflow-hidden",
+      "flex items-center justify-center flex-shrink-0 overflow-hidden rounded-full",
       @size_class,
       @class
     ]}>
@@ -622,13 +541,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a modal dialog as an overlay.
-
-  ## Examples
-
-      <.modal id="add-location" show on_cancel={JS.navigate(~p"/back")}>
-        <h2>Add Location</h2>
-        ...
-      </.modal>
   """
   attr :id, :string, required: true
   attr :show, :boolean, default: false
@@ -663,7 +575,7 @@ defmodule HuddlzWeb.CoreComponents do
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
               phx-key="escape"
               phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
-              class="relative border border-base-300 bg-base-200 shadow-[0_0_30px_oklch(75%_0.18_195/0.15)] p-6"
+              class="relative border border-base-300 bg-base-200 rounded shadow-pop p-6"
             >
               <button
                 phx-click={JS.exec("data-cancel", to: "##{@id}")}
@@ -710,9 +622,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders an atom or string as a human-readable label.
-
-  Underscores become spaces and the first letter is capitalized.
-  Use for enum values like `:in_person` → `"In person"`.
   """
   def humanize(value) do
     value
@@ -741,10 +650,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders pagination controls.
-
-  ## Examples
-
-      <.pagination current_page={@page} total_pages={@total_pages} event_name="change_page" />
   """
   attr :current_page, :integer, required: true
   attr :total_pages, :integer, required: true
@@ -757,7 +662,7 @@ defmodule HuddlzWeb.CoreComponents do
       <div class="flex items-center gap-1">
         <button
           :if={@current_page > 1}
-          class="px-3 py-1.5 text-sm font-medium border border-base-300 btn-neon transition-colors"
+          class="px-3 py-1.5 text-sm font-bold border border-base-300 rounded-sm hover:border-primary transition-colors"
           phx-click={@event_name}
           phx-value-page={@current_page - 1}
         >
@@ -770,9 +675,9 @@ defmodule HuddlzWeb.CoreComponents do
           <% else %>
             <button
               class={[
-                "w-8 h-8 text-sm font-medium font-display transition-colors",
+                "w-8 h-8 text-sm font-bold rounded-sm transition-colors",
                 if(page == @current_page,
-                  do: "bg-primary text-primary-content neon-glow",
+                  do: "bg-primary text-primary-content",
                   else: "hover:bg-base-300"
                 )
               ]}
@@ -786,7 +691,7 @@ defmodule HuddlzWeb.CoreComponents do
 
         <button
           :if={@current_page < @total_pages}
-          class="px-3 py-1.5 text-sm font-medium border border-base-300 btn-neon transition-colors"
+          class="px-3 py-1.5 text-sm font-bold border border-base-300 rounded-sm hover:border-primary transition-colors"
           phx-click={@event_name}
           phx-value-page={@current_page + 1}
         >
@@ -797,7 +702,6 @@ defmodule HuddlzWeb.CoreComponents do
     """
   end
 
-  # Helper function to generate pagination range
   defp pagination_range(_current_page, total_pages) when total_pages <= 7 do
     1..total_pages |> Enum.to_list()
   end
@@ -825,11 +729,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a date picker input.
-
-  ## Examples
-
-      <.date_picker field={@form[:date]} />
-      <.date_picker name="event_date" value={@date} />
   """
   attr :id, :any, default: nil
   attr :name, :any
@@ -859,7 +758,7 @@ defmodule HuddlzWeb.CoreComponents do
     <fieldset class="fieldset mb-4">
       <label
         for={@id}
-        class="mono-label text-primary/70 mb-1.5 block"
+        class="mono-label text-base-content/60 mb-2 block"
       >
         {@label}
       </label>
@@ -871,7 +770,7 @@ defmodule HuddlzWeb.CoreComponents do
           value={@value}
           min={@min}
           class={[
-            "input border border-base-300 bg-base-100/5 w-full pr-10 focus:border-primary focus:ring-0 text-base-content",
+            "w-full h-11 px-3 pr-10 rounded-sm bg-base-200 border border-base-300 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none text-base-content text-sm transition",
             @errors != [] && "border-error"
           ]}
           {@rest}
@@ -888,11 +787,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a time picker with 15-minute increments and manual entry.
-
-  ## Examples
-
-      <.time_picker field={@form[:start_time]} />
-      <.time_picker name="start_time" value={@time} />
   """
   attr :id, :any, default: nil
   attr :name, :any
@@ -919,7 +813,7 @@ defmodule HuddlzWeb.CoreComponents do
     <fieldset class="fieldset mb-4">
       <label
         for={@id}
-        class="mono-label text-primary/70 mb-1.5 block"
+        class="mono-label text-base-content/60 mb-2 block"
       >
         {@label}
       </label>
@@ -931,7 +825,7 @@ defmodule HuddlzWeb.CoreComponents do
         list={"time-options-#{@id}"}
         class={[
           @class ||
-            "input border border-base-300 bg-base-100/5 w-full focus:border-primary focus:ring-0 text-base-content",
+            "w-full h-11 px-3 rounded-sm bg-base-200 border border-base-300 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none text-base-content text-sm transition",
           @errors != [] && "border-error"
         ]}
         {@rest}
@@ -951,11 +845,6 @@ defmodule HuddlzWeb.CoreComponents do
 
   @doc """
   Renders a duration picker with preset options.
-
-  ## Examples
-
-      <.duration_picker field={@form[:duration_minutes]} />
-      <.duration_picker name="duration" value={60} />
   """
   attr :id, :any, default: nil
   attr :name, :any
@@ -982,7 +871,7 @@ defmodule HuddlzWeb.CoreComponents do
     <fieldset class="fieldset mb-4">
       <label
         for={@id}
-        class="mono-label text-primary/70 mb-1.5 block"
+        class="mono-label text-base-content/60 mb-2 block"
       >
         {@label}
       </label>
@@ -991,7 +880,7 @@ defmodule HuddlzWeb.CoreComponents do
         name={@name}
         class={[
           @class ||
-            "select border border-base-300 bg-base-100/5 w-full focus:border-primary focus:ring-0 text-base-content",
+            "w-full h-11 px-3 rounded-sm bg-base-200 border border-base-300 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none text-base-content text-sm transition",
           @errors != [] && "border-error"
         ]}
         {@rest}
@@ -1011,7 +900,6 @@ defmodule HuddlzWeb.CoreComponents do
     """
   end
 
-  # Helper function for time picker options
   defp time_option_value(hour, minute) do
     hour_str = hour |> Integer.to_string() |> String.pad_leading(2, "0")
     minute_str = minute |> Integer.to_string() |> String.pad_leading(2, "0")

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -2,10 +2,9 @@ defmodule HuddlzWeb.Layouts do
   @moduledoc """
   This module holds different layouts used by your application.
 
-  See the `layouts` directory for all templates available.
-  The "root" layout is a skeleton rendered as part of the
-  application router. The "app" layout is rendered as component
-  in regular views and live views.
+  Reconciled with the search-organize prototype: header search button uses
+  Inter heavy weight at sentence case (no Space Mono uppercase); user
+  dropdown and mobile menu use rounded-sm corners matching the new theme.
   """
   use HuddlzWeb, :html
 
@@ -18,7 +17,7 @@ defmodule HuddlzWeb.Layouts do
         <div class="flex h-20 items-center gap-5">
           <%!-- Brand --%>
           <a href="/" class="flex items-center flex-shrink-0">
-            <span class="font-display text-2xl tracking-tighter text-glow">huddlz</span>
+            <span class="text-2xl font-extrabold tracking-tight">huddlz</span>
           </a>
 
           <%!-- Search (desktop) --%>
@@ -27,7 +26,7 @@ defmodule HuddlzWeb.Layouts do
             action="/discover"
             role="search"
             aria-label="Search huddlz"
-            class="hidden md:flex flex-1 max-w-2xl items-stretch h-12 border border-base-300 rounded-md overflow-hidden bg-base-200/40 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/15 transition-colors"
+            class="hidden md:flex flex-1 max-w-2xl items-stretch h-12 border border-base-300 rounded-sm overflow-hidden bg-base-200/40 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/15 transition-colors"
           >
             <span class="grid place-items-center w-12 text-primary flex-shrink-0">
               <.icon name="hero-magnifying-glass" class="w-5 h-5" />
@@ -42,7 +41,7 @@ defmodule HuddlzWeb.Layouts do
             />
             <button
               type="submit"
-              class="flex-shrink-0 px-6 bg-primary text-primary-content font-display uppercase text-xs font-black tracking-wider hover:bg-primary/90 transition-colors"
+              class="flex-shrink-0 px-6 bg-primary text-primary-content text-sm font-extrabold hover:brightness-110 transition-colors"
             >
               Search
             </button>
@@ -76,7 +75,7 @@ defmodule HuddlzWeb.Layouts do
                   phx-click-away={JS.hide(to: "#user-menu")}
                   phx-window-keydown={JS.hide(to: "#user-menu")}
                   phx-key="escape"
-                  class="hidden absolute right-0 mt-3 z-50 border border-base-300 bg-base-200 w-64 shadow-xl shadow-primary/5 rounded-md overflow-hidden"
+                  class="hidden absolute right-0 mt-3 z-50 border border-base-300 bg-base-200 w-64 shadow-pop rounded overflow-hidden"
                 >
                   <li class="px-4 py-3 border-b border-base-300">
                     <p class="text-sm font-bold truncate">
@@ -150,13 +149,13 @@ defmodule HuddlzWeb.Layouts do
             <% else %>
               <a
                 href="/register"
-                class="inline-flex items-center h-12 px-5 text-sm font-bold border border-base-300 rounded-md text-base-content hover:border-primary hover:text-primary transition-colors"
+                class="inline-flex items-center h-12 px-5 text-sm font-bold border border-base-300 rounded-sm text-base-content hover:border-primary hover:text-primary transition-colors"
               >
                 Sign Up
               </a>
               <a
                 href="/sign-in"
-                class="inline-flex items-center h-12 px-5 text-sm font-bold bg-primary text-primary-content rounded-md hover:bg-primary/90 transition-colors"
+                class="inline-flex items-center h-12 px-5 text-sm font-extrabold bg-primary text-primary-content rounded-sm hover:brightness-110 transition-colors"
               >
                 Sign In
               </a>
@@ -164,7 +163,7 @@ defmodule HuddlzWeb.Layouts do
             <%!-- Mobile menu button --%>
             <button
               type="button"
-              class="md:hidden grid place-items-center w-12 h-12 border border-base-300 rounded-md hover:border-primary transition-colors"
+              class="md:hidden grid place-items-center w-12 h-12 border border-base-300 rounded-sm hover:border-primary transition-colors"
               phx-click={JS.toggle(to: "#mobile-menu")}
               aria-label="Open menu"
             >
@@ -179,7 +178,7 @@ defmodule HuddlzWeb.Layouts do
           action="/discover"
           role="search"
           aria-label="Search huddlz"
-          class="md:hidden pb-4 flex items-stretch h-12 border border-base-300 rounded-md overflow-hidden bg-base-200/40 focus-within:border-primary"
+          class="md:hidden pb-4 flex items-stretch h-12 border border-base-300 rounded-sm overflow-hidden bg-base-200/40 focus-within:border-primary"
         >
           <span class="grid place-items-center w-12 text-primary flex-shrink-0">
             <.icon name="hero-magnifying-glass" class="w-5 h-5" />
@@ -194,7 +193,7 @@ defmodule HuddlzWeb.Layouts do
           />
           <button
             type="submit"
-            class="flex-shrink-0 px-5 bg-primary text-primary-content font-display uppercase text-xs font-black tracking-wider"
+            class="flex-shrink-0 px-5 bg-primary text-primary-content text-sm font-extrabold"
           >
             Search
           </button>
@@ -220,7 +219,7 @@ defmodule HuddlzWeb.Layouts do
     <footer class="border-t border-base-300 px-6 sm:px-8 lg:px-12 mt-12 sm:mt-16 lg:mt-20">
       <div class="py-12 grid grid-cols-2 lg:grid-cols-5 gap-8">
         <div class="col-span-2 lg:col-span-1">
-          <p class="font-display text-2xl tracking-tighter text-glow">huddlz</p>
+          <p class="text-2xl font-extrabold tracking-tight">huddlz</p>
           <p class="mt-3 text-sm text-base-content/60 max-w-xs">
             Real-life communities, easier to discover and organize.
           </p>
@@ -291,10 +290,6 @@ defmodule HuddlzWeb.Layouts do
 
   @doc """
   Shows the flash group with standard titles and content.
-
-  ## Examples
-
-      <.flash_group flash={@flash} />
   """
   attr :flash, :map, required: true, doc: "the map of flash messages"
   attr :id, :string, default: "flash-group", doc: "the optional id of flash container"

--- a/lib/huddlz_web/live/me_live.ex
+++ b/lib/huddlz_web/live/me_live.ex
@@ -167,19 +167,16 @@ defmodule HuddlzWeb.MeLive do
         <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <span class="mono-label text-primary/70">// Signed in</span>
-            <h1 class="font-display text-3xl tracking-tight text-glow mt-2">
+            <h1 class="text-3xl font-extrabold tracking-tight text-base-content mt-2">
               My huddlz.
             </h1>
             <p :if={tab_intro(@tab)} class="mt-2 text-base-content/60 max-w-2xl">
               {tab_intro(@tab)}
             </p>
           </div>
-          <.link
-            navigate={~p"/discover"}
-            class="self-start lg:self-end inline-flex items-center px-5 py-2 text-sm font-medium bg-primary text-primary-content border border-primary btn-neon"
-          >
+          <.button variant="primary" navigate={~p"/discover"} class="self-start lg:self-end">
             Find another huddl
-          </.link>
+          </.button>
         </header>
 
         <nav class="flex flex-wrap items-center gap-2" aria-label="Member dashboard tabs">
@@ -301,7 +298,7 @@ defmodule HuddlzWeb.MeLive do
     ~H"""
     <section>
       <div class="flex items-baseline justify-between gap-2">
-        <h2 class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3">
+        <h2 class="text-lg font-extrabold tracking-tight text-base-content flex items-baseline gap-3">
           <span class="mono-label text-primary/70">// {@title}</span>
           <span class="text-sm font-body font-normal text-base-content/40">
             ({@count})
@@ -310,7 +307,7 @@ defmodule HuddlzWeb.MeLive do
         <.link
           :if={@view_all_path && @count > @limit}
           navigate={@view_all_path}
-          class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+          class="text-xs font-bold text-primary hover:underline"
         >
           View all →
         </.link>
@@ -342,7 +339,7 @@ defmodule HuddlzWeb.MeLive do
     <div class="border border-base-300 p-6">
       <span class="mono-label text-primary/70">// Coming up</span>
       <%= if @next do %>
-        <h3 class="font-display text-lg tracking-tight text-glow mt-3">
+        <h3 class="text-lg font-extrabold tracking-tight text-base-content mt-3">
           {@next.title}
         </h3>
         <p class="text-sm text-base-content/60 mt-1">
@@ -354,7 +351,7 @@ defmodule HuddlzWeb.MeLive do
         </p>
         <.link
           navigate={~p"/groups/#{@next.group.slug}/huddlz/#{@next.id}"}
-          class="mt-4 inline-flex text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+          class="mt-4 inline-flex text-xs font-bold text-primary hover:underline"
         >
           View details →
         </.link>
@@ -399,7 +396,7 @@ defmodule HuddlzWeb.MeLive do
     ~H"""
     <section>
       <div class="flex items-baseline justify-between gap-2">
-        <h2 class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3">
+        <h2 class="text-lg font-extrabold tracking-tight text-base-content flex items-baseline gap-3">
           <span class="mono-label text-primary/70">// {@title}</span>
           <span class="text-sm font-body font-normal text-base-content/40">
             ({@count})
@@ -408,7 +405,7 @@ defmodule HuddlzWeb.MeLive do
         <.link
           :if={@view_all_path && @count > @limit}
           navigate={@view_all_path}
-          class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+          class="text-xs font-bold text-primary hover:underline"
         >
           View all →
         </.link>
@@ -438,7 +435,7 @@ defmodule HuddlzWeb.MeLive do
       </p>
       <.link
         navigate={~p"/discover?scope=groups"}
-        class="mt-4 inline-flex text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+        class="mt-4 inline-flex text-xs font-bold text-primary hover:underline"
       >
         Discover groups →
       </.link>
@@ -472,7 +469,7 @@ defmodule HuddlzWeb.MeLive do
     <div class="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-10">
       <div class="lg:col-span-2 space-y-6">
         <div class="flex items-baseline justify-between gap-2">
-          <h2 class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3">
+          <h2 class="text-lg font-extrabold tracking-tight text-base-content flex items-baseline gap-3">
             <span class="mono-label text-primary/70">// Updates</span>
             <span :if={@unread > 0} class="text-sm font-body font-normal text-primary">
               ({@unread} unread)
@@ -482,7 +479,7 @@ defmodule HuddlzWeb.MeLive do
             :if={@unread > 0}
             type="button"
             phx-click="mark_all_read"
-            class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+            class="text-xs font-bold text-primary hover:underline"
           >
             Mark all as read
           </button>
@@ -526,14 +523,12 @@ defmodule HuddlzWeb.MeLive do
       <div class="flex items-start justify-between gap-4">
         <div class="flex-1 min-w-0">
           <div class="flex items-baseline gap-2 flex-wrap">
-            <span class="text-xs px-2 py-0.5 font-medium border border-current/20 text-primary/80">
-              {category_label(@notification.trigger)}
-            </span>
+            <.huddl_badge variant="cyan">{category_label(@notification.trigger)}</.huddl_badge>
             <span class="text-xs text-base-content/50">
               {format_time_ago(@notification.inserted_at)}
             </span>
           </div>
-          <h3 class="font-display text-base tracking-tight mt-2">
+          <h3 class="text-base font-extrabold tracking-tight text-base-content mt-2">
             {@notification.title}
           </h3>
           <p :if={@notification.description} class="text-sm text-base-content/60 mt-1">
@@ -545,7 +540,7 @@ defmodule HuddlzWeb.MeLive do
           <.link
             :if={@notification.source_url}
             navigate={@notification.source_url}
-            class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+            class="text-xs font-bold text-primary hover:underline"
           >
             View →
           </.link>
@@ -554,7 +549,7 @@ defmodule HuddlzWeb.MeLive do
             type="button"
             phx-click="mark_read"
             phx-value-id={@notification.id}
-            class="text-xs text-base-content/50 hover:text-primary font-medium tracking-wide uppercase"
+            class="text-xs font-bold text-base-content/50 hover:text-primary"
           >
             Mark read
           </button>
@@ -573,7 +568,7 @@ defmodule HuddlzWeb.MeLive do
       </p>
       <.link
         navigate={~p"/profile/notifications"}
-        class="mt-4 inline-flex text-xs text-primary hover:underline font-medium tracking-wide uppercase"
+        class="mt-4 inline-flex text-xs font-bold text-primary hover:underline"
       >
         Open preferences →
       </.link>
@@ -601,7 +596,7 @@ defmodule HuddlzWeb.MeLive do
     <div class="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-10">
       <div class="lg:col-span-2 space-y-6">
         <div class="flex items-baseline justify-between gap-2">
-          <h2 class="font-display text-lg tracking-tight text-glow flex items-baseline gap-3">
+          <h2 class="text-lg font-extrabold tracking-tight text-base-content flex items-baseline gap-3">
             <span class="mono-label text-primary/70">// Invites</span>
             <span :if={@invites != []} class="text-sm font-body font-normal text-base-content/40">
               ({length(@invites)})

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -98,7 +98,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   defp category_section(assigns) do
     ~H"""
     <section class="border border-base-300 p-6">
-      <h2 class="font-display text-2xl tracking-tight text-glow">{@title}</h2>
+      <h2 class="text-2xl font-extrabold tracking-tight text-base-content">{@title}</h2>
       <p class="text-base-content/70 mt-1">{@description}</p>
 
       <div class="mt-6 space-y-1">
@@ -121,7 +121,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   defp read_only_section(assigns) do
     ~H"""
     <section class="border border-base-300 p-6">
-      <h2 class="font-display text-2xl tracking-tight text-glow">{@title}</h2>
+      <h2 class="text-2xl font-extrabold tracking-tight text-base-content">{@title}</h2>
       <p class="text-base-content/70 mt-1">{@description}</p>
 
       <ul class="mt-6 space-y-2">


### PR DESCRIPTION
## Summary

Drop-in style reconciliation per the handoff bundle. Aligns the dark theme to the search-organize prototype: calmer cyan, neutral panels, 5/7px radii, Inter-heavy headings instead of Space Mono uppercase, soft shadow instead of neon halo.

- **Bundle (`refactor(design)`)** — 4-file replacement: `app.css`, `core_components`, `community_components`, `layouts`. `font-display` is now Inter 900; `text-glow` / `btn-neon` are kept but neutralised so un-swept screens degrade gracefully. New `<.huddl_badge>` helper, `shadow-pop` / `blur-bg` utilities. Buttons drop uppercase Space Mono. Inputs become bordered fields on `bg-base-200`.
- **Sweep (`refactor(me)`)** — restyle the recently shipped `/me` dashboard + notification preferences to use the new vocabulary: h1/h2/h3 → `font-extrabold tracking-tight`; CTA → `<.button variant=\"primary\">`; "View all" / "Mark read" links drop `tracking-wide uppercase font-medium`; notification category badge uses `<.huddl_badge variant=\"cyan\">`.

The wider codebase (huddl_live, group_live, auth_live, etc. — 18 files) still references the old utility classes. Per the handoff README those degrade gracefully and are intended to be swept per-surface in follow-ups, not in this PR.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format` — clean
- [x] `mix credo --strict` — no issues
- [x] `mix test` — 1 doctest + 1163 tests, 0 failures
- [ ] Eyeball `/me` (all four tabs), `/profile/notifications`, header search, modal, and `<.input>` fields in the dev server to confirm visual parity with the prototype