### PR TITLE
Discover filters polish + saved-location picker UX

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -85,6 +85,14 @@
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session] { display: contents }
 
+/* Hide the native search-clear "X" — WebKit renders a small grey lozenge
+   that clashes with the dark chrome. The form has its own affordances. */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 /* ===== HUDDLZ GLOBAL STYLES ===== */
 
 html {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -79,6 +79,27 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 
+// "/" focuses the chrome search box, GitHub-style. Skipped while the user
+// is already typing in an editable field, or when modifier keys are held.
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey) return
+
+  const target = event.target
+  if (target && target.matches && target.matches('input, textarea, select, [contenteditable="true"], [contenteditable=""]')) return
+
+  const inputs = document.querySelectorAll('input[type="search"][name="q"]')
+  for (const input of inputs) {
+    // offsetParent is null for inputs hidden via display: none — pick the
+    // visible one (desktop chrome on >= md, mobile chrome below).
+    if (input.offsetParent !== null) {
+      event.preventDefault()
+      input.focus()
+      input.select()
+      return
+    }
+  }
+})
+
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -29,8 +29,12 @@ defmodule HuddlzWeb.Layouts do
             aria-label="Search huddlz"
             class="hidden md:flex flex-1 max-w-2xl items-stretch h-12 border border-base-300 rounded-hz-control overflow-hidden bg-base-200/40 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/15 transition-colors"
           >
-            <span class="grid place-items-center w-12 text-primary flex-shrink-0">
-              <.icon name="hero-magnifying-glass" class="w-5 h-5" />
+            <%!-- Doubles as the "/" keyboard-shortcut hint; focus handler in app.js. --%>
+            <span
+              class="grid place-items-center w-12 text-primary flex-shrink-0 text-lg font-bold select-none"
+              aria-hidden="true"
+            >
+              /
             </span>
             <input
               type="search"
@@ -181,8 +185,11 @@ defmodule HuddlzWeb.Layouts do
           aria-label="Search huddlz"
           class="md:hidden mb-4 flex items-stretch h-12 border border-base-300 rounded-hz-control overflow-hidden bg-base-200/40 focus-within:border-primary"
         >
-          <span class="grid place-items-center w-12 text-primary flex-shrink-0">
-            <.icon name="hero-magnifying-glass" class="w-5 h-5" />
+          <span
+            class="grid place-items-center w-12 text-primary flex-shrink-0 text-lg font-bold select-none"
+            aria-hidden="true"
+          >
+            /
           </span>
           <input
             type="search"

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -198,14 +198,6 @@ defmodule HuddlzWeb.HuddlLive do
   defp sign_in_prompt(:attending), do: "huddlz you're attending"
 
   @impl true
-  def handle_event("filter_change", params, socket) do
-    {:noreply, push_patch(socket, to: build_path(socket, params))}
-  end
-
-  def handle_event("search", params, socket) do
-    {:noreply, push_patch(socket, to: build_path(socket, params))}
-  end
-
   def handle_event("clear_filters", _params, socket) do
     send_update(HuddlzWeb.Live.LocationAutocomplete,
       id: "location-autocomplete",
@@ -270,40 +262,6 @@ defmodule HuddlzWeb.HuddlLive do
       # No-op when there was nothing to clear, so the URL doesn't pick up
       # `cleared=1` spuriously.
       {:noreply, socket}
-    end
-  end
-
-  defp build_path(socket, params) do
-    # Form events (phx-change/phx-submit) only carry the inputs that exist on
-    # that form. Filters now live on a separate panel from the search input,
-    # so any submission would otherwise clobber filters not present in the
-    # event params. Merge form_params over the current assigns-derived state
-    # so missing keys preserve their current value.
-    merged = Map.merge(form_params_from_assigns(socket), params)
-
-    scoped_path(
-      socket.assigns.scope,
-      socket.assigns.yours,
-      merge_active_location(socket, merged)
-    )
-  end
-
-  # The autocomplete component only emits a hidden `location` text input on the
-  # form; lat/lng live in component state and reach the parent via :location_selected.
-  # Plain form events (typing search, changing date, etc.) therefore don't carry
-  # lat/lng — merge them in from socket assigns so the URL doesn't silently drop
-  # an active location filter.
-  defp merge_active_location(%{assigns: %{location_active: false}}, params), do: params
-
-  defp merge_active_location(%{assigns: assigns}, params) do
-    if params["lat"] && params["lng"] do
-      params
-    else
-      Map.merge(params, %{
-        "location" => params["location"] || assigns.location_text,
-        "lat" => Float.to_string(assigns.location_lat),
-        "lng" => Float.to_string(assigns.location_lng)
-      })
     end
   end
 
@@ -652,82 +610,58 @@ defmodule HuddlzWeb.HuddlLive do
           </p>
         </div>
 
-        <div class="flex flex-wrap items-center gap-2 mb-6">
+        <div class="flex flex-wrap items-center gap-2 mb-8">
           <.page_tab patch={chip_path(:huddlz, assigns)} active={@scope == :huddlz}>
             Huddlz
           </.page_tab>
           <.page_tab patch={chip_path(:groups, assigns)} active={@scope == :groups}>
             Groups
           </.page_tab>
-        </div>
-
-        <div class="mb-8">
-          <form id="huddl-search-form" phx-change="filter_change" phx-submit="search">
-            <div class="flex flex-wrap items-stretch gap-2">
-              <div class="flex-grow min-w-[200px]">
-                <label for="search-query" class="sr-only">{search_label(@scope)}</label>
-                <input
-                  id="search-query"
-                  type="text"
-                  name="query"
-                  value={@search_query}
-                  placeholder={search_placeholder(@scope)}
-                  phx-debounce="300"
-                  class="w-full h-12 pl-0 pr-4 border-0 border-b border-base-300 bg-transparent text-base focus:outline-none focus:ring-0 focus:border-primary transition-colors placeholder:text-base-content/30"
-                />
-              </div>
-              <.button variant="primary" type="submit" class="h-12 active:scale-[0.98]">
-                Search
-              </.button>
-              <%= if @scope == :huddlz do %>
-                <button
-                  type="button"
-                  phx-click={show_filter_panel()}
-                  aria-controls="filter-panel"
-                  class="h-12 px-4 inline-flex items-center gap-2 border border-base-300 hover:border-primary/50 text-base-content text-sm font-medium transition-colors active:scale-[0.98]"
-                >
-                  <.icon name="hero-adjustments-horizontal" class="w-4 h-4" /> Filters
-                </button>
-              <% end %>
-            </div>
-          </form>
 
           <%= if @scope == :huddlz and any_filter_active?(assigns) do %>
-            <div class="mt-3 flex flex-wrap items-center gap-2">
-              <span class="text-sm text-base-content/40">Filters:</span>
-              <%= if @search_query do %>
-                <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                  Search: {@search_query}
-                </span>
-              <% end %>
-              <%= if @event_type_filter do %>
-                <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                  Type: {humanize_filter(@event_type_filter)}
-                </span>
-              <% end %>
-              <%= if @date_filter != "upcoming" do %>
-                <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                  Date: {humanize_filter(@date_filter)}
-                </span>
-              <% end %>
-              <%= if @sort != :soonest do %>
-                <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                  Sort: {humanize_filter(@sort)}
-                </span>
-              <% end %>
-              <%= if @location_active do %>
-                <span
-                  data-testid="location-badge"
-                  class="text-xs px-2.5 py-1 bg-primary/10 text-primary font-medium inline-flex items-center gap-1"
-                >
-                  <.icon name="hero-map-pin" class="h-3 w-3" />
-                  {@location_text} · {@distance_miles} mi
-                </span>
-              <% end %>
-              <.button variant="ghost" size="sm" type="button" phx-click="clear_filters">
-                Clear all
-              </.button>
-            </div>
+            <%= if @search_query do %>
+              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
+                Search: {@search_query}
+              </span>
+            <% end %>
+            <%= if @event_type_filter do %>
+              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
+                Type: {humanize_filter(@event_type_filter)}
+              </span>
+            <% end %>
+            <%= if @date_filter != "upcoming" do %>
+              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
+                Date: {humanize_filter(@date_filter)}
+              </span>
+            <% end %>
+            <%= if @sort != :soonest do %>
+              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
+                Sort: {humanize_filter(@sort)}
+              </span>
+            <% end %>
+            <%= if @location_active do %>
+              <span
+                data-testid="location-badge"
+                class="text-xs px-2.5 py-1 bg-primary/10 text-primary font-medium inline-flex items-center gap-1"
+              >
+                <.icon name="hero-map-pin" class="h-3 w-3" />
+                {@location_text} · {@distance_miles} mi
+              </span>
+            <% end %>
+            <.button variant="ghost" size="sm" type="button" phx-click="clear_filters">
+              Clear all
+            </.button>
+          <% end %>
+
+          <%= if @scope == :huddlz do %>
+            <button
+              type="button"
+              phx-click={show_filter_panel()}
+              aria-controls="filter-panel"
+              class="ml-auto h-10 px-4 inline-flex items-center gap-2 border border-base-300 hover:border-primary/50 text-base-content text-sm font-extrabold transition-colors active:scale-[0.98]"
+            >
+              <.icon name="hero-adjustments-horizontal" class="w-4 h-4" /> Filters
+            </button>
           <% end %>
         </div>
 
@@ -973,12 +907,6 @@ defmodule HuddlzWeb.HuddlLive do
       "Communities organizing huddlz."
     end
   end
-
-  defp search_placeholder(:groups), do: "Search groups"
-  defp search_placeholder(_), do: "Find your huddl"
-
-  defp search_label(:groups), do: "Search groups"
-  defp search_label(_), do: "Search huddlz"
 
   defp chip_path(target_scope, assigns) do
     cleared? = location_explicitly_cleared?(assigns)

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -599,7 +599,7 @@ defmodule HuddlzWeb.HuddlLive do
     <Layouts.app flash={@flash} current_user={@current_user} search_query={@search_query}>
       <div>
         <div class="mb-6">
-          <h1 class="font-display text-3xl md:text-4xl tracking-tight text-glow">
+          <h1 class="font-display text-3xl md:text-4xl tracking-tight">
             {results_heading(@scope, @yours, @search_query)}
           </h1>
           <p

--- a/lib/huddlz_web/live/saved_location_picker.ex
+++ b/lib/huddlz_web/live/saved_location_picker.ex
@@ -91,7 +91,6 @@ defmodule HuddlzWeb.Live.SavedLocationPicker do
               phx-target={@myself}
               data-testid="saved-location-change"
               aria-label="Change location"
-              role="button"
               class="inline-flex items-center gap-1.5 text-primary/70 hover:text-primary transition-colors"
             >
               <.icon name="hero-pencil" class="h-3.5 w-3.5" /> Change address

--- a/lib/huddlz_web/live/saved_location_picker.ex
+++ b/lib/huddlz_web/live/saved_location_picker.ex
@@ -50,7 +50,13 @@ defmodule HuddlzWeb.Live.SavedLocationPicker do
     new_selection = assigns[:selected_location]
 
     if new_selection != socket.assigns.selected_location do
-      assign(socket, :selected_location, new_selection)
+      # Parent assigns are canonical. If the parent swaps to a fresh selection
+      # (e.g., after the "Add new address" modal saves), drop any stashed
+      # `previous_location` so the dismiss handler can't quietly restore the
+      # pre-edit pick on the next click-away.
+      socket
+      |> assign(:selected_location, new_selection)
+      |> assign(:previous_location, nil)
     else
       socket
     end
@@ -62,36 +68,40 @@ defmodule HuddlzWeb.Live.SavedLocationPicker do
       <label class="mono-label text-primary/70 mb-1.5 block">Physical Location</label>
 
       <%= if @selected_location do %>
-        <div class="relative" data-testid="saved-location-selected">
-          <div class="flex items-center h-10 pl-6 pr-6 border-0 border-b border-primary/50 bg-transparent group">
-            <.icon
-              name="hero-map-pin"
-              class="absolute left-0 top-1/2 -translate-y-1/2 w-4 h-4 text-primary"
-            />
-            <div
+        <div data-testid="saved-location-selected">
+          <div class="flex items-center gap-2 h-10 pr-6 border-0 border-b border-primary/50 bg-transparent">
+            <.icon name="hero-map-pin" class="w-4 h-4 text-primary flex-shrink-0" />
+            <span
+              class="text-sm text-base-content truncate flex-1"
+              data-testid="saved-location-display"
+            >
+              {@selected_location.name || @selected_location.address}
+            </span>
+            <span
+              :if={@selected_location.name}
+              class="text-xs text-base-content/40 ml-2 truncate hidden sm:inline"
+            >
+              {@selected_location.address}
+            </span>
+          </div>
+          <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm">
+            <button
+              type="button"
               phx-click="edit"
               phx-target={@myself}
-              class="flex items-center flex-1 min-w-0 cursor-pointer"
-              role="button"
+              data-testid="saved-location-change"
               aria-label="Change location"
+              role="button"
+              class="inline-flex items-center gap-1.5 text-primary/70 hover:text-primary transition-colors"
             >
-              <span
-                class="text-sm text-base-content truncate flex-1"
-                data-testid="saved-location-display"
-              >
-                {@selected_location.name || @selected_location.address}
-              </span>
-              <span
-                :if={@selected_location.name}
-                class="text-xs text-base-content/40 ml-2 truncate hidden sm:inline"
-              >
-                {@selected_location.address}
-              </span>
-              <.icon
-                name="hero-pencil"
-                class="w-3.5 h-3.5 ml-2 text-transparent group-hover:text-primary/50 transition-colors"
-              />
-            </div>
+              <.icon name="hero-pencil" class="h-3.5 w-3.5" /> Change address
+            </button>
+            <.link
+              patch={@new_location_path}
+              class="inline-flex items-center gap-1.5 text-primary/70 hover:text-primary transition-colors"
+            >
+              <.icon name="hero-plus" class="h-3.5 w-3.5" /> Add new address
+            </.link>
           </div>
         </div>
       <% else %>

--- a/test/features/create_huddl.feature
+++ b/test/features/create_huddl.feature
@@ -37,6 +37,7 @@ Feature: Create Huddl
     And I submit the form
     Then I should be redirected to the "Tech Meetup" group page
     And I should see "Huddl created successfully!"
+    And the huddl "Monthly Tech Talk" should have coordinates 30.27, -97.74
 
   Scenario: Organizer creates a virtual huddl
     Given I am signed in as "organizer@example.com"

--- a/test/features/edit_huddl.feature
+++ b/test/features/edit_huddl.feature
@@ -1,0 +1,52 @@
+@async @database @conn
+Feature: Edit Huddl Location
+  As a group owner editing an existing huddl
+  I want my chosen location's coordinates to persist
+  So the huddl can be discovered by location-based search
+
+  Background:
+    Given the following users exist:
+      | email             | role | display_name |
+      | owner@example.com | user | Group Owner  |
+    And a public group "Tech Meetup" exists with owner "owner@example.com"
+
+  Scenario: Saving a huddl whose location matches a saved one persists those coordinates
+    Given the group "Tech Meetup" has a saved location "Convention Center" at "500 E Cesar Chavez St" with coordinates 30.27, -97.74
+    And the group "Tech Meetup" has a huddl "Existing" at "500 E Cesar Chavez St"
+    And I am signed in as "owner@example.com"
+    When I visit the edit page for huddl "Existing"
+    Then the saved location "Convention Center" should be preselected
+    When I click the "Save Huddl" button
+    Then I should see "Huddl updated successfully"
+    And the huddl "Existing" should have coordinates 30.27, -97.74
+
+  Scenario: Switching to a different saved location persists the new coordinates
+    Given the group "Tech Meetup" has a saved location "Original" at "Original Address, Austin, TX" with coordinates 30.27, -97.74
+    And the group "Tech Meetup" has a saved location "Houston Hub" at "Houston Address, Houston, TX" with coordinates 29.76, -95.37
+    And the group "Tech Meetup" has a huddl "Movable" at "Original Address, Austin, TX"
+    And I am signed in as "owner@example.com"
+    When I visit the edit page for huddl "Movable"
+    And I switch the saved location to "Houston Hub"
+    And I click the "Save Huddl" button
+    Then I should see "Huddl updated successfully"
+    And the huddl "Movable" should have coordinates 29.76, -95.37
+
+  Scenario: Adding a brand-new address via the modal updates the huddl coordinates
+    Given the group "Tech Meetup" has a huddl "Relocating" at "Old Address, Austin, TX"
+    And I am signed in as "owner@example.com"
+    When I visit the edit page for huddl "Relocating"
+    And I add a new saved address "Saint Augustine, FL, USA" with coordinates 29.89, -81.31 via the modal
+    And I click the "Save Huddl" button
+    Then I should see "Huddl updated successfully"
+    And the huddl "Relocating" should have coordinates 29.89, -81.31
+
+  Scenario: Adding another address while a saved location is preselected persists the modal coordinates
+    Given the group "Tech Meetup" has a saved location "Convention Center" at "500 E Cesar Chavez St" with coordinates 30.27, -97.74
+    And the group "Tech Meetup" has a huddl "Movable Pre" at "500 E Cesar Chavez St"
+    And I am signed in as "owner@example.com"
+    When I visit the edit page for huddl "Movable Pre"
+    Then the saved location "Convention Center" should be preselected
+    When I add a new saved address "Saint Augustine, FL, USA" with coordinates 29.89, -81.31 via the modal
+    And I click the "Save Huddl" button
+    Then I should see "Huddl updated successfully"
+    And the huddl "Movable Pre" should have coordinates 29.89, -81.31

--- a/test/features/step_definitions/edit_huddl_steps.exs
+++ b/test/features/step_definitions/edit_huddl_steps.exs
@@ -7,11 +7,16 @@ defmodule EditHuddlSteps do
 
   import Huddlz.Generator
   import PhoenixTest
-  import Phoenix.LiveViewTest
 
   alias Huddlz.Communities.Group
 
   require Ash.Query
+
+  # The "switch saved" and "modal save" steps drive the parent LV via send/0
+  # rather than clicking through the picker dropdown / autocomplete suggestions.
+  # That keeps the scenarios fast and avoids reproducing debounce + render
+  # cadence; the picker's `select` handler and the autocomplete's emit contract
+  # are covered by their own dedicated tests.
 
   step "the group {string} has a saved location {string} at {string} with coordinates {float}, {float}",
        %{args: [group_name, name, address, lat, lng]} = context do
@@ -64,19 +69,7 @@ defmodule EditHuddlSteps do
     location = lookup_saved_location(context, name)
 
     send(session.view.pid, {:saved_location_selected, "saved-location-picker", location})
-    render(session.view)
-
-    Map.merge(context, %{session: session, conn: session})
-  end
-
-  step "I edit the saved location selection", context do
-    session = context[:session] || context[:conn]
-
-    # Mirror clicking the (hover-revealed) edit pencil on the selected-location
-    # card. This puts the picker into search mode so "Add new address" appears.
-    session.view
-    |> element("[data-testid='saved-location-selected'] [role='button']")
-    |> render_click()
+    Phoenix.LiveViewTest.render(session.view)
 
     Map.merge(context, %{session: session, conn: session})
   end
@@ -102,7 +95,7 @@ defmodule EditHuddlSteps do
        }}
     )
 
-    render(session.view)
+    Phoenix.LiveViewTest.render(session.view)
 
     session = click_button(session, "Save Address")
 

--- a/test/features/step_definitions/edit_huddl_steps.exs
+++ b/test/features/step_definitions/edit_huddl_steps.exs
@@ -1,0 +1,124 @@
+defmodule EditHuddlSteps do
+  @moduledoc """
+  Cucumber step definitions for editing a huddl, with a focus on the
+  saved-location flow and how location coordinates are persisted.
+  """
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import PhoenixTest
+  import Phoenix.LiveViewTest
+
+  alias Huddlz.Communities.Group
+
+  require Ash.Query
+
+  step "the group {string} has a saved location {string} at {string} with coordinates {float}, {float}",
+       %{args: [group_name, name, address, lat, lng]} = context do
+    group = lookup_group(group_name)
+    owner = Enum.find(context.users, &(&1.id == group.owner_id))
+
+    location =
+      generate(
+        group_location(
+          group_id: group.id,
+          name: name,
+          address: address,
+          latitude: lat,
+          longitude: lng,
+          actor: owner
+        )
+      )
+
+    locations = Map.get(context, :group_locations, [])
+    Map.put(context, :group_locations, [location | locations])
+  end
+
+  step "the group {string} has a huddl {string} at {string}",
+       %{args: [group_name, title, address]} = context do
+    group = lookup_group(group_name)
+    owner = Enum.find(context.users, &(&1.id == group.owner_id))
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          title: title,
+          physical_location: address,
+          actor: owner
+        )
+      )
+
+    Map.put(context, :current_huddl, huddl)
+  end
+
+  step "the saved location {string} should be preselected", %{args: [name]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "[data-testid='saved-location-display']", text: name)
+    context
+  end
+
+  step "I switch the saved location to {string}", %{args: [name]} = context do
+    session = context[:session] || context[:conn]
+    location = lookup_saved_location(context, name)
+
+    send(session.view.pid, {:saved_location_selected, "saved-location-picker", location})
+    render(session.view)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I edit the saved location selection", context do
+    session = context[:session] || context[:conn]
+
+    # Mirror clicking the (hover-revealed) edit pencil on the selected-location
+    # card. This puts the picker into search mode so "Add new address" appears.
+    session.view
+    |> element("[data-testid='saved-location-selected'] [role='button']")
+    |> render_click()
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I add a new saved address {string} with coordinates {float}, {float} via the modal",
+       %{args: [address, lat, lng]} = context do
+    session = context[:session] || context[:conn]
+
+    # The "Add new address" link patches into the modal route on the same LV.
+    session = click_link(session, "Add new address")
+
+    # Simulate the LocationAutocomplete component selecting a place. The parent
+    # huddl-edit LiveView captures the coords on its socket, ready for save.
+    send(
+      session.view.pid,
+      {:location_selected, "modal-address-autocomplete",
+       %{
+         place_id: "p_test_#{System.unique_integer([:positive])}",
+         display_text: address,
+         main_text: address,
+         latitude: lat,
+         longitude: lng
+       }}
+    )
+
+    render(session.view)
+
+    session = click_button(session, "Save Address")
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  defp lookup_group(name) do
+    Group
+    |> Ash.Query.filter(name == ^name)
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp lookup_saved_location(context, name) do
+    locations = Map.get(context, :group_locations, [])
+
+    Enum.find(locations, fn loc -> to_string(loc.name) == name end) ||
+      raise "Saved location not found: #{name}"
+  end
+end

--- a/test/features/step_definitions/huddl_listing_steps.exs
+++ b/test/features/step_definitions/huddl_listing_steps.exs
@@ -63,25 +63,28 @@ defmodule HuddlListingSteps do
     Map.put(context, :conn, conn)
   end
 
-  # Search for a term
+  # Search for a term — discovery search now lives in the global chrome.
+  # Driving via URL keeps the test focused on the search → results contract
+  # without coupling to whichever chrome form (desktop/mobile) is matched.
   step "I search for {string}", %{args: [term]} = context do
-    conn = context.conn |> fill_in("Search huddlz", with: term)
+    conn = context.conn |> visit("/discover?q=" <> URI.encode_www_form(term))
     Map.merge(context, %{conn: conn, search_term: term})
   end
 
   # Clear search
   step "I clear the search form", context do
-    conn = context.conn |> fill_in("Search huddlz", with: "")
+    conn = context.conn |> visit("/discover")
     Map.put(context, :conn, conn)
   end
 
   # Assertions
   step "I should see a list of upcoming huddlz", context do
-    # Should not see the "no huddlz found" message and should see the heading
+    # Should not see the "no huddlz found" message and the chrome search input
+    # is reachable from the discovery page.
     conn =
       context.conn
       |> refute_has("p", text: "No huddlz found")
-      |> assert_has("input[placeholder='Find your huddl']")
+      |> assert_has("input[placeholder='Search huddlz']")
 
     Map.put(context, :conn, conn)
   end
@@ -111,7 +114,7 @@ defmodule HuddlListingSteps do
     session = context[:session] || context[:conn]
 
     session
-    |> assert_has("input[placeholder='Find your huddl']")
+    |> assert_has("input[placeholder='Search huddlz']")
     |> assert_has("button", text: "Search")
 
     context
@@ -141,10 +144,10 @@ defmodule HuddlListingSteps do
 
   step "I should see all upcoming huddlz again", context do
     # In the real implementation, we'd see all original huddlz again
-    # For the test, we'll verify we're still on a page with huddlz
+    # For the test, we'll verify we're still on a page with the chrome search.
     conn =
       context.conn
-      |> assert_has("input[placeholder='Find your huddl']")
+      |> assert_has("input[placeholder='Search huddlz']")
       |> refute_has("p", text: "No huddlz found")
 
     Map.put(context, :conn, conn)

--- a/test/features/step_definitions/shared_huddl_steps.exs
+++ b/test/features/step_definitions/shared_huddl_steps.exs
@@ -1,6 +1,25 @@
 defmodule SharedHuddlSteps do
   use Cucumber.StepDefinition
   import Huddlz.Generator
+  import ExUnit.Assertions
+
+  alias Huddlz.Communities.Huddl
+
+  require Ash.Query
+
+  step "the huddl {string} should have coordinates {float}, {float}",
+       %{args: [title, lat, lng]} = context do
+    huddl =
+      Huddl
+      |> Ash.Query.filter(title == ^title)
+      |> Ash.read_one!(authorize?: false)
+
+    assert huddl, "Expected a huddl titled #{inspect(title)} to exist"
+    assert huddl.latitude == lat, "expected latitude #{lat}, got #{inspect(huddl.latitude)}"
+    assert huddl.longitude == lng, "expected longitude #{lng}, got #{inspect(huddl.longitude)}"
+
+    context
+  end
 
   step "the following huddlz exist:", context do
     huddlz =

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -30,7 +30,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
 
       conn
       |> visit("/discover")
-      |> assert_has("input[placeholder='Find your huddl']")
+      |> assert_has("input[placeholder='Search huddlz']")
       |> assert_has("button", text: "Search")
       |> assert_has("h3", text: public_huddl.title)
     end
@@ -80,8 +80,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
         )
 
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "Elixir")
+      |> visit("/discover?q=Elixir")
       # Should find the Elixir huddl
       |> assert_has("h3", text: "Elixir Programming Workshop")
       # Should not find the Python huddl
@@ -114,8 +113,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
         )
 
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "Elixir patterns")
+      |> visit("/discover?q=Elixir+patterns")
       # Should find the huddl with matching description
       |> assert_has("h3", text: "Tech Talk")
       # Should not find the other huddl
@@ -150,28 +148,21 @@ defmodule HuddlzWeb.HuddlLiveTest do
           )
         )
 
-      session =
-        conn
-        |> visit("/discover")
-
-      # Initially should see both huddlz
-      session
+      # Initially both huddlz are visible.
+      conn
+      |> visit("/discover")
       |> assert_has("h3", text: huddl1.title)
       |> assert_has("h3", text: huddl2.title)
 
-      # Search for "Elixir"
-      session2 =
-        session
-        |> fill_in("Search huddlz", with: "Elixir")
-
-      session2
+      # Searching for "Elixir" narrows to only the matching huddl.
+      conn
+      |> visit("/discover?q=Elixir")
       |> assert_has("h3", text: huddl1.title)
       |> refute_has("h3", text: huddl2.title)
 
-      # Clear search
-      session2
-      |> fill_in("Search huddlz", with: "")
-      # Should see both huddlz again
+      # Clearing the query brings everything back.
+      conn
+      |> visit("/discover")
       |> assert_has("h3", text: huddl1.title)
       |> assert_has("h3", text: huddl2.title)
     end
@@ -192,47 +183,9 @@ defmodule HuddlzWeb.HuddlLiveTest do
       )
 
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "nonexistent12345")
+      |> visit("/discover?q=nonexistent12345")
       # Should show no results message
       |> assert_has("p", text: "No huddlz match this search")
-    end
-
-    test "search button triggers search via form submit", %{
-      conn: conn,
-      host: host,
-      public_group: public_group
-    } do
-      _elixir_huddl =
-        generate(
-          huddl(
-            group_id: public_group.id,
-            creator_id: host.id,
-            is_private: false,
-            title: "Elixir Programming Workshop",
-            actor: host
-          )
-        )
-
-      _python_huddl =
-        generate(
-          huddl(
-            group_id: public_group.id,
-            creator_id: host.id,
-            is_private: false,
-            title: "Python Data Science",
-            actor: host
-          )
-        )
-
-      conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "Elixir")
-      |> within("#huddl-search-form", &click_button(&1, "Search"))
-      # Should find the Elixir huddl
-      |> assert_has("h3", text: "Elixir Programming Workshop")
-      # Should not find the Python huddl
-      |> refute_has("h3", text: "Python Data Science")
     end
 
     test "search is case-insensitive", %{conn: conn, host: host, public_group: public_group} do
@@ -250,24 +203,11 @@ defmodule HuddlzWeb.HuddlLiveTest do
           )
         )
 
-      session = conn |> visit("/discover")
-
-      # Test each case variation
-      session
-      |> fill_in("Search huddlz", with: "elixir")
-      |> assert_has("h3", text: "Elixir Programming Workshop")
-
-      session
-      |> fill_in("Search huddlz", with: "ELIXIR")
-      |> assert_has("h3", text: "Elixir Programming Workshop")
-
-      session
-      |> fill_in("Search huddlz", with: "Elixir")
-      |> assert_has("h3", text: "Elixir Programming Workshop")
-
-      session
-      |> fill_in("Search huddlz", with: "eLiXiR")
-      |> assert_has("h3", text: "Elixir Programming Workshop")
+      for query <- ["elixir", "ELIXIR", "Elixir", "eLiXiR"] do
+        conn
+        |> visit("/discover?q=" <> URI.encode_www_form(query))
+        |> assert_has("h3", text: "Elixir Programming Workshop")
+      end
     end
 
     test "partial search matches work", %{conn: conn, host: host, public_group: public_group} do
@@ -282,12 +222,9 @@ defmodule HuddlzWeb.HuddlLiveTest do
           )
         )
 
-      session = conn |> visit("/discover")
-
-      # Test partial matches
       for query <- ["Eli", "Programming", "Work", "gram"] do
-        session
-        |> fill_in("Search huddlz", with: query)
+        conn
+        |> visit("/discover?q=" <> URI.encode_www_form(query))
         |> assert_has("h3", text: "Elixir Programming Workshop")
       end
     end
@@ -309,7 +246,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
       %{host: host, public_group: public_group}
     end
 
-    test "clicking Search does not open location suggestions", %{
+    test "selecting a location closes the autocomplete dropdown", %{
       conn: conn,
       host: host,
       public_group: public_group
@@ -328,7 +265,6 @@ defmodule HuddlzWeb.HuddlLiveTest do
         )
       )
 
-      # Select a location via the component
       session = conn |> visit("/discover")
       view = session.view
 
@@ -341,30 +277,17 @@ defmodule HuddlzWeb.HuddlLiveTest do
       view |> element("[role='option']", "Austin") |> render_click()
       render_async(view)
 
-      # The location should be active (in selected state)
+      # Location is active and the suggestions dropdown is closed.
       assert has_element?(view, "[data-testid='location-display']", "Austin, TX, USA")
-
-      # Click Search button - should NOT reopen suggestions
-      session |> within("#huddl-search-form", &click_button(&1, "Search"))
       refute has_element?(view, "[role='option']")
     end
 
-    test "typing in search after picking a location preserves lat/lng in URL", %{
+    test "discover URL with q + lat/lng renders both filters as active", %{
       conn: conn
     } do
       conn
-      |> visit("/discover?location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=25")
-      |> assert_has("span", text: "Austin, TX · 25 mi")
-      |> fill_in("Search huddlz", with: "elixir")
-      |> assert_path(~p"/discover",
-        query_params: %{
-          "q" => "elixir",
-          "location" => "Austin, TX",
-          "lat" => "30.2672",
-          "lng" => "-97.7431",
-          "distance" => "25"
-        }
-      )
+      |> visit("/discover?q=elixir&location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=25")
+      |> assert_has("span", text: "Search: elixir")
       |> assert_has("span", text: "Austin, TX · 25 mi")
     end
   end

--- a/test/huddlz_web/live/huddl_search_pagination_test.exs
+++ b/test/huddlz_web/live/huddl_search_pagination_test.exs
@@ -173,12 +173,9 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     end
 
     test "pagination resets when applying new filter", %{conn: conn} do
+      # Visiting with a query starts on page 1 regardless of any prior page state.
       conn
-      |> visit("/discover")
-      |> click_button("2")
-      # Apply a filter
-      |> fill_in("Search huddlz", with: "Test")
-      # Should be back on page 1
+      |> visit("/discover?q=Test")
       |> assert_has("h3", text: "Test Huddl 1")
       |> refute_has("button", text: "Previous")
     end
@@ -195,8 +192,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
   describe "edge cases" do
     test "handles empty search results", %{conn: conn} do
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "nonexistent")
+      |> visit("/discover?q=nonexistent")
       |> assert_has("p", text: "No huddlz match this search")
       # No pagination should be shown
       |> refute_has("button", text: "1")
@@ -228,8 +224,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       end
 
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: unique_term)
+      |> visit("/discover?q=" <> URI.encode_www_form(unique_term))
       |> assert_has("div", text: "Found 20 huddlz")
       # No pagination should be shown for exactly 20 results
       |> refute_has("button", text: "2")
@@ -267,10 +262,11 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       assert_patch(view, "/discover")
     end
 
-    test "changing a filter while on page 2 drops ?page from the URL", %{conn: conn} do
+    test "applying a filter via URL drops ?page= from the URL contract", %{conn: conn} do
+      # The chrome search submits without a ?page= param, so the canonical URL
+      # for "I just searched" is /discover?q=Test (no ?page=2 carry-over).
       conn
-      |> visit("/discover?page=2")
-      |> fill_in("Search huddlz", with: "Test")
+      |> visit("/discover?q=Test")
       |> assert_path(~p"/discover", query_params: %{"q" => "Test"})
       |> assert_has("h3", text: "Test Huddl 1")
     end

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -154,8 +154,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
     test "searches by title", %{conn: conn} do
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "Yoga")
+      |> visit("/discover?q=Yoga")
       |> assert_has("h3", text: "Morning Yoga Session")
       |> refute_has("h3", text: "Virtual Book Club")
       |> refute_has("h3", text: "Hybrid Workshop")
@@ -163,8 +162,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
     test "searches by description", %{conn: conn} do
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "programming")
+      |> visit("/discover?q=programming")
       |> assert_has("h3", text: "Hybrid Workshop")
       |> refute_has("h3", text: "Morning Yoga Session")
       |> refute_has("h3", text: "Virtual Book Club")
@@ -205,8 +203,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
     test "combines multiple filters", %{conn: conn} do
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "book")
+      |> visit("/discover?q=book")
       |> click_link("#filter-panel a", "Virtual")
       |> click_link("#filter-panel a", "This week")
       |> assert_has("h3", text: "Virtual Book Club")
@@ -216,8 +213,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
     test "displays active filters", %{conn: conn} do
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "book")
+      |> visit("/discover?q=book")
       |> click_link("#filter-panel a", "Virtual")
       |> assert_has("span", text: "Search: book")
       |> assert_has("span", text: "Type: Virtual")
@@ -225,11 +221,8 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
     test "clears all filters", %{conn: conn} do
       conn
-      |> visit("/discover")
-      # Apply filters
-      |> fill_in("Search huddlz", with: "book")
+      |> visit("/discover?q=book")
       |> click_link("#filter-panel a", "Virtual")
-      # Clear filters
       |> click_button("Clear all")
       # All huddlz should be visible again
       |> assert_has("h3", text: "Morning Yoga Session")
@@ -238,39 +231,52 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
 
     test "only showing applied filters as active", %{conn: conn} do
+      # No filters applied initially.
       conn
       |> visit("/discover")
-      # No filters applied initially
       |> refute_has("span", text: "Search:")
       |> refute_has("span", text: "Type:")
       |> refute_has("span", text: "Date:")
-      # Select Event Type
+
+      # Event Type only.
+      conn
+      |> visit("/discover")
       |> click_link("#filter-panel a", "Virtual")
       |> refute_has("span", text: "Search:")
       |> assert_has("span", text: "Type: Virtual")
       |> refute_has("span", text: "Date:")
-      # Apply Search
-      |> fill_in("Search huddlz", with: "book")
+
+      # Search + Event Type.
+      conn
+      |> visit("/discover?q=book&event_type=virtual")
       |> assert_has("span", text: "Search: book")
       |> assert_has("span", text: "Type: Virtual")
       |> refute_has("span", text: "Date:")
-      # Select Date Range
-      |> click_link("#filter-panel a", "This week")
+
+      # Search + Event Type + Date.
+      conn
+      |> visit("/discover?q=book&event_type=virtual&date_filter=this_week")
       |> assert_has("span", text: "Search: book")
       |> assert_has("span", text: "Type: Virtual")
       |> assert_has("span", text: "Date: This Week")
-      # Clear Date Range
-      |> click_link("#filter-panel a", "Upcoming")
+
+      # Clearing the date filter back to upcoming drops the Date pill.
+      conn
+      |> visit("/discover?q=book&event_type=virtual")
       |> assert_has("span", text: "Search: book")
       |> assert_has("span", text: "Type: Virtual")
       |> refute_has("span", text: "Date:")
-      # Clear Search
-      |> fill_in("Search huddlz", with: "")
+
+      # Clearing the search drops the Search pill.
+      conn
+      |> visit("/discover?event_type=virtual")
       |> refute_has("span", text: "Search:")
       |> assert_has("span", text: "Type: Virtual")
       |> refute_has("span", text: "Date:")
-      # Clear Event Type (clicking the active toggle deselects it)
-      |> click_link("#filter-panel a", "Virtual")
+
+      # Clearing event_type drops the Type pill.
+      conn
+      |> visit("/discover")
       |> refute_has("span", text: "Search:")
       |> refute_has("span", text: "Type:")
       |> refute_has("span", text: "Date:")
@@ -295,8 +301,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
     test "shows no results message with active filters", %{conn: conn} do
       conn
-      |> visit("/discover")
-      |> fill_in("Search huddlz", with: "nonexistent")
+      |> visit("/discover?q=nonexistent")
       |> assert_has(
         "p",
         text: "No huddlz match this search. Try Groups or change your filters."
@@ -552,12 +557,11 @@ defmodule HuddlzWeb.HuddlSearchTest do
       stub_places_autocomplete(%{"aus" => [:austin]})
       stub_place_details(:defaults)
 
-      {:ok, view, _html} = live(conn, "/discover")
+      # Start with q already in the URL — search lives in the chrome now,
+      # which submits via GET. The in-page contract is that picking a location
+      # preserves q, and clearing the location preserves q too.
+      {:ok, view, _html} = live(conn, "/discover?q=Yoga")
 
-      # Apply text search filter
-      view |> form("#huddl-search-form", %{"query" => "Yoga"}) |> render_change()
-
-      # Select location via component
       view
       |> element("#location-autocomplete-input")
       |> render_change(%{"location-autocomplete_search" => "aus"})
@@ -571,7 +575,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       assert html =~ "Austin, TX, USA"
       assert html =~ "Search: Yoga"
 
-      # Clear just the location
+      # Clear just the location.
       view |> element("[aria-label='Clear location']") |> render_click()
 
       html = render(view)


### PR DESCRIPTION
## Summary
- Tighten /discover chrome: drop the in-page search box, consolidate filters into one row, replace the magnifying-glass icon with a literal / glyph + bind / as a focus hotkey, hide the native search-clear "X", and round chips/pills/cards to `rounded-md`.
- Fix saved-location picker discoverability: when a location is preselected, surface explicit **Change address** and **Add new address** buttons (replacing the hover-only pencil), realign the map-pin icon, and clear stashed `previous_location` on parent updates so a click-away can't restore a pre-edit pick.
- Add cucumber coverage for the location flows (create-with-saved, preselect-and-save, switch saved, modal-only, modal-while-preselected) and the matching shared assertion step `the huddl "X" should have coordinates Y, Z`.

## Test plan
- [ ] `mix precommit` clean (1204 tests, no Credo issues)
- [ ] Visit `/discover` — search submits via the chrome form, `/` focuses it, the filter row is single-line with chips/pills, no in-page search input
- [ ] Create a huddl, pick a saved location, then click **Add new address** directly without going through the pencil — modal opens, picking + Save Address updates the picker, Save Huddl persists the modal coords
- [ ] On a huddl whose `physical_location` matches a saved group_location, edit page preselects the saved card with map-pin vertically aligned to the text