### PR TITLE
feat(v3): add v3_app layout and shared component primitives (PR-F2)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -194,3 +194,2250 @@ html {
     opacity: 0.5;
   }
 }
+/* ===========================================================
+   V3 DESIGN — clickthrough styles, scoped under body.v3
+   Ported from docs/design/clickthrough/styles.css
+   Legacy styles above remain unaffected.
+   =========================================================== */
+
+/* huddlz design clickthrough — shared styles */
+
+body.v3 {
+  color-scheme: dark;
+  --bg: #020404;
+  --panel: #050808;
+  --panel-2: #081011;
+  --panel-3: #0b1416;
+  --line: #142022;
+  --line-strong: #243639;
+  --text: #f4fbfb;
+  --soft: #b7c1c3;
+  --muted: #7d888b;
+  --cyan: #18cbd4;
+  --cyan-dim: #0fa6ad;
+  --cyan-soft: rgba(24, 203, 212, 0.14);
+  --magenta: #e84fb4;
+  --warn: #f6c177;
+  --shadow: 0 28px 80px rgba(0, 0, 0, 0.56);
+  --radius: 7px;
+  --radius-sm: 5px;
+  --radius-pill: 999px;
+  --font: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "SFMono-Regular", "Space Mono", Consolas, "Liberation Mono", monospace;
+  --rail-w: 264px;
+}
+
+
+
+body.v3 { margin: 0; padding: 0; }
+
+body.v3 {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 78% 6%, rgba(24, 203, 212, 0.08), transparent 420px),
+    radial-gradient(circle at 12% 92%, rgba(232, 79, 180, 0.04), transparent 380px),
+    var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+
+
+
+/* ─────────────────────────────────────────────  APP SHELL  ───── */
+body.v3:not(.is-landing):not(.is-auth):not(.is-signed-out) {
+  display: grid;
+  grid-template-columns: var(--rail-w) 1fr;
+  min-height: 100vh;
+}
+
+body.v3.is-signed-out {
+  display: block;
+  min-height: 100vh;
+}
+
+body.v3.is-signed-out .main { min-height: 100vh; }
+
+@media (max-width: 1100px) {
+
+  body.v3:not(.is-landing):not(.is-auth):not(.is-signed-out) { grid-template-columns: 240px 1fr; }
+}
+
+
+/* Mobile nav toggle (CSS-only checkbox hack) */
+body.v3 .nav-toggle { display: none; }
+body.v3 .nav-trigger { display: none; }
+body.v3 .nav-scrim { display: none; }
+
+@media (max-width: 760px) {
+
+  body.v3:not(.is-landing):not(.is-auth):not(.is-signed-out) {
+    grid-template-columns: 1fr;
+  }
+
+  /* Show hamburger in topbar */
+  body.v3 .nav-trigger {
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 auto;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--soft);
+    cursor: pointer;
+  }
+
+  body.v3 .nav-trigger svg { width: 18px; height: 18px; }
+  body.v3 .nav-trigger:hover { color: var(--cyan); border-color: var(--cyan); }
+
+  /* Sidebar becomes a slide-in drawer */
+  body.v3:not(.is-landing):not(.is-auth) .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(320px, 86vw);
+    z-index: 60;
+    transform: translateX(-100%);
+    transition: transform 200ms ease;
+    box-shadow: var(--shadow);
+    background: var(--panel);
+  }
+
+  /* Scrim */
+  body.v3 .nav-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    background: rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 200ms ease;
+  }
+
+  /* Open state */
+  body.v3:not(.is-landing):not(.is-auth) .nav-toggle:checked ~ .sidebar { transform: translateX(0); }
+  body.v3:not(.is-landing):not(.is-auth) .nav-toggle:checked ~ .nav-scrim {
+    display: block;
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+
+/* ─────────────────────────────────────────────  SIDEBAR  ─────── */
+body.v3 .sidebar {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(8, 16, 17, 0.9) 0%, rgba(5, 8, 8, 0.92) 100%);
+  height: 100vh;
+  position: sticky;
+  top: 0;
+}
+
+body.v3 .sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 72px;
+  padding: 0 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+body.v3 .brand-glyph {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--cyan);
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 14px;
+  box-shadow: 0 0 16px rgba(24, 203, 212, 0.3) inset;
+}
+
+body.v3 .brand-text {
+  color: #eaffff;
+  font-family: var(--mono);
+  font-size: 18px;
+  text-shadow: 0 0 12px rgba(24, 203, 212, 0.32);
+}
+
+body.v3 .sb-nav {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 14px 12px 12px;
+}
+
+body.v3 .sb-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  color: var(--soft);
+  font-size: 13.5px;
+  font-weight: 580;
+}
+
+body.v3 .sb-item svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+
+body.v3 .sb-item:hover {
+  background: rgba(24, 203, 212, 0.06);
+  color: var(--text);
+}
+
+body.v3 .sb-item:hover svg { color: var(--soft); }
+
+body.v3 .sb-item.active {
+  background: rgba(24, 203, 212, 0.08);
+  color: var(--text);
+  font-weight: 700;
+}
+
+body.v3 .sb-item.active svg { color: var(--cyan); }
+
+body.v3 .sb-item .badge {
+  margin-left: auto;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  background: var(--cyan);
+  color: #001011;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+body.v3 .group-mark {
+  width: 22px;
+  height: 22px;
+  background: linear-gradient(135deg, #18cbd4, #0a4d52);
+  color: #001011;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 800;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+}
+
+body.v3 .group-mark.mark-magenta {
+  background: linear-gradient(135deg, #e84fb4, #2a0a2a);
+  color: #1a0610;
+}
+
+body.v3 .group-mark.mark-warm {
+  background: linear-gradient(135deg, #f6c177, #4a1f0a);
+  color: #1a0c00;
+}
+
+body.v3 .sb-orgs {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+body.v3 .sb-account {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border-top: 1px solid var(--line);
+}
+
+body.v3 .sb-org-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 36px;
+  margin: 1px 0;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  color: var(--soft);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+body.v3 .sb-org-row .name {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+body.v3 .sb-org-row:hover {
+  background: rgba(24, 203, 212, 0.06);
+  color: var(--text);
+}
+
+body.v3 .sb-org-row.active {
+  color: var(--text);
+  font-weight: 700;
+  background: rgba(24, 203, 212, 0.08);
+}
+
+body.v3 .sb-sub {
+  margin: 4px 12px 8px 32px;
+  padding-left: 12px;
+  border-left: 1px solid var(--line);
+}
+
+body.v3 .sb-sub-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 30px;
+  padding: 0 10px;
+  margin: 1px 0;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+body.v3 .sb-sub-item:hover { color: var(--text); background: rgba(24, 203, 212, 0.05); }
+
+body.v3 .sb-sub-item.active {
+  color: var(--cyan);
+  font-weight: 700;
+}
+
+body.v3 .sb-org-row.create { color: var(--muted); }
+body.v3 .sb-org-row.create:hover { color: var(--cyan); }
+
+body.v3 .plus-mark {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  border: 1px dashed var(--line-strong);
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+body.v3 .sb-org-row.create:hover .plus-mark {
+  border-color: var(--cyan);
+  border-style: solid;
+  color: var(--cyan);
+}
+
+body.v3 .sb-user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-top: 1px solid var(--line);
+  background: rgba(2, 4, 4, 0.6);
+  color: inherit;
+  transition: background 120ms ease;
+}
+
+body.v3 a.sb-user:hover { background: rgba(24, 203, 212, 0.06); }
+
+body.v3 .sb-user .avatar {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #f6c177, #e84fb4);
+  color: #200817;
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: 13px;
+  object-fit: cover;
+}
+
+body.v3 .sb-user .who { display: flex; flex-direction: column; min-width: 0; }
+
+body.v3 .sb-user .name {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+body.v3 .sb-user .role {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─────────────────────────────────────────────  TOPBAR  ─────── */
+body.v3 .main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+body.v3 .content-topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 72px;
+  padding: 0 32px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(2, 4, 4, 0.65);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+}
+
+body.v3 .topbar-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  margin-right: 8px;
+  z-index: 20;
+}
+
+body.v3 .topbar-search {
+  flex: 1 1 auto;
+  max-width: 560px;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: rgba(2, 4, 4, 0.6);
+  color: var(--muted);
+  font-size: 13.5px;
+  font-weight: 580;
+}
+
+body.v3 .topbar-search:focus-within { border-color: var(--cyan); box-shadow: 0 0 0 3px var(--cyan-soft); }
+body.v3 .topbar-search input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  padding: 0;
+}
+body.v3 .topbar-search input::placeholder { color: var(--muted); }
+body.v3 .topbar-search input::-webkit-search-cancel-button { display: none; }
+
+body.v3 .topbar-search .lead-key {
+  flex: 0 0 auto;
+  width: 22px;
+  display: grid;
+  place-items: center;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  user-select: none;
+}
+
+body.v3 .content-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+body.v3 .icon-pill {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--soft);
+  display: grid;
+  place-items: center;
+}
+
+body.v3 .icon-pill .dot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--magenta);
+  box-shadow: 0 0 8px var(--magenta);
+}
+
+body.v3 .btn-primary {
+  height: 36px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--cyan);
+  color: #001011;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body.v3 .btn-secondary {
+  height: 36px;
+  padding: 0 16px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body.v3 .btn-secondary:hover { border-color: var(--cyan); color: var(--cyan); }
+
+/* ─────────────────────────────────────────────  CONTENT  ────── */
+body.v3 .content-body {
+  flex: 1 1 auto;
+  padding: 32px 32px 64px;
+  overflow-y: auto;
+}
+
+body.v3 .page-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+body.v3 .page-head h1 {
+  margin: 0 0 8px;
+  font-family: var(--mono);
+  font-size: 34px;
+  letter-spacing: -0.005em;
+  line-height: 1.05;
+  text-shadow: 0 0 24px rgba(24, 203, 212, 0.18);
+}
+
+body.v3 .page-head p {
+  margin: 0;
+  max-width: 640px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+body.v3 .page-head .actions { display: flex; gap: 10px; flex: 0 0 auto; }
+
+body.v3 .eyebrow {
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* Scope tabs (Huddlz / Groups on explore) */
+body.v3 .scope-tabs {
+  display: inline-flex;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 4, 4, 0.4);
+  padding: 4px;
+  margin-bottom: 16px;
+}
+
+body.v3 .scope-tab {
+  padding: 7px 16px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--soft);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+body.v3 .scope-tab.is-active {
+  background: var(--cyan-soft);
+  color: var(--cyan);
+}
+
+/* Filter bar (explore) */
+body.v3 .filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px 24px;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  margin-bottom: 16px;
+}
+
+body.v3 .filter-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+body.v3 .filter-label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+body.v3 .filter-location {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 32px 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-pill);
+  background: rgba(2, 4, 4, 0.5);
+  color: var(--cyan);
+}
+
+body.v3 .filter-location-input {
+  width: 140px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+
+body.v3 .filter-location-input::placeholder { color: var(--muted); }
+
+body.v3 .filter-location-clear {
+  position: absolute;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1;
+}
+
+body.v3 .filter-location-clear:hover { color: var(--text); }
+
+body.v3 .filter-distance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body.v3 .filter-distance input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 140px;
+  height: 4px;
+  background: var(--line-strong);
+  border-radius: 2px;
+  outline: 0;
+}
+
+body.v3 .filter-distance input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--cyan);
+  border: 2px solid var(--bg);
+  cursor: pointer;
+  box-shadow: 0 0 8px rgba(24, 203, 212, 0.5);
+}
+
+body.v3 .filter-distance input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--cyan);
+  border: 2px solid var(--bg);
+  cursor: pointer;
+  box-shadow: 0 0 8px rgba(24, 203, 212, 0.5);
+}
+
+body.v3 .filter-distance-value {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--cyan);
+  min-width: 40px;
+}
+
+body.v3 .chip-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+body.v3 .chip-group .chip { height: 28px; padding: 0 12px; font-size: 12px; }
+
+/* Filters / chips */
+body.v3 .filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+body.v3 .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--soft);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+body.v3 .chip.is-active {
+  border-color: var(--cyan);
+  color: var(--cyan);
+  background: var(--cyan-soft);
+}
+
+/* Grid + cards */
+body.v3 .grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+body.v3 .grid.two { grid-template-columns: repeat(2, 1fr); }
+
+@media (max-width: 1280px) {
+ body.v3 .grid { grid-template-columns: repeat(2, 1fr); } }
+
+@media (max-width: 720px) {
+ body.v3 .grid, body.v3 .grid.two { grid-template-columns: 1fr; } }
+
+
+body.v3 .card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  overflow: hidden;
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+body.v3 .card:hover { border-color: var(--line-strong); transform: translateY(-1px); }
+
+body.v3 .card-cover {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+}
+
+body.v3 .card-cover-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+body.v3 .card-cover.gradient-1 { background: linear-gradient(135deg, #06424a 0%, #0c1c20 50%, #1a0c30 100%); }
+body.v3 .card-cover.gradient-2 { background: linear-gradient(160deg, #2c0a36 0%, #050810 60%, #0a3a44 100%); }
+body.v3 .card-cover.gradient-3 { background: linear-gradient(135deg, #1a3633 0%, #050810 60%, #2a1010 100%); }
+body.v3 .card-cover.gradient-4 { background: linear-gradient(135deg, #14232a 0%, #060a14 60%, #2a0e2a 100%); }
+body.v3 .card-cover.gradient-5 { background: linear-gradient(120deg, #082a2a 0%, #050a14 70%, #1a0c2a 100%); }
+body.v3 .card-cover.gradient-6 { background: linear-gradient(160deg, #181818 0%, #051820 50%, #1a3340 100%); }
+
+body.v3 .card-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 30%, rgba(2, 4, 4, 0.55) 100%);
+}
+
+body.v3 .date-stamp {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 2;
+  width: 50px;
+  height: 50px;
+  border: 1px solid var(--cyan);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 4, 4, 0.78);
+  color: var(--cyan);
+  font-family: var(--mono);
+  display: grid;
+  grid-template-rows: auto auto;
+  place-items: center;
+  padding: 4px 0;
+}
+
+body.v3 .date-stamp .m { font-size: 9.5px; letter-spacing: 0.18em; }
+body.v3 .date-stamp .d { font-size: 18px; font-weight: 700; line-height: 1; }
+
+body.v3 .card-tag {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+  padding: 3px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: var(--radius-pill);
+  background: rgba(2, 4, 4, 0.78);
+  color: var(--soft);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+body.v3 .card-tag.hybrid { color: var(--cyan); border-color: rgba(24, 203, 212, 0.4); }
+body.v3 .card-tag.online { color: var(--warn); border-color: rgba(246, 193, 119, 0.4); }
+body.v3 .card-tag.in-person { color: var(--magenta); border-color: rgba(232, 79, 180, 0.35); }
+
+body.v3 .card-body { padding: 14px 16px 16px; display: flex; flex-direction: column; gap: 8px; }
+
+body.v3 .card-group {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+body.v3 .card-title { font-size: 16px; font-weight: 700; line-height: 1.25; color: var(--text); }
+
+body.v3 .card-meta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+body.v3 .card-meta .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--muted); }
+
+body.v3 .card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-top: 1px solid var(--line);
+}
+
+body.v3 .stack { display: flex; align-items: center; }
+
+body.v3 .stack .pip {
+  width: 22px;
+  height: 22px;
+  margin-left: -6px;
+  border: 1.5px solid var(--panel-2);
+  background: linear-gradient(135deg, #18cbd4, #051820);
+}
+
+body.v3 .stack .pip:first-child { margin-left: 0; }
+body.v3 .stack .pip:nth-child(2) { background: linear-gradient(135deg, #e84fb4, #2a0a2a); }
+body.v3 .stack .pip:nth-child(3) { background: linear-gradient(135deg, #f6c177, #4a2a0a); }
+
+body.v3 .stack-count { margin-left: 10px; color: var(--soft); font-size: 12px; font-weight: 600; }
+
+body.v3 .save-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  display: grid;
+  place-items: center;
+}
+
+body.v3 .save-btn:hover { color: var(--cyan); border-color: var(--cyan); }
+
+/* ─────────────────────────────────────────  KPI / INSIGHT TILES  ─── */
+body.v3 .kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+@media (max-width: 1100px) {
+ body.v3 .kpis { grid-template-columns: repeat(2, 1fr); } }
+
+
+body.v3 .kpi {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  padding: 18px 20px;
+}
+
+body.v3 .kpi .label {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.v3 .kpi .value {
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+}
+
+body.v3 .kpi .delta {
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cyan);
+}
+
+body.v3 .kpi .delta.warn { color: var(--warn); }
+body.v3 .kpi .delta.muted { color: var(--muted); }
+
+body.v3 .kpi .spark {
+  margin-top: 12px;
+  width: 100%;
+  height: 28px;
+  display: block;
+  color: var(--cyan);
+  opacity: 0.9;
+}
+
+/* ─────────────────────────────────────────  TABLES / LISTS  ──── */
+body.v3 .panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  padding: 18px 20px;
+  margin-bottom: 24px;
+}
+
+body.v3 .panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+body.v3 .panel-head h2 {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 16px;
+  letter-spacing: -0.005em;
+}
+
+body.v3 .panel-sub { margin-top: 4px; color: var(--muted); font-size: 12px; }
+
+body.v3 .panel.split {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 28px;
+  align-items: start;
+}
+
+@media (max-width: 1100px) {
+ body.v3 .panel.split { grid-template-columns: 1fr; } }
+
+
+body.v3 .row-list { display: flex; flex-direction: column; }
+
+body.v3 .row {
+  display: grid;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+  font-size: 13.5px;
+}
+
+body.v3 .row:first-child { border-top: 0; }
+
+body.v3 .row .meta { color: var(--muted); font-size: 12px; }
+body.v3 .row .row-title .title-tag {
+  margin-left: 8px;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+/* Used by org-huddlz / org-members lists */
+body.v3 .row.huddlz-row { grid-template-columns: 56px 1fr 130px 120px 120px 80px; }
+body.v3 .row.members-row { grid-template-columns: 48px 1fr 120px 110px; }
+
+
+body.v3 .row .row-title { font-weight: 700; color: var(--text); }
+body.v3 .row .pill {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-pill);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+body.v3 .pill.cyan { color: var(--cyan); border-color: rgba(24, 203, 212, 0.4); }
+body.v3 .pill.warn { color: var(--warn); border-color: rgba(246, 193, 119, 0.35); }
+body.v3 .pill.magenta { color: var(--magenta); border-color: rgba(232, 79, 180, 0.35); }
+body.v3 .pill.muted { color: var(--muted); }
+
+/* Capacity bar */
+body.v3 .bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--line);
+  overflow: hidden;
+}
+
+body.v3 .bar > span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background: linear-gradient(90deg, var(--cyan), var(--cyan-dim));
+}
+
+body.v3 .bar.warn > span { background: linear-gradient(90deg, var(--warn), #b8722e); }
+
+/* Huddl RSVP banners */
+body.v3 .rsvp-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 4, 4, 0.5);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+body.v3 .rsvp-banner.cyan { color: var(--cyan); border-color: rgba(24, 203, 212, 0.4); background: var(--cyan-soft); }
+body.v3 .rsvp-banner.warn { color: var(--warn); border-color: rgba(246, 193, 119, 0.35); background: rgba(246, 193, 119, 0.08); }
+body.v3 .rsvp-banner svg { flex: 0 0 auto; }
+
+body.v3 .virtual-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+body.v3 .virtual-hint svg { flex: 0 0 auto; color: var(--cyan); }
+
+body.v3 .btn-secondary.virtual-link {
+  border-color: rgba(24, 203, 212, 0.4);
+  color: var(--cyan);
+}
+
+body.v3 .btn-secondary.virtual-link:hover { border-color: var(--cyan); }
+
+/* ─────────────────────────────────────────  CALENDAR  ────────── */
+body.v3 .cal-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+body.v3 .cal-month-title {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+body.v3 .cal-view-tabs { margin-left: auto; }
+
+body.v3 .cal-month-eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--cyan);
+  opacity: 0.7;
+}
+
+body.v3 .cal-month-name {
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+body.v3 .cal-month-count {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+body.v3 .cal-view-tabs {
+  display: inline-flex;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  padding: 4px;
+  background: rgba(2, 4, 4, 0.4);
+}
+
+body.v3 .cal-view-tabs .scope-tab { padding: 5px 14px; font-size: 12px; }
+
+body.v3 .cal-nav { display: flex; gap: 4px; }
+
+body.v3 .cal-nav-btn {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--soft);
+}
+
+body.v3 .cal-nav-btn:hover { color: var(--cyan); border-color: var(--cyan); }
+
+body.v3 .cal-nav-today {
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--soft);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.v3 .cal-nav-today:hover { color: var(--cyan); border-color: var(--cyan); }
+
+body.v3 .cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+body.v3 .cal-day-name {
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--cyan);
+  opacity: 0.7;
+  text-align: center;
+}
+
+body.v3 .cal-day-name:not(:last-child) { border-right: 1px solid var(--line); }
+
+body.v3 .cal-cell {
+  min-height: 100px;
+  padding: 8px 8px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: rgba(2, 4, 4, 0.3);
+}
+
+body.v3 .cal-cell:nth-child(7n) { /* last column */
+  border-right: 0;
+}
+
+body.v3 .cal-cell:not(:nth-child(7n)) { border-right: 1px solid var(--line); }
+
+body.v3 .cal-grid:nth-of-type(2) .cal-cell { border-bottom: 1px solid var(--line); }
+body.v3 .cal-grid:nth-of-type(2) .cal-cell:nth-last-child(-n+7) { border-bottom: 0; }
+
+body.v3 .cal-cell.out-of-month { background: rgba(2, 4, 4, 0.55); }
+body.v3 .cal-cell.out-of-month .cal-day-num { color: var(--muted); opacity: 0.5; }
+
+body.v3 .cal-day-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--soft);
+  font-variant-numeric: tabular-nums;
+}
+
+body.v3 .cal-day-num.is-today {
+  color: var(--cyan);
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 8px rgba(24, 203, 212, 0.4);
+}
+
+body.v3 .cal-pill {
+  display: block;
+  padding: 3px 6px;
+  border: 1px solid rgba(24, 203, 212, 0.35);
+  border-radius: 3px;
+  color: var(--cyan);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+body.v3 .cal-pill:hover { background: var(--cyan-soft); border-color: var(--cyan); }
+
+body.v3 .cal-pill.tentative {
+  border-color: rgba(246, 193, 119, 0.4);
+  color: var(--warn);
+}
+
+body.v3 .cal-pill.tentative:hover { background: rgba(246, 193, 119, 0.08); border-color: var(--warn); }
+
+body.v3 .cal-pill.past {
+  border-color: var(--line);
+  color: var(--muted);
+}
+
+body.v3 .cal-pill.past:hover { color: var(--soft); }
+
+body.v3 .cal-pill.out-of-month-pill {
+  border-color: var(--line);
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+body.v3 .cal-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--soft);
+}
+
+body.v3 .cal-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+body.v3 .cal-legend-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+body.v3 .cal-legend-note { margin-left: auto; font-size: 12px; }
+
+@media (max-width: 760px) {
+
+  body.v3 .cal-cell { min-height: 64px; padding: 4px; }
+  body.v3 .cal-day-name { padding: 6px 2px; font-size: 10px; letter-spacing: 0.08em; }
+  body.v3 .cal-pill { font-size: 10px; padding: 2px 4px; }
+  body.v3 .cal-day-num { font-size: 11px; }
+  body.v3 .cal-day-num.is-today { width: 18px; height: 18px; }
+  body.v3 .cal-legend-note { margin-left: 0; flex: 1 1 100%; }
+}
+
+
+/* Group page — members preview grid */
+body.v3 .member-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+body.v3 .member-grid.compact {
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 6px;
+}
+
+body.v3 .member-mini {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--soft);
+}
+
+body.v3 .member-grid.compact .member-mini { justify-content: center; gap: 0; }
+
+body.v3 .member-mini .member-mark {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  font-size: 11px;
+}
+
+body.v3 .member-grid.compact .member-mark { width: 28px; height: 28px; font-size: 10px; }
+
+body.v3 .role-pill {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+/* Sub-section inside huddl-side */
+body.v3 .huddl-side-section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+}
+
+body.v3 .huddl-side-section h3 {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-family: var(--mono);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* Notification preference rows (settings page) */
+body.v3 .pref-list .row { grid-template-columns: 1fr auto; gap: 18px; }
+
+/* Notification row */
+body.v3 .row.notif-row { grid-template-columns: 14px 1fr 80px; gap: 14px; }
+body.v3 .row.notif-row.unread .row-title { color: var(--text); }
+body.v3 .row.notif-row:not(.unread) .row-title { color: var(--soft); }
+body.v3 .row.notif-row:not(.unread) .meta { color: var(--muted); }
+
+body.v3 .notif-mark {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--line-strong);
+  margin-top: 6px;
+}
+
+body.v3 .notif-mark.cyan { background: var(--cyan); box-shadow: 0 0 8px rgba(24, 203, 212, 0.5); }
+body.v3 .notif-mark.warn { background: var(--warn); box-shadow: 0 0 8px rgba(246, 193, 119, 0.5); }
+body.v3 .notif-mark.muted { background: var(--line-strong); box-shadow: none; }
+
+/* Tiny avatar pip used in member list */
+body.v3 .member-mark {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 800;
+  color: #001011;
+  background: linear-gradient(135deg, #18cbd4, #0a4d52);
+  border-radius: var(--radius-sm);
+}
+
+body.v3 .member-mark.m1 { background: linear-gradient(135deg, #e84fb4, #2a0a2a); color: #1a0610; }
+body.v3 .member-mark.m2 { background: linear-gradient(135deg, #f6c177, #4a2a0a); color: #1a0c00; }
+body.v3 .member-mark.m3 { background: linear-gradient(135deg, #18cbd4, #0a4d52); }
+body.v3 .member-mark.m4 { background: linear-gradient(135deg, #e84fb4, #f6c177); color: #200817; }
+body.v3 .member-mark.m5 { background: linear-gradient(135deg, #4a90ff, #1a3a80); color: #001033; }
+
+/* ────────────────────────────────────────────  GROUP / HUDDL  ─── */
+body.v3 .hero {
+  position: relative;
+  height: 280px;
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: linear-gradient(135deg, #06424a 0%, #0c1c20 50%, #1a0c30 100%);
+  margin-bottom: 32px;
+}
+
+body.v3 .hero-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+}
+
+body.v3 .hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 40%, rgba(2, 4, 4, 0.85) 100%);
+}
+
+body.v3 .hero-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 28px 32px;
+  z-index: 2;
+}
+
+body.v3 .hero-content h1 {
+  margin: 0 0 6px;
+  font-family: var(--mono);
+  font-size: 38px;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  text-shadow: 0 0 24px rgba(24, 203, 212, 0.18);
+}
+
+body.v3 .hero-content .meta {
+  display: flex;
+  gap: 18px;
+  color: var(--soft);
+  font-size: 13px;
+}
+
+body.v3 .huddl-frame {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas:
+    "intro side"
+    "rest  side";
+  gap: 28px;
+  align-items: start;
+}
+
+body.v3 .huddl-intro { grid-area: intro; }
+body.v3 .huddl-side { grid-area: side; }
+body.v3 .huddl-rest { grid-area: rest; display: flex; flex-direction: column; gap: 0; }
+
+@media (max-width: 1100px) {
+
+  body.v3 .huddl-frame {
+    grid-template-columns: 1fr;
+    grid-template-areas: "intro" "side" "rest";
+  }
+}
+
+
+body.v3 .huddl-side {
+  position: sticky;
+  top: 96px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  padding: 24px;
+}
+
+body.v3 .huddl-side h3 {
+  margin: 0 0 16px;
+  font-size: 14px;
+  font-family: var(--mono);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+body.v3 .facts {
+  list-style: none;
+  margin: 0 0 24px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+body.v3 .facts li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  font-size: 13px;
+}
+
+body.v3 .facts svg { width: 16px; height: 16px; flex: 0 0 auto; color: var(--cyan); margin-top: 2px; }
+
+body.v3 .facts .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+body.v3 .facts .value { color: var(--text); font-weight: 600; }
+
+body.v3 .prose { color: var(--soft); font-size: 15px; line-height: 1.65; }
+body.v3 .prose p { margin: 0 0 16px; }
+body.v3 .prose h2 {
+  margin: 32px 0 12px;
+  font-family: var(--mono);
+  font-size: 20px;
+  letter-spacing: -0.005em;
+  color: var(--text);
+}
+
+/* ─────────────────────────────────────────  LANDING PAGE  ────── */
+body.is-landing {
+  display: block;
+  background:
+    radial-gradient(circle at 78% 8%, rgba(24, 203, 212, 0.14), transparent 480px),
+    radial-gradient(circle at 18% 88%, rgba(232, 79, 180, 0.10), transparent 480px),
+    var(--bg);
+}
+
+body.v3 .land-topbar {
+  display: flex;
+  align-items: center;
+  height: 80px;
+  padding: 0 64px;
+  border-bottom: 1px solid var(--line);
+}
+
+body.v3 .land-topbar .nav { margin-left: auto; display: flex; align-items: center; gap: 16px; }
+
+body.v3 .land-topbar .nav a {
+  color: var(--soft);
+  font-size: 14px;
+  font-weight: 580;
+}
+
+body.v3 .land-topbar .nav a:hover { color: var(--text); }
+
+body.v3 .land-hero {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 96px 32px 80px;
+  text-align: center;
+}
+
+body.v3 .land-hero h1 {
+  margin: 16px auto 24px;
+  font-family: var(--mono);
+  font-size: clamp(44px, 6.4vw, 88px);
+  line-height: 0.98;
+  letter-spacing: -0.01em;
+  max-width: 12ch;
+  text-shadow: 0 0 40px rgba(24, 203, 212, 0.24);
+}
+
+body.v3 .land-hero p {
+  max-width: 620px;
+  margin: 0 auto 32px;
+  color: var(--soft);
+  font-size: 19px;
+  line-height: 1.5;
+}
+
+body.v3 .land-cta { display: flex; justify-content: center; gap: 12px; }
+
+body.v3 .land-cta .btn-primary, body.v3 .land-cta .btn-secondary { height: 48px; padding: 0 22px; font-size: 14px; }
+
+body.v3 .land-features {
+  max-width: 1180px;
+  margin: 56px auto 0;
+  padding: 0 32px 96px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+@media (max-width: 880px) {
+ body.v3 .land-features { grid-template-columns: 1fr; } }
+
+
+body.v3 .feat {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  padding: 28px 26px;
+}
+
+body.v3 .feat .feat-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--cyan);
+  background: rgba(24, 203, 212, 0.08);
+  color: var(--cyan);
+  margin-bottom: 16px;
+}
+
+body.v3 .feat h3 { margin: 0 0 8px; font-size: 17px; font-weight: 700; color: var(--text); }
+body.v3 .feat p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.55; }
+
+body.v3 .land-foot {
+  border-top: 1px solid var(--line);
+  padding: 32px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+  font-family: var(--mono);
+  letter-spacing: 0.04em;
+}
+
+/* ─────────────────────────────────────────  AUTH PAGES  ─────── */
+body.is-auth {
+  display: block;
+  background:
+    radial-gradient(circle at 78% 8%, rgba(24, 203, 212, 0.10), transparent 480px),
+    radial-gradient(circle at 18% 88%, rgba(232, 79, 180, 0.06), transparent 480px),
+    var(--bg);
+}
+
+body.v3 .auth-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+body.v3 .auth-topbar {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  height: 80px;
+  padding: 0 32px;
+}
+
+body.v3 .auth-topbar a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+body.v3 .auth-frame {
+  width: 100%;
+  max-width: 440px;
+  padding: 24px 32px 64px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 18px;
+}
+
+body.v3 .auth-frame h1 {
+  margin: 16px 0 6px;
+  font-family: var(--mono);
+  font-size: 30px;
+  letter-spacing: -0.005em;
+  text-shadow: 0 0 24px rgba(24, 203, 212, 0.18);
+}
+
+body.v3 .auth-frame .lede {
+  margin: 0 0 8px;
+  color: var(--soft);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+body.v3 .auth-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  padding: 24px;
+}
+
+body.v3 .auth-card .form-grid { max-width: none; gap: 14px; }
+body.v3 .auth-card .form-foot { border: 0; padding: 0; margin-top: 18px; }
+body.v3 .auth-card .form-foot .btn-primary { flex: 1 1 auto; justify-content: center; height: 44px; font-size: 14px; }
+
+body.v3 .auth-aside {
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body.v3 .auth-aside a { color: var(--cyan); font-weight: 700; }
+body.v3 .auth-aside a:hover { text-decoration: underline; }
+
+body.v3 .auth-state {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  padding: 28px 24px;
+  text-align: center;
+}
+
+body.v3 .auth-state .icon-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border: 1px solid var(--cyan);
+  border-radius: 50%;
+  background: rgba(24, 203, 212, 0.08);
+  color: var(--cyan);
+  margin-bottom: 18px;
+}
+
+body.v3 .auth-state.warn .icon-mark {
+  border-color: var(--warn);
+  background: rgba(246, 193, 119, 0.10);
+  color: var(--warn);
+}
+
+body.v3 .auth-state h2 {
+  margin: 0 0 10px;
+  font-family: var(--mono);
+  font-size: 18px;
+  color: var(--text);
+}
+
+body.v3 .auth-state p { margin: 0 0 18px; color: var(--soft); font-size: 14px; line-height: 1.5; }
+
+/* ─────────────────────────────────────────  PROFILE / SETTINGS  ─── */
+body.v3 .profile-head {
+  display: flex;
+  gap: 24px;
+  align-items: flex-end;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 28px;
+}
+
+body.v3 .big-avatar {
+  width: 88px;
+  height: 88px;
+  background: linear-gradient(135deg, #f6c177, #e84fb4);
+  color: #200817;
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: 28px;
+  flex: 0 0 auto;
+  object-fit: cover;
+}
+
+body.v3 .profile-head h1 {
+  margin: 0 0 6px;
+  font-family: var(--mono);
+  font-size: 28px;
+  letter-spacing: -0.005em;
+}
+
+body.v3 .profile-head .who { color: var(--muted); font-size: 13px; }
+
+body.v3 .settings-list {
+  display: flex;
+  flex-direction: column;
+}
+
+body.v3 .settings-list .row {
+  grid-template-columns: 1fr auto;
+  cursor: pointer;
+}
+
+body.v3 .settings-list .row:hover { color: var(--text); }
+body.v3 .settings-list .row .row-title { font-weight: 600; }
+body.v3 .settings-list .row .row-desc { color: var(--muted); font-size: 12px; margin-top: 2px; }
+
+/* ─────────────────────────────────────────  FORMS  ───────────── */
+body.v3 .form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 560px;
+}
+
+body.v3 .form-row { display: flex; flex-direction: column; gap: 6px; }
+
+body.v3 .form-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+body.v3 .form-input, body.v3 .form-textarea, body.v3 .form-select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 4, 4, 0.6);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  outline: 0;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+body.v3 .form-input:focus, body.v3 .form-textarea:focus, body.v3 .form-select:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 3px var(--cyan-soft);
+}
+
+body.v3 .form-textarea { min-height: 120px; resize: vertical; line-height: 1.5; }
+
+body.v3 .form-help { color: var(--muted); font-size: 12px; }
+body.v3 .form-error { color: var(--warn); font-size: 12px; }
+
+body.v3 .form-control.read-only {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 4, 4, 0.4);
+  color: var(--soft);
+  font-size: 14px;
+}
+
+body.v3 .form-foot {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  gap: 10px;
+}
+
+body.v3 .location-control {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+body.v3 .location-display {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+body.v3 .location-current {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 16, 17, 0.5);
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+body.v3 .location-current svg { color: var(--cyan); flex: 0 0 auto; }
+
+body.v3 .location-actions { display: inline-flex; gap: 8px; flex-wrap: wrap; }
+
+body.v3 .location-control .form-input { padding-right: 36px; }
+
+body.v3 .form-clear {
+  position: absolute;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+}
+
+body.v3 .form-clear:hover { color: var(--text); }
+
+body.v3 .btn-secondary.muted-btn { color: var(--muted); }
+body.v3 .btn-secondary.muted-btn:hover { color: var(--warn); border-color: var(--warn); }
+
+body.v3 .profile-photo-row {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+}
+
+body.v3 .profile-photo-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+/* Inline form row (multiple fields side by side) */
+body.v3 .form-row-inline {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: flex-end;
+}
+
+body.v3 .form-row-inline > div { display: flex; flex-direction: column; gap: 6px; }
+
+/* Slug control */
+body.v3 .slug-control {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 4, 4, 0.6);
+  overflow: hidden;
+}
+
+body.v3 .slug-control:focus-within {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 3px var(--cyan-soft);
+}
+
+body.v3 .slug-prefix {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-right: 1px solid var(--line);
+  background: rgba(2, 4, 4, 0.4);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+body.v3 .slug-control .form-input {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+body.v3 .slug-control .form-input:focus { box-shadow: none; }
+
+body.v3 .warn-text { color: var(--warn); }
+
+/* Upload zone */
+body.v3 .upload-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 24px;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius);
+  background: rgba(2, 4, 4, 0.4);
+  text-align: center;
+}
+
+body.v3 .upload-icon {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  color: var(--muted);
+}
+
+body.v3 .upload-prompt { color: var(--soft); font-size: 14px; }
+body.v3 .upload-link { color: var(--cyan); font-weight: 700; cursor: pointer; }
+body.v3 .upload-link:hover { text-decoration: underline; }
+body.v3 .upload-meta { font-size: 12px; }
+
+body.v3 .image-preview .card-cover {
+  border-radius: var(--radius-sm);
+  width: 100%;
+  background-size: cover;
+  background-position: center;
+}
+
+/* Event-type radio cards */
+body.v3 .event-type-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 760px) {
+
+  body.v3 .event-type-grid { grid-template-columns: 1fr; }
+}
+
+
+body.v3 .event-type-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-3);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+body.v3 .event-type-option:hover { border-color: var(--line-strong); }
+
+body.v3 .event-type-option.is-active {
+  border-color: var(--cyan);
+  background: var(--cyan-soft);
+}
+
+body.v3 .event-type-option input { display: none; }
+
+body.v3 .event-type-icon {
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  color: var(--soft);
+}
+
+body.v3 .event-type-option.is-active .event-type-icon {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+body.v3 .event-type-title { font-size: 14px; font-weight: 700; color: var(--text); }
+body.v3 .event-type-desc { color: var(--muted); font-size: 12px; margin-top: 2px; line-height: 1.4; }
+
+/* Edit scope row (huddl-edit) */
+body.v3 .edit-scope-row { padding: 0; }
+body.v3 .edit-scope-row p { margin: 6px 0 12px; color: var(--soft); font-size: 13.5px; }
+body.v3 .edit-scope-row strong { color: var(--text); }
+
+/* Toggle pill (notification prefs etc.) */
+body.v3 .toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+body.v3 .toggle input { display: none; }
+
+body.v3 .toggle .track {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--line-strong);
+  transition: background 120ms ease;
+}
+
+body.v3 .toggle .track::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #f0fafa;
+  transition: transform 120ms ease;
+}
+
+body.v3 .toggle input:checked + .track {
+  background: var(--cyan);
+  box-shadow: 0 0 12px rgba(24, 203, 212, 0.4);
+}
+
+body.v3 .toggle input:checked + .track::after { transform: translateX(16px); }
+
+body.v3 .toggle input:disabled + .track {
+  opacity: 0.5;
+  background: var(--cyan-dim);
+}
+
+body.v3 .toggle .toggle-text {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  min-width: 28px;
+}
+
+body.v3 .toggle input:checked ~ .toggle-text { color: var(--cyan); }
+body.v3 .toggle input:disabled ~ .toggle-text { color: var(--muted); opacity: 0.7; }
+
+/* Insights chip strip on listing pages */
+body.v3 .insight-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+body.v3 .insight-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  color: var(--soft);
+  font-size: 12.5px;
+}
+
+body.v3 .insight-pill strong { color: var(--text); font-weight: 700; font-family: var(--mono); }
+body.v3 .insight-pill svg { width: 13px; height: 13px; color: var(--cyan); }
+
+/* Subtle helper */
+body.v3 .muted { color: var(--muted); }
+body.v3 .cyan { color: var(--cyan); }
+
+/* ───────────────────────────────────────  PAGINATION  ──────────── */
+body.v3 .pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+}
+
+body.v3 .page-numbers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+body.v3 .page-num {
+  display: inline-grid;
+  place-items: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--soft);
+  border-radius: var(--radius-sm);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+body.v3 .page-num:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+body.v3 .page-num.is-active {
+  background: var(--cyan-soft);
+  border-color: var(--cyan-dim);
+  color: var(--cyan);
+}
+
+body.v3 .page-ellipsis {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 0 4px;
+}
+
+body.v3 .page-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--soft);
+  border-radius: var(--radius-sm);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+body.v3 .page-nav:not(:disabled):hover {
+  color: var(--text);
+  border-color: var(--cyan-dim);
+}
+
+body.v3 .page-nav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ───────────────────────────────────────  MOBILE OVERRIDES  ───── */
+@media (max-width: 760px) {
+
+  body.v3 .content-topbar { height: 60px; padding: 0 12px; gap: 10px; }
+  body.v3 .content-body { padding: 18px 12px 56px; }
+  body.v3 .page-head { flex-direction: column; align-items: stretch; gap: 16px; margin-bottom: 20px; }
+  body.v3 .page-head h1 { font-size: 26px; }
+  body.v3 .page-head .actions { flex-wrap: wrap; }
+  body.v3 .hero { height: 200px; margin-bottom: 20px; }
+  body.v3 .hero-content { padding: 18px 16px; }
+  body.v3 .hero-content h1 { font-size: 26px; }
+  body.v3 .panel { padding: 14px 14px; }
+  body.v3 .panel.split { gap: 18px; }
+  body.v3 .filters { gap: 6px; }
+  body.v3 .insight-strip { gap: 8px; }
+  /* Listings on org pages: collapse multi-column rows */
+  body.v3 .row.huddlz-row, body.v3 .row.members-row { grid-template-columns: 56px 1fr; row-gap: 8px; }
+  body.v3 .row.members-row { grid-template-columns: 48px 1fr; }
+  /* Land marketing */
+  body.v3 .land-topbar { height: 64px; padding: 0 16px; }
+  body.v3 .land-hero { padding: 56px 16px 48px; }
+  body.v3 .land-features { padding: 0 16px 64px; }
+  body.v3 .profile-head { flex-direction: column; align-items: flex-start; gap: 14px; }
+  body.v3 .pagination { justify-content: center; flex-wrap: wrap; }
+  body.v3 .pagination .page-numbers { order: -1; flex-basis: 100%; justify-content: center; flex-wrap: wrap; }
+}
+

--- a/lib/huddlz_web.ex
+++ b/lib/huddlz_web.ex
@@ -90,6 +90,8 @@ defmodule HuddlzWeb do
       # Core UI components
       import HuddlzWeb.CoreComponents
       import HuddlzWeb.CommunityComponents
+      # V3 design components — see HuddlzWeb.V3 for the migration context.
+      use HuddlzWeb.V3
 
       # Common modules used in templates
       alias HuddlzWeb.Layouts

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -292,6 +292,294 @@ defmodule HuddlzWeb.Layouts do
   end
 
   @doc """
+  V3 app layout — sidebar + topbar shell wrapping the inner content.
+
+  Mirrors the clickthrough mockup at `/dev/design/clickthrough/explore` (and
+  the `clickthrough_shell` function component in `HuddlzWeb.DevDesignHTML`),
+  but reads the real `current_user` and renders an admin link when the user
+  is an admin.
+
+  Pair with `on_mount {HuddlzWeb.LiveUserAuth, :v3_app}` to flip the body
+  class to `"v3"` so the v3 styles in `app.css` take effect.
+  """
+  attr :flash, :map, required: true
+  attr :current_user, :map, default: nil
+
+  attr :active, :string,
+    default: nil,
+    doc: "active surface key for nav highlighting (e.g. \"discover\", \"my-huddlz\")"
+
+  attr :query, :string, default: "", doc: "current search query — prefilled in topbar input"
+  slot :inner_block, required: true
+
+  def v3_app(assigns) do
+    assigns = assign_new(assigns, :signed_in, fn -> assigns.current_user != nil end)
+
+    ~H"""
+    <%= if @signed_in do %>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+      <label for="nav-toggle" class="nav-scrim" aria-hidden="true"></label>
+      <aside class="sidebar">
+        <a class="sidebar-brand" href="/">
+          <div class="brand-glyph">h</div>
+          <div class="brand-text">huddlz</div>
+        </a>
+
+        <nav class="sb-nav">
+          <a class={["sb-item", @active == "discover" && "active"]} href="/discover">
+            <.v3_nav_icon name="search" />
+            <span class="label">Explore</span>
+          </a>
+          <a class={["sb-item", @active == "my-huddlz" && "active"]} href="/my-huddlz">
+            <.v3_nav_icon name="ticket" />
+            <span class="label">My huddlz</span>
+          </a>
+          <a class={["sb-item", @active == "my-groups" && "active"]} href="/my-groups">
+            <.v3_nav_icon name="users" />
+            <span class="label">My groups</span>
+          </a>
+          <a class={["sb-item", @active == "calendar" && "active"]} href="/calendar">
+            <.v3_nav_icon name="calendar" />
+            <span class="label">My calendar</span>
+          </a>
+        </nav>
+
+        <div class="sb-account">
+          <a class={["sb-item", @active == "profile" && "active"]} href="/profile">
+            <.v3_nav_icon name="user" />
+            <span class="label">Profile</span>
+          </a>
+          <a
+            class={["sb-item", @active == "settings" && "active"]}
+            href="/profile/notifications"
+          >
+            <.v3_nav_icon name="cog" />
+            <span class="label">Settings</span>
+          </a>
+          <a class={["sb-item", @active == "help" && "active"]} href="/help">
+            <.v3_nav_icon name="help" />
+            <span class="label">Help</span>
+          </a>
+          <%= if @current_user && @current_user.role == :admin do %>
+            <a class={["sb-item", @active == "admin" && "active"]} href="/admin">
+              <.v3_nav_icon name="shield" />
+              <span class="label">Admin</span>
+            </a>
+          <% end %>
+        </div>
+
+        <a class="sb-user" href="/profile" aria-label="View profile">
+          <span class="avatar" aria-hidden="true"></span>
+          <div class="who">
+            <div class="name">{display_name(@current_user)}</div>
+            <div class="role">{@current_user.email}</div>
+          </div>
+        </a>
+      </aside>
+    <% end %>
+
+    <main class="main">
+      <header class="content-topbar">
+        <%= if @signed_in do %>
+          <label for="nav-toggle" class="nav-trigger" aria-label="Open navigation">
+            <.v3_nav_icon name="bars" />
+          </label>
+        <% else %>
+          <a class="topbar-brand" href="/" aria-label="huddlz home">
+            <div class="brand-glyph">h</div>
+            <div class="brand-text">huddlz</div>
+          </a>
+        <% end %>
+        <form class="topbar-search" action="/discover" method="get" role="search">
+          <span class="lead-key" aria-hidden="true">/</span>
+          <input type="search" name="q" placeholder="Search huddlz" value={@query} />
+        </form>
+        <div class="content-actions">
+          <%= if @signed_in do %>
+            <a
+              class={["icon-pill", @active == "notifications" && "active"]}
+              href="/notifications"
+              aria-label="Notifications"
+            >
+              <.v3_nav_icon name="bell" />
+            </a>
+          <% else %>
+            <a class="btn-secondary" href="/sign-in">Sign in</a>
+            <a class="btn-primary" href="/register">Sign up</a>
+          <% end %>
+        </div>
+      </header>
+
+      <div class="content-body">
+        <.flash_group flash={@flash} />
+        {render_slot(@inner_block)}
+      </div>
+    </main>
+    """
+  end
+
+  attr :name, :string, required: true
+
+  defp v3_nav_icon(%{name: "search"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "ticket"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M3 9a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2a2 2 0 0 0 0 4v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a2 2 0 0 0 0-4z" /><path
+        d="M14 7v10"
+        stroke-dasharray="2 2"
+      />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "users"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="9" cy="9" r="3" /><circle cx="17" cy="9" r="2.5" /><path d="M3 19a6 6 0 0 1 12 0" /><path d="M14 17a5 5 0 0 1 7 2" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "calendar"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect x="3" y="5" width="18" height="16" rx="2" /><path d="M16 3v4M8 3v4M3 11h18" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "user"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "cog"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "help"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="9" /><path d="M9.5 9a2.5 2.5 0 0 1 5 0c0 1.5-2.5 2-2.5 3.5" /><path d="M12 17h.01" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "shield"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M12 3 4 6v6c0 5 3.5 8.5 8 9 4.5-.5 8-4 8-9V6l-8-3z" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "bars"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M4 7h16M4 12h16M4 17h16" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "bell"} = assigns) do
+    ~H"""
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.7 21a2 2 0 0 1-3.4 0" />
+    </svg>
+    """
+  end
+
+  defp display_name(%{display_name: name}) when is_binary(name) and name != "", do: name
+  defp display_name(%{email: email}) when is_binary(email), do: email
+  defp display_name(_), do: "Account"
+
+  @doc """
   Shows the flash group with standard titles and content.
   """
   attr :flash, :map, required: true, doc: "the map of flash messages"

--- a/lib/huddlz_web/components/layouts/root.html.heex
+++ b/lib/huddlz_web/components/layouts/root.html.heex
@@ -40,7 +40,7 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>
   </head>
-  <body>
+  <body class={Map.get(assigns, :body_class, "")}>
     {@inner_content}
   </body>
 </html>

--- a/lib/huddlz_web/components/v3.ex
+++ b/lib/huddlz_web/components/v3.ex
@@ -1,0 +1,34 @@
+defmodule HuddlzWeb.V3 do
+  @moduledoc """
+  V3 design components facade.
+
+  V3 is the third (and intentionally last) redesign of the huddlz UI; the
+  clickthrough mockup at `/dev/design/clickthrough/*` is the design source
+  of truth. Components defined under `HuddlzWeb.V3.*` mirror the v3
+  vocabulary (`card`, `panel`, `chip`, `pill`, `row`, etc.) and are styled
+  from `body.v3 { ... }` rules in `assets/css/app.css`.
+
+  Importing this module brings every v3 function component into scope under
+  a `v3_*` prefix (e.g. `<.v3_button>`, `<.v3_card>`, `<.v3_pill>`),
+  avoiding collisions with the legacy daisy-styled components in
+  `HuddlzWeb.CoreComponents` during the migration window.
+
+  After the migration completes we delete `core_components.ex` and
+  `community_components.ex`, drop the `v3_` prefix on these functions, and
+  flatten the namespace to `HuddlzWeb.Components.*`. See
+  `~/.claude/plans/user-prompt-we-have-created-iterative-bird.md` for the
+  full migration plan.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      import HuddlzWeb.V3.Button
+      import HuddlzWeb.V3.Card
+      import HuddlzWeb.V3.Chip
+      import HuddlzWeb.V3.Input
+      import HuddlzWeb.V3.ListRow
+      import HuddlzWeb.V3.Panel
+      import HuddlzWeb.V3.Pill
+    end
+  end
+end

--- a/lib/huddlz_web/components/v3/button.ex
+++ b/lib/huddlz_web/components/v3/button.ex
@@ -1,0 +1,48 @@
+defmodule HuddlzWeb.V3.Button do
+  @moduledoc """
+  V3 button — `btn-primary` (cyan fill, one per surface) or `btn-secondary`
+  (outline). Renders a `<button>` by default; pass `href`/`navigate`/`patch`
+  to render a `<.link>`.
+
+  Variants:
+
+    * `:primary` — headline action, cyan fill
+    * `:secondary` — outline (default)
+    * `:muted` — outline with muted text colour
+    * `:destructive` — outline using the warn/error colour
+  """
+  use Phoenix.Component
+
+  attr :variant, :atom,
+    values: [:primary, :secondary, :muted, :destructive],
+    default: :secondary
+
+  attr :class, :any, default: nil
+
+  attr :rest, :global, include: ~w(href navigate patch type disabled name value form)
+
+  slot :inner_block, required: true
+
+  def v3_button(%{rest: rest} = assigns) do
+    if rest[:href] || rest[:navigate] || rest[:patch] do
+      ~H"""
+      <.link class={[base_class(@variant), @class]} {@rest}>
+        {render_slot(@inner_block)}
+      </.link>
+      """
+    else
+      assigns = assign_new(assigns, :type, fn -> "button" end)
+
+      ~H"""
+      <button type={@type} class={[base_class(@variant), @class]} {@rest}>
+        {render_slot(@inner_block)}
+      </button>
+      """
+    end
+  end
+
+  defp base_class(:primary), do: "btn-primary"
+  defp base_class(:secondary), do: "btn-secondary"
+  defp base_class(:muted), do: "btn-secondary muted-btn"
+  defp base_class(:destructive), do: "btn-secondary destructive-btn"
+end

--- a/lib/huddlz_web/components/v3/card.ex
+++ b/lib/huddlz_web/components/v3/card.ex
@@ -1,0 +1,81 @@
+defmodule HuddlzWeb.V3.Card do
+  @moduledoc """
+  V3 card — anchor card used for huddlz, groups, and saved items in grid views.
+
+  Slot-driven so callers can compose cover image, date stamp, tag, body, and
+  foot independently. The default `gradient` cycles through 1–6 to vary cover
+  fallbacks across a list.
+  """
+  use Phoenix.Component
+
+  attr :href, :string, default: nil
+  attr :navigate, :string, default: nil
+  attr :patch, :string, default: nil
+
+  attr :gradient, :integer,
+    values: [1, 2, 3, 4, 5, 6],
+    default: 1,
+    doc: "1–6 selects the cover fallback gradient"
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  slot :cover, doc: "cover content (img, date stamp, card-tag)"
+  slot :body, required: true, doc: "card body — group label, title, meta"
+  slot :foot, doc: "optional card foot — pill + relative time"
+
+  def v3_card(assigns) do
+    ~H"""
+    <.link
+      href={@href}
+      navigate={@navigate}
+      patch={@patch}
+      class={["card", @class]}
+      {@rest}
+    >
+      <div :if={@cover != []} class={"card-cover gradient-#{@gradient}"}>
+        {render_slot(@cover)}
+      </div>
+      <div class="card-body">
+        {render_slot(@body)}
+      </div>
+      <div :if={@foot != []} class="card-foot">
+        {render_slot(@foot)}
+      </div>
+    </.link>
+    """
+  end
+
+  @doc """
+  Renders a date stamp (used inside a `<:cover>` slot of `v3_card`).
+  """
+  attr :month, :string, required: true, doc: "3-letter month abbreviation, uppercase"
+  attr :day, :any, required: true, doc: "day of month"
+
+  def v3_date_stamp(assigns) do
+    ~H"""
+    <div class="date-stamp">
+      <span class="m">{@month}</span>
+      <span class="d">{@day}</span>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a card type tag (used inside a `<:cover>` slot of `v3_card`).
+
+  Variants: `:in_person`, `:online`, `:hybrid`.
+  """
+  attr :variant, :atom, values: [:in_person, :online, :hybrid], required: true
+  slot :inner_block, required: true
+
+  def v3_card_tag(assigns) do
+    ~H"""
+    <span class={["card-tag", tag_class(@variant)]}>{render_slot(@inner_block)}</span>
+    """
+  end
+
+  defp tag_class(:in_person), do: "in-person"
+  defp tag_class(:online), do: "online"
+  defp tag_class(:hybrid), do: "hybrid"
+end

--- a/lib/huddlz_web/components/v3/chip.ex
+++ b/lib/huddlz_web/components/v3/chip.ex
@@ -1,0 +1,35 @@
+defmodule HuddlzWeb.V3.Chip do
+  @moduledoc """
+  V3 filter chip — used in `chip-group` filter bars.
+
+  Renders as a `<button>` by default; pass `href`/`navigate`/`patch` to
+  render as a link instead.
+  """
+  use Phoenix.Component
+
+  attr :active, :boolean, default: false
+  attr :class, :any, default: nil
+
+  attr :rest, :global,
+    include: ~w(href navigate patch type phx-click phx-value-id phx-target name value)
+
+  slot :inner_block, required: true
+
+  def v3_chip(%{rest: rest} = assigns) do
+    if rest[:href] || rest[:navigate] || rest[:patch] do
+      ~H"""
+      <.link class={["chip", @active && "is-active", @class]} {@rest}>
+        {render_slot(@inner_block)}
+      </.link>
+      """
+    else
+      assigns = assign_new(assigns, :type, fn -> "button" end)
+
+      ~H"""
+      <button type={@type} class={["chip", @active && "is-active", @class]} {@rest}>
+        {render_slot(@inner_block)}
+      </button>
+      """
+    end
+  end
+end

--- a/lib/huddlz_web/components/v3/input.ex
+++ b/lib/huddlz_web/components/v3/input.ex
@@ -1,0 +1,140 @@
+defmodule HuddlzWeb.V3.Input do
+  @moduledoc """
+  V3 form primitives — `v3_input/1`, `v3_textarea/1`, `v3_select/1`.
+
+  Each renders a `form-row` containing a `form-label`, the field control, and
+  optional `form-help` / `form-error` text. They accept either a
+  `Phoenix.HTML.FormField` via the `field` attr, or a manual `name`/`value`/
+  `errors` triple.
+  """
+  use Phoenix.Component
+
+  alias Phoenix.HTML.Form
+  alias Phoenix.HTML.FormField
+
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :type, :string, default: "text"
+  attr :help, :string, default: nil
+  attr :errors, :list, default: []
+  attr :field, FormField, doc: "a Phoenix.HTML.FormField struct"
+  attr :class, :any, default: nil
+
+  attr :rest, :global, include: ~w(autocomplete disabled form list max maxlength min minlength
+                pattern placeholder readonly required step inputmode)
+
+  def v3_input(%{field: %FormField{} = field} = assigns) do
+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(errors, &translate_error/1))
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> v3_input()
+  end
+
+  def v3_input(assigns) do
+    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+
+    ~H"""
+    <div class="form-row">
+      <label :if={@label} for={@id} class="form-label">{@label}</label>
+      <input
+        type={@type}
+        id={@id}
+        name={@name}
+        value={Form.normalize_value(@type, @value)}
+        class={["form-input", @class]}
+        {@rest}
+      />
+      <p :if={@help && @errors == []} class="form-help">{@help}</p>
+      <p :for={msg <- @errors} class="form-error">{msg}</p>
+    </div>
+    """
+  end
+
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :help, :string, default: nil
+  attr :errors, :list, default: []
+  attr :field, FormField, doc: "a Phoenix.HTML.FormField struct"
+  attr :class, :any, default: nil
+
+  attr :rest, :global, include: ~w(autocomplete disabled form maxlength minlength
+                placeholder readonly required rows cols)
+
+  def v3_textarea(%{field: %FormField{} = field} = assigns) do
+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(errors, &translate_error/1))
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> v3_textarea()
+  end
+
+  def v3_textarea(assigns) do
+    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+
+    ~H"""
+    <div class="form-row">
+      <label :if={@label} for={@id} class="form-label">{@label}</label>
+      <textarea id={@id} name={@name} class={["form-textarea", @class]} {@rest}>{Form.normalize_value("textarea", @value)}</textarea>
+      <p :if={@help && @errors == []} class="form-help">{@help}</p>
+      <p :for={msg <- @errors} class="form-error">{msg}</p>
+    </div>
+    """
+  end
+
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :help, :string, default: nil
+  attr :errors, :list, default: []
+  attr :field, FormField, doc: "a Phoenix.HTML.FormField struct"
+  attr :class, :any, default: nil
+  attr :options, :list, required: true, doc: "list of {label, value} tuples or values"
+  attr :prompt, :string, default: nil
+
+  attr :rest, :global, include: ~w(autocomplete disabled form multiple required size)
+
+  def v3_select(%{field: %FormField{} = field} = assigns) do
+    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(errors, &translate_error/1))
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> v3_select()
+  end
+
+  def v3_select(assigns) do
+    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+
+    ~H"""
+    <div class="form-row">
+      <label :if={@label} for={@id} class="form-label">{@label}</label>
+      <select id={@id} name={@name} class={["form-select", @class]} {@rest}>
+        <option :if={@prompt} value="">{@prompt}</option>
+        {Phoenix.HTML.Form.options_for_select(@options, @value)}
+      </select>
+      <p :if={@help && @errors == []} class="form-help">{@help}</p>
+      <p :for={msg <- @errors} class="form-error">{msg}</p>
+    </div>
+    """
+  end
+
+  defp translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
+end

--- a/lib/huddlz_web/components/v3/list_row.ex
+++ b/lib/huddlz_web/components/v3/list_row.ex
@@ -1,0 +1,23 @@
+defmodule HuddlzWeb.V3.ListRow do
+  @moduledoc """
+  V3 row-list — flexible row layout used in member rosters, notification
+  inboxes, settings pages, and help-center sections.
+
+  Wrap multiple rows in a `<div class="row-list">` and use `v3_list_row/1`
+  for each item.
+  """
+  use Phoenix.Component
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def v3_list_row(assigns) do
+    ~H"""
+    <div class={["row", @class]} {@rest}>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+end

--- a/lib/huddlz_web/components/v3/panel.ex
+++ b/lib/huddlz_web/components/v3/panel.ex
@@ -1,0 +1,36 @@
+defmodule HuddlzWeb.V3.Panel do
+  @moduledoc """
+  V3 panel surface — bordered container with optional `panel-head` (h2 + pill)
+  and `panel-sub` (subtitle).
+
+  ```
+  <.v3_panel>
+    <:head>
+      <h2>Members</h2>
+    </:head>
+    <:sub>43 active this week</:sub>
+    Panel content here.
+  </.v3_panel>
+  ```
+  """
+  use Phoenix.Component
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  slot :head, doc: "panel header content (h2 + optional trailing pill)"
+  slot :sub, doc: "subtitle text rendered under the head"
+  slot :inner_block, required: true
+
+  def v3_panel(assigns) do
+    ~H"""
+    <section class={["panel", @class]} {@rest}>
+      <header :if={@head != []} class="panel-head">
+        {render_slot(@head)}
+      </header>
+      <p :if={@sub != []} class="panel-sub">{render_slot(@sub)}</p>
+      {render_slot(@inner_block)}
+    </section>
+    """
+  end
+end

--- a/lib/huddlz_web/components/v3/pill.ex
+++ b/lib/huddlz_web/components/v3/pill.ex
@@ -1,0 +1,28 @@
+defmodule HuddlzWeb.V3.Pill do
+  @moduledoc """
+  V3 status pill — small inline badge used for RSVP states, role tags, etc.
+  """
+  use Phoenix.Component
+
+  attr :variant, :atom,
+    values: [:default, :cyan, :warn, :magenta, :muted],
+    default: :default
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def v3_pill(assigns) do
+    ~H"""
+    <span class={["pill", variant_class(@variant), @class]} {@rest}>
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  defp variant_class(:default), do: nil
+  defp variant_class(:cyan), do: "cyan"
+  defp variant_class(:warn), do: "warn"
+  defp variant_class(:magenta), do: "magenta"
+  defp variant_class(:muted), do: "muted"
+end

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -62,6 +62,12 @@ defmodule HuddlzWeb.LiveUserAuth do
     {:cont, maybe_load_user_details(socket)}
   end
 
+  # Flips the body class to `"v3"` so v3-scoped styles in app.css take effect.
+  # Pair with `<Layouts.v3_app>` in the LiveView template.
+  def on_mount(:v3_app, _params, _session, socket) do
+    {:cont, assign(socket, :body_class, "v3")}
+  end
+
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)
        when not is_nil(user) do
     case Ash.load(

--- a/test/huddlz_web/components/v3_test.exs
+++ b/test/huddlz_web/components/v3_test.exs
@@ -1,0 +1,227 @@
+defmodule HuddlzWeb.V3Test do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+
+  use HuddlzWeb.V3
+
+  describe "v3_pill/1" do
+    test "renders default pill with no extra variant class" do
+      assigns = %{}
+
+      html = rendered_to_string(~H"<.v3_pill>Going</.v3_pill>")
+
+      assert html =~ "Going"
+      assert html =~ ~s(class="pill)
+      refute html =~ "cyan"
+      refute html =~ "warn"
+    end
+
+    test "renders cyan/warn/muted variants" do
+      assigns = %{}
+
+      cyan = rendered_to_string(~H"<.v3_pill variant={:cyan}>Hosting</.v3_pill>")
+      warn = rendered_to_string(~H"<.v3_pill variant={:warn}>Waitlist</.v3_pill>")
+      muted = rendered_to_string(~H"<.v3_pill variant={:muted}>Past</.v3_pill>")
+
+      assert cyan =~ "pill cyan"
+      assert warn =~ "pill warn"
+      assert muted =~ "pill muted"
+    end
+  end
+
+  describe "v3_chip/1" do
+    test "renders a button chip by default with active state" do
+      assigns = %{}
+
+      active = rendered_to_string(~H"<.v3_chip active>Upcoming · 6</.v3_chip>")
+      inactive = rendered_to_string(~H"<.v3_chip>Past</.v3_chip>")
+
+      assert active =~ "<button"
+      assert active =~ "chip is-active"
+      assert active =~ "Upcoming · 6"
+
+      assert inactive =~ "<button"
+      assert inactive =~ ~s(class="chip)
+      refute inactive =~ "is-active"
+    end
+
+    test "renders a link when href is given" do
+      assigns = %{}
+      html = rendered_to_string(~H|<.v3_chip href="/discover">Discover</.v3_chip>|)
+
+      assert html =~ "<a"
+      assert html =~ ~s(href="/discover")
+      assert html =~ "chip"
+    end
+  end
+
+  describe "v3_button/1" do
+    test "renders btn-primary variant" do
+      assigns = %{}
+      html = rendered_to_string(~H"<.v3_button variant={:primary}>Save</.v3_button>")
+
+      assert html =~ "btn-primary"
+      assert html =~ "Save"
+    end
+
+    test "renders secondary by default and as a link with href" do
+      assigns = %{}
+
+      btn = rendered_to_string(~H"<.v3_button>Cancel</.v3_button>")
+      link = rendered_to_string(~H|<.v3_button href="/discover">Browse</.v3_button>|)
+
+      assert btn =~ "<button"
+      assert btn =~ "btn-secondary"
+
+      assert link =~ "<a"
+      assert link =~ ~s(href="/discover")
+      assert link =~ "btn-secondary"
+    end
+  end
+
+  describe "v3_panel/1" do
+    test "renders panel with optional head and sub" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.v3_panel>
+          <:head>
+            <h2>Members</h2>
+          </:head>
+          <:sub>Roster summary</:sub>
+          Body content
+        </.v3_panel>
+        """)
+
+      assert html =~ ~s(class="panel)
+      assert html =~ "panel-head"
+      assert html =~ "<h2>Members</h2>"
+      assert html =~ ~s(class="panel-sub")
+      assert html =~ "Roster summary"
+      assert html =~ "Body content"
+    end
+
+    test "renders panel without head when not given" do
+      assigns = %{}
+      html = rendered_to_string(~H"<.v3_panel>Just body</.v3_panel>")
+
+      assert html =~ "Just body"
+      refute html =~ "panel-head"
+      refute html =~ "panel-sub"
+    end
+  end
+
+  describe "v3_card/1" do
+    test "renders an anchor card with body, optional cover and foot" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.v3_card href="/groups/foo" gradient={3}>
+          <:cover>
+            <.v3_date_stamp month="MAY" day={22} />
+            <.v3_card_tag variant={:hybrid}>Hybrid</.v3_card_tag>
+          </:cover>
+          <:body>
+            <span class="card-group">Phoenix Elixir</span>
+            <div class="card-title">Ash workshop</div>
+          </:body>
+          <:foot>
+            <.v3_pill variant={:cyan}>Hosting</.v3_pill>
+          </:foot>
+        </.v3_card>
+        """)
+
+      assert html =~ "<a"
+      assert html =~ ~s(href="/groups/foo")
+      assert html =~ ~s(class="card)
+      assert html =~ "card-cover gradient-3"
+      assert html =~ "date-stamp"
+      assert html =~ ~s(class="card-tag hybrid")
+      assert html =~ "Hybrid"
+      assert html =~ "Ash workshop"
+      assert html =~ "card-foot"
+      assert html =~ "pill cyan"
+    end
+  end
+
+  describe "v3_list_row/1" do
+    test "renders a row with passed content and class" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.v3_list_row class="notif-row unread">
+          <div class="row-title">New invite</div>
+        </.v3_list_row>
+        """)
+
+      assert html =~ ~s(class="row notif-row unread")
+      assert html =~ "New invite"
+    end
+  end
+
+  describe "v3_input/1" do
+    test "renders form-row with label, input, help" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.v3_input
+          name="title"
+          value=""
+          label="Title"
+          help="What you'd call this huddl on a flyer"
+        />
+        """)
+
+      assert html =~ ~s(class="form-row")
+      assert html =~ ~s(class="form-label")
+      assert html =~ "Title</label>"
+      assert html =~ ~s(class="form-input)
+      assert html =~ ~s(name="title")
+      assert html =~ ~s(class="form-help")
+    end
+  end
+
+  describe "v3_textarea/1" do
+    test "renders form-textarea" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.v3_textarea name="description" value="" label="Description" />
+        """)
+
+      assert html =~ "<textarea"
+      assert html =~ ~s(class="form-textarea)
+      assert html =~ ~s(name="description")
+    end
+  end
+
+  describe "v3_select/1" do
+    test "renders form-select with options and prompt" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.v3_select
+          name="frequency"
+          value=""
+          label="Frequency"
+          prompt="Choose..."
+          options={[{"Weekly", "weekly"}, {"Monthly", "monthly"}]}
+        />
+        """)
+
+      assert html =~ "<select"
+      assert html =~ ~s(class="form-select)
+      assert html =~ ~s(value="">Choose...</option>)
+      assert html =~ ~s(value="weekly">Weekly</option>)
+      assert html =~ ~s(value="monthly">Monthly</option>)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Foundation **PR-F2** of the v3 migration. Stacked on **#186**. Adds the wrapper component, on_mount hook, and shared primitives so subsequent page PRs can swap one LiveView at a time onto the v3 design.

- **`Layouts.v3_app/1`** — sidebar + topbar shell mirroring the clickthrough mockup (Explore / My huddlz / My groups / Calendar nav, Profile / Settings / Help / Admin account section). Admin link only renders when `current_user.role == :admin` so admins keep a path to `/admin` from day one of the migration, even before Phase 6 restyles it.
- **`LiveUserAuth.on_mount(:v3_app, ...)`** — assigns `body_class: \"v3\"` so the v3-scoped CSS in `app.css` (PR-F1) takes effect.
- **`HuddlzWeb.V3` facade** — wired into `huddlz_web.ex` `html_helpers/0` via `use HuddlzWeb.V3`, bringing all v3 components into scope under a `v3_*` prefix to coexist with legacy `core_components` during the migration window.
- **Shared primitives** under `lib/huddlz_web/components/v3/`:
  - `Button` — `v3_button` (primary / secondary / muted / destructive)
  - `Card` — `v3_card`, `v3_date_stamp`, `v3_card_tag`
  - `Chip` — `v3_chip` (with `is-active`)
  - `Input` — `v3_input`, `v3_textarea`, `v3_select` (FormField-aware)
  - `ListRow` — `v3_list_row`
  - `Panel` — `v3_panel` (with head + sub slots)
  - `Pill` — `v3_pill` (default / cyan / warn / magenta / muted)
- 13 component tests in `test/huddlz_web/components/v3_test.exs`.

## After this lands

Phase 1 (auth + landing) and Phase 7 (`/help`) are unblocked and can run in parallel, with up to ~10 page PRs open simultaneously across phases 2–7. See the migration plan for the full PR breakdown.

## Stacked PR ordering

Merge **#186 first**, then this PR (which is currently targeting that branch). Once #186 is merged, this PR will rebase onto `main` automatically.

## Test plan

- [x] `mix precommit` clean (1220 tests, 0 failures, credo clean)
- [ ] Smoke-test in dev: write a tiny LiveView using `<Layouts.v3_app>` + `on_mount {HuddlzWeb.LiveUserAuth, :v3_app}` and visit it; confirm sidebar renders, admin link appears for admin users only.