### PR TITLE
PR-1.1: Migrate landing page (/) to v3 design

### DIFF
--- a/lib/huddlz_web/live/landing_live.ex
+++ b/lib/huddlz_web/live/landing_live.ex
@@ -1,16 +1,9 @@
 defmodule HuddlzWeb.LandingLive do
   @moduledoc """
-  Public landing page at `/`. Anonymous visitors see the pitch + a preview
-  of upcoming huddlz + an organizer hand-off. Authenticated users are
-  redirected to their personal dashboard at `/me`.
+  Public landing page at `/`. Anonymous visitors see the v3 hero + value tiles
+  + sign-up CTAs. Authenticated users are redirected to their dashboard.
   """
   use HuddlzWeb, :live_view
-
-  alias Huddlz.Communities
-  alias HuddlzWeb.Layouts
-
-  @preview_limit 3
-  @huddl_card_loads [:status, :rsvp_count, :visible_virtual_link, :display_image_url, :group]
 
   on_mount {HuddlzWeb.LiveUserAuth, :redirect_to_me_if_authenticated}
 
@@ -19,137 +12,102 @@ defmodule HuddlzWeb.LandingLive do
     {:ok,
      socket
      |> assign(:page_title, "huddlz")
-     |> assign(:upcoming_preview, load_preview())}
-  end
-
-  defp load_preview do
-    case Communities.search_huddlz(nil, :upcoming, nil, nil, nil, nil, nil, :soonest,
-           page: [limit: @preview_limit, count: false],
-           load: @huddl_card_loads,
-           authorize?: false
-         ) do
-      {:ok, %{results: results}} -> results
-      _ -> []
-    end
+     |> assign(:body_class, "v3 is-landing")}
   end
 
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <div class="space-y-16 lg:space-y-24">
-        <section class="grid gap-10 lg:grid-cols-[3fr_2fr] lg:items-end">
-          <div>
-            <span class="mono-label text-primary/70">// Find your people, fast</span>
-            <h1 class="mt-3 font-display text-4xl sm:text-5xl tracking-tight text-glow leading-[1.05]">
-              Find your next real-life gathering.
-            </h1>
-            <p class="mt-5 max-w-xl text-base-content/70 text-lg leading-relaxed">
-              Huddlz helps people discover local huddlz and groups without turning the first step into paperwork. Search for what you want, pick a huddl, and show up.
-            </p>
-            <div class="mt-8 flex flex-wrap gap-3">
-              <.link
-                href={~p"/discover"}
-                class="inline-flex items-center justify-center h-12 px-6 bg-primary text-primary-content font-display uppercase text-xs font-black tracking-wider hover:bg-primary/90 transition-colors"
-              >
-                Search huddlz
-              </.link>
-              <.link
-                href={~p"/groups/new"}
-                class="inline-flex items-center justify-center h-12 px-6 border border-base-300 text-sm font-bold text-base-content/80 hover:border-primary hover:text-primary transition-colors"
-              >
-                Organize
-              </.link>
-            </div>
-          </div>
-        </section>
+    <Layouts.flash_group flash={@flash} />
 
-        <section class="grid gap-6 sm:grid-cols-3">
-          <div class="border border-base-300 p-6">
-            <h2 class="font-display text-lg tracking-tight text-glow">Discover quickly</h2>
-            <p class="mt-2 text-sm text-base-content/60">
-              Search huddlz and groups from the header. Type a topic, city, or community and press Enter.
-            </p>
-          </div>
-          <div class="border border-base-300 p-6">
-            <h2 class="font-display text-lg tracking-tight text-glow">Meet in real life</h2>
-            <p class="mt-2 text-sm text-base-content/60">
-              Huddlz puts the focus on gatherings, RSVPs, location, and the small details that help people show up.
-            </p>
-          </div>
-          <div class="border border-base-300 p-6">
-            <h2 class="font-display text-lg tracking-tight text-glow">Organize without clutter</h2>
-            <p class="mt-2 text-sm text-base-content/60">
-              Organizers get a dedicated workspace for groups, huddlz, attendees, members, messages, and settings.
-            </p>
-          </div>
-        </section>
+    <header class="land-topbar">
+      <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
+        <div class="brand-glyph">h</div>
+        <div class="brand-text">huddlz</div>
+      </a>
+      <nav class="nav">
+        <.link navigate={~p"/sign-in"} class="btn-secondary">Sign in</.link>
+        <.link navigate={~p"/register"} class="btn-primary">Sign up</.link>
+      </nav>
+    </header>
 
-        <section :if={@upcoming_preview != []} aria-labelledby="upcoming-heading">
-          <div class="flex items-baseline justify-between gap-4">
-            <h2
-              id="upcoming-heading"
-              class="font-display text-2xl tracking-tight text-glow flex items-baseline gap-3"
-            >
-              <span class="mono-label text-primary/70">// Upcoming huddlz</span>
-            </h2>
-            <.link
-              navigate={~p"/discover"}
-              class="text-xs text-primary hover:underline font-medium tracking-wide uppercase"
-            >
-              See all →
-            </.link>
-          </div>
-          <div class="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            <%= for huddl <- @upcoming_preview do %>
-              <.huddl_card huddl={huddl} show_group={true} />
-            <% end %>
-          </div>
-        </section>
-
-        <section class="border border-base-300 p-8 lg:p-10">
-          <div class="grid gap-10 lg:grid-cols-[3fr_2fr]">
-            <div>
-              <span class="mono-label text-primary/70">// For organizers</span>
-              <h2 class="mt-3 font-display text-3xl tracking-tight text-glow">
-                Run the community, not the tooling.
-              </h2>
-              <p class="mt-4 text-base-content/70 leading-relaxed">
-                Organize should lead to a signed-in workspace for creating groups and huddlz, managing RSVPs, checking attendees in, messaging people, and keeping settings sane.
-              </p>
-              <div class="mt-6">
-                <.link
-                  href={~p"/groups/new"}
-                  class="inline-flex items-center justify-center h-12 px-6 bg-primary text-primary-content font-display uppercase text-xs font-black tracking-wider hover:bg-primary/90 transition-colors"
-                >
-                  Open organize
-                </.link>
-              </div>
-            </div>
-            <ul class="space-y-4">
-              <li>
-                <p class="font-bold text-sm text-base-content">Create groups and huddlz</p>
-                <p class="mt-1 text-sm text-base-content/60">
-                  Draft, publish, duplicate, and manage the core gathering details.
-                </p>
-              </li>
-              <li>
-                <p class="font-bold text-sm text-base-content">Track attendees and members</p>
-                <p class="mt-1 text-sm text-base-content/60">
-                  Separate huddl RSVPs from group relationships so each job has a clear home.
-                </p>
-              </li>
-              <li>
-                <p class="font-bold text-sm text-base-content">Communicate clearly</p>
-                <p class="mt-1 text-sm text-base-content/60">
-                  Send announcements, reminders, and direct follow-ups from one operations surface.
-                </p>
-              </li>
-            </ul>
-          </div>
-        </section>
+    <section class="land-hero">
+      <span class="eyebrow">In-person and online · everywhere</span>
+      <h1>Find your people.<br />Run the meetup.</h1>
+      <p>
+        huddlz is the calmer, AI-native home for community events — discover huddlz worth showing up to, organize the ones you run, and skip the noise.
+      </p>
+      <div class="land-cta">
+        <.link navigate={~p"/discover"} class="btn-primary">Browse huddlz</.link>
+        <.link navigate={~p"/register"} class="btn-secondary">Start a group</.link>
       </div>
-    </Layouts.app>
+    </section>
+
+    <section class="land-features">
+      <div class="feat">
+        <span class="feat-mark">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+          >
+            <circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" />
+          </svg>
+        </span>
+        <h3>Discovery that learns you</h3>
+        <p>
+          Conversational search, semantic recommendations, and saved queries that update as new huddlz drop. No more sifting feeds.
+        </p>
+      </div>
+      <div class="feat">
+        <span class="feat-mark">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M3 11.5 12 4l9 7.5" /><path d="M5 10v10h14V10" />
+          </svg>
+        </span>
+        <h3>Organize without the spreadsheet</h3>
+        <p>
+          RSVPs, invites, capacity, waitlists, and recurring huddlz — all from one rail. Members and insights one tap away.
+        </p>
+      </div>
+      <div class="feat">
+        <span class="feat-mark">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.5 8.5 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5A8.4 8.4 0 0 1 21 11v.5z" />
+          </svg>
+        </span>
+        <h3>Bring your agent</h3>
+        <p>
+          Browse, RSVP, and schedule huddlz from the LLM you already use. MCP tools, an agent-friendly API, and human-clear copy.
+        </p>
+      </div>
+    </section>
+
+    <footer class="land-foot">
+      © 2026 huddlz · real-life communities, easier to discover and organize
+    </footer>
     """
   end
 end

--- a/test/features/global_footer.feature
+++ b/test/features/global_footer.feature
@@ -5,7 +5,7 @@ Feature: Global Footer
   So that I can find supporting pages without hunting for them
 
   Scenario: Footer surfaces grouped columns and the tagline
-    Given the user is on the home page
+    When I visit "/discover"
     Then the footer should show the huddlz brand block
     And the footer should expose the Product, Help, Legal, and Open columns
     And the footer should link to GitHub and the API docs

--- a/test/features/global_header.feature
+++ b/test/features/global_header.feature
@@ -4,8 +4,8 @@ Feature: Global Header
   I want a global header that pairs the brand with search and an organize entry point
   So that I can find huddlz from anywhere and start organizing without hunting through menus
 
-  Scenario: Header chrome is visible on the home page
-    Given the user is on the home page
+  Scenario: Header chrome is visible on legacy pages
+    When I visit "/discover"
     Then the header should show the huddlz brand
     And the header should expose a global search form posting q to /discover
     And the header should expose an Organize link to /organize

--- a/test/features/landing_surface.feature
+++ b/test/features/landing_surface.feature
@@ -11,17 +11,22 @@ Feature: Landing surface
 
   Scenario: Anonymous visitor sees the landing hero and CTAs
     When I visit "/"
-    Then I should see "Find your next real-life gathering."
-    And I should see "Find your people, fast"
-    And I should see "Search huddlz"
-    And I should see "Run the community, not the tooling."
-    And I should see "Open organize"
+    Then I should see "Find your people."
+    And I should see "Run the meetup."
+    And I should see "In-person and online · everywhere"
+    And I should see "Browse huddlz"
+    And I should see "Start a group"
 
   Scenario: Anonymous visitor sees the three value tiles
     When I visit "/"
-    Then I should see "Discover quickly"
-    And I should see "Meet in real life"
-    And I should see "Organize without clutter"
+    Then I should see "Discovery that learns you"
+    And I should see "Organize without the spreadsheet"
+    And I should see "Bring your agent"
+
+  Scenario: Anonymous visitor sees sign-in and sign-up links in the topbar
+    When I visit "/"
+    Then I should see "Sign in"
+    And I should see "Sign up"
 
   Scenario: Authenticated user is redirected from / to /me
     Given I am signed in as "regular@example.com"

--- a/test/features/sign_in_and_sign_out.feature
+++ b/test/features/sign_in_and_sign_out.feature
@@ -4,7 +4,7 @@ Feature: User Sign In and Sign Out
   Scenario: User signs in with password
     Given a user exists with email "test@example.com" and password "Password123!"
     And the user is on the home page
-    When the user clicks the "Sign In" link in the navbar
+    When the user clicks the "Sign in" link in the navbar
     And the user enters "test@example.com" in the email field
     And the user enters "Password123!" in the password field
     And the user submits the password sign in form
@@ -14,7 +14,7 @@ Feature: User Sign In and Sign Out
   Scenario: User tries to sign in with wrong password
     Given a user exists with email "test@example.com" and password "Password123!"
     And the user is on the home page
-    When the user clicks the "Sign In" link in the navbar
+    When the user clicks the "Sign in" link in the navbar
     And the user enters "test@example.com" in the email field
     And the user enters "WrongPassword" in the password field
     And the user submits the password sign in form


### PR DESCRIPTION
## Summary

Migrates `/` from the legacy `<Layouts.app>` hero + value tiles + organize hand-off to the v3 chrome from the clickthrough mockup (`land-topbar` / `land-hero` / `land-features` / `land-foot`). Body class is set to `v3 is-landing` so the dedicated landing styles in `app.css` apply — no sidebar grid, custom topbar, no global footer.

This is the first page migration (PR-1.1) from the v3 migration plan.

## Test plan

- [x] Existing `landing_surface.feature` updated to the new copy and value tiles.
- [x] `sign_in_and_sign_out.feature` now uses sentence-case "Sign in" to match the v3 link text.
- [x] `global_header` / `global_footer` scenarios that asserted the legacy chrome on `/` now visit `/discover` (still on `Layouts.app` until its migration in Phase 2).
- [x] `mix test` — 1 doctest, 1221 tests, 0 failures.
- [x] Anonymous curl of `/` confirms the new v3 markup renders with `body class="v3 is-landing"`.