### PR TITLE
PR-1.2: Migrate auth pages to v3 auth shell

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1893,6 +1893,14 @@ body.v3 .auth-card .form-grid { max-width: none; gap: 14px; }
 body.v3 .auth-card .form-foot { border: 0; padding: 0; margin-top: 18px; }
 body.v3 .auth-card .form-foot .btn-primary { flex: 1 1 auto; justify-content: center; height: 44px; font-size: 14px; }
 
+body.v3 .auth-card .auth-aux-btn {
+  align-self: flex-start;
+  height: 32px;
+  padding: 0 12px;
+  font-size: 12px;
+  margin-top: -10px;
+}
+
 body.v3 .auth-aside {
   text-align: center;
   color: var(--muted);

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -418,6 +418,76 @@ defmodule HuddlzWeb.Layouts do
     """
   end
 
+  @doc """
+  V3 auth shell — chromeless wrapper used by `/sign-in`, `/register`, `/reset`,
+  and `/reset/:token`. Renders the brand topbar, the flash group, and an
+  `auth-frame` container around the inner content.
+
+  Pair with `assign(socket, :body_class, "v3 is-auth")` in the LiveView's
+  `mount/3` so the v3 auth styles in `app.css` take effect.
+  """
+  attr :flash, :map, required: true
+  slot :inner_block, required: true
+
+  def auth_shell(assigns) do
+    ~H"""
+    <Layouts.flash_group flash={@flash} />
+
+    <div class="auth-shell">
+      <header class="auth-topbar">
+        <a href={~p"/"}>
+          <div class="brand-glyph">h</div>
+          <div class="brand-text">huddlz</div>
+        </a>
+      </header>
+
+      <div class="auth-frame">
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Cyan check or warn circle inside `.icon-mark` — used by auth-state success
+  and expired/invalid blocks.
+  """
+  attr :name, :string, required: true, values: ~w(check warn)
+
+  def auth_state_icon(%{name: "check"} = assigns) do
+    ~H"""
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M5 13l4 4L19 7" />
+    </svg>
+    """
+  end
+
+  def auth_state_icon(%{name: "warn"} = assigns) do
+    ~H"""
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="9" /><path d="M12 7v6" /><path d="M12 17h.01" />
+    </svg>
+    """
+  end
+
   attr :name, :string, required: true
 
   defp v3_nav_icon(%{name: "search"} = assigns) do

--- a/lib/huddlz_web/live/auth_live/register.ex
+++ b/lib/huddlz_web/live/auth_live/register.ex
@@ -1,27 +1,24 @@
 defmodule HuddlzWeb.AuthLive.Register do
   @moduledoc """
-  LiveView for new user registration with email, password, and display name.
+  Registration page at `/register`. Email + display name + password. Mounted
+  under the v3 auth shell — chromeless, no sidebar, no global topbar.
   """
   use HuddlzWeb, :live_view
 
   alias AshPhoenix.Form
   alias Huddlz.Accounts.DisplayNameGenerator
   alias Huddlz.Accounts.User
-  import HuddlzWeb.Layouts
   require Ash
 
   @impl true
   def mount(_params, _session, socket) do
-    # Get the password strategy to pass proper context
     strategy = AshAuthentication.Info.strategy!(User, :password)
 
-    # Build context like the default Ash auth does
     context = %{
       strategy: strategy,
       private: %{ash_authentication?: true}
     }
 
-    # Add token_type if sign_in_tokens are enabled for registration
     context =
       if Map.get(strategy, :sign_in_tokens_enabled?) do
         Map.put(context, :token_type, :sign_in)
@@ -38,26 +35,38 @@ defmodule HuddlzWeb.AuthLive.Register do
 
     {:ok,
      socket
-     |> assign(check_errors: false)
+     |> assign(:page_title, "Create account")
+     |> assign(:body_class, "v3 is-auth")
+     |> assign(:check_errors, false)
      |> assign_form(password_form)}
   end
 
   @impl true
   def render(assigns) do
     ~H"""
-    <.app flash={@flash} current_user={assigns[:current_user]}>
-      <div class="mx-auto max-w-md">
-        <h1 class="font-display text-2xl tracking-tight text-center">Create your account</h1>
-        <p class="text-center text-base-content/40 mt-2">
-          Sign up to start creating and joining huddlz
-        </p>
+    <Layouts.flash_group flash={@flash} />
 
-        <%!-- Password Registration Form --%>
-        <.surface_panel class="p-6 mt-8">
-          <h2 class="font-display text-xl mb-4">Sign up with password</h2>
+    <div class="auth-shell">
+      <header class="auth-topbar">
+        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
+          <div class="brand-glyph">h</div>
+          <div class="brand-text">huddlz</div>
+        </a>
+      </header>
 
-          <.form for={@form} id="registration-form" phx-change="validate" phx-submit="register">
-            <.input
+      <div class="auth-frame">
+        <h1>Create your account</h1>
+        <p class="lede">Names aren't unique on huddlz — pick anything you like.</p>
+
+        <.form
+          for={@form}
+          id="registration-form"
+          phx-change="validate"
+          phx-submit="register"
+          class="auth-card"
+        >
+          <div class="form-grid">
+            <.v3_input
               field={@form[:email]}
               type="email"
               label="Email"
@@ -65,40 +74,39 @@ defmodule HuddlzWeb.AuthLive.Register do
               autocomplete="email"
             />
 
-            <div>
-              <.input
-                field={@form[:display_name]}
+            <div class="form-row">
+              <label for="user_display_name" class="form-label">Display Name</label>
+              <input
                 type="text"
-                label="Display Name"
+                id="user_display_name"
+                name="user[display_name]"
+                value={Phoenix.HTML.Form.normalize_value("text", @form[:display_name].value)}
+                class="form-input"
                 placeholder="First and Last Name"
                 autocomplete="name"
               />
-              <.button
+              <button
                 type="button"
                 phx-click="generate_display_name"
-                variant="ghost"
-                size="sm"
-                class="mt-1"
+                class="btn-secondary"
+                style="margin-top:6px;align-self:flex-start;height:32px;padding:0 12px;font-size:12px"
               >
-                <.icon name="hero-arrow-path" class="h-4 w-4" /> Generate Random Name
-              </.button>
+                Generate random name
+              </button>
+              <p :for={msg <- field_errors(@form[:display_name])} class="form-error">{msg}</p>
             </div>
 
-            <div>
-              <.input
-                field={@form[:password]}
-                type="password"
-                label="Password"
-                placeholder="At least 8 characters"
-                autocomplete="new-password"
-                phx-debounce="blur"
-              />
-              <div class="text-xs text-base-content/60 mt-1 mb-4">
-                Password must be at least 8 characters long
-              </div>
-            </div>
+            <.v3_input
+              field={@form[:password]}
+              type="password"
+              label="Password"
+              placeholder="At least 8 characters"
+              autocomplete="new-password"
+              help="At least 8 characters."
+              phx-debounce="blur"
+            />
 
-            <.input
+            <.v3_input
               field={@form[:password_confirmation]}
               type="password"
               label="Confirm Password"
@@ -106,38 +114,28 @@ defmodule HuddlzWeb.AuthLive.Register do
               autocomplete="new-password"
               phx-debounce="blur"
             />
+          </div>
+          <div class="form-foot">
+            <button type="submit" class="btn-primary" phx-disable-with="Creating account...">
+              Create account
+            </button>
+          </div>
+        </.form>
 
-            <div class="mt-6">
-              <.button type="submit" phx-disable-with="Creating account..." class="w-full">
-                Create account
-              </.button>
-            </div>
-          </.form>
-        </.surface_panel>
-
-        <div class="text-center mt-8">
-          <span class="text-sm text-base-content/50">
-            Already have an account?
-          </span>
-          <a href="/sign-in" class="text-primary hover:underline font-medium text-sm ml-1">
-            Sign in
-          </a>
+        <div class="auth-aside">
+          Already have an account? <.link navigate={~p"/sign-in"}>Sign in</.link>
         </div>
       </div>
-    </.app>
+    </div>
     """
   end
 
   @impl true
   def handle_event("generate_display_name", _params, socket) do
-    # Generate a new random display name
     new_display_name = DisplayNameGenerator.generate()
-
-    # Get current form params and update display_name
     current_params = Form.params(socket.assigns.form.source)
     updated_params = Map.put(current_params, "display_name", new_display_name)
 
-    # Validate the form with the new display_name
     form =
       socket.assigns.form.source
       |> Form.validate(updated_params)
@@ -189,11 +187,9 @@ defmodule HuddlzWeb.AuthLive.Register do
   end
 
   defp handle_successful_registration(socket, result) do
-    # Get the token from the metadata
     token = result.__metadata__.token
 
     if token do
-      # Redirect to the sign-in URL with the token
       redirect(socket, to: "/auth/user/password/sign_in_with_token?token=#{token}")
     else
       socket
@@ -207,6 +203,20 @@ defmodule HuddlzWeb.AuthLive.Register do
 
   defp assign_form(socket, form) do
     assign(socket, :form, to_form(form))
+  end
+
+  defp field_errors(field) do
+    if Phoenix.Component.used_input?(field) do
+      Enum.map(field.errors, &translate_field_error/1)
+    else
+      []
+    end
+  end
+
+  defp translate_field_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
   end
 
   defp get_form_errors(form) do

--- a/lib/huddlz_web/live/auth_live/register.ex
+++ b/lib/huddlz_web/live/auth_live/register.ex
@@ -44,89 +44,72 @@ defmodule HuddlzWeb.AuthLive.Register do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.flash_group flash={@flash} />
+    <Layouts.auth_shell flash={@flash}>
+      <h1>Create your account</h1>
+      <p class="lede">Names aren't unique on huddlz — pick anything you like.</p>
 
-    <div class="auth-shell">
-      <header class="auth-topbar">
-        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
-          <div class="brand-glyph">h</div>
-          <div class="brand-text">huddlz</div>
-        </a>
-      </header>
+      <.form
+        for={@form}
+        id="registration-form"
+        phx-change="validate"
+        phx-submit="register"
+        class="auth-card"
+      >
+        <div class="form-grid">
+          <.v3_input
+            field={@form[:email]}
+            type="email"
+            label="Email"
+            placeholder="you@example.com"
+            autocomplete="email"
+          />
 
-      <div class="auth-frame">
-        <h1>Create your account</h1>
-        <p class="lede">Names aren't unique on huddlz — pick anything you like.</p>
+          <.v3_input
+            field={@form[:display_name]}
+            type="text"
+            label="Display Name"
+            placeholder="First and Last Name"
+            autocomplete="name"
+          />
 
-        <.form
-          for={@form}
-          id="registration-form"
-          phx-change="validate"
-          phx-submit="register"
-          class="auth-card"
-        >
-          <div class="form-grid">
-            <.v3_input
-              field={@form[:email]}
-              type="email"
-              label="Email"
-              placeholder="you@example.com"
-              autocomplete="email"
-            />
+          <button
+            type="button"
+            phx-click="generate_display_name"
+            class="btn-secondary auth-aux-btn"
+          >
+            Generate random name
+          </button>
 
-            <div class="form-row">
-              <label for="user_display_name" class="form-label">Display Name</label>
-              <input
-                type="text"
-                id="user_display_name"
-                name="user[display_name]"
-                value={Phoenix.HTML.Form.normalize_value("text", @form[:display_name].value)}
-                class="form-input"
-                placeholder="First and Last Name"
-                autocomplete="name"
-              />
-              <button
-                type="button"
-                phx-click="generate_display_name"
-                class="btn-secondary"
-                style="margin-top:6px;align-self:flex-start;height:32px;padding:0 12px;font-size:12px"
-              >
-                Generate random name
-              </button>
-              <p :for={msg <- field_errors(@form[:display_name])} class="form-error">{msg}</p>
-            </div>
+          <.v3_input
+            field={@form[:password]}
+            type="password"
+            label="Password"
+            placeholder="At least 8 characters"
+            autocomplete="new-password"
+            help="At least 8 characters."
+            phx-debounce="blur"
+          />
 
-            <.v3_input
-              field={@form[:password]}
-              type="password"
-              label="Password"
-              placeholder="At least 8 characters"
-              autocomplete="new-password"
-              help="At least 8 characters."
-              phx-debounce="blur"
-            />
-
-            <.v3_input
-              field={@form[:password_confirmation]}
-              type="password"
-              label="Confirm Password"
-              placeholder="Type your password again"
-              autocomplete="new-password"
-              phx-debounce="blur"
-            />
-          </div>
-          <div class="form-foot">
-            <button type="submit" class="btn-primary" phx-disable-with="Creating account...">
-              Create account
-            </button>
-          </div>
-        </.form>
-
-        <div class="auth-aside">
-          Already have an account? <.link navigate={~p"/sign-in"}>Sign in</.link>
+          <.v3_input
+            field={@form[:password_confirmation]}
+            type="password"
+            label="Confirm Password"
+            placeholder="Type your password again"
+            autocomplete="new-password"
+            phx-debounce="blur"
+          />
         </div>
+        <div class="form-foot">
+          <button type="submit" class="btn-primary" phx-disable-with="Creating account...">
+            Create account
+          </button>
+        </div>
+      </.form>
+
+      <div class="auth-aside">
+        Already have an account? <.link navigate={~p"/sign-in"}>Sign in</.link>
       </div>
-    </div>
+    </Layouts.auth_shell>
     """
   end
 
@@ -203,20 +186,6 @@ defmodule HuddlzWeb.AuthLive.Register do
 
   defp assign_form(socket, form) do
     assign(socket, :form, to_form(form))
-  end
-
-  defp field_errors(field) do
-    if Phoenix.Component.used_input?(field) do
-      Enum.map(field.errors, &translate_field_error/1)
-    else
-      []
-    end
-  end
-
-  defp translate_field_error({msg, opts}) do
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
   end
 
   defp get_form_errors(form) do

--- a/lib/huddlz_web/live/auth_live/reset_password.ex
+++ b/lib/huddlz_web/live/auth_live/reset_password.ex
@@ -24,72 +24,50 @@ defmodule HuddlzWeb.AuthLive.ResetPassword do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.flash_group flash={@flash} />
-
-    <div class="auth-shell">
-      <header class="auth-topbar">
-        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
-          <div class="brand-glyph">h</div>
-          <div class="brand-text">huddlz</div>
-        </a>
-      </header>
-
-      <div class="auth-frame">
-        <%= if @submitted do %>
-          <div class="auth-state">
-            <div class="icon-mark">
-              <svg
-                width="22"
-                height="22"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M5 13l4 4L19 7" />
-              </svg>
-            </div>
-            <h2>Check your email</h2>
-            <p>
-              If an account exists for that email, you will receive password reset instructions shortly.
-            </p>
-            <.link navigate={~p"/sign-in"} class="btn-primary">Back to sign in</.link>
+    <Layouts.auth_shell flash={@flash}>
+      <%= if @submitted do %>
+        <div class="auth-state">
+          <div class="icon-mark">
+            <Layouts.auth_state_icon name="check" />
           </div>
-        <% else %>
-          <h1>Reset your password</h1>
-          <p class="lede">Enter your email and we'll send a link to set a new password.</p>
+          <h2>Check your email</h2>
+          <p>
+            If an account exists for that email, you will receive password reset instructions shortly.
+          </p>
+          <.link navigate={~p"/sign-in"} class="btn-primary">Back to sign in</.link>
+        </div>
+      <% else %>
+        <h1>Reset your password</h1>
+        <p class="lede">Enter your email and we'll send a link to set a new password.</p>
 
-          <.form
-            for={@form}
-            id="reset-password-form"
-            phx-change="validate"
-            phx-submit="request_reset"
-            class="auth-card"
-          >
-            <div class="form-grid">
-              <.v3_input
-                field={@form[:email]}
-                type="email"
-                label="Email"
-                placeholder="you@example.com"
-                autocomplete="email"
-              />
-            </div>
-            <div class="form-foot">
-              <button type="submit" class="btn-primary" phx-disable-with="Sending...">
-                Send reset instructions
-              </button>
-            </div>
-          </.form>
-
-          <div class="auth-aside">
-            <.link navigate={~p"/sign-in"}>Back to sign in</.link>
+        <.form
+          for={@form}
+          id="reset-password-form"
+          phx-change="validate"
+          phx-submit="request_reset"
+          class="auth-card"
+        >
+          <div class="form-grid">
+            <.v3_input
+              field={@form[:email]}
+              type="email"
+              label="Email"
+              placeholder="you@example.com"
+              autocomplete="email"
+            />
           </div>
-        <% end %>
-      </div>
-    </div>
+          <div class="form-foot">
+            <button type="submit" class="btn-primary" phx-disable-with="Sending...">
+              Send reset instructions
+            </button>
+          </div>
+        </.form>
+
+        <div class="auth-aside">
+          <.link navigate={~p"/sign-in"}>Back to sign in</.link>
+        </div>
+      <% end %>
+    </Layouts.auth_shell>
     """
   end
 

--- a/lib/huddlz_web/live/auth_live/reset_password.ex
+++ b/lib/huddlz_web/live/auth_live/reset_password.ex
@@ -1,12 +1,13 @@
 defmodule HuddlzWeb.AuthLive.ResetPassword do
   @moduledoc """
-  LiveView for requesting a password reset token via email.
+  Reset-request page at `/reset`. Asks the user for an email address; emits
+  the reset email if an account exists. Always shows the success state — we
+  don't reveal whether the address is registered.
   """
   use HuddlzWeb, :live_view
+
   alias AshPhoenix.Form
   alias Huddlz.Accounts.User
-
-  import HuddlzWeb.Layouts
 
   @impl true
   def mount(_params, _session, socket) do
@@ -14,6 +15,8 @@ defmodule HuddlzWeb.AuthLive.ResetPassword do
 
     {:ok,
      socket
+     |> assign(:page_title, "Reset password")
+     |> assign(:body_class, "v3 is-auth")
      |> assign(:form, to_form(form))
      |> assign(:submitted, false)}
   end
@@ -21,61 +24,72 @@ defmodule HuddlzWeb.AuthLive.ResetPassword do
   @impl true
   def render(assigns) do
     ~H"""
-    <.app flash={@flash} current_user={assigns[:current_user]}>
-      <div class="max-w-md mx-auto">
-        <div class="border border-base-300 p-6">
-          <h2 class="font-display text-2xl tracking-tight mb-4">Reset your password</h2>
+    <Layouts.flash_group flash={@flash} />
 
-          <%= if @submitted do %>
-            <div class="border border-success/30 p-4 bg-success/5 flex items-start gap-3">
-              <.icon name="hero-check-circle" class="w-5 h-5 text-success flex-shrink-0 mt-0.5" />
-              <span class="text-sm">
-                If an account exists for that email, you will receive password reset instructions shortly.
-              </span>
+    <div class="auth-shell">
+      <header class="auth-topbar">
+        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
+          <div class="brand-glyph">h</div>
+          <div class="brand-text">huddlz</div>
+        </a>
+      </header>
+
+      <div class="auth-frame">
+        <%= if @submitted do %>
+          <div class="auth-state">
+            <div class="icon-mark">
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M5 13l4 4L19 7" />
+              </svg>
             </div>
-
-            <.link
-              navigate="/sign-in"
-              class="block text-center text-primary hover:underline font-medium mt-6"
-            >
-              Back to sign in
-            </.link>
-          <% else %>
-            <p class="text-sm mb-6 text-base-content/50">
-              Enter your email address and we'll send you instructions to reset your password.
+            <h2>Check your email</h2>
+            <p>
+              If an account exists for that email, you will receive password reset instructions shortly.
             </p>
+            <.link navigate={~p"/sign-in"} class="btn-primary">Back to sign in</.link>
+          </div>
+        <% else %>
+          <h1>Reset your password</h1>
+          <p class="lede">Enter your email and we'll send a link to set a new password.</p>
 
-            <.form
-              for={@form}
-              phx-change="validate"
-              phx-submit="request_reset"
-              id="reset-password-form"
-            >
-              <.input
+          <.form
+            for={@form}
+            id="reset-password-form"
+            phx-change="validate"
+            phx-submit="request_reset"
+            class="auth-card"
+          >
+            <div class="form-grid">
+              <.v3_input
                 field={@form[:email]}
                 type="email"
                 label="Email"
                 placeholder="you@example.com"
                 autocomplete="email"
               />
-
-              <div class="mt-6">
-                <.button phx-disable-with="Sending..." class="w-full">
-                  Send reset instructions
-                </.button>
-              </div>
-            </.form>
-
-            <div class="text-center mt-6">
-              <span class="text-sm text-base-content/50">Remember your password? </span>
-              <.link navigate="/sign-in" class="text-primary hover:underline font-medium text-sm">
-                Sign in
-              </.link>
             </div>
-          <% end %>
-        </div>
+            <div class="form-foot">
+              <button type="submit" class="btn-primary" phx-disable-with="Sending...">
+                Send reset instructions
+              </button>
+            </div>
+          </.form>
+
+          <div class="auth-aside">
+            <.link navigate={~p"/sign-in"}>Back to sign in</.link>
+          </div>
+        <% end %>
       </div>
-    </.app>
+    </div>
     """
   end
 
@@ -88,16 +102,13 @@ defmodule HuddlzWeb.AuthLive.ResetPassword do
   def handle_event("request_reset", %{"form" => params}, socket) do
     _form = socket.assigns.form.source |> Form.validate(params)
 
-    # Use Ash.run_action for this action type
     input = Ash.ActionInput.for_action(User, :request_password_reset_token, params)
 
     case Ash.run_action(input) do
       :ok ->
-        # Always show success message for security (don't reveal if email exists)
         {:noreply, assign(socket, :submitted, true)}
 
       {:error, _} ->
-        # Also show success for security (don't reveal if email exists)
         {:noreply, assign(socket, :submitted, true)}
     end
   end

--- a/lib/huddlz_web/live/auth_live/reset_password_confirm.ex
+++ b/lib/huddlz_web/live/auth_live/reset_password_confirm.ex
@@ -1,17 +1,22 @@
 defmodule HuddlzWeb.AuthLive.ResetPasswordConfirm do
   @moduledoc """
-  LiveView for setting a new password using a reset token.
+  Reset-confirm page at `/reset/:token`. Renders either the new-password form
+  (when the token is valid) or an expired-link state (when it isn't).
   """
   use HuddlzWeb, :live_view
+
   alias AshPhoenix.Form
   alias Huddlz.Accounts.User
-
-  import HuddlzWeb.Layouts
 
   @impl true
   def mount(%{"token" => token}, _session, socket) do
     strategy = AshAuthentication.Info.strategy!(User, :password)
     domain = AshAuthentication.Info.authentication_domain!(User)
+
+    socket =
+      socket
+      |> assign(:page_title, "Set new password")
+      |> assign(:body_class, "v3 is-auth")
 
     with {:ok, %{"sub" => subject}, _resource} <- AshAuthentication.Jwt.verify(token, User),
          {:ok, user} <- AshAuthentication.subject_to_user(subject, User) do
@@ -39,6 +44,8 @@ defmodule HuddlzWeb.AuthLive.ResetPasswordConfirm do
   def mount(_params, _session, socket) do
     {:ok,
      socket
+     |> assign(:page_title, "Set new password")
+     |> assign(:body_class, "v3 is-auth")
      |> assign(:token_valid, false)
      |> assign(:trigger_action, false)}
   end
@@ -46,85 +53,104 @@ defmodule HuddlzWeb.AuthLive.ResetPasswordConfirm do
   @impl true
   def render(assigns) do
     ~H"""
-    <.app flash={@flash} current_user={assigns[:current_user]}>
-      <div class="max-w-md mx-auto">
-        <div class="border border-base-300 p-6">
-          <%= if @token_valid do %>
-            <h2 class="font-display text-2xl tracking-tight mb-4">Set new password</h2>
+    <Layouts.flash_group flash={@flash} />
 
-            <.form
-              :let={f}
-              for={@form}
-              phx-change="validate"
-              phx-submit="reset_password"
-              phx-trigger-action={@trigger_action}
-              action="/auth/user/password/reset"
-              method="POST"
-              id="reset-password-confirm-form"
-            >
-              <input
-                type="hidden"
-                name={Phoenix.HTML.Form.input_name(f, :reset_token)}
-                value={@token}
-              />
+    <div class="auth-shell">
+      <header class="auth-topbar">
+        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
+          <div class="brand-glyph">h</div>
+          <div class="brand-text">huddlz</div>
+        </a>
+      </header>
 
-              <%= if f[:reset_token].errors != [] do %>
-                <div class="border border-error/30 p-4 bg-error/5 flex items-start gap-3 mb-4">
-                  <.icon name="hero-x-circle" class="w-5 h-5 text-error flex-shrink-0 mt-0.5" />
-                  <span class="text-sm">This password reset link is invalid or has expired.</span>
-                </div>
-                <div class="mt-4">
-                  <.link
-                    navigate="/reset"
-                    class="block text-center text-primary hover:underline font-medium"
+      <div class="auth-frame">
+        <%= if @token_valid do %>
+          <h1>Set a new password</h1>
+          <p class="lede">Almost there. Pick a new password and you'll be signed in.</p>
+
+          <.form
+            :let={f}
+            for={@form}
+            phx-change="validate"
+            phx-submit="reset_password"
+            phx-trigger-action={@trigger_action}
+            action="/auth/user/password/reset"
+            method="POST"
+            id="reset-password-confirm-form"
+            class="auth-card"
+          >
+            <input
+              type="hidden"
+              name={Phoenix.HTML.Form.input_name(f, :reset_token)}
+              value={@token}
+            />
+
+            <%= if f[:reset_token].errors != [] do %>
+              <div class="auth-state warn">
+                <div class="icon-mark">
+                  <svg
+                    width="22"
+                    height="22"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
                   >
-                    Request new reset link
-                  </.link>
+                    <circle cx="12" cy="12" r="9" /><path d="M12 7v6" /><path d="M12 17h.01" />
+                  </svg>
                 </div>
-              <% else %>
-                <.input
+                <h2>This password reset link is invalid or has expired</h2>
+                <p>Reset links expire after a short window for security. Request a new one.</p>
+                <.link navigate={~p"/reset"} class="btn-primary">Request new reset link</.link>
+              </div>
+            <% else %>
+              <div class="form-grid">
+                <.v3_input
                   field={f[:password]}
                   type="password"
                   label="New password"
                   autocomplete="new-password"
+                  help="At least 8 characters."
                 />
-
-                <.input
+                <.v3_input
                   field={f[:password_confirmation]}
                   type="password"
                   label="Confirm new password"
                   autocomplete="new-password"
                 />
-
-                <div class="text-xs text-base-content/60 mt-1 mb-4">
-                  Password must be at least 8 characters long
-                </div>
-
-                <div class="mt-6">
-                  <.button phx-disable-with="Resetting..." class="w-full">
-                    Reset password
-                  </.button>
-                </div>
-              <% end %>
-            </.form>
-          <% else %>
-            <h2 class="font-display text-2xl tracking-tight mb-4">Invalid reset link</h2>
-
-            <div class="border border-error/30 p-4 bg-error/5 flex items-start gap-3">
-              <.icon name="hero-x-circle" class="w-5 h-5 text-error flex-shrink-0 mt-0.5" />
-              <span class="text-sm">This password reset link is invalid or has expired.</span>
+              </div>
+              <div class="form-foot">
+                <button type="submit" class="btn-primary" phx-disable-with="Resetting...">
+                  Reset password
+                </button>
+              </div>
+            <% end %>
+          </.form>
+        <% else %>
+          <div class="auth-state warn">
+            <div class="icon-mark">
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="9" /><path d="M12 7v6" /><path d="M12 17h.01" />
+              </svg>
             </div>
-
-            <.link
-              navigate="/reset"
-              class="block text-center text-primary hover:underline font-medium mt-6"
-            >
-              Request new reset link
-            </.link>
-          <% end %>
-        </div>
+            <h2>This password reset link is invalid or has expired</h2>
+            <p>The link may have expired or already been used. Request a fresh one.</p>
+            <.link navigate={~p"/reset"} class="btn-primary">Request new reset link</.link>
+          </div>
+        <% end %>
       </div>
-    </.app>
+    </div>
     """
   end
 

--- a/lib/huddlz_web/live/auth_live/reset_password_confirm.ex
+++ b/lib/huddlz_web/live/auth_live/reset_password_confirm.ex
@@ -53,103 +53,69 @@ defmodule HuddlzWeb.AuthLive.ResetPasswordConfirm do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.flash_group flash={@flash} />
+    <Layouts.auth_shell flash={@flash}>
+      <%= if @token_valid do %>
+        <h1>Set a new password</h1>
+        <p class="lede">Almost there. Pick a new password and you'll be signed in.</p>
 
-    <div class="auth-shell">
-      <header class="auth-topbar">
-        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
-          <div class="brand-glyph">h</div>
-          <div class="brand-text">huddlz</div>
-        </a>
-      </header>
+        <.form
+          :let={f}
+          for={@form}
+          phx-change="validate"
+          phx-submit="reset_password"
+          phx-trigger-action={@trigger_action}
+          action="/auth/user/password/reset"
+          method="POST"
+          id="reset-password-confirm-form"
+          class="auth-card"
+        >
+          <input
+            type="hidden"
+            name={Phoenix.HTML.Form.input_name(f, :reset_token)}
+            value={@token}
+          />
 
-      <div class="auth-frame">
-        <%= if @token_valid do %>
-          <h1>Set a new password</h1>
-          <p class="lede">Almost there. Pick a new password and you'll be signed in.</p>
-
-          <.form
-            :let={f}
-            for={@form}
-            phx-change="validate"
-            phx-submit="reset_password"
-            phx-trigger-action={@trigger_action}
-            action="/auth/user/password/reset"
-            method="POST"
-            id="reset-password-confirm-form"
-            class="auth-card"
-          >
-            <input
-              type="hidden"
-              name={Phoenix.HTML.Form.input_name(f, :reset_token)}
-              value={@token}
-            />
-
-            <%= if f[:reset_token].errors != [] do %>
-              <div class="auth-state warn">
-                <div class="icon-mark">
-                  <svg
-                    width="22"
-                    height="22"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <circle cx="12" cy="12" r="9" /><path d="M12 7v6" /><path d="M12 17h.01" />
-                  </svg>
-                </div>
-                <h2>This password reset link is invalid or has expired</h2>
-                <p>Reset links expire after a short window for security. Request a new one.</p>
-                <.link navigate={~p"/reset"} class="btn-primary">Request new reset link</.link>
-              </div>
-            <% else %>
-              <div class="form-grid">
-                <.v3_input
-                  field={f[:password]}
-                  type="password"
-                  label="New password"
-                  autocomplete="new-password"
-                  help="At least 8 characters."
-                />
-                <.v3_input
-                  field={f[:password_confirmation]}
-                  type="password"
-                  label="Confirm new password"
-                  autocomplete="new-password"
-                />
-              </div>
-              <div class="form-foot">
-                <button type="submit" class="btn-primary" phx-disable-with="Resetting...">
-                  Reset password
-                </button>
-              </div>
-            <% end %>
-          </.form>
-        <% else %>
-          <div class="auth-state warn">
-            <div class="icon-mark">
-              <svg
-                width="22"
-                height="22"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.8"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <circle cx="12" cy="12" r="9" /><path d="M12 7v6" /><path d="M12 17h.01" />
-              </svg>
+          <%= if f[:reset_token].errors != [] do %>
+            <.expired_token_state />
+          <% else %>
+            <div class="form-grid">
+              <.v3_input
+                field={f[:password]}
+                type="password"
+                label="New password"
+                autocomplete="new-password"
+                help="At least 8 characters."
+              />
+              <.v3_input
+                field={f[:password_confirmation]}
+                type="password"
+                label="Confirm new password"
+                autocomplete="new-password"
+              />
             </div>
-            <h2>This password reset link is invalid or has expired</h2>
-            <p>The link may have expired or already been used. Request a fresh one.</p>
-            <.link navigate={~p"/reset"} class="btn-primary">Request new reset link</.link>
-          </div>
-        <% end %>
+            <div class="form-foot">
+              <button type="submit" class="btn-primary" phx-disable-with="Resetting...">
+                Reset password
+              </button>
+            </div>
+          <% end %>
+        </.form>
+      <% else %>
+        <.expired_token_state />
+      <% end %>
+    </Layouts.auth_shell>
+    """
+  end
+
+  defp expired_token_state(assigns) do
+    ~H"""
+    <div class="auth-state warn">
+      <div class="icon-mark">
+        <Layouts.auth_state_icon name="warn" />
       </div>
+      <h2>This password reset link is invalid or has expired</h2>
+      <p>The link may have expired or already been used. Request a fresh one.</p>
+      <.link navigate={~p"/reset"} class="btn-primary">Request new reset link</.link>
     </div>
     """
   end

--- a/lib/huddlz_web/live/auth_live/sign_in.ex
+++ b/lib/huddlz_web/live/auth_live/sign_in.ex
@@ -11,60 +11,44 @@ defmodule HuddlzWeb.AuthLive.SignIn do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.flash_group flash={@flash} />
+    <Layouts.auth_shell flash={@flash}>
+      <h1>Sign in</h1>
+      <p class="lede">Welcome back. Sign in to RSVP, organize, and follow your groups.</p>
 
-    <div class="auth-shell">
-      <header class="auth-topbar">
-        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
-          <div class="brand-glyph">h</div>
-          <div class="brand-text">huddlz</div>
-        </a>
-      </header>
-
-      <div class="auth-frame">
-        <h1>Sign in</h1>
-        <p class="lede">Welcome back. Sign in to RSVP, organize, and follow your groups.</p>
-
-        <.form
-          :let={f}
-          for={@password_form}
-          id="password-sign-in-form"
-          phx-submit="sign_in_with_password"
-          phx-change="validate_password"
-          phx-trigger-action={@trigger_action}
-          action="/auth/user/password/sign_in"
-          method="post"
-          class="auth-card"
-        >
-          <div class="form-grid">
-            <.v3_input
-              field={f[:email]}
-              type="email"
-              label="Email"
-              autocomplete="email"
-            />
-            <.v3_input
-              field={f[:password]}
-              type="password"
-              label="Password"
-              autocomplete="current-password"
-            />
-          </div>
-          <div class="form-foot">
-            <button type="submit" class="btn-primary" phx-disable-with="Signing in...">
-              Sign in
-            </button>
-          </div>
-        </.form>
-
-        <div class="auth-aside">
-          <.link navigate={~p"/reset"}>Forgot your password?</.link>
+      <.form
+        :let={f}
+        for={@password_form}
+        id="password-sign-in-form"
+        phx-submit="sign_in_with_password"
+        phx-change="validate_password"
+        phx-trigger-action={@trigger_action}
+        action="/auth/user/password/sign_in"
+        method="post"
+        class="auth-card"
+      >
+        <div class="form-grid">
+          <.v3_input field={f[:email]} type="email" label="Email" autocomplete="email" />
+          <.v3_input
+            field={f[:password]}
+            type="password"
+            label="Password"
+            autocomplete="current-password"
+          />
         </div>
-        <div class="auth-aside">
-          Don't have an account? <.link navigate={~p"/register"}>Sign up</.link>
+        <div class="form-foot">
+          <button type="submit" class="btn-primary" phx-disable-with="Signing in...">
+            Sign in
+          </button>
         </div>
+      </.form>
+
+      <div class="auth-aside">
+        <.link navigate={~p"/reset"}>Forgot your password?</.link>
       </div>
-    </div>
+      <div class="auth-aside">
+        Don't have an account? <.link navigate={~p"/register"}>Sign up</.link>
+      </div>
+    </Layouts.auth_shell>
     """
   end
 

--- a/lib/huddlz_web/live/auth_live/sign_in.ex
+++ b/lib/huddlz_web/live/auth_live/sign_in.ex
@@ -1,82 +1,82 @@
 defmodule HuddlzWeb.AuthLive.SignIn do
   @moduledoc """
-  LiveView for user sign-in with email and password authentication.
+  Sign-in page at `/sign-in`. Email + password only. Mounted under the v3
+  auth shell — chromeless, no sidebar, no global topbar.
   """
   use HuddlzWeb, :live_view
 
   alias AshPhoenix.Form
   alias Huddlz.Accounts.User
-  import HuddlzWeb.Layouts
 
   @impl true
   def render(assigns) do
     ~H"""
-    <.app flash={@flash} current_user={assigns[:current_user]}>
-      <div class="mx-auto max-w-md">
-        <h1 class="font-display text-2xl tracking-tight text-center">Sign in to your account</h1>
-        <p class="text-center text-base-content/40 mt-2">Welcome back!</p>
+    <Layouts.flash_group flash={@flash} />
 
-        <%!-- Password Sign In Form --%>
-        <.surface_panel class="p-6 mt-8">
-          <h2 class="font-display text-xl mb-4">Sign in with password</h2>
+    <div class="auth-shell">
+      <header class="auth-topbar">
+        <a href={~p"/"} style="display:flex;align-items:center;gap:10px">
+          <div class="brand-glyph">h</div>
+          <div class="brand-text">huddlz</div>
+        </a>
+      </header>
 
-          <.form
-            :let={f}
-            for={@password_form}
-            id="password-sign-in-form"
-            phx-submit="sign_in_with_password"
-            phx-change="validate_password"
-            phx-trigger-action={@trigger_action}
-            action="/auth/user/password/sign_in"
-            method="post"
-          >
-            <.input field={f[:email]} type="email" label="Email" autocomplete="email" />
-            <.input
+      <div class="auth-frame">
+        <h1>Sign in</h1>
+        <p class="lede">Welcome back. Sign in to RSVP, organize, and follow your groups.</p>
+
+        <.form
+          :let={f}
+          for={@password_form}
+          id="password-sign-in-form"
+          phx-submit="sign_in_with_password"
+          phx-change="validate_password"
+          phx-trigger-action={@trigger_action}
+          action="/auth/user/password/sign_in"
+          method="post"
+          class="auth-card"
+        >
+          <div class="form-grid">
+            <.v3_input
+              field={f[:email]}
+              type="email"
+              label="Email"
+              autocomplete="email"
+            />
+            <.v3_input
               field={f[:password]}
               type="password"
               label="Password"
               autocomplete="current-password"
             />
-
-            <div class="mt-6">
-              <.button phx-disable-with="Signing in..." class="w-full">
-                Sign in
-              </.button>
-            </div>
-          </.form>
-
-          <div class="text-sm mt-4">
-            <a href="/reset" class="text-primary hover:underline font-medium">
-              Forgot your password?
-            </a>
           </div>
-        </.surface_panel>
+          <div class="form-foot">
+            <button type="submit" class="btn-primary" phx-disable-with="Signing in...">
+              Sign in
+            </button>
+          </div>
+        </.form>
 
-        <div class="text-center mt-8">
-          <span class="text-sm text-base-content/50">
-            Don't have an account?
-          </span>
-          <a href="/register" class="text-primary hover:underline font-medium text-sm ml-1">
-            Sign up
-          </a>
+        <div class="auth-aside">
+          <.link navigate={~p"/reset"}>Forgot your password?</.link>
+        </div>
+        <div class="auth-aside">
+          Don't have an account? <.link navigate={~p"/register"}>Sign up</.link>
         </div>
       </div>
-    </.app>
+    </div>
     """
   end
 
   @impl true
   def mount(_params, _session, socket) do
-    # Get the password strategy to pass proper context
     strategy = AshAuthentication.Info.strategy!(User, :password)
 
-    # Build context like the default Ash auth does
     context = %{
       strategy: strategy,
       private: %{ash_authentication?: true}
     }
 
-    # Add token_type if sign_in_tokens are enabled
     context =
       if Map.get(strategy, :sign_in_tokens_enabled?) do
         Map.put(context, :token_type, :sign_in)
@@ -95,18 +95,17 @@ defmodule HuddlzWeb.AuthLive.SignIn do
 
     {:ok,
      socket
-     |> assign(:page_title, "Sign In")
+     |> assign(:page_title, "Sign in")
+     |> assign(:body_class, "v3 is-auth")
      |> assign(:password_form, password_form)
      |> assign(:trigger_action, false)}
   end
 
   @impl true
   def handle_event("sign_in_with_password", %{"user" => params}, socket) do
-    # Match Ash's sign-in form behavior exactly
     strategy = AshAuthentication.Info.strategy!(User, :password)
 
     if Map.get(strategy, :sign_in_tokens_enabled?) do
-      # Token-based sign in (Ash's default behavior)
       case Form.submit(socket.assigns.password_form.source, params: params, read_one?: true) do
         {:ok, user} ->
           token = user.__metadata__.token
@@ -126,7 +125,6 @@ defmodule HuddlzWeb.AuthLive.SignIn do
            )}
       end
     else
-      # Direct form submission with phx-trigger-action
       form =
         socket.assigns.password_form.source
         |> Form.validate(params)

--- a/test/features/me_dashboard.feature
+++ b/test/features/me_dashboard.feature
@@ -14,7 +14,7 @@ Feature: Me dashboard
 
   Scenario: Anonymous visitor is redirected from /me to sign-in
     When I visit "/me"
-    Then I should see "Sign In"
+    Then I should see "Sign in"
 
   Scenario: Signed-in user with no activity sees the My Huddlz tab by default with empty sections
     Given I am signed in as "host@example.com"

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -14,7 +14,7 @@ Feature: Organizer workspace
 
   Scenario: Anonymous visitor is redirected from /organize to sign-in
     When I visit "/organize"
-    Then I should see "Sign In"
+    Then I should see "Sign in"
 
   Scenario: Signed-in user with no groups sees the empty-state CTA
     Given I am signed in as "host@example.com"

--- a/test/features/step_definitions/password_authentication_steps.exs
+++ b/test/features/step_definitions/password_authentication_steps.exs
@@ -203,7 +203,7 @@ defmodule PasswordAuthenticationSteps do
   step "I should see the password sign-in form", context do
     session = context[:session] || context[:conn]
     assert_has(session, "form#password-sign-in-form")
-    assert_has(session, "h2", text: "Sign in with password")
+    assert_has(session, "h1", text: "Sign in")
     {:ok, context}
   end
 

--- a/test/features/step_definitions/sign_in_and_sign_out_steps.exs
+++ b/test/features/step_definitions/sign_in_and_sign_out_steps.exs
@@ -61,9 +61,8 @@ defmodule SignInAndSignOutSteps do
   step "the user should be signed in", context do
     session = context[:session] || context[:conn]
 
-    # Check that we're on the home page with a signed-in user
-    assert_has(session, "a", text: "Profile")
-    refute_has(session, "a", text: "Sign In")
+    # A signed-in session has a "Sign out" link reachable from the chrome.
+    assert_has(session, "a", text: "Sign out")
 
     {:ok, context}
   end
@@ -72,9 +71,8 @@ defmodule SignInAndSignOutSteps do
   step "the user should not be signed in", context do
     session = context[:session] || context[:conn]
 
-    # Check that we still see the sign in link
-    assert_has(session, "a", text: "Sign In")
-    refute_has(session, "a", text: "Profile")
+    # No "Sign out" link means we're not signed in.
+    refute_has(session, "a", text: "Sign out")
 
     {:ok, context}
   end

--- a/test/huddlz_web/live/basic_password_reset_test.exs
+++ b/test/huddlz_web/live/basic_password_reset_test.exs
@@ -87,7 +87,7 @@ defmodule HuddlzWeb.BasicPasswordResetTest do
       session = visit(conn, reset_path)
 
       # Should show the password reset form
-      assert_has(session, "h2", text: "Set new password")
+      assert_has(session, "h1", text: "Set a new password")
       assert_has(session, "input[type='password']")
       assert_has(session, "button", text: "Reset password")
     end
@@ -97,7 +97,6 @@ defmodule HuddlzWeb.BasicPasswordResetTest do
       session = visit(conn, "/reset/invalid-token-123")
 
       # Should show the invalid state immediately
-      assert_has(session, "h2", text: "Invalid reset link")
       assert_has(session, "*", text: "This password reset link is invalid or has expired")
     end
 

--- a/test/huddlz_web/live/password_reset_full_flow_test.exs
+++ b/test/huddlz_web/live/password_reset_full_flow_test.exs
@@ -62,7 +62,7 @@ defmodule HuddlzWeb.PasswordResetFullFlowTest do
       session = visit(conn, reset_path)
 
       # Should be on our custom password reset form
-      assert_has(session, "h2", text: "Set new password")
+      assert_has(session, "h1", text: "Set a new password")
       assert_has(session, "button", text: "Reset password")
 
       # Our custom form uses LiveView instead of a form action
@@ -204,7 +204,6 @@ defmodule HuddlzWeb.PasswordResetFullFlowTest do
       # When visiting with an invalid token, the error is shown on mount
       session = visit(conn, "/reset/invalid-token-123")
 
-      assert_has(session, "h2", text: "Invalid reset link")
       assert_has(session, "*", text: "This password reset link is invalid or has expired")
     end
   end


### PR DESCRIPTION
## Summary

- Wraps `/sign-in`, `/register`, `/reset`, and `/reset/:token` in the chromeless v3 auth shell from the clickthrough mockup. Each page sets `body_class: \"v3 is-auth\"` and uses the v3 form vocabulary (`auth-card`, `form-grid`, `form-foot`, `.v3_input`, `btn-primary`).
- Reset-confirm renders an `.auth-state.warn` block for the expired/invalid-token state.
- Email-confirmation flow is unchanged — AshAuthentication renders its own page; the gap log marks this as no-op for Phase 1.

This wraps up Phase 1 of the v3 migration (landing + help + auth).

## Test plan
- [x] `mix precommit` clean (1224 tests + credo + format)
- [x] Browser-verified `/sign-in`, `/register`, `/reset`, `/reset/invalid-token` render with `body.class = \"v3 is-auth\"`, correct h1, working form IDs
- [x] Updated step assertions that previously relied on legacy `Sign In` / `Profile` link text in the topbar — now check `Sign out` instead, which is consistent across v3 sidebar and legacy topbar

## Notes
- Build refs the migration plan in `~/.claude/plans/user-prompt-we-have-created-iterative-bird.md`.