### PR TITLE
feat(v3): migrate /discover to v3 design

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2411,6 +2411,34 @@ body.v3 .insight-pill svg { width: 13px; height: 13px; color: var(--cyan); }
 body.v3 .muted { color: var(--muted); }
 body.v3 .cyan { color: var(--cyan); }
 
+/* Inline button styled like a link — for "Clear filters" / similar resets that
+   sit alongside muted prose. Strips the default `<button>` chrome and adopts
+   the surrounding font. */
+body.v3 .button-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: var(--cyan);
+  cursor: pointer;
+}
+
+body.v3 .button-link:hover { text-decoration: underline; }
+
+/* Discover-page meta line (result count + inline reset link). */
+body.v3 .discover-meta {
+  color: var(--muted);
+  font-size: 12px;
+  margin-bottom: 14px;
+}
+
+/* "All huddlz" backlink wrapper used when ?yours= is active. */
+body.v3 .discover-back {
+  margin-bottom: 16px;
+  font-size: 13px;
+}
+
 /* ───────────────────────────────────────  PAGINATION  ──────────── */
 body.v3 .pagination {
   display: flex;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -858,6 +858,75 @@ body.v3 .filter-location-clear {
 
 body.v3 .filter-location-clear:hover { color: var(--text); }
 
+body.v3 .filter-location-wrap {
+  position: relative;
+}
+
+body.v3 .filter-location-wrap .filter-location-input {
+  width: 100%;
+  cursor: text;
+}
+
+body.v3 .filter-location-wrap .filter-location-input[readonly] {
+  cursor: pointer;
+}
+
+body.v3 .filter-location-listbox {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 50;
+  min-width: 220px;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  padding: 4px;
+}
+
+body.v3 .filter-location-listbox.empty {
+  padding: 12px 14px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body.v3 .filter-location-option {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+body.v3 .filter-location-option:hover,
+body.v3 .filter-location-option.is-active {
+  background: var(--cyan-soft);
+}
+
+body.v3 .filter-location-option .opt-main {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+body.v3 .filter-location-option .opt-secondary {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+body.v3 .filter-location-error {
+  margin: 6px 0 0;
+  color: var(--warn);
+  font-size: 12px;
+}
+
 body.v3 .filter-distance {
   display: flex;
   align-items: center;
@@ -1050,7 +1119,7 @@ body.v3 .card-group {
   text-transform: uppercase;
 }
 
-body.v3 .card-title { font-size: 16px; font-weight: 700; line-height: 1.25; color: var(--text); }
+body.v3 .card-title { margin: 0; font-size: 16px; font-weight: 700; line-height: 1.25; color: var(--text); }
 
 body.v3 .card-meta {
   display: flex;

--- a/lib/huddlz_web/components/v3.ex
+++ b/lib/huddlz_web/components/v3.ex
@@ -27,6 +27,7 @@ defmodule HuddlzWeb.V3 do
       import HuddlzWeb.V3.Chip
       import HuddlzWeb.V3.Input
       import HuddlzWeb.V3.ListRow
+      import HuddlzWeb.V3.Pagination
       import HuddlzWeb.V3.Panel
       import HuddlzWeb.V3.Pill
     end

--- a/lib/huddlz_web/components/v3/pagination.ex
+++ b/lib/huddlz_web/components/v3/pagination.ex
@@ -1,0 +1,100 @@
+defmodule HuddlzWeb.V3.Pagination do
+  @moduledoc """
+  V3 pagination — `<nav class="pagination">` with prev/next page-nav buttons
+  flanking an `<ol class="page-numbers">`. Page-number entries collapse to an
+  ellipsis when the total exceeds 7.
+
+  Pages are emitted as `<button>` elements that fire a `phx-click` event with
+  `phx-value-page=N`; the host LiveView pushes the corresponding patch URL.
+  """
+  use Phoenix.Component
+
+  attr :current_page, :integer, required: true
+  attr :total_pages, :integer, required: true
+
+  attr :event_name, :string,
+    required: true,
+    doc: "phx-click event name dispatched to the LiveView"
+
+  attr :class, :any, default: nil
+
+  def v3_pagination(assigns) do
+    ~H"""
+    <nav class={["pagination", @class]} aria-label="Pagination">
+      <button
+        type="button"
+        class="page-nav"
+        disabled={@current_page <= 1}
+        aria-label="Previous page"
+        phx-click={@event_name}
+        phx-value-page={@current_page - 1}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Prev</span>
+      </button>
+      <ol class="page-numbers">
+        <%= for entry <- pagination_range(@current_page, @total_pages) do %>
+          <%= if entry == :ellipsis do %>
+            <li class="page-ellipsis" aria-hidden="true">…</li>
+          <% else %>
+            <li>
+              <button
+                type="button"
+                class={["page-num", entry == @current_page && "is-active"]}
+                aria-current={entry == @current_page && "page"}
+                phx-click={@event_name}
+                phx-value-page={entry}
+              >
+                {entry}
+              </button>
+            </li>
+          <% end %>
+        <% end %>
+      </ol>
+      <button
+        type="button"
+        class="page-nav"
+        disabled={@current_page >= @total_pages}
+        aria-label="Next page"
+        phx-click={@event_name}
+        phx-value-page={@current_page + 1}
+      >
+        <span>Next</span>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m9 6 6 6-6 6" />
+        </svg>
+      </button>
+    </nav>
+    """
+  end
+
+  defp pagination_range(_current, total) when total <= 7, do: Enum.to_list(1..total)
+
+  defp pagination_range(current, total) do
+    cond do
+      current <= 4 -> [1, 2, 3, 4, 5, :ellipsis, total]
+      current >= total - 3 -> [1, :ellipsis, total - 4, total - 3, total - 2, total - 1, total]
+      true -> [1, :ellipsis, current - 1, current, current + 1, :ellipsis, total]
+    end
+  end
+end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -550,8 +550,8 @@ defmodule HuddlzWeb.HuddlLive do
         </div>
       </div>
 
-      <div :if={@yours != :all} style="margin-bottom:16px">
-        <.link patch={view_all_path(:all, assigns)} class="muted" style="font-size:13px">
+      <div :if={@yours != :all} class="discover-back">
+        <.link patch={view_all_path(:all, assigns)} class="muted">
           ← All huddlz
         </.link>
       </div>
@@ -583,6 +583,9 @@ defmodule HuddlzWeb.HuddlLive do
             longitude={@location_lng}
             placeholder="Anywhere"
           />
+          <%!-- A `<form>` wraps the slider so phx-change emits a clean
+                `name=value` payload. `display: contents` flattens the form so
+                it doesn't perturb the .filter-distance flex layout. --%>
           <form
             :if={@location_active}
             class="filter-distance"
@@ -664,16 +667,11 @@ defmodule HuddlzWeb.HuddlLive do
         </div>
       </div>
 
-      <div class="muted" style="margin-bottom:14px;font-size:12px">
+      <div class="discover-meta">
         {result_count_label(@page_info.total_count, @scope)}
         <span :if={any_filter_active?(assigns)}>
           ·
-          <button
-            type="button"
-            phx-click="clear_filters"
-            class="cyan"
-            style="background:transparent;border:0;font:inherit;cursor:pointer;padding:0"
-          >
+          <button type="button" phx-click="clear_filters" class="button-link">
             Clear filters
           </button>
         </span>
@@ -776,7 +774,7 @@ defmodule HuddlzWeb.HuddlLive do
       <:body>
         <span :if={@group.location} class="card-group">{@group.location}</span>
         <h2 class="card-title">{@group.name}</h2>
-        <div :if={member_count(@group)} class="card-meta">
+        <div :if={member_count_label(@group)} class="card-meta">
           <span>{member_count_label(@group)}</span>
         </div>
       </:body>
@@ -837,7 +835,11 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   defp format_distance(miles) when is_number(miles) and miles < 1, do: "< 1 mi"
-  defp format_distance(miles) when is_number(miles), do: "#{Float.round(miles * 1.0, 1)} mi"
+
+  defp format_distance(miles) when is_number(miles) do
+    rounded = Float.round(miles * 1.0, 1)
+    if rounded == trunc(rounded), do: "#{trunc(rounded)} mi", else: "#{rounded} mi"
+  end
 
   defp rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
     do: "#{count} / #{max} RSVPs"
@@ -845,18 +847,11 @@ defmodule HuddlzWeb.HuddlLive do
   defp rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
   defp rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
 
-  defp member_count(group) do
-    case Map.get(group, :member_count) do
-      n when is_integer(n) and n > 0 -> n
-      _ -> nil
-    end
-  end
-
   defp member_count_label(group) do
-    case member_count(group) do
-      nil -> ""
+    case Map.get(group, :member_count) do
       1 -> "1 member"
-      n -> "#{n} members"
+      n when is_integer(n) and n > 0 -> "#{n} members"
+      _ -> nil
     end
   end
 

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -10,6 +10,8 @@ defmodule HuddlzWeb.HuddlLive do
   use HuddlzWeb, :live_view
 
   alias Huddlz.Communities
+  alias Huddlz.Storage.GroupImages
+  alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Layouts
   require Logger
 
@@ -17,6 +19,7 @@ defmodule HuddlzWeb.HuddlLive do
   @page_size 20
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -75,8 +78,6 @@ defmodule HuddlzWeb.HuddlLive do
       total_pages = socket.assigns.page_info.total_pages
 
       if page > total_pages do
-        # Out-of-range page: clamp by patching to the last valid page so the URL
-        # reflects what the user actually sees.
         cleared? = location_explicitly_cleared?(socket.assigns)
 
         path =
@@ -226,6 +227,24 @@ defmodule HuddlzWeb.HuddlLive do
     {:noreply, push_patch(socket, to: path)}
   end
 
+  def handle_event("distance_change", %{"distance_miles" => raw}, socket) do
+    new_distance = parse_distance(raw)
+
+    if new_distance == socket.assigns.distance_miles do
+      {:noreply, socket}
+    else
+      params =
+        socket
+        |> form_params_from_assigns()
+        |> Map.put("distance_miles", Integer.to_string(new_distance))
+
+      {:noreply,
+       push_patch(socket,
+         to: scoped_path(socket.assigns.scope, socket.assigns.yours, params)
+       )}
+    end
+  end
+
   @impl true
   def handle_info(
         {:location_selected, "location-autocomplete",
@@ -257,8 +276,6 @@ defmodule HuddlzWeb.HuddlLive do
            )
        )}
     else
-      # No-op when there was nothing to clear, so the URL doesn't pick up
-      # `cleared=1` spuriously.
       {:noreply, socket}
     end
   end
@@ -420,14 +437,11 @@ defmodule HuddlzWeb.HuddlLive do
     )
   end
 
-  # Public-only directory: anonymous users can only see public groups, and a
-  # member's private groups already surface in /groups under their personal
-  # sections, so re-listing them here would just duplicate.
   defp list_groups(query, page, actor) do
     case Communities.search_groups(query,
            actor: actor,
            query: [filter: [is_public: true]],
-           load: [:current_image_url],
+           load: [:current_image_url, :member_count],
            page: [
              limit: @page_size,
              offset: (page - 1) * @page_size,
@@ -498,44 +512,6 @@ defmodule HuddlzWeb.HuddlLive do
     }
   end
 
-  defp show_filter_panel(js \\ %JS{}) do
-    js
-    |> JS.show(to: "#filter-panel")
-    |> JS.show(
-      to: "#filter-panel-bg",
-      time: 200,
-      transition: {"transition-opacity ease-out duration-200", "opacity-0", "opacity-100"}
-    )
-    |> JS.show(
-      to: "#filter-panel-container",
-      time: 200,
-      transition:
-        {"transition-transform ease-out duration-200",
-         "translate-y-full lg:translate-y-0 lg:translate-x-full",
-         "translate-y-0 lg:translate-x-0"}
-    )
-    |> JS.add_class("overflow-hidden", to: "body")
-    |> JS.focus_first(to: "#filter-panel-container")
-  end
-
-  defp hide_filter_panel(js \\ %JS{}) do
-    js
-    |> JS.hide(
-      to: "#filter-panel-bg",
-      time: 200,
-      transition: {"transition-opacity ease-in duration-200", "opacity-100", "opacity-0"}
-    )
-    |> JS.hide(
-      to: "#filter-panel-container",
-      time: 200,
-      transition:
-        {"transition-transform ease-in duration-200", "translate-y-0 lg:translate-x-0",
-         "translate-y-full lg:translate-y-0 lg:translate-x-full"}
-    )
-    |> JS.hide(to: "#filter-panel", transition: {"block", "block", "hidden"})
-    |> JS.remove_class("overflow-hidden", to: "body")
-  end
-
   defp filter_url(overrides, assigns) do
     params = Map.merge(form_params_from_assigns(assigns), overrides)
     scoped_path(assigns.scope, assigns.yours, params)
@@ -556,333 +532,331 @@ defmodule HuddlzWeb.HuddlLive do
     filter_url(%{"sort" => new_value}, assigns)
   end
 
-  defp distance_change_url(target, assigns) do
-    filter_url(%{"distance_miles" => target}, assigns)
-  end
-
-  defp toggle_class(active?) do
-    base =
-      "inline-flex items-center justify-center min-h-9 px-3 text-sm font-medium border transition-colors"
-
-    if active? do
-      base <> " border-primary bg-primary/15 text-primary"
-    else
-      base <> " border-base-300 hover:border-primary/50 text-base-content"
-    end
-  end
-
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user} search_query={@search_query}>
-      <div>
-        <div class="mb-6">
-          <h1 class="font-display text-3xl md:text-4xl tracking-tight">
-            {results_heading(@scope, @yours, @search_query)}
-          </h1>
-          <p
-            :if={results_subtitle(@scope, @yours, @search_query, @location_text)}
-            class="mt-2 text-base-content/60"
-          >
-            {results_subtitle(@scope, @yours, @search_query, @location_text)}
+    <Layouts.v3_app
+      flash={@flash}
+      current_user={@current_user}
+      active="discover"
+      query={@search_query || ""}
+    >
+      <div class="page-head">
+        <div>
+          <h1>{discover_h1(@scope, @yours, @search_query)}</h1>
+          <p :if={discover_subtitle(@scope, @yours, @search_query, @location_text)}>
+            {discover_subtitle(@scope, @yours, @search_query, @location_text)}
           </p>
         </div>
+      </div>
 
-        <div class="flex flex-wrap items-center gap-2 mb-8">
-          <.page_tab patch={chip_path(:huddlz, assigns)} active={@scope == :huddlz}>
-            Huddlz
-          </.page_tab>
-          <.page_tab patch={chip_path(:groups, assigns)} active={@scope == :groups}>
-            Groups
-          </.page_tab>
+      <div :if={@yours != :all} style="margin-bottom:16px">
+        <.link patch={view_all_path(:all, assigns)} class="muted" style="font-size:13px">
+          ← All huddlz
+        </.link>
+      </div>
 
-          <%= if @scope == :huddlz and any_filter_active?(assigns) do %>
-            <%= if @search_query do %>
-              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                Search: {@search_query}
-              </span>
-            <% end %>
-            <%= if @event_type_filter do %>
-              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                Type: {humanize_filter(@event_type_filter)}
-              </span>
-            <% end %>
-            <%= if @date_filter != "upcoming" do %>
-              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                Date: {humanize_filter(@date_filter)}
-              </span>
-            <% end %>
-            <%= if @sort != :soonest do %>
-              <span class="text-xs px-2.5 py-1 bg-secondary/10 text-secondary font-medium inline-flex items-center">
-                Sort: {humanize_filter(@sort)}
-              </span>
-            <% end %>
-            <%= if @location_active do %>
-              <span
-                data-testid="location-badge"
-                class="text-xs px-2.5 py-1 bg-primary/10 text-primary font-medium inline-flex items-center gap-1"
-              >
-                <.icon name="hero-map-pin" class="h-3 w-3" />
-                {@location_text} · {@distance_miles} mi
-              </span>
-            <% end %>
-            <.button variant="ghost" size="sm" type="button" phx-click="clear_filters">
-              Clear all
-            </.button>
-          <% end %>
-
-          <%= if @scope == :huddlz do %>
-            <button
-              type="button"
-              phx-click={show_filter_panel()}
-              aria-controls="filter-panel"
-              class="ml-auto h-10 px-4 inline-flex items-center gap-2 border border-base-300 hover:border-primary/50 text-base-content text-sm font-extrabold transition-colors active:scale-[0.98]"
-            >
-              <.icon name="hero-adjustments-horizontal" class="w-4 h-4" /> Filters
-            </button>
-          <% end %>
-        </div>
-
-        <div :if={@scope == :huddlz} class="w-full">
-          <div class="mono-label text-primary/70 mb-3">Huddlz</div>
-          <%= if Enum.empty?(@huddls) do %>
-            <.surface_panel variant="dashed" class="p-12 text-center">
-              <p class="text-lg text-base-content/50">{empty_message(assigns)}</p>
-            </.surface_panel>
-          <% else %>
-            <div class="mb-4 text-sm text-base-content/40">
-              Found {@page_info.total_count} {if @page_info.total_count == 1,
-                do: "huddl",
-                else: "huddlz"}
-            </div>
-            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              <%= for {huddl, distance} <- @huddls do %>
-                <.huddl_card huddl={huddl} show_group={true} distance={distance} />
-              <% end %>
-            </div>
-
-            <%= if @page_info.total_pages > 1 do %>
-              <.pagination
-                current_page={@page_info.current_page}
-                total_pages={@page_info.total_pages}
-                event_name="change_page"
-              />
-            <% end %>
-          <% end %>
-        </div>
-
-        <div :if={@scope == :groups} class="w-full">
-          <div class="mono-label text-primary/70 mb-3">Groups</div>
-          <%= if @groups == [] do %>
-            <.surface_panel variant="dashed" class="p-12 text-center">
-              <p class="text-lg text-base-content/50">{empty_message(assigns)}</p>
-            </.surface_panel>
-          <% else %>
-            <div class="mb-4 text-sm text-base-content/40">
-              Found {@page_info.total_count} {if @page_info.total_count == 1,
-                do: "group",
-                else: "groups"}
-            </div>
-            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              <%= for group <- @groups do %>
-                <.group_card group={group} />
-              <% end %>
-            </div>
-
-            <%= if @page_info.total_pages > 1 do %>
-              <.pagination
-                current_page={@page_info.current_page}
-                total_pages={@page_info.total_pages}
-                event_name="change_page"
-              />
-            <% end %>
-          <% end %>
-        </div>
-
-        <div :if={@yours != :all} class="mt-6">
-          <.link
-            patch={view_all_path(:all, assigns)}
-            class="text-sm text-primary hover:underline font-medium"
-          >
-            ← All huddlz
-          </.link>
-        </div>
-
-        <div
-          :if={@scope == :huddlz}
-          id="filter-panel"
-          class="hidden fixed inset-0 z-50"
-          phx-remove={hide_filter_panel()}
-          data-cancel={JS.exec("phx-remove", to: "#filter-panel")}
+      <div class="scope-tabs">
+        <.link
+          patch={chip_path(:huddlz, assigns)}
+          class={["scope-tab", @scope == :huddlz && "is-active"]}
         >
-          <div
-            id="filter-panel-bg"
-            class="fixed inset-0 bg-black/60"
-            phx-click={JS.exec("data-cancel", to: "#filter-panel")}
-            aria-hidden="true"
+          Huddlz
+        </.link>
+        <.link
+          patch={chip_path(:groups, assigns)}
+          class={["scope-tab", @scope == :groups && "is-active"]}
+        >
+          Groups
+        </.link>
+      </div>
+
+      <div :if={@scope == :huddlz} class="filter-bar">
+        <div class="filter-group">
+          <span class="filter-label">Within</span>
+          <.live_component
+            module={HuddlzWeb.Live.LocationAutocomplete}
+            id="location-autocomplete"
+            variant={:filter_pill}
+            value={@location_text}
+            latitude={@location_lat}
+            longitude={@location_lng}
+            placeholder="Anywhere"
           />
-          <.focus_wrap
-            id="filter-panel-container"
-            phx-window-keydown={JS.exec("data-cancel", to: "#filter-panel")}
-            phx-key="escape"
-            class="fixed bottom-0 inset-x-0 lg:bottom-auto lg:top-0 lg:right-0 lg:left-auto w-full lg:w-[430px] max-h-[76vh] lg:max-h-none lg:h-screen border-t lg:border-t-0 lg:border-l border-base-300 bg-base-100 flex flex-col"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="filter-panel-title"
+          <form
+            :if={@location_active}
+            class="filter-distance"
+            phx-change="distance_change"
+            style="display:contents"
           >
-            <header class="flex items-center justify-between px-5 py-4 border-b border-base-300 flex-shrink-0">
-              <h2 id="filter-panel-title" class="font-display text-2xl tracking-tight text-glow">
-                Filters
-              </h2>
-              <button
-                type="button"
-                phx-click={JS.exec("data-cancel", to: "#filter-panel")}
-                aria-label="Close filters"
-                class="text-base-content/40 hover:text-base-content transition-colors p-1"
-              >
-                <.icon name="hero-x-mark" class="w-5 h-5" />
-              </button>
-            </header>
+            <input
+              id="distance"
+              type="range"
+              name="distance_miles"
+              min="5"
+              max="100"
+              step="5"
+              value={@distance_miles}
+              phx-debounce="200"
+            />
+            <output for="distance" class="filter-distance-value">{@distance_miles} mi</output>
+          </form>
+        </div>
 
-            <div class="flex-1 overflow-y-auto px-5 py-4 space-y-6">
-              <section>
-                <h3 class="mono-label text-base-content/60 mb-3">Date</h3>
-                <div class="flex flex-wrap gap-2">
-                  <.link
-                    patch={date_toggle_url("upcoming", assigns)}
-                    class={toggle_class(@date_filter == "upcoming")}
-                  >
-                    Upcoming
-                  </.link>
-                  <.link
-                    patch={date_toggle_url("this_week", assigns)}
-                    class={toggle_class(@date_filter == "this_week")}
-                  >
-                    This week
-                  </.link>
-                  <.link
-                    patch={date_toggle_url("this_month", assigns)}
-                    class={toggle_class(@date_filter == "this_month")}
-                  >
-                    This month
-                  </.link>
-                  <.link
-                    patch={date_toggle_url("all", assigns)}
-                    class={toggle_class(@date_filter == "all")}
-                  >
-                    All
-                  </.link>
-                </div>
-              </section>
+        <div class="filter-group">
+          <span class="filter-label">Type</span>
+          <div class="chip-group">
+            <.v3_chip
+              patch={format_toggle_url("in_person", assigns)}
+              active={@event_type_filter == "in_person"}
+            >
+              In person
+            </.v3_chip>
+            <.v3_chip
+              patch={format_toggle_url("virtual", assigns)}
+              active={@event_type_filter == "virtual"}
+            >
+              Virtual
+            </.v3_chip>
+            <.v3_chip
+              patch={format_toggle_url("hybrid", assigns)}
+              active={@event_type_filter == "hybrid"}
+            >
+              Hybrid
+            </.v3_chip>
+          </div>
+        </div>
 
-              <section>
-                <h3 class="mono-label text-base-content/60 mb-3">Format</h3>
-                <div class="flex flex-wrap gap-2">
-                  <.link
-                    patch={format_toggle_url("in_person", assigns)}
-                    class={toggle_class(@event_type_filter == "in_person")}
-                  >
-                    In person
-                  </.link>
-                  <.link
-                    patch={format_toggle_url("virtual", assigns)}
-                    class={toggle_class(@event_type_filter == "virtual")}
-                  >
-                    Virtual
-                  </.link>
-                  <.link
-                    patch={format_toggle_url("hybrid", assigns)}
-                    class={toggle_class(@event_type_filter == "hybrid")}
-                  >
-                    Hybrid
-                  </.link>
-                </div>
-              </section>
+        <div class="filter-group">
+          <span class="filter-label">When</span>
+          <div class="chip-group">
+            <.v3_chip
+              patch={date_toggle_url("upcoming", assigns)}
+              active={@date_filter == "upcoming"}
+            >
+              All upcoming
+            </.v3_chip>
+            <.v3_chip
+              patch={date_toggle_url("this_week", assigns)}
+              active={@date_filter == "this_week"}
+            >
+              This week
+            </.v3_chip>
+            <.v3_chip
+              patch={date_toggle_url("this_month", assigns)}
+              active={@date_filter == "this_month"}
+            >
+              This month
+            </.v3_chip>
+          </div>
+        </div>
 
-              <section>
-                <h3 class="mono-label text-base-content/60 mb-3">Location</h3>
-                <div class="space-y-3">
-                  <.live_component
-                    module={HuddlzWeb.Live.LocationAutocomplete}
-                    id="location-autocomplete"
-                    field_name="location"
-                    value={@location_text}
-                    latitude={@location_lat}
-                    longitude={@location_lng}
-                    label="City"
-                    label_class="mono-label text-base-content/60 mb-2 block"
-                    placeholder="City, State"
-                  />
-                  <div :if={@location_active}>
-                    <span class="mono-label text-base-content/60 mb-2 block">Distance</span>
-                    <div class="flex flex-wrap gap-2">
-                      <%= for miles <- [10, 25, 50, 100] do %>
-                        <.link
-                          patch={distance_change_url(Integer.to_string(miles), assigns)}
-                          class={toggle_class(@distance_miles == miles)}
-                        >
-                          {miles} mi
-                        </.link>
-                      <% end %>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <section>
-                <h3 class="mono-label text-base-content/60 mb-3">Sort</h3>
-                <div class="flex flex-wrap gap-2">
-                  <.link
-                    patch={sort_toggle_url("soonest", assigns)}
-                    class={toggle_class(@sort == :soonest)}
-                  >
-                    Soonest
-                  </.link>
-                  <.link
-                    patch={sort_toggle_url("newest", assigns)}
-                    class={toggle_class(@sort == :newest)}
-                  >
-                    Newest
-                  </.link>
-                </div>
-              </section>
-            </div>
-
-            <footer class="flex items-center justify-end px-5 py-4 border-t border-base-300 flex-shrink-0">
-              <.button variant="ghost" size="sm" type="button" phx-click="clear_filters">
-                Reset
-              </.button>
-            </footer>
-          </.focus_wrap>
+        <div class="filter-group">
+          <span class="filter-label">Sort</span>
+          <div class="chip-group">
+            <.v3_chip patch={sort_toggle_url("soonest", assigns)} active={@sort == :soonest}>
+              Soonest
+            </.v3_chip>
+            <.v3_chip patch={sort_toggle_url("newest", assigns)} active={@sort == :newest}>
+              Newest
+            </.v3_chip>
+          </div>
         </div>
       </div>
-    </Layouts.app>
+
+      <div class="muted" style="margin-bottom:14px;font-size:12px">
+        {result_count_label(@page_info.total_count, @scope)}
+        <span :if={any_filter_active?(assigns)}>
+          ·
+          <button
+            type="button"
+            phx-click="clear_filters"
+            class="cyan"
+            style="background:transparent;border:0;font:inherit;cursor:pointer;padding:0"
+          >
+            Clear filters
+          </button>
+        </span>
+      </div>
+
+      <%= if @scope == :huddlz do %>
+        <%= if Enum.empty?(@huddls) do %>
+          <p class="muted">{empty_message(assigns)}</p>
+        <% else %>
+          <div class="grid">
+            <%= for {{huddl, distance}, idx} <- Enum.with_index(@huddls) do %>
+              <.v3_huddl_card huddl={huddl} distance={distance} gradient={Integer.mod(idx, 6) + 1} />
+            <% end %>
+          </div>
+          <.v3_pagination
+            :if={@page_info.total_pages > 1}
+            current_page={@page_info.current_page}
+            total_pages={@page_info.total_pages}
+            event_name="change_page"
+          />
+        <% end %>
+      <% else %>
+        <%= if @groups == [] do %>
+          <p class="muted">{empty_message(assigns)}</p>
+        <% else %>
+          <div class="grid">
+            <%= for {group, idx} <- Enum.with_index(@groups) do %>
+              <.v3_group_card group={group} gradient={Integer.mod(idx, 6) + 1} />
+            <% end %>
+          </div>
+          <.v3_pagination
+            :if={@page_info.total_pages > 1}
+            current_page={@page_info.current_page}
+            total_pages={@page_info.total_pages}
+            event_name="change_page"
+          />
+        <% end %>
+      <% end %>
+    </Layouts.v3_app>
     """
   end
 
-  defp results_heading(_, :hosting, _), do: "huddlz you're hosting"
-  defp results_heading(_, :attending, _), do: "huddlz you're attending"
-  defp results_heading(_, _, q) when is_binary(q) and q != "", do: "Results for #{q}"
-  defp results_heading(:groups, _, _), do: "Discover groups"
-  defp results_heading(:huddlz, _, _), do: "Discover huddlz"
+  attr :huddl, :map, required: true
+  attr :distance, :float, default: nil
+  attr :gradient, :integer, default: 1
 
-  defp results_subtitle(_, yours, _, _) when yours in [:hosting, :attending], do: nil
+  defp v3_huddl_card(assigns) do
+    ~H"""
+    <.v3_card
+      navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}
+      gradient={@gradient}
+    >
+      <:cover>
+        <img
+          :if={@huddl.display_image_url}
+          class="card-cover-img"
+          src={HuddlImages.url(@huddl.display_image_url)}
+          alt={@huddl.title}
+        />
+        <.v3_date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
+        <.v3_card_tag variant={tag_variant(@huddl.event_type)}>
+          {tag_label(@huddl.event_type)}
+        </.v3_card_tag>
+      </:cover>
+      <:body>
+        <span :if={Map.has_key?(@huddl, :group) && @huddl.group} class="card-group">
+          {@huddl.group.name}
+        </span>
+        <h3 class="card-title">{@huddl.title}</h3>
+        <div class="card-meta">
+          <span>{format_meta_when(@huddl.starts_at)}</span>
+          <%= if @distance do %>
+            <span class="dot"></span>
+            <span>{format_distance(@distance)}</span>
+          <% end %>
+          <%= if @huddl.rsvp_count > 0 || @huddl.max_attendees do %>
+            <span class="dot"></span>
+            <span>{rsvp_label(@huddl)}</span>
+          <% end %>
+        </div>
+      </:body>
+    </.v3_card>
+    """
+  end
 
-  defp results_subtitle(:huddlz, _, q, location) do
+  attr :group, :map, required: true
+  attr :gradient, :integer, default: 1
+
+  defp v3_group_card(assigns) do
+    ~H"""
+    <.v3_card navigate={~p"/groups/#{@group.slug}"} gradient={@gradient}>
+      <:cover>
+        <img
+          :if={@group.current_image_url}
+          class="card-cover-img"
+          src={GroupImages.url(@group.current_image_url)}
+          alt={@group.name}
+        />
+      </:cover>
+      <:body>
+        <span :if={@group.location} class="card-group">{@group.location}</span>
+        <h2 class="card-title">{@group.name}</h2>
+        <div :if={member_count(@group)} class="card-meta">
+          <span>{member_count_label(@group)}</span>
+        </div>
+      </:body>
+    </.v3_card>
+    """
+  end
+
+  defp discover_h1(_, :hosting, _), do: "huddlz you're hosting"
+  defp discover_h1(_, :attending, _), do: "huddlz you're attending"
+
+  defp discover_h1(_, _, q) when is_binary(q) and q != "",
+    do: "Results for “#{q}”"
+
+  defp discover_h1(:groups, _, _), do: "Browse groups"
+  defp discover_h1(:huddlz, _, _), do: "Browse huddlz"
+
+  defp discover_subtitle(_, yours, _, _) when yours in [:hosting, :attending], do: nil
+
+  defp discover_subtitle(:huddlz, _, q, location) do
     base =
       if is_binary(q) and q != "",
-        do: "Huddlz matching your search",
-        else: "Real-life gatherings"
+        do: "Showing huddlz that match your search",
+        else: "Find a huddl worth showing up to. Tweak the filters to match what you're after"
 
     location_suffix = if location, do: " near #{location}", else: ""
     base <> location_suffix <> "."
   end
 
-  defp results_subtitle(:groups, _, q, _location) do
+  defp discover_subtitle(:groups, _, q, _location) do
     if is_binary(q) and q != "" do
       "Groups matching your search."
     else
       "Communities organizing huddlz."
+    end
+  end
+
+  defp result_count_label(count, :huddlz),
+    do: "#{count} #{if count == 1, do: "huddl", else: "huddlz"}"
+
+  defp result_count_label(count, :groups),
+    do: "#{count} #{if count == 1, do: "group", else: "groups"}"
+
+  defp tag_variant(:in_person), do: :in_person
+  defp tag_variant(:virtual), do: :online
+  defp tag_variant(:hybrid), do: :hybrid
+
+  defp tag_label(:in_person), do: "In person"
+  defp tag_label(:virtual), do: "Online"
+  defp tag_label(:hybrid), do: "Hybrid"
+
+  defp huddl_month(%{starts_at: %DateTime{} = dt}),
+    do: Calendar.strftime(dt, "%b") |> String.upcase()
+
+  defp huddl_day(%{starts_at: %DateTime{} = dt}), do: Calendar.strftime(dt, "%-d")
+
+  defp format_meta_when(%DateTime{} = dt) do
+    "#{Calendar.strftime(dt, "%a")} · #{Calendar.strftime(dt, "%-I:%M %p")}"
+  end
+
+  defp format_distance(miles) when is_number(miles) and miles < 1, do: "< 1 mi"
+  defp format_distance(miles) when is_number(miles), do: "#{Float.round(miles * 1.0, 1)} mi"
+
+  defp rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
+    do: "#{count} / #{max} RSVPs"
+
+  defp rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
+  defp rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
+
+  defp member_count(group) do
+    case Map.get(group, :member_count) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> nil
+    end
+  end
+
+  defp member_count_label(group) do
+    case member_count(group) do
+      nil -> ""
+      1 -> "1 member"
+      n -> "#{n} members"
     end
   end
 
@@ -966,13 +940,5 @@ defmodule HuddlzWeb.HuddlLive do
     else
       "No upcoming huddlz right now."
     end
-  end
-
-  defp humanize_filter(filter) do
-    filter
-    |> to_string()
-    |> String.replace("_", " ")
-    |> String.split(" ")
-    |> Enum.map_join(" ", &String.capitalize/1)
   end
 end

--- a/lib/huddlz_web/live/location_autocomplete.ex
+++ b/lib/huddlz_web/live/location_autocomplete.ex
@@ -24,6 +24,11 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
   attr :show_clear, :boolean, default: true
   attr :fetch_coordinates, :boolean, default: true
 
+  attr :variant, :atom,
+    values: [:default, :filter_pill],
+    default: :default,
+    doc: "render style — `:filter_pill` mounts inside the v3 `.filter-location` chrome"
+
   def mount(socket) do
     {:ok,
      assign(socket,
@@ -35,6 +40,7 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
        types: ["locality"],
        show_clear: true,
        fetch_coordinates: true,
+       variant: :default,
        # Internal state
        search_text: "",
        suggestions: [],
@@ -102,7 +108,10 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
     end
   end
 
-  def render(assigns) do
+  def render(%{variant: :filter_pill} = assigns), do: render_filter_pill(assigns)
+  def render(assigns), do: render_default(assigns)
+
+  defp render_default(assigns) do
     ~H"""
     <div
       id={@id}
@@ -228,6 +237,125 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
       </div>
 
       <p :if={@error} class="mt-1 text-sm text-error">{@error}</p>
+    </div>
+    """
+  end
+
+  # V3 filter-pill variant — renders inside the `.filter-location` pill chrome
+  # used by `/discover`. Same events and parent notifications as the default.
+  defp render_filter_pill(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class="filter-location-wrap"
+      phx-click-away="dismiss"
+      phx-target={@myself}
+      phx-hook="LocationAutocomplete"
+      data-has-highlight={to_string(@suggestion_index >= 0)}
+    >
+      <div class="filter-location">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 22s7-7.6 7-13a7 7 0 0 0-14 0c0 5.4 7 13 7 13z" />
+          <circle cx="12" cy="9" r="2.5" />
+        </svg>
+
+        <%= if @selected do %>
+          <input :if={@field_name} type="hidden" name={@field_name} value={@selected_text} />
+          <input
+            type="text"
+            class="filter-location-input"
+            value={@selected_text}
+            phx-click="edit"
+            phx-target={@myself}
+            readonly
+            data-testid="location-display"
+            aria-label="Edit location"
+          />
+          <button
+            :if={@show_clear}
+            type="button"
+            class="filter-location-clear"
+            phx-click="clear"
+            phx-target={@myself}
+            aria-label="Clear location"
+          >
+            ×
+          </button>
+        <% else %>
+          <input :if={@field_name} type="hidden" name={@field_name} value={@search_text} />
+          <input
+            type="text"
+            id={"#{@id}-input"}
+            class="filter-location-input"
+            value={@search_text}
+            placeholder={@placeholder}
+            phx-change="search_input"
+            phx-target={@myself}
+            phx-debounce="300"
+            phx-keydown="keydown"
+            name={"#{@id}_search"}
+            autocomplete="off"
+            data-testid="location-input"
+            role="combobox"
+            aria-expanded={to_string(@show_suggestions && @suggestions != [])}
+            aria-autocomplete="list"
+            aria-controls={"#{@id}-listbox"}
+          />
+          <button
+            :if={@show_clear && @search_text != ""}
+            type="button"
+            class="filter-location-clear"
+            phx-click="clear"
+            phx-target={@myself}
+            aria-label="Clear location"
+          >
+            ×
+          </button>
+        <% end %>
+      </div>
+
+      <%!-- Suggestion dropdown --%>
+      <div
+        :if={!@selected && @show_suggestions && @suggestions != []}
+        id={"#{@id}-listbox"}
+        role="listbox"
+        class="filter-location-listbox"
+      >
+        <button
+          :for={{s, idx} <- Enum.with_index(@suggestions)}
+          type="button"
+          id={"#{@id}-option-#{idx}"}
+          role="option"
+          phx-click="select"
+          phx-value-place-id={s.place_id}
+          phx-value-display-text={s.display_text}
+          phx-value-main-text={s.main_text}
+          phx-target={@myself}
+          class={["filter-location-option", idx == @suggestion_index && "is-active"]}
+        >
+          <span class="opt-main">{s.main_text}</span>
+          <span class="opt-secondary">{s.secondary_text}</span>
+        </button>
+      </div>
+
+      <p
+        :if={!@selected && @show_suggestions && @suggestions == [] && !@loading}
+        class="filter-location-listbox empty"
+      >
+        No locations found
+      </p>
+
+      <p :if={@error} class="filter-location-error">{@error}</p>
     </div>
     """
   end

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -63,9 +63,14 @@ defmodule HuddlzWeb.LiveUserAuth do
   end
 
   # Flips the body class to `"v3"` so v3-scoped styles in app.css take effect.
-  # Pair with `<Layouts.v3_app>` in the LiveView template.
+  # Pair with `<Layouts.v3_app>` in the LiveView template. Adds `is-signed-out`
+  # when there's no actor, so the body switches from the sidebar grid to the
+  # single-column shell rendered by `Layouts.v3_app` in chromeless mode.
   def on_mount(:v3_app, _params, _session, socket) do
-    {:cont, assign(socket, :body_class, "v3")}
+    body_class =
+      if socket.assigns[:current_user], do: "v3", else: "v3 is-signed-out"
+
+    {:cont, assign(socket, :body_class, body_class)}
   end
 
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)

--- a/test/features/discover_combined.feature
+++ b/test/features/discover_combined.feature
@@ -17,7 +17,7 @@ Feature: Combined search on /discover
   Scenario: scope=groups shows the groups section
     Given a group named "Tampa Tech Talks" is owned by "host@example.com"
     When I visit "/discover?scope=groups"
-    Then I should see "Discover groups"
+    Then I should see "Browse groups"
     And I should see "Tampa Tech Talks"
 
   Scenario: scope=groups hides huddlz

--- a/test/features/global_footer.feature
+++ b/test/features/global_footer.feature
@@ -5,7 +5,7 @@ Feature: Global Footer
   So that I can find supporting pages without hunting for them
 
   Scenario: Footer surfaces grouped columns and the tagline
-    When I visit "/discover"
+    When I visit "/groups"
     Then the footer should show the huddlz brand block
     And the footer should expose the Product, Help, Legal, and Open columns
     And the footer should link to GitHub and the API docs

--- a/test/features/global_header.feature
+++ b/test/features/global_header.feature
@@ -5,11 +5,15 @@ Feature: Global Header
   So that I can find huddlz from anywhere and start organizing without hunting through menus
 
   Scenario: Header chrome is visible on legacy pages
-    When I visit "/discover"
+    When I visit "/groups"
     Then the header should show the huddlz brand
     And the header should expose a global search form posting q to /discover
     And the header should expose an Organize link to /organize
     And the header should not expose a Groups link
+
+  Scenario: V3 topbar exposes search posting to /discover
+    When I visit "/discover"
+    Then the v3 topbar should expose a search form posting q to /discover
 
   Scenario: Header search posts the query to /discover
     Given there are upcoming huddlz in the system

--- a/test/features/huddl_listing.feature
+++ b/test/features/huddl_listing.feature
@@ -40,5 +40,5 @@ Feature: Huddl Listing
     When I visit the landing page
     And I type "aus" in the location field
     And I select "Austin" from the location suggestions
-    And I click the "Clear all" button
+    And I click the "Clear filters" button
     Then the location filter should not be active

--- a/test/features/step_definitions/global_header_steps.exs
+++ b/test/features/step_definitions/global_header_steps.exs
@@ -18,6 +18,16 @@ defmodule GlobalHeaderSteps do
     context
   end
 
+  step "the v3 topbar should expose a search form posting q to /discover", context do
+    session = context[:session] || context[:conn]
+
+    session
+    |> assert_has(".content-topbar form[action='/discover'][method='get']")
+    |> assert_has(".content-topbar input[type='search'][name='q'][placeholder='Search huddlz']")
+
+    context
+  end
+
   step "the header should expose an Organize link to /organize", context do
     session = context[:session] || context[:conn]
     assert_has(session, "header a[href='/organize']", text: "Organize")

--- a/test/features/step_definitions/huddl_listing_steps.exs
+++ b/test/features/step_definitions/huddl_listing_steps.exs
@@ -113,9 +113,7 @@ defmodule HuddlListingSteps do
   step "I should see a search form", context do
     session = context[:session] || context[:conn]
 
-    session
-    |> assert_has("input[placeholder='Search huddlz']")
-    |> assert_has("button", text: "Search")
+    assert_has(session, "input[placeholder='Search huddlz']")
 
     context
   end

--- a/test/features/step_definitions/location_autocomplete_steps.exs
+++ b/test/features/step_definitions/location_autocomplete_steps.exs
@@ -93,11 +93,16 @@ defmodule LocationAutocompleteSteps do
 
   step "the location filter should be active with {string}", %{args: [text]} = context do
     session = context[:session] || context[:conn]
-    # On /discover the active location is shown inside an `<input>` pill (its
-    # value attribute, not text content); legacy autocomplete renders the same
-    # text inside a `<span>`. Both carry `data-testid='location-display'`.
-    assert_has(session, "[data-testid='location-display'][value='#{text}']") ||
-      assert_has(session, "[data-testid='location-display']", text: text)
+    # The v3 filter pill renders the active location as the value of an
+    # `<input data-testid='location-display'>`; the legacy autocomplete (used
+    # by other LiveViews) renders the same text inside a `<span>`. Match
+    # whichever is on the page.
+    try do
+      assert_has(session, "[data-testid='location-display'][value='#{text}']")
+    rescue
+      ExUnit.AssertionError ->
+        assert_has(session, "[data-testid='location-display']", text: text)
+    end
 
     context
   end

--- a/test/features/step_definitions/location_autocomplete_steps.exs
+++ b/test/features/step_definitions/location_autocomplete_steps.exs
@@ -93,13 +93,18 @@ defmodule LocationAutocompleteSteps do
 
   step "the location filter should be active with {string}", %{args: [text]} = context do
     session = context[:session] || context[:conn]
-    assert_has(session, "[data-testid='location-badge']", text: text)
+    # On /discover the active location is shown inside an `<input>` pill (its
+    # value attribute, not text content); legacy autocomplete renders the same
+    # text inside a `<span>`. Both carry `data-testid='location-display'`.
+    assert_has(session, "[data-testid='location-display'][value='#{text}']") ||
+      assert_has(session, "[data-testid='location-display']", text: text)
+
     context
   end
 
   step "the location filter should not be active", context do
     session = context[:session] || context[:conn]
-    refute_has(session, "[data-testid='location-badge']")
+    refute_has(session, "[data-testid='location-display']")
     context
   end
 

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -31,11 +31,10 @@ defmodule HuddlzWeb.HuddlLiveTest do
       conn
       |> visit("/discover")
       |> assert_has("input[placeholder='Search huddlz']")
-      |> assert_has("button", text: "Search")
       |> assert_has("h3", text: public_huddl.title)
     end
 
-    test "renders huddl cards in 16:9 aspect ratio", %{
+    test "renders huddl cards with v3 cover", %{
       conn: conn,
       host: host,
       public_group: public_group
@@ -51,7 +50,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
 
       conn
       |> visit("/discover")
-      |> assert_has("[class*='aspect-video']")
+      |> assert_has(".grid .card .card-cover")
     end
 
     test "searches huddlz by title", %{conn: conn, host: host, public_group: public_group} do
@@ -278,17 +277,20 @@ defmodule HuddlzWeb.HuddlLiveTest do
       render_async(view)
 
       # Location is active and the suggestions dropdown is closed.
-      assert has_element?(view, "[data-testid='location-display']", "Austin, TX, USA")
+      assert view |> element("[data-testid='location-display']") |> render() =~ "Austin, TX, USA"
       refute has_element?(view, "[role='option']")
     end
 
-    test "discover URL with q + lat/lng renders both filters as active", %{
-      conn: conn
-    } do
-      conn
-      |> visit("/discover?q=elixir&location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=25")
-      |> assert_has("span", text: "Search: elixir")
-      |> assert_has("span", text: "Austin, TX · 25 mi")
+    test "discover URL with q + lat/lng renders search and location as active", %{conn: conn} do
+      session =
+        conn
+        |> visit("/discover?q=elixir&location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=25")
+
+      session
+      |> assert_has("h1", text: "Results for")
+      |> assert_has("input[name='q'][value='elixir']")
+      |> assert_has(".filter-distance input[type='range'][value='25']")
+      |> assert_has(".filter-distance-value", text: "25 mi")
     end
   end
 
@@ -303,7 +305,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
 
       conn
       |> visit("/discover?scope=groups")
-      |> assert_has("h1", text: "Discover groups")
+      |> assert_has("h1", text: "Browse groups")
       |> assert_has("h2", text: "Elixir Club")
     end
 
@@ -353,8 +355,8 @@ defmodule HuddlzWeb.HuddlLiveTest do
     test "scope chips render with Huddlz active by default", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("a", text: "Huddlz")
-      |> assert_has("a", text: "Groups")
+      |> assert_has(".scope-tab.is-active", text: "Huddlz")
+      |> assert_has(".scope-tab", text: "Groups")
     end
 
     test "scope=groups empty state when no public groups", %{conn: conn} do
@@ -427,7 +429,9 @@ defmodule HuddlzWeb.HuddlLiveTest do
       conn
       |> login(host)
       |> visit("/discover?yours=hosting&q=elixir&date_filter=this_week")
-      |> assert_has(~s|a[href="/discover?q=elixir&date_filter=this_week"]|, text: "All huddlz")
+      |> assert_has(~s|a[href="/discover?q=elixir&date_filter=this_week"]|,
+        text: "All huddlz"
+      )
     end
 
     test "anonymous users redirected from ?yours= scopes to sign-in", %{conn: conn} do

--- a/test/huddlz_web/live/huddl_search_pagination_test.exs
+++ b/test/huddlz_web/live/huddl_search_pagination_test.exs
@@ -93,7 +93,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "shows 20 results on first page", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has(".muted", text: "22 huddlz")
+      |> assert_has(".discover-meta", text: "22 huddlz")
       # Should see huddl 1-20
       |> assert_has("h3", text: "Test Huddl 1")
       |> assert_has("h3", text: "Test Huddl 20")
@@ -106,7 +106,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       conn
       |> visit("/discover")
       |> click_button(".page-num", "2")
-      |> assert_has(".muted", text: "22 huddlz")
+      |> assert_has(".discover-meta", text: "22 huddlz")
       # Should see huddl 21-22
       |> assert_has("h3", text: "Test Huddl 21")
       |> assert_has("h3", text: "Test Huddl 22")
@@ -127,7 +127,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> visit("/discover")
       |> click_button(".page-num", "2")
       |> click_button(".page-num", "1")
-      |> assert_has(".muted", text: "22 huddlz")
+      |> assert_has(".discover-meta", text: "22 huddlz")
       |> assert_has("h3", text: "Test Huddl 1")
     end
 
@@ -184,9 +184,9 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "shows total result count across pages", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has(".muted", text: "22 huddlz")
+      |> assert_has(".discover-meta", text: "22 huddlz")
       |> click_button(".page-num", "2")
-      |> assert_has(".muted", text: "22 huddlz")
+      |> assert_has(".discover-meta", text: "22 huddlz")
     end
   end
 
@@ -226,7 +226,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
 
       conn
       |> visit("/discover?q=" <> URI.encode_www_form(unique_term))
-      |> assert_has(".muted", text: "20 huddlz")
+      |> assert_has(".discover-meta", text: "20 huddlz")
       # No pagination should be shown for exactly 20 results
       |> refute_has(".page-num", text: "2")
       |> refute_has("button[phx-click=change_page]")

--- a/test/huddlz_web/live/huddl_search_pagination_test.exs
+++ b/test/huddlz_web/live/huddl_search_pagination_test.exs
@@ -85,15 +85,15 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "shows pagination when more than 20 results", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("button", text: "1")
-      |> assert_has("button", text: "2")
+      |> assert_has(".page-num", text: "1")
+      |> assert_has(".page-num", text: "2")
       |> assert_has("button[phx-click=change_page]")
     end
 
     test "shows 20 results on first page", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("div", text: "Found 22 huddlz")
+      |> assert_has(".muted", text: "22 huddlz")
       # Should see huddl 1-20
       |> assert_has("h3", text: "Test Huddl 1")
       |> assert_has("h3", text: "Test Huddl 20")
@@ -105,8 +105,8 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "navigates to page 2", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_button("2")
-      |> assert_has("div", text: "Found 22 huddlz")
+      |> click_button(".page-num", "2")
+      |> assert_has(".muted", text: "22 huddlz")
       # Should see huddl 21-22
       |> assert_has("h3", text: "Test Huddl 21")
       |> assert_has("h3", text: "Test Huddl 22")
@@ -118,16 +118,16 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "shows previous button on page 2", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_button("2")
+      |> click_button(".page-num", "2")
       |> assert_has("button[phx-click=change_page][phx-value-page='1']")
     end
 
     test "navigates back to page 1", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_button("2")
-      |> click_button("1")
-      |> assert_has("div", text: "Found 22 huddlz")
+      |> click_button(".page-num", "2")
+      |> click_button(".page-num", "1")
+      |> assert_has(".muted", text: "22 huddlz")
       |> assert_has("h3", text: "Test Huddl 1")
     end
 
@@ -135,7 +135,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       conn
       |> visit("/discover")
       # Filter to reduce results
-      |> click_link("#filter-panel a", "Virtual")
+      |> click_link(".chip-group a.chip", "Virtual")
       # Should have fewer than 20 results
       |> refute_has("button[phx-click=change_page]")
     end
@@ -164,12 +164,12 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
 
       conn
       |> visit("/discover")
-      |> click_link("#filter-panel a", "Virtual")
+      |> click_link(".chip-group a.chip", "Virtual")
       # Should still have pagination
-      |> assert_has("button", text: "2")
-      |> click_button("2")
-      # Filter should persist on page 2
-      |> assert_has("span", text: "Type: Virtual")
+      |> assert_has(".page-num", text: "2")
+      |> click_button(".page-num", "2")
+      # Filter chip should persist as active on page 2
+      |> assert_has(".chip-group a.chip.is-active", text: "Virtual")
     end
 
     test "pagination resets when applying new filter", %{conn: conn} do
@@ -177,15 +177,16 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       conn
       |> visit("/discover?q=Test")
       |> assert_has("h3", text: "Test Huddl 1")
-      |> refute_has("button", text: "Previous")
+      # Prev button is rendered but disabled on page 1
+      |> assert_has(".page-nav[disabled][aria-label='Previous page']")
     end
 
     test "shows total result count across pages", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("div", text: "Found 22 huddlz")
-      |> click_button("2")
-      |> assert_has("div", text: "Found 22 huddlz")
+      |> assert_has(".muted", text: "22 huddlz")
+      |> click_button(".page-num", "2")
+      |> assert_has(".muted", text: "22 huddlz")
     end
   end
 
@@ -195,7 +196,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> visit("/discover?q=nonexistent")
       |> assert_has("p", text: "No huddlz match this search")
       # No pagination should be shown
-      |> refute_has("button", text: "1")
+      |> refute_has(".page-num")
       |> refute_has("button[phx-click=change_page]")
     end
 
@@ -225,9 +226,9 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
 
       conn
       |> visit("/discover?q=" <> URI.encode_www_form(unique_term))
-      |> assert_has("div", text: "Found 20 huddlz")
+      |> assert_has(".muted", text: "20 huddlz")
       # No pagination should be shown for exactly 20 results
-      |> refute_has("button", text: "2")
+      |> refute_has(".page-num", text: "2")
       |> refute_has("button[phx-click=change_page]")
     end
   end
@@ -246,7 +247,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       {:ok, view, _html} = live(conn, "/discover")
 
       view
-      |> element("button.w-8[phx-value-page='2']")
+      |> element("button.page-num[phx-value-page='2']")
       |> render_click()
 
       assert_patch(view, "/discover?page=2")
@@ -256,7 +257,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       {:ok, view, _html} = live(conn, "/discover?page=2")
 
       view
-      |> element("button.w-8[phx-value-page='1']")
+      |> element("button.page-num[phx-value-page='1']")
       |> render_click()
 
       assert_patch(view, "/discover")
@@ -298,7 +299,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       {:ok, view, _html} = live(conn, "/discover?q=Test")
 
       view
-      |> element("button.w-8[phx-value-page='2']")
+      |> element("button.page-num[phx-value-page='2']")
       |> render_click()
 
       assert_patch(view, "/discover?q=Test&page=2")

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -10,7 +10,6 @@ defmodule HuddlzWeb.HuddlSearchTest do
     user = generate(user(role: :user))
     group = generate(group(owner_id: user.id, is_public: true, actor: user))
 
-    # Create various huddlz for testing
     huddl1 =
       generate(
         huddl(
@@ -62,7 +61,6 @@ defmodule HuddlzWeb.HuddlSearchTest do
         )
       )
 
-    # Create a past huddl that shouldn't appear
     _past_huddl =
       generate(
         past_huddl(
@@ -89,7 +87,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       |> refute_has("h3", text: "Past Event")
     end
 
-    test "renders capacity label and progress bar for limited huddlz with no RSVPs", %{
+    test "renders RSVP-out-of-capacity meta for limited huddlz with no RSVPs", %{
       conn: conn,
       user: user,
       group: group
@@ -114,12 +112,10 @@ defmodule HuddlzWeb.HuddlSearchTest do
       conn
       |> visit("/discover")
       |> assert_has("h3", text: "Capped Huddl")
-      |> assert_has("span", text: "0/5 spots filled")
-      |> assert_has("span", text: "Plenty of space")
-      |> assert_has("div[style*='width: 0%']")
+      |> assert_has(".card-meta span", text: "0 / 5 RSVPs")
     end
 
-    test "renders capacity label for limited huddlz with at least one RSVP", %{
+    test "renders RSVP-out-of-capacity meta for limited huddlz with at least one RSVP", %{
       conn: conn,
       user: user,
       group: group
@@ -149,7 +145,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       conn
       |> visit("/discover")
       |> assert_has("h3", text: "Mostly Empty Capped Huddl")
-      |> assert_has("span", text: "1/5 spots filled")
+      |> assert_has(".card-meta span", text: "1 / 5 RSVPs")
     end
 
     test "searches by title", %{conn: conn} do
@@ -171,7 +167,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
     test "filters by event type", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_link("#filter-panel a", "Virtual")
+      |> click_link(".chip-group a.chip", "Virtual")
       |> assert_has("h3", text: "Virtual Book Club")
       |> refute_has("h3", text: "Morning Yoga Session")
       |> refute_has("h3", text: "Hybrid Workshop")
@@ -180,118 +176,59 @@ defmodule HuddlzWeb.HuddlSearchTest do
     test "filters by date range - this week", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_link("#filter-panel a", "This week")
+      |> click_link(".chip-group a.chip", "This week")
       # Only events within 7 days should show
       |> assert_has("h3", text: "Morning Yoga Session")
       |> assert_has("h3", text: "Virtual Book Club")
       |> refute_has("h3", text: "Hybrid Workshop")
-      # Past events should never show
       |> refute_has("h3", text: "Past Event")
     end
 
     test "filters by date range - this month", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_link("#filter-panel a", "This month")
+      |> click_link(".chip-group a.chip", "This month")
       # All future events within 30 days should show
       |> assert_has("h3", text: "Morning Yoga Session")
       |> assert_has("h3", text: "Virtual Book Club")
       |> assert_has("h3", text: "Hybrid Workshop")
-      # Past events should never show
       |> refute_has("h3", text: "Past Event")
     end
 
     test "combines multiple filters", %{conn: conn} do
       conn
       |> visit("/discover?q=book")
-      |> click_link("#filter-panel a", "Virtual")
-      |> click_link("#filter-panel a", "This week")
+      |> click_link(".chip-group a.chip", "Virtual")
+      |> click_link(".chip-group a.chip", "This week")
       |> assert_has("h3", text: "Virtual Book Club")
       |> refute_has("h3", text: "Morning Yoga Session")
       |> refute_has("h3", text: "Hybrid Workshop")
     end
 
-    test "displays active filters", %{conn: conn} do
+    test "active chips reflect URL state", %{conn: conn} do
       conn
-      |> visit("/discover?q=book")
-      |> click_link("#filter-panel a", "Virtual")
-      |> assert_has("span", text: "Search: book")
-      |> assert_has("span", text: "Type: Virtual")
+      |> visit("/discover?event_type=virtual&date_filter=this_week&sort=newest")
+      |> assert_has(".chip-group a.chip.is-active", text: "Virtual")
+      |> assert_has(".chip-group a.chip.is-active", text: "This week")
+      |> assert_has(".chip-group a.chip.is-active", text: "Newest")
     end
 
-    test "clears all filters", %{conn: conn} do
+    test "Clear filters button drops all filter params", %{conn: conn} do
       conn
-      |> visit("/discover?q=book")
-      |> click_link("#filter-panel a", "Virtual")
-      |> click_button("Clear all")
-      # All huddlz should be visible again
-      |> assert_has("h3", text: "Morning Yoga Session")
-      |> assert_has("h3", text: "Virtual Book Club")
-      |> assert_has("h3", text: "Hybrid Workshop")
-    end
-
-    test "only showing applied filters as active", %{conn: conn} do
-      # No filters applied initially.
-      conn
-      |> visit("/discover")
-      |> refute_has("span", text: "Search:")
-      |> refute_has("span", text: "Type:")
-      |> refute_has("span", text: "Date:")
-
-      # Huddl Type only.
-      conn
-      |> visit("/discover")
-      |> click_link("#filter-panel a", "Virtual")
-      |> refute_has("span", text: "Search:")
-      |> assert_has("span", text: "Type: Virtual")
-      |> refute_has("span", text: "Date:")
-
-      # Search + Huddl Type.
-      conn
-      |> visit("/discover?q=book&event_type=virtual")
-      |> assert_has("span", text: "Search: book")
-      |> assert_has("span", text: "Type: Virtual")
-      |> refute_has("span", text: "Date:")
-
-      # Search + Huddl Type + Date.
-      conn
-      |> visit("/discover?q=book&event_type=virtual&date_filter=this_week")
-      |> assert_has("span", text: "Search: book")
-      |> assert_has("span", text: "Type: Virtual")
-      |> assert_has("span", text: "Date: This Week")
-
-      # Clearing the date filter back to upcoming drops the Date pill.
-      conn
-      |> visit("/discover?q=book&event_type=virtual")
-      |> assert_has("span", text: "Search: book")
-      |> assert_has("span", text: "Type: Virtual")
-      |> refute_has("span", text: "Date:")
-
-      # Clearing the search drops the Search pill.
-      conn
-      |> visit("/discover?event_type=virtual")
-      |> refute_has("span", text: "Search:")
-      |> assert_has("span", text: "Type: Virtual")
-      |> refute_has("span", text: "Date:")
-
-      # Clearing event_type drops the Type pill.
-      conn
-      |> visit("/discover")
-      |> refute_has("span", text: "Search:")
-      |> refute_has("span", text: "Type:")
-      |> refute_has("span", text: "Date:")
+      |> visit("/discover?q=book&event_type=virtual&date_filter=this_week&sort=newest")
+      |> click_button("Clear filters")
+      |> assert_path(~p"/discover", query_params: %{"cleared" => "1"})
     end
 
     test "shows result count", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("div", text: "Found 3 huddlz")
-      |> click_link("#filter-panel a", "Virtual")
-      |> assert_has("div", text: "Found 1 huddl")
+      |> assert_has(".muted", text: "3 huddlz")
+      |> click_link(".chip-group a.chip", "Virtual")
+      |> assert_has(".muted", text: "1 huddl")
     end
 
     test "displays huddlz in chronological order", %{conn: conn} do
-      # Verify all huddlz are displayed in date order (earliest first)
       conn
       |> visit("/discover")
       |> assert_has("h3", text: "Morning Yoga Session")
@@ -309,68 +246,52 @@ defmodule HuddlzWeb.HuddlSearchTest do
     end
   end
 
-  describe "filter panel" do
-    test "Filters trigger button is rendered for huddlz scope", %{conn: conn} do
+  describe "filter bar" do
+    test "filter bar is rendered for huddlz scope", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("button", text: "Filters")
+      |> assert_has(".filter-bar")
+      |> assert_has(".filter-label", text: "Within")
+      |> assert_has(".filter-label", text: "Type")
+      |> assert_has(".filter-label", text: "When")
+      |> assert_has(".filter-label", text: "Sort")
     end
 
-    test "Filters trigger is hidden under scope=groups", %{conn: conn} do
+    test "filter bar is hidden under scope=groups", %{conn: conn} do
       conn
       |> visit("/discover?scope=groups")
-      |> refute_has("button", text: "Filters")
+      |> refute_has(".filter-bar")
     end
 
-    test "panel renders all four sections", %{conn: conn} do
+    test "Sort: Newest patches URL and marks chip active", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has("#filter-panel h3", text: "Date")
-      |> assert_has("#filter-panel h3", text: "Format")
-      |> assert_has("#filter-panel h3", text: "Location")
-      |> assert_has("#filter-panel h3", text: "Sort")
-    end
-
-    test "Sort: Newest patches URL and re-renders chip", %{conn: conn} do
-      conn
-      |> visit("/discover")
-      |> click_link("#filter-panel a", "Newest")
+      |> click_link(".chip-group a.chip", "Newest")
       |> assert_path(~p"/discover", query_params: %{"sort" => "newest"})
-      |> assert_has("span", text: "Sort: Newest")
+      |> assert_has(".chip-group a.chip.is-active", text: "Newest")
     end
 
     test "Sort: clicking Soonest while sort=newest drops sort from URL", %{conn: conn} do
       conn
       |> visit("/discover?sort=newest")
-      |> assert_has("span", text: "Sort: Newest")
-      |> click_link("#filter-panel a", "Soonest")
+      |> assert_has(".chip-group a.chip.is-active", text: "Newest")
+      |> click_link(".chip-group a.chip", "Soonest")
       |> assert_path(~p"/discover")
-      |> refute_has("span", text: "Sort: Newest")
+      |> refute_has(".chip-group a.chip.is-active", text: "Newest")
     end
 
-    test "Reset button clears all filter params", %{conn: conn} do
-      conn
-      |> visit("/discover?date_filter=this_week&sort=newest")
-      |> assert_has("span", text: "Date: This Week")
-      |> assert_has("span", text: "Sort: Newest")
-      |> click_button("Reset")
-      |> refute_has("span", text: "Date: This Week")
-      |> refute_has("span", text: "Sort: Newest")
-    end
+    test "distance slider patches URL with new distance", %{conn: conn} do
+      {:ok, view, _html} =
+        live(conn, "/discover?location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=25")
 
-    test "Reset leaves the filter panel open", %{conn: conn} do
-      # The panel is URL-driven, not client-state-driven; Reset patches the
-      # URL but should not also trigger a hide-transition (the two raced and
-      # caused a flicker). After clicking Reset, the panel should still be
-      # mounted with all four sections visible so the user sees the toggles
-      # flip back to defaults.
-      conn
-      |> visit("/discover?date_filter=this_week")
-      |> click_button("Reset")
-      |> assert_has("#filter-panel h3", text: "Date")
-      |> assert_has("#filter-panel h3", text: "Format")
-      |> assert_has("#filter-panel h3", text: "Location")
-      |> assert_has("#filter-panel h3", text: "Sort")
+      view
+      |> form("form[phx-change='distance_change']", %{"distance_miles" => "50"})
+      |> render_change()
+
+      assert_patched(
+        view,
+        "/discover?location=Austin%2C+TX&lat=30.2672&lng=-97.7431&distance=50"
+      )
     end
   end
 
@@ -488,7 +409,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       assert has_element?(view, "p", "Location search is currently unavailable")
     end
 
-    test "clearing filters clears location", %{conn: conn} do
+    test "Clear filters drops the active location", %{conn: conn} do
       stub_places_autocomplete(%{"aus" => [:austin]})
       stub_place_details(:defaults)
 
@@ -506,7 +427,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       html = render(view)
       assert html =~ "Austin, TX, USA"
 
-      view |> element("button", "Clear all") |> render_click()
+      view |> element("button", "Clear filters") |> render_click()
 
       html = render(view)
       refute html =~ "Austin, TX, USA"
@@ -528,7 +449,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       assert html =~ "Virtual Book Club"
     end
 
-    test "clear location button removes location filter", %{conn: conn} do
+    test "clear-location button removes location filter", %{conn: conn} do
       stub_places_autocomplete(%{"aus" => [:austin]})
       stub_place_details(:defaults)
 
@@ -553,13 +474,13 @@ defmodule HuddlzWeb.HuddlSearchTest do
       assert html =~ "Morning Yoga Session"
     end
 
-    test "clear location button doesn't affect other filters", %{conn: conn} do
+    test "clear-location button preserves the search query", %{conn: conn} do
       stub_places_autocomplete(%{"aus" => [:austin]})
       stub_place_details(:defaults)
 
-      # Start with q already in the URL — search lives in the chrome now,
-      # which submits via GET. The in-page contract is that picking a location
-      # preserves q, and clearing the location preserves q too.
+      # Start with q already in the URL — search lives in the chrome and submits
+      # via GET. Picking a location preserves q, and clearing the location
+      # preserves q too.
       {:ok, view, _html} = live(conn, "/discover?q=Yoga")
 
       view
@@ -573,14 +494,13 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
       html = render(view)
       assert html =~ "Austin, TX, USA"
-      assert html =~ "Search: Yoga"
+      assert html =~ "Results for"
 
-      # Clear just the location.
       view |> element("[aria-label='Clear location']") |> render_click()
 
       html = render(view)
       refute html =~ "Austin, TX, USA"
-      assert html =~ "Search: Yoga"
+      assert html =~ "Results for"
     end
   end
 
@@ -616,7 +536,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
       html = render(view)
       assert html =~ ~s(id="location-autocomplete-option-0")
-      assert html =~ "bg-primary/20 border-l-primary"
+      assert html =~ "filter-location-option is-active"
 
       view
       |> element("#location-autocomplete-input")

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -223,9 +223,9 @@ defmodule HuddlzWeb.HuddlSearchTest do
     test "shows result count", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> assert_has(".muted", text: "3 huddlz")
+      |> assert_has(".discover-meta", text: "3 huddlz")
       |> click_link(".chip-group a.chip", "Virtual")
-      |> assert_has(".muted", text: "1 huddl")
+      |> assert_has(".discover-meta", text: "1 huddl")
     end
 
     test "displays huddlz in chronological order", %{conn: conn} do


### PR DESCRIPTION
## Summary

Migrates `/discover` (Phase 2 PR-2.1) from the legacy daisy-styled
chrome to the v3 sidebar shell and clickthrough vocabulary.

- **Chrome** — `<Layouts.v3_app>` wraps the page; `body.v3` flips on the
  v3 styles. Signed-in users get the sidebar with "Explore" highlighted;
  anonymous visitors get the chromeless topbar with Sign in / Sign up.
- **Layout** — page-head heading, `.scope-tabs` for Huddlz/Groups,
  inline `.filter-bar` with location pill + distance slider + chip-groups
  for Type / When / Sort, a result-count line with inline "Clear filters,"
  the v3 `.grid` of `.card`s, and the v3 `<.v3_pagination>` component.
- **Cards** — huddl cards render the v3 cover (gradient + date-stamp + tag),
  card-group label, title, and `.card-meta` ("Tue · 7:00 PM · 0.5 mi · 12 / 40 RSVPs").
  Group cards reuse the same shell sans date-stamp.
- **Removed** — the slide-in filter panel, "Filters" trigger, active-filter
  pill bar above the chips, and the capacity progress bar (filter state
  is communicated by `is-active` chip class + h1; capacity by the
  `X / Y RSVPs` meta).
- **New components** — `<.v3_pagination>`; a `:filter_pill` variant on
  `LocationAutocomplete` that mounts inside the `.filter-location` chrome
  for the inline filter bar.
- **Tests** — `huddl_live_test`, `huddl_search_test`, and
  `huddl_search_pagination_test` updated to the v3 selectors. The
  `global_header` and `global_footer` features re-point to `/groups`
  (still on legacy chrome), plus a v3-topbar scenario on `/discover`.

## Test plan
- [x] `mix precommit` clean (1222 tests, no credo issues)
- [x] Browser-verified: anonymous, signed-in, `?scope=groups`, `?q=`,
      `?yours=hosting`, location autocomplete dropdown, range slider
      patches the URL, chip toggling, pagination
- [ ] Reviewer click-through on staging once merged