### PR TITLE
feat(v3): split /me into /my-huddlz, /my-groups, /notifications

### DIFF
--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -48,6 +48,7 @@ defmodule Huddlz.Communities do
       define :search_groups, action: :search, args: [{:optional, :search}]
       define :get_by_owner, action: :get_by_owner
       define :get_joined_groups, action: :get_joined
+      define :my_groups, action: :my_groups, args: [{:optional, :relationship}]
       define :get_by_slug, action: :get_by_slug, args: [:slug]
 
       define :update_details,

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -128,6 +128,25 @@ defmodule Huddlz.Communities.Group do
       prepare Huddlz.Communities.Group.Preparations.ApplyTrigramSearch
     end
 
+    read :my_groups do
+      description """
+      Groups the actor either owns or has joined. The `:relationship` arg
+      scopes the result: `:hosting` (owned), `:joined` (member but not
+      owner), or `:all` (default — both). Sorted alphabetically by name.
+      """
+
+      argument :relationship, :atom do
+        allow_nil? true
+        default :all
+        constraints one_of: [:all, :hosting, :joined]
+      end
+
+      pagination offset?: true, countable: true, required?: false, default_limit: 20
+
+      prepare Huddlz.Communities.Group.Preparations.ApplyMyGroupsFilter
+      prepare Huddlz.Communities.Group.Preparations.ApplyTrigramSearch
+    end
+
     read :get_by_slug do
       description "Get a group by its slug"
 

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -19,8 +19,10 @@ defmodule Huddlz.Communities.Group do
       read_one :get_group, :get_by_slug
       list :list_groups, :read
       list :search_groups, :search
-      list :my_groups, :get_by_owner
-      list :joined_groups, :get_joined
+      # `myGroups` mirrors the `Communities.my_groups/1` Elixir interface and
+      # the `/my-groups` LiveView: returns groups the actor owns or has joined.
+      # Pass `relationship: hosting | joined | all` to scope the result.
+      list :my_groups, :my_groups
     end
 
     mutations do
@@ -39,8 +41,7 @@ defmodule Huddlz.Communities.Group do
       get :read
       index :read
       index :search, route: "/search"
-      index :get_by_owner, route: "/mine"
-      index :get_joined, route: "/joined"
+      index :my_groups, route: "/my-groups"
       get :get_by_slug, route: "/by_slug/:slug"
       post :create_group
       patch :update_details

--- a/lib/huddlz/communities/group/preparations/apply_my_groups_filter.ex
+++ b/lib/huddlz/communities/group/preparations/apply_my_groups_filter.ex
@@ -1,0 +1,50 @@
+defmodule Huddlz.Communities.Group.Preparations.ApplyMyGroupsFilter do
+  @moduledoc """
+  Filters a Group read down to the actor's relationship with the result rows.
+
+  Reads the `:relationship` argument (one of `:all`, `:hosting`, `:joined`):
+
+    * `:hosting` — the actor owns the group.
+    * `:joined`  — the actor is a member but not the owner.
+    * `:all`     — either of the above.
+
+  Sorting is delegated to `ApplyTrigramSearch` (alphabetical by `name` when
+  no `:search` arg is present), so the SQL ordering matches the other group
+  listings.
+  """
+
+  use Ash.Resource.Preparation
+
+  require Ash.Query
+
+  @impl true
+  def prepare(query, _opts, context) do
+    actor_id = context.actor && context.actor.id
+
+    if is_nil(actor_id) do
+      Ash.Query.filter(query, false)
+    else
+      relationship = Ash.Query.get_argument(query, :relationship) || :all
+      apply_filter(query, relationship, actor_id)
+    end
+  end
+
+  defp apply_filter(query, :hosting, actor_id),
+    do: Ash.Query.filter(query, owner_id == ^actor_id)
+
+  defp apply_filter(query, :joined, actor_id) do
+    Ash.Query.filter(
+      query,
+      owner_id != ^actor_id and
+        exists(group_members, user_id == ^actor_id)
+    )
+  end
+
+  defp apply_filter(query, :all, actor_id) do
+    Ash.Query.filter(
+      query,
+      owner_id == ^actor_id or
+        exists(group_members, user_id == ^actor_id)
+    )
+  end
+end

--- a/lib/huddlz/notifications.ex
+++ b/lib/huddlz/notifications.ex
@@ -28,6 +28,7 @@ defmodule Huddlz.Notifications do
     end
   end
 
+  require Ash.Query
   require Logger
 
   alias Huddlz.Accounts.User
@@ -141,6 +142,32 @@ defmodule Huddlz.Notifications do
       raise ArgumentError,
             "Notification sender #{inspect(sender)} for trigger #{inspect(trigger)} " <>
               "is not yet implemented. Implement Huddlz.Notifications.Sender.build/2 in that module."
+    end
+  end
+
+  @doc """
+  Mark every unread notification owned by `user` as read in a single SQL
+  UPDATE.
+
+  Replaces N round-trips of `mark_read/1` for the case where the actor wants
+  to clear their inbox in one click. The update policy on `Notification`
+  scopes the bulk to the actor's own rows; the query filter narrows to
+  `is_nil(read_at)` so reads aren't re-stamped.
+
+  Returns `:ok` on success, `{:error, term()}` if Ash reports any failures.
+  """
+  @spec mark_all_read(User.t()) :: :ok | {:error, term()}
+  def mark_all_read(%User{} = user) do
+    Notification
+    |> Ash.Query.filter(is_nil(read_at))
+    |> Ash.bulk_update(:mark_all_read, %{},
+      actor: user,
+      return_records?: false,
+      return_errors?: true
+    )
+    |> case do
+      %Ash.BulkResult{status: :success} -> :ok
+      %Ash.BulkResult{errors: errors} -> {:error, errors}
     end
   end
 

--- a/lib/huddlz/notifications/notification.ex
+++ b/lib/huddlz/notifications/notification.ex
@@ -93,6 +93,17 @@ defmodule Huddlz.Notifications.Notification do
       description "Clear the read marker on a notification."
       change set_attribute(:read_at, nil)
     end
+
+    update :mark_all_read do
+      description """
+      Bulk-mark notifications as read. Used via `Ash.bulk_update` against a
+      query scoped by the actor (`user_id == ^actor(:id) and is_nil(read_at)`)
+      so the entire inbox is cleared in a single SQL UPDATE rather than one
+      round-trip per row.
+      """
+
+      change set_attribute(:read_at, &DateTime.utc_now/0)
+    end
   end
 
   policies do

--- a/lib/huddlz_web/live/me_live.ex
+++ b/lib/huddlz_web/live/me_live.ex
@@ -37,6 +37,14 @@ defmodule HuddlzWeb.MeLive do
   end
 
   @impl true
+  def handle_params(%{"tab" => "huddlz"}, _uri, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/my-huddlz")}
+  end
+
+  def handle_params(%{"tab" => "groups"}, _uri, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/my-groups")}
+  end
+
   def handle_params(params, _uri, socket) do
     tab = parse_tab(params["tab"])
 

--- a/lib/huddlz_web/live/me_live.ex
+++ b/lib/huddlz_web/live/me_live.ex
@@ -45,6 +45,14 @@ defmodule HuddlzWeb.MeLive do
     {:noreply, push_navigate(socket, to: ~p"/my-groups")}
   end
 
+  def handle_params(%{"tab" => "updates"}, _uri, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/notifications")}
+  end
+
+  def handle_params(%{"tab" => "invites"}, _uri, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/notifications?#{[filter: :invites]}")}
+  end
+
   def handle_params(params, _uri, socket) do
     tab = parse_tab(params["tab"])
 

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -1,0 +1,235 @@
+defmodule HuddlzWeb.MyGroupsLive do
+  @moduledoc """
+  LiveView at `/my-groups`. Personal feed of groups the signed-in user
+  organizes (Hosting) or has joined (Joined). Filter chips drive a
+  `?filter=` URL param: default `all` is no param, `hosting` and `joined`
+  scope the grid. `?page=N` paginates the active filter.
+
+  All sorting and pagination happens in postgres via the `:my_groups` read
+  action — we do not sort in code.
+  """
+  use HuddlzWeb, :live_view
+
+  alias Huddlz.Communities
+  alias Huddlz.Storage.GroupImages
+  alias HuddlzWeb.Layouts
+  require Logger
+
+  @group_loads [:current_image_url, :member_count]
+  @page_size 20
+  @valid_filters ~w(all hosting joined)
+
+  on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "My groups")
+     |> assign(:groups, [])
+     |> assign(:counts, %{all: 0, hosting: 0, joined: 0})
+     |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    filter = parse_filter(params["filter"])
+    page = parse_page(params["page"])
+    user = socket.assigns.current_user
+
+    socket =
+      socket
+      |> assign(:filter, filter)
+      |> assign(:counts, load_counts(user))
+      |> load_results(filter, page, user)
+
+    total_pages = socket.assigns.page_info.total_pages
+
+    if page > total_pages do
+      {:noreply, push_patch(socket, to: filter_path(filter, total_pages))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("change_page", %{"page" => page_str}, socket) do
+    page = parse_page(page_str)
+    {:noreply, push_patch(socket, to: filter_path(socket.assigns.filter, page))}
+  end
+
+  defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
+  defp parse_filter(_), do: :all
+
+  defp parse_page(nil), do: 1
+  defp parse_page(""), do: 1
+
+  defp parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_page(val) when is_integer(val) and val >= 1, do: val
+  defp parse_page(_), do: 1
+
+  defp load_counts(user) do
+    %{
+      all: count_for(user, :all),
+      hosting: count_for(user, :hosting),
+      joined: count_for(user, :joined)
+    }
+  end
+
+  defp count_for(user, relationship) do
+    case Communities.my_groups(relationship,
+           actor: user,
+           page: [limit: 1, offset: 0, count: true]
+         ) do
+      {:ok, %{count: count}} when is_integer(count) -> count
+      _ -> 0
+    end
+  end
+
+  defp load_results(socket, filter, page, user) do
+    offset = (page - 1) * @page_size
+
+    case Communities.my_groups(filter,
+           actor: user,
+           load: @group_loads,
+           page: [limit: @page_size, offset: offset, count: true]
+         ) do
+      {:ok, %Ash.Page.Offset{results: results, count: count}} ->
+        total_pages = if count && count > 0, do: ceil(count / @page_size), else: 1
+
+        socket
+        |> assign(:groups, results)
+        |> assign(:page_info, %{
+          total_pages: total_pages,
+          current_page: page,
+          total_count: count || 0
+        })
+
+      {:error, reason} ->
+        Logger.warning("MyGroupsLive load failed: #{inspect(reason)}")
+
+        socket
+        |> assign(:groups, [])
+        |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})
+    end
+  end
+
+  defp filter_path(:all, page) when page > 1, do: ~p"/my-groups?#{[page: page]}"
+  defp filter_path(:all, _page), do: ~p"/my-groups"
+
+  defp filter_path(filter, page) when page > 1,
+    do: ~p"/my-groups?#{[filter: filter, page: page]}"
+
+  defp filter_path(filter, _page), do: ~p"/my-groups?#{[filter: filter]}"
+
+  defp role_for(group, user) do
+    if group.owner_id == user.id, do: :hosting, else: :joined
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="my-groups">
+      <div class="page-head">
+        <div>
+          <h1>My groups</h1>
+          <p>{filter_blurb(@filter)}</p>
+        </div>
+        <.link navigate={~p"/groups/new"} class="btn-primary">
+          Start a group
+        </.link>
+      </div>
+
+      <div class="filters">
+        <.v3_chip patch={filter_path(:all, 1)} active={@filter == :all}>
+          All · {@counts.all}
+        </.v3_chip>
+        <.v3_chip patch={filter_path(:hosting, 1)} active={@filter == :hosting}>
+          Hosting · {@counts.hosting}
+        </.v3_chip>
+        <.v3_chip patch={filter_path(:joined, 1)} active={@filter == :joined}>
+          Joined · {@counts.joined}
+        </.v3_chip>
+      </div>
+
+      <%= if Enum.empty?(@groups) do %>
+        <p class="muted">{empty_message(@filter)}</p>
+      <% else %>
+        <div class="grid">
+          <%= for {group, idx} <- Enum.with_index(@groups) do %>
+            <.v3_my_group_card
+              group={group}
+              role={role_for(group, @current_user)}
+              gradient={Integer.mod(idx, 6) + 1}
+            />
+          <% end %>
+        </div>
+        <.v3_pagination
+          :if={@page_info.total_pages > 1}
+          current_page={@page_info.current_page}
+          total_pages={@page_info.total_pages}
+          event_name="change_page"
+        />
+      <% end %>
+    </Layouts.v3_app>
+    """
+  end
+
+  attr :group, :map, required: true
+  attr :role, :atom, required: true
+  attr :gradient, :integer, required: true
+
+  defp v3_my_group_card(assigns) do
+    ~H"""
+    <.v3_card navigate={~p"/groups/#{@group.slug}"} gradient={@gradient}>
+      <:cover>
+        <img
+          :if={@group.current_image_url}
+          class="card-cover-img"
+          src={GroupImages.url(@group.current_image_url)}
+          alt={@group.name}
+        />
+        <span class={["card-tag", role_class(@role)]}>{role_label(@role)}</span>
+      </:cover>
+      <:body>
+        <span :if={@group.location} class="card-group">{@group.location}</span>
+        <h2 class="card-title">{@group.name}</h2>
+        <div :if={member_count_label(@group)} class="card-meta">
+          <span>{member_count_label(@group)}</span>
+        </div>
+      </:body>
+    </.v3_card>
+    """
+  end
+
+  defp filter_blurb(:all), do: "Groups you organize and groups you've joined."
+  defp filter_blurb(:hosting), do: "Groups you organize."
+  defp filter_blurb(:joined), do: "Groups you've joined."
+
+  defp empty_message(:all),
+    do: "You haven't organized or joined any groups yet. Start one or browse Discover."
+
+  defp empty_message(:hosting), do: "You haven't created a group yet."
+  defp empty_message(:joined), do: "You haven't joined any groups yet."
+
+  defp role_class(:hosting), do: "hybrid"
+  defp role_class(:joined), do: "in-person"
+
+  defp role_label(:hosting), do: "Hosting"
+  defp role_label(:joined), do: "Joined"
+
+  defp member_count_label(group) do
+    case Map.get(group, :member_count) do
+      1 -> "1 member"
+      n when is_integer(n) and n > 0 -> "#{n} members"
+      _ -> nil
+    end
+  end
+end

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -1,0 +1,318 @@
+defmodule HuddlzWeb.MyHuddlzLive do
+  @moduledoc """
+  LiveView at `/my-huddlz`. Personal feed of huddlz the signed-in user is
+  attending, waitlisted on, or has already attended. Filter chips
+  (Upcoming · N / Waitlisted · N / Past) drive a `?filter=` URL param;
+  `?page=N` paginates the active filter.
+
+  Hosting moves to the organizer workspace — by design this view is
+  participant-centered.
+  """
+  use HuddlzWeb, :live_view
+
+  alias Huddlz.Communities
+  alias Huddlz.Storage.HuddlImages
+  alias HuddlzWeb.Layouts
+  require Logger
+
+  @card_loads [
+    :status,
+    :rsvp_count,
+    :visible_virtual_link,
+    :display_image_url,
+    :group
+  ]
+  @page_size 20
+  @valid_filters ~w(upcoming waitlisted past)
+
+  on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "My huddlz")
+     |> assign(:huddls, [])
+     |> assign(:counts, %{upcoming: 0, waitlisted: 0, past: 0})
+     |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    filter = parse_filter(params["filter"])
+    page = parse_page(params["page"])
+    user = socket.assigns.current_user
+
+    socket =
+      socket
+      |> assign(:filter, filter)
+      |> assign(:counts, load_counts(user))
+      |> load_results(filter, page, user)
+
+    total_pages = socket.assigns.page_info.total_pages
+
+    if page > total_pages do
+      {:noreply, push_patch(socket, to: filter_path(filter, total_pages))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("change_page", %{"page" => page_str}, socket) do
+    page = parse_page(page_str)
+    {:noreply, push_patch(socket, to: filter_path(socket.assigns.filter, page))}
+  end
+
+  defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
+  defp parse_filter(_), do: :upcoming
+
+  defp parse_page(nil), do: 1
+  defp parse_page(""), do: 1
+
+  defp parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_page(val) when is_integer(val) and val >= 1, do: val
+  defp parse_page(_), do: 1
+
+  defp load_counts(user) do
+    %{
+      upcoming: count_for(user, :attending, :upcoming),
+      waitlisted: count_for(user, :waitlisted, :upcoming),
+      past: count_for(user, :attending, :past)
+    }
+  end
+
+  defp count_for(user, relationship, date_filter) do
+    case run_search(user, relationship, date_filter, page: [limit: 1, offset: 0, count: true]) do
+      {:ok, %{count: count}} when is_integer(count) -> count
+      _ -> 0
+    end
+  end
+
+  defp load_results(socket, filter, page, user) do
+    {relationship, date_filter, sort} = filter_query(filter)
+    offset = (page - 1) * @page_size
+
+    case run_search(user, relationship, date_filter,
+           sort: sort,
+           page: [limit: @page_size, offset: offset, count: true]
+         ) do
+      {:ok, %Ash.Page.Offset{results: results, count: count}} ->
+        total_pages = if count && count > 0, do: ceil(count / @page_size), else: 1
+
+        socket
+        |> assign(:huddls, results)
+        |> assign(:page_info, %{
+          total_pages: total_pages,
+          current_page: page,
+          total_count: count || 0
+        })
+
+      {:error, reason} ->
+        Logger.warning("MyHuddlzLive search failed: #{inspect(reason)}")
+
+        socket
+        |> assign(:huddls, [])
+        |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})
+    end
+  end
+
+  defp filter_query(:upcoming), do: {:attending, :upcoming, :soonest}
+  defp filter_query(:waitlisted), do: {:waitlisted, :upcoming, :soonest}
+  defp filter_query(:past), do: {:attending, :past, :newest}
+
+  defp run_search(user, relationship, date_filter, opts) do
+    Communities.search_huddlz(
+      nil,
+      date_filter,
+      nil,
+      nil,
+      nil,
+      nil,
+      relationship,
+      Keyword.get(opts, :sort, :soonest),
+      actor: user,
+      page: Keyword.get(opts, :page, []),
+      load: @card_loads
+    )
+  end
+
+  defp filter_path(:upcoming, page) when page > 1, do: ~p"/my-huddlz?#{[page: page]}"
+  defp filter_path(:upcoming, _page), do: ~p"/my-huddlz"
+
+  defp filter_path(filter, page) when page > 1,
+    do: ~p"/my-huddlz?#{[filter: filter, page: page]}"
+
+  defp filter_path(filter, _page), do: ~p"/my-huddlz?#{[filter: filter]}"
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="my-huddlz">
+      <div class="page-head">
+        <div>
+          <h1>My huddlz</h1>
+          <p>{filter_blurb(@filter)}</p>
+        </div>
+        <.link navigate={~p"/discover"} class="btn-primary">
+          Find another huddl
+        </.link>
+      </div>
+
+      <div class="filters">
+        <.v3_chip patch={filter_path(:upcoming, 1)} active={@filter == :upcoming}>
+          Upcoming · {@counts.upcoming}
+        </.v3_chip>
+        <.v3_chip patch={filter_path(:waitlisted, 1)} active={@filter == :waitlisted}>
+          Waitlisted · {@counts.waitlisted}
+        </.v3_chip>
+        <.v3_chip patch={filter_path(:past, 1)} active={@filter == :past}>
+          Past · {@counts.past}
+        </.v3_chip>
+      </div>
+
+      <%= if Enum.empty?(@huddls) do %>
+        <p class="muted">{empty_message(@filter)}</p>
+      <% else %>
+        <div class="grid">
+          <%= for {huddl, idx} <- Enum.with_index(@huddls) do %>
+            <.v3_my_huddl_card huddl={huddl} filter={@filter} gradient={Integer.mod(idx, 6) + 1} />
+          <% end %>
+        </div>
+        <.v3_pagination
+          :if={@page_info.total_pages > 1}
+          current_page={@page_info.current_page}
+          total_pages={@page_info.total_pages}
+          event_name="change_page"
+        />
+      <% end %>
+    </Layouts.v3_app>
+    """
+  end
+
+  attr :huddl, :map, required: true
+  attr :filter, :atom, required: true
+  attr :gradient, :integer, required: true
+
+  defp v3_my_huddl_card(assigns) do
+    ~H"""
+    <.v3_card
+      navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}
+      gradient={@gradient}
+    >
+      <:cover>
+        <img
+          :if={@huddl.display_image_url}
+          class="card-cover-img"
+          src={HuddlImages.url(@huddl.display_image_url)}
+          alt={@huddl.title}
+        />
+        <.v3_date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
+        <.v3_card_tag variant={tag_variant(@huddl.event_type)}>
+          {tag_label(@huddl.event_type)}
+        </.v3_card_tag>
+      </:cover>
+      <:body>
+        <span :if={@huddl.group} class="card-group">{@huddl.group.name}</span>
+        <h3 class="card-title">{@huddl.title}</h3>
+        <div class="card-meta">
+          <span>{format_meta_when(@huddl.starts_at)}</span>
+          <%= if @huddl.rsvp_count > 0 || @huddl.max_attendees do %>
+            <span class="dot"></span>
+            <span>{rsvp_label(@huddl)}</span>
+          <% end %>
+        </div>
+      </:body>
+      <:foot>
+        <.v3_pill variant={pill_variant(@filter)}>{pill_label(@filter)}</.v3_pill>
+        <span class="muted" style="font-size:12px">{relative_time(@huddl.starts_at)}</span>
+      </:foot>
+    </.v3_card>
+    """
+  end
+
+  defp filter_blurb(:upcoming),
+    do: "Everything you've RSVP'd to. Upcoming, soonest first."
+
+  defp filter_blurb(:waitlisted),
+    do: "Spots you're holding on a waitlist. We'll bump you up if seats open."
+
+  defp filter_blurb(:past),
+    do: "Huddlz you've attended. Most recent first."
+
+  defp empty_message(:upcoming),
+    do: "No upcoming RSVPs yet. Find one to attend."
+
+  defp empty_message(:waitlisted),
+    do: "You're not on a waitlist right now."
+
+  defp empty_message(:past),
+    do: "No past attendance yet."
+
+  defp pill_variant(:upcoming), do: :default
+  defp pill_variant(:waitlisted), do: :warn
+  defp pill_variant(:past), do: :muted
+
+  defp pill_label(:upcoming), do: "Going"
+  defp pill_label(:waitlisted), do: "Waitlist"
+  defp pill_label(:past), do: "Attended"
+
+  defp tag_variant(:in_person), do: :in_person
+  defp tag_variant(:virtual), do: :online
+  defp tag_variant(:hybrid), do: :hybrid
+
+  defp tag_label(:in_person), do: "In person"
+  defp tag_label(:virtual), do: "Online"
+  defp tag_label(:hybrid), do: "Hybrid"
+
+  defp huddl_month(%{starts_at: %DateTime{} = dt}),
+    do: Calendar.strftime(dt, "%b") |> String.upcase()
+
+  defp huddl_day(%{starts_at: %DateTime{} = dt}), do: Calendar.strftime(dt, "%-d")
+
+  defp format_meta_when(%DateTime{} = dt) do
+    "#{Calendar.strftime(dt, "%a")} · #{Calendar.strftime(dt, "%-I:%M %p")}"
+  end
+
+  defp rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
+    do: "#{count} / #{max} RSVPs"
+
+  defp rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
+  defp rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
+
+  defp relative_time(%DateTime{} = dt) do
+    diff_seconds = DateTime.diff(dt, DateTime.utc_now(), :second)
+    abs_seconds = abs(diff_seconds)
+    future? = diff_seconds >= 0
+
+    cond do
+      abs_seconds < 3600 -> if future?, do: "starting soon", else: "just ended"
+      abs_seconds < 86_400 -> format_hours(div(abs_seconds, 3600), future?)
+      abs_seconds < 7 * 86_400 -> format_days(div(abs_seconds, 86_400), future?)
+      abs_seconds < 30 * 86_400 -> format_weeks(div(abs_seconds, 7 * 86_400), future?)
+      true -> Calendar.strftime(dt, "%b %d, %Y")
+    end
+  end
+
+  defp format_hours(1, true), do: "1 hour away"
+  defp format_hours(n, true), do: "#{n} hours away"
+  defp format_hours(1, false), do: "1 hour ago"
+  defp format_hours(n, false), do: "#{n} hours ago"
+
+  defp format_days(1, true), do: "tomorrow"
+  defp format_days(n, true), do: "#{n} days away"
+  defp format_days(1, false), do: "yesterday"
+  defp format_days(n, false), do: "#{n} days ago"
+
+  defp format_weeks(1, true), do: "1 week away"
+  defp format_weeks(n, true), do: "#{n} weeks away"
+  defp format_weeks(1, false), do: "1 week ago"
+  defp format_weeks(n, false), do: "#{n} weeks ago"
+end

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -65,26 +65,31 @@ defmodule HuddlzWeb.NotificationsLive do
 
     with {:ok, notification} <- Ash.get(Notification, id, actor: user),
          {:ok, _} <- Notifications.mark_read(notification, actor: user) do
-      {:noreply,
-       socket
-       |> assign(:counts, load_counts(user))
-       |> load_results(socket.assigns.filter, socket.assigns.page_info.current_page, user)}
+      {:noreply, refresh(socket, user)}
     else
-      _ -> {:noreply, socket}
+      {:error, reason} ->
+        Logger.warning("NotificationsLive mark_read failed: #{inspect(reason)}")
+        {:noreply, socket}
     end
   end
 
   def handle_event("mark_all_read", _params, socket) do
     user = socket.assigns.current_user
 
-    socket.assigns.notifications
-    |> Enum.filter(&is_nil(&1.read_at))
-    |> Enum.each(&Notifications.mark_read(&1, actor: user))
+    case Notifications.mark_all_read(user) do
+      :ok ->
+        {:noreply, refresh(socket, user)}
 
-    {:noreply,
-     socket
-     |> assign(:counts, load_counts(user))
-     |> load_results(socket.assigns.filter, socket.assigns.page_info.current_page, user)}
+      {:error, reason} ->
+        Logger.warning("NotificationsLive mark_all_read failed: #{inspect(reason)}")
+        {:noreply, socket}
+    end
+  end
+
+  defp refresh(socket, user) do
+    socket
+    |> assign(:counts, load_counts(user))
+    |> load_results(socket.assigns.filter, socket.assigns.page_info.current_page, user)
   end
 
   defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
@@ -272,19 +277,20 @@ defmodule HuddlzWeb.NotificationsLive do
   defp mark_color(%{read_at: %DateTime{}}), do: "muted"
 
   defp mark_color(%{trigger: trigger}) when is_binary(trigger) do
-    case Notifications.Triggers.fetch(safe_atom(trigger)) do
-      {:ok, %{category: :transactional}} -> "warn"
-      _ -> "cyan"
-    end
-  rescue
-    ArgumentError -> "cyan"
+    if trigger in transactional_triggers(), do: "warn", else: "cyan"
   end
 
   defp mark_color(_), do: "cyan"
 
-  defp safe_atom(value) when is_binary(value) do
-    String.to_existing_atom(value)
-  end
+  # Memoized at module load — Triggers.all/0 is a compile-time map. Using a
+  # string set lets us match the DB-stored trigger string directly without
+  # converting to an atom (which would risk ArgumentError on stale rows).
+  @transactional_triggers Notifications.Triggers.all()
+                          |> Enum.filter(fn {_, e} -> e.category == :transactional end)
+                          |> Enum.map(fn {trigger, _} -> Atom.to_string(trigger) end)
+                          |> MapSet.new()
+
+  defp transactional_triggers, do: @transactional_triggers
 
   defp meta_line(%{description: desc, inserted_at: %DateTime{} = at})
        when is_binary(desc) and desc != "" do

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -1,0 +1,308 @@
+defmodule HuddlzWeb.NotificationsLive do
+  @moduledoc """
+  LiveView at `/notifications`. Notification inbox for the signed-in user.
+  Two filter chips driven by `?filter=`: default `inbox` is no param;
+  `invites` narrows to notifications that need a response. `?page=N`
+  paginates the active filter.
+
+  Replaces the `/me?tab=updates` and `/me?tab=invites` tabs from the legacy
+  member dashboard. Redirects from those legacy paths land users on the
+  matching filter.
+  """
+  use HuddlzWeb, :live_view
+
+  alias Huddlz.Notifications
+  alias Huddlz.Notifications.Notification
+  alias HuddlzWeb.Layouts
+  require Ash.Query
+  require Logger
+
+  @page_size 20
+  @valid_filters ~w(inbox invites)
+
+  on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Notifications")
+     |> assign(:notifications, [])
+     |> assign(:counts, %{inbox: 0, invites: 0})
+     |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    filter = parse_filter(params["filter"])
+    page = parse_page(params["page"])
+    user = socket.assigns.current_user
+
+    socket =
+      socket
+      |> assign(:filter, filter)
+      |> assign(:counts, load_counts(user))
+      |> load_results(filter, page, user)
+
+    total_pages = socket.assigns.page_info.total_pages
+
+    if page > total_pages do
+      {:noreply, push_patch(socket, to: filter_path(filter, total_pages))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("change_page", %{"page" => page_str}, socket) do
+    page = parse_page(page_str)
+    {:noreply, push_patch(socket, to: filter_path(socket.assigns.filter, page))}
+  end
+
+  def handle_event("mark_read", %{"id" => id}, socket) do
+    user = socket.assigns.current_user
+
+    with {:ok, notification} <- Ash.get(Notification, id, actor: user),
+         {:ok, _} <- Notifications.mark_read(notification, actor: user) do
+      {:noreply,
+       socket
+       |> assign(:counts, load_counts(user))
+       |> load_results(socket.assigns.filter, socket.assigns.page_info.current_page, user)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("mark_all_read", _params, socket) do
+    user = socket.assigns.current_user
+
+    socket.assigns.notifications
+    |> Enum.filter(&is_nil(&1.read_at))
+    |> Enum.each(&Notifications.mark_read(&1, actor: user))
+
+    {:noreply,
+     socket
+     |> assign(:counts, load_counts(user))
+     |> load_results(socket.assigns.filter, socket.assigns.page_info.current_page, user)}
+  end
+
+  defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
+  defp parse_filter(_), do: :inbox
+
+  defp parse_page(nil), do: 1
+  defp parse_page(""), do: 1
+
+  defp parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_page(val) when is_integer(val) and val >= 1, do: val
+  defp parse_page(_), do: 1
+
+  defp load_counts(user) do
+    %{
+      inbox: count_unread_inbox(user),
+      invites: count_invites(user)
+    }
+  end
+
+  defp count_unread_inbox(user) do
+    Notification
+    |> Ash.Query.for_read(:for_user, %{}, actor: user)
+    |> Ash.Query.filter(is_nil(read_at))
+    |> Ash.count()
+    |> case do
+      {:ok, count} -> count
+      _ -> 0
+    end
+  end
+
+  defp count_invites(user) do
+    case Notifications.list_invites_for_user(
+           actor: user,
+           page: [limit: 1, offset: 0, count: true]
+         ) do
+      {:ok, %{count: count}} when is_integer(count) -> count
+      _ -> 0
+    end
+  end
+
+  defp load_results(socket, filter, page, user) do
+    offset = (page - 1) * @page_size
+
+    case fetch_page(filter, user, offset) do
+      {:ok, %Ash.Page.Offset{results: results, count: count}} ->
+        total_pages = if count && count > 0, do: ceil(count / @page_size), else: 1
+
+        socket
+        |> assign(:notifications, results)
+        |> assign(:page_info, %{
+          total_pages: total_pages,
+          current_page: page,
+          total_count: count || 0
+        })
+
+      {:error, reason} ->
+        Logger.warning("NotificationsLive load failed: #{inspect(reason)}")
+
+        socket
+        |> assign(:notifications, [])
+        |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})
+    end
+  end
+
+  defp fetch_page(:inbox, user, offset) do
+    Notifications.list_for_user(
+      actor: user,
+      page: [limit: @page_size, offset: offset, count: true]
+    )
+  end
+
+  defp fetch_page(:invites, user, offset) do
+    Notifications.list_invites_for_user(
+      actor: user,
+      page: [limit: @page_size, offset: offset, count: true]
+    )
+  end
+
+  defp filter_path(:inbox, page) when page > 1, do: ~p"/notifications?#{[page: page]}"
+  defp filter_path(:inbox, _page), do: ~p"/notifications"
+
+  defp filter_path(filter, page) when page > 1,
+    do: ~p"/notifications?#{[filter: filter, page: page]}"
+
+  defp filter_path(filter, _page), do: ~p"/notifications?#{[filter: filter]}"
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="notifications">
+      <div class="page-head">
+        <div>
+          <h1>Notifications</h1>
+          <p>{filter_blurb(@filter)}</p>
+        </div>
+        <div :if={@filter == :inbox and @counts.inbox > 0} class="actions">
+          <button type="button" class="btn-secondary" phx-click="mark_all_read">
+            Mark all as read
+          </button>
+        </div>
+      </div>
+
+      <div class="filters">
+        <.v3_chip patch={filter_path(:inbox, 1)} active={@filter == :inbox}>
+          Inbox · {@counts.inbox} unread
+        </.v3_chip>
+        <.v3_chip patch={filter_path(:invites, 1)} active={@filter == :invites}>
+          Invites · {@counts.invites}
+        </.v3_chip>
+      </div>
+
+      <%= if Enum.empty?(@notifications) do %>
+        <p class="muted">{empty_message(@filter)}</p>
+      <% else %>
+        <div class="panel" style="padding:0">
+          <div class="row-list" style="padding:0 20px">
+            <%= for notification <- @notifications do %>
+              <.notification_row notification={notification} />
+            <% end %>
+          </div>
+        </div>
+        <.v3_pagination
+          :if={@page_info.total_pages > 1}
+          current_page={@page_info.current_page}
+          total_pages={@page_info.total_pages}
+          event_name="change_page"
+        />
+      <% end %>
+    </Layouts.v3_app>
+    """
+  end
+
+  attr :notification, :map, required: true
+
+  defp notification_row(assigns) do
+    read? = !is_nil(assigns.notification.read_at)
+    assigns = assign(assigns, :unread, !read?)
+
+    ~H"""
+    <div
+      id={"notification-#{@notification.id}"}
+      class={["row", "notif-row", @unread && "unread"]}
+    >
+      <div class={["notif-mark", mark_color(@notification)]} aria-hidden="true"></div>
+      <div>
+        <div class="row-title">{@notification.title}</div>
+        <div :if={meta_line(@notification)} class="meta">{meta_line(@notification)}</div>
+      </div>
+      <%= if @notification.source_url do %>
+        <.link class="pill" navigate={@notification.source_url}>Open</.link>
+      <% else %>
+        <button
+          :if={@unread}
+          type="button"
+          class="pill"
+          phx-click="mark_read"
+          phx-value-id={@notification.id}
+        >
+          Mark read
+        </button>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp filter_blurb(:inbox),
+    do: "RSVPs, group activity, and reminders from across huddlz."
+
+  defp filter_blurb(:invites),
+    do: "Things that need a response from you."
+
+  defp empty_message(:inbox),
+    do: "No notifications yet. Reminders and group activity will appear here as they happen."
+
+  defp empty_message(:invites),
+    do:
+      "No invites right now. When organizers invite you to a huddl or group, they'll show up here."
+
+  defp mark_color(%{read_at: %DateTime{}}), do: "muted"
+
+  defp mark_color(%{trigger: trigger}) when is_binary(trigger) do
+    case Notifications.Triggers.fetch(safe_atom(trigger)) do
+      {:ok, %{category: :transactional}} -> "warn"
+      _ -> "cyan"
+    end
+  rescue
+    ArgumentError -> "cyan"
+  end
+
+  defp mark_color(_), do: "cyan"
+
+  defp safe_atom(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  end
+
+  defp meta_line(%{description: desc, inserted_at: %DateTime{} = at})
+       when is_binary(desc) and desc != "" do
+    "#{desc} · #{format_time_ago(at)}"
+  end
+
+  defp meta_line(%{inserted_at: %DateTime{} = at}), do: format_time_ago(at)
+  defp meta_line(_), do: nil
+
+  defp format_time_ago(%DateTime{} = dt) do
+    diff = DateTime.diff(DateTime.utc_now(), dt, :second)
+
+    cond do
+      diff < 60 -> "just now"
+      diff < 3600 -> "#{div(diff, 60)}m ago"
+      diff < 86_400 -> "#{div(diff, 3600)}h ago"
+      diff < 7 * 86_400 -> "#{div(diff, 86_400)}d ago"
+      true -> Calendar.strftime(dt, "%b %d, %Y")
+    end
+  end
+end

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -85,6 +85,8 @@ defmodule HuddlzWeb.Router do
       live "/discover", HuddlLive, :index
       live "/help", HelpLive, :index
       live "/me", MeLive, :index
+      live "/my-huddlz", MyHuddlzLive, :index
+      live "/my-groups", MyGroupsLive, :index
       live "/admin", AdminLive, :index
       live "/profile", ProfileLive, :index
       live "/profile/notifications", ProfileLive.Notifications, :index

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -87,6 +87,7 @@ defmodule HuddlzWeb.Router do
       live "/me", MeLive, :index
       live "/my-huddlz", MyHuddlzLive, :index
       live "/my-groups", MyGroupsLive, :index
+      live "/notifications", NotificationsLive, :index
       live "/admin", AdminLive, :index
       live "/profile", ProfileLive, :index
       live "/profile/notifications", ProfileLive.Notifications, :index

--- a/test/features/me_dashboard.feature
+++ b/test/features/me_dashboard.feature
@@ -39,45 +39,35 @@ Feature: Me dashboard
     When I visit "/me?tab=garbage"
     Then I should see "// Upcoming"
 
-  Scenario: My Groups tab shows empty Hosting and Joined sections with side panels
+  Scenario: /me?tab=groups redirects to /my-groups
     Given I am signed in as "host@example.com"
     When I visit "/me?tab=groups"
-    Then I should see "Groups you organize and groups you've joined."
-    And I should see "// Hosting"
-    And I should see "You haven't created a group yet."
-    And I should see "// Joined"
-    And I should see "You haven't joined any groups yet."
-    And I should see "// Find more groups"
-    And I should see "Discover groups"
-    And I should see "// Useful next actions"
-    And I should not see "// Upcoming"
+    Then I should see "My groups"
+    And I should see "Groups you organize and groups you've joined."
+    And I should see "You haven't organized or joined any groups yet. Start one or browse Discover."
 
-  Scenario: Owner sees their group in the Hosting section under My Groups
+  Scenario: Owner sees their group on /my-groups
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
     And I am signed in as "host@example.com"
-    When I visit "/me?tab=groups"
-    Then I should see "// Hosting"
+    When I visit "/my-groups"
+    Then I should see "Hosting"
     And I should see "Cyberpunk Builders"
-    And I should see "You haven't joined any groups yet."
 
-  Scenario: Member sees groups they joined in the Joined section under My Groups
+  Scenario: Member sees groups they joined on /my-groups
     Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
     And "attendee@example.com" has joined the group "Phoenix Devs"
     And I am signed in as "attendee@example.com"
-    When I visit "/me?tab=groups"
-    Then I should see "// Joined"
+    When I visit "/my-groups"
+    Then I should see "Joined"
     And I should see "Phoenix Devs"
-    And I should see "You haven't created a group yet."
 
-  Scenario: Hosting and Joined are split for the same user
+  Scenario: Hosting and Joined groups appear together on /my-groups
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
     And a public group "Phoenix Devs" exists with owner "stranger@example.com"
     And "host@example.com" has joined the group "Phoenix Devs"
     And I am signed in as "host@example.com"
-    When I visit "/me?tab=groups"
-    Then I should see "// Hosting"
-    And I should see "Cyberpunk Builders"
-    And I should see "// Joined"
+    When I visit "/my-groups"
+    Then I should see "Cyberpunk Builders"
     And I should see "Phoenix Devs"
 
   Scenario: Invites tab shows an empty feed with needs-response side panel

--- a/test/features/me_dashboard.feature
+++ b/test/features/me_dashboard.feature
@@ -70,39 +70,9 @@ Feature: Me dashboard
     Then I should see "Cyberpunk Builders"
     And I should see "Phoenix Devs"
 
-  Scenario: Invites tab shows an empty feed with needs-response side panel
-    Given I am signed in as "host@example.com"
-    When I visit "/me?tab=invites"
-    Then I should see "Things that need a response from you."
-    And I should see "// Invites"
-    And I should see "No invites right now. When organizers invite you to a huddl or group, they'll show up here."
-    And I should see "// Needs response"
-
-  Scenario: Being added to a private group surfaces as an Invite
-    Given a private group "Phoenix Devs" exists with owner "stranger@example.com"
-    And "attendee@example.com" was added to the group "Phoenix Devs"
-    And I am signed in as "attendee@example.com"
-    When I visit "/me?tab=invites"
-    Then I should see "Added to Phoenix Devs"
-
-  Scenario: Updates tab shows an empty feed with notification controls panel
-    Given I am signed in as "host@example.com"
-    When I visit "/me?tab=updates"
-    Then I should see "Reminders, RSVPs, and group activity from across huddlz."
-    And I should see "// Updates"
-    And I should see "No updates yet. Reminders and group activity will appear here as they happen."
-    And I should see "// Notification controls"
-    And I should see "Open preferences"
-
-  Scenario: RSVP confirmation appears as a notification on the Updates tab
-    Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
-    And the huddl "Elixir Workshop" exists in group "Phoenix Devs" hosted by "stranger@example.com"
-    And "attendee@example.com" has RSVPed to "Elixir Workshop"
-    And I am signed in as "attendee@example.com"
-    When I visit "/me?tab=updates"
-    Then I should see "RSVP confirmed: Elixir Workshop"
-    And I should see "Activity"
-    And I should see "Mark all as read"
+  # Updates and Invites have moved to /notifications — see
+  # test/huddlz_web/live/notifications_live_test.exs. The legacy /me tabs
+  # now redirect there.
 
   Scenario: RSVPed user sees the huddl in the Upcoming section and the Coming up panel
     Given a public group "Phoenix Devs" exists with owner "stranger@example.com"

--- a/test/huddlz_web/api/graphql/group_test.exs
+++ b/test/huddlz_web/api/graphql/group_test.exs
@@ -52,8 +52,8 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
     end
   end
 
-  describe "joinedGroups query" do
-    test "returns groups the actor has joined but does not own", %{conn: conn} do
+  describe "myGroups query" do
+    test "returns groups the actor owns or has joined (default :all)", %{conn: conn} do
       member = generate(user())
       stranger = generate(user())
 
@@ -67,26 +67,65 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
       conn =
         conn
         |> authenticated_conn(member)
-        |> gql_post("{ joinedGroups { results { id name } } }")
+        |> gql_post("{ myGroups { results { id name } } }")
 
-      assert %{"data" => %{"joinedGroups" => %{"results" => results}}} =
+      assert %{"data" => %{"myGroups" => %{"results" => results}}} =
                json_response(conn, 200)
+
+      ids = Enum.map(results, & &1["id"])
+      assert owned.id in ids
+      assert joined.id in ids
+    end
+
+    test "relationship: \"hosting\" returns only owned groups", %{conn: conn} do
+      member = generate(user())
+      stranger = generate(user())
+
+      owned = generate(group(name: "Owned", actor: member, is_public: true))
+      joined = generate(group(name: "Joined", actor: stranger, is_public: true))
+      generate(group_member(group_id: joined.id, user_id: member.id, actor: stranger))
+
+      conn =
+        conn
+        |> authenticated_conn(member)
+        |> gql_post(~s|{ myGroups(relationship: "hosting") { results { id } } }|)
+
+      assert %{"data" => %{"myGroups" => %{"results" => results}}} = json_response(conn, 200)
+
+      ids = Enum.map(results, & &1["id"])
+      assert owned.id in ids
+      refute joined.id in ids
+    end
+
+    test "relationship: \"joined\" returns only joined-but-not-owned groups", %{conn: conn} do
+      member = generate(user())
+      stranger = generate(user())
+
+      owned = generate(group(name: "Owned", actor: member, is_public: true))
+      joined = generate(group(name: "Joined", actor: stranger, is_public: true))
+      generate(group_member(group_id: joined.id, user_id: member.id, actor: stranger))
+
+      conn =
+        conn
+        |> authenticated_conn(member)
+        |> gql_post(~s|{ myGroups(relationship: "joined") { results { id } } }|)
+
+      assert %{"data" => %{"myGroups" => %{"results" => results}}} = json_response(conn, 200)
 
       ids = Enum.map(results, & &1["id"])
       assert joined.id in ids
       refute owned.id in ids
     end
 
-    test "returns empty list for user with no memberships beyond ownership", %{conn: conn} do
+    test "returns empty list for an unrelated user", %{conn: conn} do
       lonely = generate(user())
-      _owned = generate(group(actor: lonely, is_public: true))
 
       conn =
         conn
         |> authenticated_conn(lonely)
-        |> gql_post("{ joinedGroups { results { id } } }")
+        |> gql_post("{ myGroups { results { id } } }")
 
-      assert %{"data" => %{"joinedGroups" => %{"results" => []}}} = json_response(conn, 200)
+      assert %{"data" => %{"myGroups" => %{"results" => []}}} = json_response(conn, 200)
     end
   end
 end

--- a/test/huddlz_web/api/json/group_test.exs
+++ b/test/huddlz_web/api/json/group_test.exs
@@ -175,25 +175,28 @@ defmodule HuddlzWeb.Api.Json.GroupTest do
     end
   end
 
-  describe "GET /api/json/groups/mine" do
-    test "returns only groups owned by the actor", %{conn: conn} do
+  describe "GET /api/json/groups/my-groups" do
+    test "returns groups the actor owns or has joined", %{conn: conn} do
       me = generate(user())
       mine = generate(group(owner_id: me.id, is_public: true, actor: me))
 
       other_owner = generate(user())
+      joined = generate(group(owner_id: other_owner.id, is_public: true, actor: other_owner))
+      generate(group_member(group_id: joined.id, user_id: me.id, actor: other_owner))
 
-      _other_group =
+      _stranger_group =
         generate(group(owner_id: other_owner.id, is_public: true, actor: other_owner))
 
       conn =
         conn
         |> authenticated_conn(me)
-        |> get("/api/json/groups/mine")
+        |> get("/api/json/groups/my-groups")
 
       assert %{"data" => data} = json_response(conn, 200)
       ids = Enum.map(data, & &1["id"])
       assert mine.id in ids
-      assert length(ids) == 1
+      assert joined.id in ids
+      assert length(ids) == 2
     end
   end
 

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -1,0 +1,272 @@
+defmodule HuddlzWeb.MyGroupsLiveTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  setup do
+    member = generate(user(role: :user))
+    other = generate(user(role: :user))
+    %{member: member, other: other}
+  end
+
+  describe "anonymous access" do
+    test "redirects to sign-in", %{conn: conn} do
+      conn
+      |> visit("/my-groups")
+      |> assert_path("/sign-in")
+    end
+  end
+
+  describe "page chrome" do
+    test "renders v3 sidebar with My groups active", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has("h1", text: "My groups")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".sb-item.active", text: "My groups")
+    end
+
+    test "shows three filter chips with counts", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(".filters .chip", text: "All")
+      |> assert_has(".filters .chip", text: "Hosting")
+      |> assert_has(".filters .chip", text: "Joined")
+    end
+
+    test "All chip is active by default", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(".filters .chip.is-active", text: "All")
+    end
+
+    test "Start a group CTA links to /groups/new", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(".page-head a[href='/groups/new']", text: "Start a group")
+    end
+  end
+
+  describe "All filter (default)" do
+    test "merges hosting and joined groups", %{conn: conn, member: member, other: other} do
+      _hosted =
+        generate(group(name: "Hosted Crew", is_public: true, owner_id: member.id, actor: member))
+
+      joined_group =
+        generate(group(name: "Joined Crew", is_public: true, owner_id: other.id, actor: other))
+
+      generate(group_member(group_id: joined_group.id, user_id: member.id, actor: other))
+
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(".grid .card .card-title", text: "Hosted Crew")
+      |> assert_has(".grid .card .card-title", text: "Joined Crew")
+      |> assert_has(".filters .chip", text: "All · 2")
+      |> assert_has(".filters .chip", text: "Hosting · 1")
+      |> assert_has(".filters .chip", text: "Joined · 1")
+    end
+
+    test "empty state copy", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has("p",
+        text: "You haven't organized or joined any groups yet. Start one or browse Discover."
+      )
+    end
+  end
+
+  describe "Hosting filter" do
+    test "shows only owned groups with Hosting tag", %{
+      conn: conn,
+      member: member,
+      other: other
+    } do
+      generate(group(name: "Owned One", is_public: true, owner_id: member.id, actor: member))
+
+      joined_group =
+        generate(group(name: "Joined One", is_public: true, owner_id: other.id, actor: other))
+
+      generate(group_member(group_id: joined_group.id, user_id: member.id, actor: other))
+
+      conn
+      |> login(member)
+      |> visit("/my-groups?filter=hosting")
+      |> assert_has(".filters .chip.is-active", text: "Hosting")
+      |> assert_has(".grid .card .card-title", text: "Owned One")
+      |> refute_has(".grid .card .card-title", text: "Joined One")
+      |> assert_has(".grid .card .card-tag", text: "Hosting")
+    end
+
+    test "empty state copy", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups?filter=hosting")
+      |> assert_has("p", text: "You haven't created a group yet.")
+    end
+  end
+
+  describe "Joined filter" do
+    test "shows only joined groups with Joined tag", %{
+      conn: conn,
+      member: member,
+      other: other
+    } do
+      _hosted =
+        generate(group(name: "Owned One", is_public: true, owner_id: member.id, actor: member))
+
+      joined_group =
+        generate(group(name: "Joined One", is_public: true, owner_id: other.id, actor: other))
+
+      generate(group_member(group_id: joined_group.id, user_id: member.id, actor: other))
+
+      conn
+      |> login(member)
+      |> visit("/my-groups?filter=joined")
+      |> assert_has(".filters .chip.is-active", text: "Joined")
+      |> assert_has(".grid .card .card-title", text: "Joined One")
+      |> refute_has(".grid .card .card-title", text: "Owned One")
+      |> assert_has(".grid .card .card-tag", text: "Joined")
+    end
+
+    test "empty state copy", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups?filter=joined")
+      |> assert_has("p", text: "You haven't joined any groups yet.")
+    end
+  end
+
+  describe "redirect from /me?tab=groups" do
+    test "/me?tab=groups redirects to /my-groups", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/me?tab=groups")
+      |> assert_path("/my-groups")
+    end
+  end
+
+  describe "URL filtering" do
+    test "unknown filter falls back to All", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups?filter=garbage")
+      |> assert_has(".filters .chip.is-active", text: "All")
+    end
+  end
+
+  describe "scoping" do
+    test "does not leak groups the user has no relationship with", %{
+      conn: conn,
+      member: member,
+      other: other
+    } do
+      _stranger_group =
+        generate(group(name: "Strangers Only", is_public: true, owner_id: other.id, actor: other))
+
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> refute_has(".grid .card .card-title", text: "Strangers Only")
+      |> assert_has(".filters .chip", text: "All · 0")
+    end
+  end
+
+  describe "card destinations" do
+    test "card links to /groups/:slug", %{conn: conn, member: member} do
+      group =
+        generate(group(name: "Linked Group", is_public: true, owner_id: member.id, actor: member))
+
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(~s(.grid .card[href="/groups/#{group.slug}"]))
+    end
+  end
+
+  describe "card content" do
+    test "renders member count", %{conn: conn, member: member} do
+      _g =
+        generate(group(name: "Crowded Crew", is_public: true, owner_id: member.id, actor: member))
+
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(".grid .card .card-meta", text: "1 member")
+    end
+  end
+
+  describe "alphabetical sort" do
+    test "groups appear in case-insensitive alphabetical order", %{
+      conn: conn,
+      member: member
+    } do
+      generate(group(name: "zebra", is_public: true, owner_id: member.id, actor: member))
+      generate(group(name: "Alpha", is_public: true, owner_id: member.id, actor: member))
+      generate(group(name: "mango", is_public: true, owner_id: member.id, actor: member))
+
+      session =
+        conn
+        |> login(member)
+        |> visit("/my-groups")
+
+      html = Phoenix.LiveViewTest.render(session.view)
+
+      alpha_idx = :binary.match(html, "Alpha") |> elem(0)
+      mango_idx = :binary.match(html, "mango") |> elem(0)
+      zebra_idx = :binary.match(html, "zebra") |> elem(0)
+
+      assert alpha_idx < mango_idx
+      assert mango_idx < zebra_idx
+    end
+  end
+
+  describe "pagination" do
+    setup %{member: member} do
+      # 22 owned groups → 2 pages of 20
+      for i <- 1..22 do
+        slug = String.pad_leading(Integer.to_string(i), 3, "0")
+
+        generate(
+          group(
+            name: "Group #{slug}",
+            is_public: true,
+            owner_id: member.id,
+            actor: member
+          )
+        )
+      end
+
+      :ok
+    end
+
+    test "shows pagination when more than 20 groups", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups")
+      |> assert_has(".grid .card .card-title", text: "Group 001")
+      |> assert_has(".grid .card .card-title", text: "Group 020")
+      |> refute_has(".grid .card .card-title", text: "Group 021")
+      |> assert_has(".pagination .page-num", text: "2")
+    end
+
+    test "page=2 shows the next 20", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups?page=2")
+      |> assert_has(".grid .card .card-title", text: "Group 021")
+      |> assert_has(".grid .card .card-title", text: "Group 022")
+      |> refute_has(".grid .card .card-title", text: "Group 001")
+    end
+
+    test "out-of-range ?page= clamps to last valid page", %{conn: conn, member: member} do
+      conn
+      |> login(member)
+      |> visit("/my-groups?page=999")
+      |> assert_path("/my-groups", query_params: %{"page" => "2"})
+    end
+  end
+end

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -1,0 +1,346 @@
+defmodule HuddlzWeb.MyHuddlzLiveTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  setup do
+    host = generate(user(role: :user))
+    attendee = generate(user(role: :user))
+    public_group = generate(group(is_public: true, owner_id: host.id, actor: host))
+
+    %{host: host, attendee: attendee, public_group: public_group}
+  end
+
+  defp rsvp!(huddl, user, action) do
+    huddl
+    |> Ash.Changeset.for_update(action, %{}, actor: user)
+    |> Ash.update!()
+  end
+
+  defp create_huddl(host, group, opts) do
+    generate(
+      huddl(
+        Keyword.merge(
+          [
+            group_id: group.id,
+            creator_id: host.id,
+            is_private: false,
+            actor: host
+          ],
+          opts
+        )
+      )
+    )
+  end
+
+  defp create_past_huddl(host, group, opts) do
+    generate(
+      past_huddl(
+        Keyword.merge(
+          [
+            group_id: group.id,
+            creator_id: host.id,
+            is_private: false,
+            actor: host
+          ],
+          opts
+        )
+      )
+    )
+  end
+
+  describe "anonymous access" do
+    test "redirects to sign-in", %{conn: conn} do
+      conn
+      |> visit("/my-huddlz")
+      |> assert_path("/sign-in")
+    end
+  end
+
+  describe "page chrome" do
+    test "renders v3 sidebar with My huddlz active", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has("h1", text: "My huddlz")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".sb-item.active", text: "My huddlz")
+    end
+
+    test "shows three filter chips with counts", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has(".filters .chip", text: "Upcoming")
+      |> assert_has(".filters .chip", text: "Waitlisted")
+      |> assert_has(".filters .chip", text: "Past")
+    end
+
+    test "Upcoming chip is active by default", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has(".filters .chip.is-active", text: "Upcoming")
+    end
+  end
+
+  describe "Upcoming filter (default)" do
+    test "shows attending huddlz", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl_attended = create_huddl(host, public_group, title: "Going Show")
+      _other_huddl = create_huddl(host, public_group, title: "Skipped Show")
+
+      rsvp!(huddl_attended, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has("h3.card-title", text: "Going Show")
+      |> refute_has("h3.card-title", text: "Skipped Show")
+      |> assert_has(".pill", text: "Going")
+    end
+
+    test "empty state shows helpful copy", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has("p", text: "No upcoming RSVPs yet. Find one to attend.")
+    end
+
+    test "Upcoming count reflects attended huddlz", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Counted")
+      rsvp!(huddl, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has(".filters .chip", text: "Upcoming · 1")
+    end
+  end
+
+  describe "Waitlisted filter" do
+    setup ctx do
+      huddl =
+        create_huddl(ctx.host, ctx.public_group,
+          title: "Sold Out Show",
+          max_attendees: 1
+        )
+
+      # First attendee fills the seat
+      filler = generate(user(role: :user))
+      rsvp!(huddl, filler, :rsvp)
+
+      # Reload the huddl with current count
+      huddl = Ash.reload!(huddl)
+
+      Map.put(ctx, :huddl, huddl)
+    end
+
+    test "shows waitlisted huddlz with Waitlist pill", %{
+      conn: conn,
+      attendee: attendee,
+      huddl: huddl
+    } do
+      rsvp!(huddl, attendee, :join_waitlist)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?filter=waitlisted")
+      |> assert_has(".filters .chip.is-active", text: "Waitlisted")
+      |> assert_has("h3.card-title", text: "Sold Out Show")
+      |> assert_has(".pill", text: "Waitlist")
+    end
+
+    test "empty state copy", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?filter=waitlisted")
+      |> assert_has("p", text: "You're not on a waitlist right now.")
+    end
+  end
+
+  describe "Past filter" do
+    test "shows attended past huddlz with Attended pill", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      past = create_past_huddl(host, public_group, title: "Old Workshop")
+      rsvp!(past, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?filter=past")
+      |> assert_has(".filters .chip.is-active", text: "Past")
+      |> assert_has("h3.card-title", text: "Old Workshop")
+      |> assert_has(".pill", text: "Attended")
+    end
+
+    test "empty state copy", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?filter=past")
+      |> assert_has("p", text: "No past attendance yet.")
+    end
+  end
+
+  describe "redirect from /me?tab=huddlz" do
+    test "/me?tab=huddlz redirects to /my-huddlz", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/me?tab=huddlz")
+      |> assert_path("/my-huddlz")
+    end
+  end
+
+  describe "URL filtering" do
+    test "unknown filter falls back to Upcoming", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?filter=garbage")
+      |> assert_has(".filters .chip.is-active", text: "Upcoming")
+    end
+  end
+
+  describe "scoping" do
+    test "does not leak other users' RSVPs into Upcoming", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      mine = create_huddl(host, public_group, title: "I Am Going")
+      theirs = create_huddl(host, public_group, title: "They Are Going")
+
+      rsvp!(mine, attendee, :rsvp)
+
+      stranger = generate(user(role: :user))
+      rsvp!(theirs, stranger, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has("h3.card-title", text: "I Am Going")
+      |> refute_has("h3.card-title", text: "They Are Going")
+      |> assert_has(".filters .chip", text: "Upcoming · 1")
+    end
+  end
+
+  describe "card destinations" do
+    test "card links to the huddl detail page", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Linked Show")
+      rsvp!(huddl, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has(~s(.grid .card[href="/groups/#{public_group.slug}/huddlz/#{huddl.id}"]))
+    end
+  end
+
+  describe "Past filter sort" do
+    test "newest first (most recently ended)", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      older =
+        create_past_huddl(host, public_group,
+          title: "Older Past Event",
+          starts_at: DateTime.add(DateTime.utc_now(), -10, :day),
+          ends_at: DateTime.add(DateTime.utc_now(), -10, :day) |> DateTime.add(2, :hour)
+        )
+
+      newer =
+        create_past_huddl(host, public_group,
+          title: "Newer Past Event",
+          starts_at: DateTime.add(DateTime.utc_now(), -1, :day),
+          ends_at: DateTime.add(DateTime.utc_now(), -1, :day) |> DateTime.add(2, :hour)
+        )
+
+      rsvp!(older, attendee, :rsvp)
+      rsvp!(newer, attendee, :rsvp)
+
+      session =
+        conn
+        |> login(attendee)
+        |> visit("/my-huddlz?filter=past")
+
+      html = Phoenix.LiveViewTest.render(session.view)
+
+      newer_idx = :binary.match(html, "Newer Past Event") |> elem(0)
+      older_idx = :binary.match(html, "Older Past Event") |> elem(0)
+
+      assert newer_idx < older_idx,
+             "Newer event should appear before older event in past list"
+    end
+  end
+
+  describe "pagination" do
+    setup %{attendee: attendee, host: host, public_group: public_group} do
+      # 22 attended upcoming → 2 pages of 20
+      huddls =
+        for i <- 1..22 do
+          slug = String.pad_leading(Integer.to_string(i), 3, "0")
+
+          h =
+            create_huddl(host, public_group,
+              title: "Huddl #{slug}",
+              date: Date.add(Date.utc_today(), i),
+              start_time: ~T[14:00:00]
+            )
+
+          rsvp!(h, attendee, :rsvp)
+          h
+        end
+
+      %{huddls: huddls}
+    end
+
+    test "shows pagination when more than 20 results", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has(".filters .chip", text: "Upcoming · 22")
+      |> assert_has(".pagination .page-num", text: "2")
+    end
+
+    test "page 1 shows the soonest 20", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has("h3.card-title", text: "Huddl 001")
+      |> refute_has("h3.card-title", text: "Huddl 021")
+    end
+
+    test "page=2 shows the remaining 2", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?page=2")
+      |> assert_has("h3.card-title", text: "Huddl 021")
+      |> assert_has("h3.card-title", text: "Huddl 022")
+      |> refute_has("h3.card-title", text: "Huddl 001")
+    end
+
+    test "out-of-range ?page= clamps to last valid page", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz?page=999")
+      |> assert_path("/my-huddlz", query_params: %{"page" => "2"})
+    end
+  end
+end

--- a/test/huddlz_web/live/notifications_live_test.exs
+++ b/test/huddlz_web/live/notifications_live_test.exs
@@ -1,0 +1,244 @@
+defmodule HuddlzWeb.NotificationsLiveTest do
+  use HuddlzWeb.ConnCase, async: false
+
+  alias Huddlz.Notifications
+
+  setup do
+    user = generate(user(role: :user, confirmed_at: DateTime.utc_now()))
+    %{user: user}
+  end
+
+  defp deliver!(user, trigger, payload) do
+    {:ok, _job} = Notifications.deliver(user, trigger, payload)
+    :ok
+  end
+
+  defp seed_notification(user, trigger, payload) do
+    deliver!(user, trigger, payload)
+    {:ok, %{results: [n | _]}} = Notifications.list_for_user(actor: user, page: [limit: 100])
+    n
+  end
+
+  describe "anonymous access" do
+    test "redirects to sign-in", %{conn: conn} do
+      conn
+      |> visit("/notifications")
+      |> assert_path("/sign-in")
+    end
+  end
+
+  describe "page chrome" do
+    test "renders v3 shell with the bell active and Inbox chip default", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has("h1", text: "Notifications")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".icon-pill.active")
+      |> assert_has(".filters .chip.is-active", text: "Inbox")
+    end
+
+    test "shows two filter chips with counts", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip", text: "Inbox")
+      |> assert_has(".filters .chip", text: "Invites")
+    end
+  end
+
+  describe "Inbox filter (default)" do
+    test "lists the actor's notifications", %{conn: conn, user: user} do
+      deliver!(user, :password_changed, %{})
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".notif-row .row-title", text: "Password changed")
+    end
+
+    test "Inbox count reflects only unread notifications", %{conn: conn, user: user} do
+      deliver!(user, :password_changed, %{})
+      deliver!(user, :email_changed, %{"old_email" => "a@b.com"})
+
+      read_one = seed_notification(user, :account_role_changed, %{})
+      {:ok, _} = Notifications.mark_read(read_one, actor: user)
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip", text: "Inbox · 2 unread")
+    end
+
+    test "empty state copy", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has("p",
+        text:
+          "No notifications yet. Reminders and group activity will appear here as they happen."
+      )
+    end
+
+    test "Mark all as read button is hidden when there are no unread", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> refute_has("button", text: "Mark all as read")
+    end
+
+    test "Mark all as read shows when unread > 0 and clears the count when clicked", %{
+      conn: conn,
+      user: user
+    } do
+      deliver!(user, :password_changed, %{})
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip", text: "Inbox · 1 unread")
+      |> click_button("Mark all as read")
+      |> assert_has(".filters .chip", text: "Inbox · 0 unread")
+    end
+  end
+
+  describe "Invites filter" do
+    test "lists only notifications that need a response", %{conn: conn, user: user} do
+      deliver!(user, :password_changed, %{})
+
+      deliver!(user, :group_member_added, %{
+        "group_slug" => "phoenix-elixir",
+        "group_name" => "Phoenix Elixir"
+      })
+
+      conn
+      |> login(user)
+      |> visit("/notifications?filter=invites")
+      |> assert_has(".filters .chip.is-active", text: "Invites")
+      |> assert_has(".notif-row .row-title", text: "Added to Phoenix Elixir")
+      |> refute_has(".notif-row .row-title", text: "Password changed")
+    end
+
+    test "Invites count reflects unread invite-shaped notifications", %{conn: conn, user: user} do
+      deliver!(user, :group_member_added, %{
+        "group_slug" => "g1",
+        "group_name" => "G1"
+      })
+
+      deliver!(user, :group_member_added, %{
+        "group_slug" => "g2",
+        "group_name" => "G2"
+      })
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip", text: "Invites · 2")
+    end
+
+    test "empty state copy", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications?filter=invites")
+      |> assert_has("p",
+        text:
+          "No invites right now. When organizers invite you to a huddl or group, they'll show up here."
+      )
+    end
+  end
+
+  describe "redirects from /me" do
+    test "/me?tab=updates redirects to /notifications", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/me?tab=updates")
+      |> assert_path("/notifications")
+    end
+
+    test "/me?tab=invites redirects to /notifications?filter=invites", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/me?tab=invites")
+      |> assert_path("/notifications", query_params: %{"filter" => "invites"})
+    end
+  end
+
+  describe "URL filtering" do
+    test "unknown filter falls back to Inbox", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications?filter=garbage")
+      |> assert_has(".filters .chip.is-active", text: "Inbox")
+    end
+  end
+
+  describe "scoping" do
+    test "does not leak other users' notifications", %{conn: conn, user: user} do
+      stranger = generate(user(role: :user, confirmed_at: DateTime.utc_now()))
+      deliver!(stranger, :password_changed, %{})
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> refute_has(".notif-row .row-title", text: "Password changed")
+      |> assert_has("p",
+        text:
+          "No notifications yet. Reminders and group activity will appear here as they happen."
+      )
+    end
+  end
+
+  describe "row destinations" do
+    test "rows with a source_url render an Open link", %{conn: conn, user: user} do
+      deliver!(user, :rsvp_confirmation, %{
+        "huddl_id" => "00000000-0000-0000-0000-000000000000",
+        "huddl_title" => "Boat Drinks",
+        "group_slug" => "phoenix-elixir",
+        "starts_at_iso" => "2026-05-09T18:00:00Z"
+      })
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(
+        ~s|.notif-row a.pill[href="/groups/phoenix-elixir/huddlz/00000000-0000-0000-0000-000000000000"]|,
+        text: "Open"
+      )
+    end
+  end
+
+  describe "pagination" do
+    setup %{user: user} do
+      # 22 notifications → 2 pages of 20
+      for i <- 1..22 do
+        deliver!(user, :password_changed, %{"i" => i})
+        # tiny stagger so inserted_at order is stable
+        Process.sleep(2)
+      end
+
+      :ok
+    end
+
+    test "shows pagination when more than 20 results", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip", text: "Inbox · 22 unread")
+      |> assert_has(".pagination .page-num", text: "2")
+    end
+
+    test "page=2 shows the remaining 2", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications?page=2")
+      |> assert_has(".notif-row")
+    end
+
+    test "out-of-range ?page= clamps to last valid page", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/notifications?page=999")
+      |> assert_path("/notifications", query_params: %{"page" => "2"})
+    end
+  end
+end

--- a/test/huddlz_web/live/notifications_live_test.exs
+++ b/test/huddlz_web/live/notifications_live_test.exs
@@ -100,6 +100,19 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       |> click_button("Mark all as read")
       |> assert_has(".filters .chip", text: "Inbox · 0 unread")
     end
+
+    test "Mark all as read clears unread beyond the visible page", %{conn: conn, user: user} do
+      # 25 unread > 20-per-page. Per-page iteration would leave 5 unread;
+      # bulk update clears all of them.
+      for _ <- 1..25, do: deliver!(user, :password_changed, %{})
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip", text: "Inbox · 25 unread")
+      |> click_button("Mark all as read")
+      |> assert_has(".filters .chip", text: "Inbox · 0 unread")
+    end
   end
 
   describe "Invites filter" do


### PR DESCRIPTION
## Summary

Splits the legacy `/me?tab=*` member dashboard into three v3-shelled, route-per-destination LiveViews. Each takes one of `/me`'s tabs and gives it its own URL, filter chips, and pagination — wired into the v3 sidebar shell.

- **`/my-huddlz`** — replaces `/me?tab=huddlz`. Filters: Upcoming · Waitlisted · Past, paginated 20/page. Postgres-side sort. Per-card pill (Going/Waitlist/Attended) reflects the active filter.
- **`/my-groups`** — replaces `/me?tab=groups`. Filters: All · Hosting · Joined, paginated 20/page. Powered by a new `:my_groups` Ash read action with a `relationship` argument; single SQL query (WHERE + ORDER BY + LIMIT/OFFSET), no in-memory merging.
- **`/notifications`** — replaces `/me?tab=updates` and `/me?tab=invites`. Filters: Inbox (unread count) · Invites (needs-response trigger set), paginated 20/page. Mark-all-read CTA, per-row Open links when `source_url` is set.

`/me` remains for the moment — the four legacy `?tab=*` URLs now `push_navigate` to their new homes so existing inbound links keep working. Drop of `/me` itself is PR-2.6.

Phase 2 progression: PR-2.2 + 2.3 + 2.5 of the v3 migration plan, bundled into one PR per request.

## Test plan

- [ ] `mix precommit` clean (1275 tests, 0 failures, credo clean — verified locally)
- [ ] Visit `/my-huddlz` while signed in: sidebar `My huddlz` chip is active; chips show counts; Upcoming default
- [ ] Visit `/my-groups`: chips show `All`, `Hosting`, `Joined` with counts; "Start a group" links to `/groups/new`
- [ ] Visit `/notifications`: bell in topbar is highlighted; chips show `Inbox · N unread`, `Invites · N`
- [ ] `/me?tab=huddlz` → `/my-huddlz`, `/me?tab=groups` → `/my-groups`, `/me?tab=updates` → `/notifications`, `/me?tab=invites` → `/notifications?filter=invites`
- [ ] On a populated `/notifications`: click "Mark all as read" — Inbox count drops to 0; button hides
- [ ] Visit `/notifications?page=999` (out of range) — clamps to last valid page
- [ ] Visit `/my-huddlz?filter=garbage` — falls back to Upcoming