### PR TITLE
feat(v3): add /calendar route with month grid and agenda view

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1436,6 +1436,8 @@ body.v3 .cal-nav-btn:hover { color: var(--cyan); border-color: var(--cyan); }
 
 body.v3 .cal-nav-today {
   height: 32px;
+  display: inline-flex;
+  align-items: center;
   padding: 0 14px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1266,12 +1266,18 @@ body.v3 .row {
   display: grid;
   align-items: center;
   gap: 16px;
-  padding: 14px 0;
+  /* padding-top is 1px short of padding-bottom to compensate for the 1px
+     border-top eating into the box (box-sizing: border-box) — without this
+     the grid track lands 1px below the row's geometric center. */
+  padding: 13px 0 14px;
   border-top: 1px solid var(--line);
   font-size: 13.5px;
 }
 
-body.v3 .row:first-child { border-top: 0; }
+body.v3 .row:first-child {
+  padding-top: 14px;
+  border-top: 0;
+}
 
 body.v3 .row .meta { color: var(--muted); font-size: 12px; }
 body.v3 .row .row-title .title-tag {

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -1,0 +1,404 @@
+defmodule HuddlzWeb.CalendarLive do
+  @moduledoc """
+  LiveView at `/calendar`. Personal calendar of huddlz the signed-in user
+  is hosting, attending, or watching from the waitlist. Month grid by
+  default with an agenda toggle; `?month=YYYY-MM` and `?view=month|agenda`
+  drive state.
+  """
+  use HuddlzWeb, :live_view
+
+  alias Huddlz.Communities
+  alias HuddlzWeb.Layouts
+  require Logger
+
+  @card_loads [:status, :group]
+
+  on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "My calendar")
+     |> assign(:today, Date.utc_today())}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    focus_month = parse_month(params["month"], socket.assigns.today)
+    view_mode = parse_view(params["view"])
+    {grid_start, grid_end} = month_grid_window(focus_month)
+    user = socket.assigns.current_user
+
+    entries = load_entries(user, grid_start, grid_end)
+    entries_by_day = group_by_day(entries)
+    in_month_count = Enum.count(entries, &in_focus_month?(&1.huddl, focus_month))
+
+    {:noreply,
+     socket
+     |> assign(:focus_month, focus_month)
+     |> assign(:view_mode, view_mode)
+     |> assign(:grid_start, grid_start)
+     |> assign(:grid_end, grid_end)
+     |> assign(:entries, entries)
+     |> assign(:entries_by_day, entries_by_day)
+     |> assign(:in_month_count, in_month_count)}
+  end
+
+  defp parse_month(nil, today), do: first_of_month(today)
+
+  defp parse_month(value, today) when is_binary(value) do
+    case Regex.run(~r/^(\d{4})-(\d{2})$/, value) do
+      [_, y, m] ->
+        with {year, ""} <- Integer.parse(y),
+             {month, ""} <- Integer.parse(m),
+             {:ok, date} <- Date.new(year, month, 1) do
+          date
+        else
+          _ -> first_of_month(today)
+        end
+
+      _ ->
+        first_of_month(today)
+    end
+  end
+
+  defp parse_month(_, today), do: first_of_month(today)
+
+  defp parse_view("agenda"), do: :agenda
+  defp parse_view(_), do: :month
+
+  defp first_of_month(date), do: %{date | day: 1}
+
+  defp month_grid_window(month_first) do
+    # Sunday-first grid. Date.day_of_week returns Mon=1..Sun=7.
+    # rem(day_of_week, 7) gives Sun=0..Sat=6 — the leading offset.
+    offset = rem(Date.day_of_week(month_first), 7)
+    grid_start = Date.add(month_first, -offset)
+    grid_end = Date.add(grid_start, 41)
+    {grid_start, grid_end}
+  end
+
+  defp load_entries(user, grid_start, grid_end) do
+    grid_start_dt = DateTime.new!(grid_start, ~T[00:00:00], "Etc/UTC")
+    grid_end_dt = DateTime.new!(grid_end, ~T[23:59:59], "Etc/UTC")
+
+    [:hosting, :attending, :waitlisted]
+    |> Enum.flat_map(fn role -> fetch(user, role) end)
+    |> Enum.uniq_by(& &1.huddl.id)
+    |> Enum.filter(fn %{huddl: h} ->
+      h.starts_at &&
+        DateTime.compare(h.starts_at, grid_start_dt) != :lt &&
+        DateTime.compare(h.starts_at, grid_end_dt) != :gt
+    end)
+  end
+
+  defp fetch(user, role) do
+    case Communities.search_huddlz(
+           nil,
+           :all,
+           nil,
+           nil,
+           nil,
+           nil,
+           role,
+           :soonest,
+           actor: user,
+           page: false,
+           load: @card_loads
+         ) do
+      {:ok, huddls} when is_list(huddls) ->
+        Enum.map(huddls, &%{huddl: &1, role: role})
+
+      {:error, reason} ->
+        Logger.warning("CalendarLive search failed (#{role}): #{inspect(reason)}")
+        []
+    end
+  end
+
+  defp group_by_day(entries) do
+    Enum.group_by(entries, fn %{huddl: %{starts_at: dt}} -> DateTime.to_date(dt) end)
+  end
+
+  defp in_focus_month?(%{starts_at: %DateTime{} = dt}, %Date{year: y, month: m}) do
+    date = DateTime.to_date(dt)
+    date.year == y && date.month == m
+  end
+
+  defp in_focus_month?(_, _), do: false
+
+  defp shift_month(date, delta) do
+    total = date.year * 12 + (date.month - 1) + delta
+    Date.new!(div(total, 12), rem(total, 12) + 1, 1)
+  end
+
+  defp month_path(month, view) do
+    base = month_param(month)
+    view_str = if view == :agenda, do: "agenda"
+
+    cond do
+      base && view_str -> ~p"/calendar?#{[month: base, view: view_str]}"
+      base -> ~p"/calendar?#{[month: base]}"
+      view_str -> ~p"/calendar?#{[view: view_str]}"
+      true -> ~p"/calendar"
+    end
+  end
+
+  defp month_param(month) do
+    today_first = first_of_month(Date.utc_today())
+    if Date.compare(month, today_first) == :eq, do: nil, else: format_month_param(month)
+  end
+
+  defp format_month_param(%Date{year: y, month: m}) do
+    :io_lib.format("~4..0B-~2..0B", [y, m]) |> IO.iodata_to_binary()
+  end
+
+  defp format_month(%Date{year: y, month: m}) do
+    {:ok, date} = Date.new(y, m, 1)
+    Calendar.strftime(date, "%B %Y")
+  end
+
+  defp format_count(0), do: "0 huddlz"
+  defp format_count(1), do: "1 huddl"
+  defp format_count(n), do: "#{n} huddlz"
+
+  defp days_in_grid(grid_start) do
+    Enum.map(0..41, &Date.add(grid_start, &1))
+  end
+
+  defp day_in_focus?(%Date{} = day, %Date{year: y, month: m}),
+    do: day.year == y and day.month == m
+
+  defp pill_class_for(entry, day, focus_month, today) do
+    base = base_pill_class(entry, today)
+    if day_in_focus?(day, focus_month), do: base, else: base <> " out-of-month-pill"
+  end
+
+  defp base_pill_class(%{role: role, huddl: %{starts_at: starts_at}}, %Date{} = today) do
+    starts_date = DateTime.to_date(starts_at)
+    past? = Date.compare(starts_date, today) == :lt
+
+    cond do
+      past? -> "cal-pill past"
+      role == :waitlisted -> "cal-pill tentative"
+      true -> "cal-pill"
+    end
+  end
+
+  defp format_pill_label(%{huddl: %{starts_at: dt, title: title}}) do
+    time = Calendar.strftime(dt, "%-I:%M %p")
+    "#{time} · #{title}"
+  end
+
+  defp huddl_path(%{huddl: %{id: id, group: %{slug: slug}}}),
+    do: ~p"/groups/#{slug}/huddlz/#{id}"
+
+  defp agenda_entries(entries) do
+    Enum.sort_by(entries, fn %{huddl: %{starts_at: dt}} -> dt end, DateTime)
+  end
+
+  defp agenda_pill_variant(%{role: role, huddl: %{starts_at: dt}}, %Date{} = today) do
+    past? = Date.compare(DateTime.to_date(dt), today) == :lt
+
+    cond do
+      past? -> :muted
+      role == :waitlisted -> :warn
+      true -> :default
+    end
+  end
+
+  defp agenda_pill_label(%{role: role, huddl: %{starts_at: dt}}, %Date{} = today) do
+    past? = Date.compare(DateTime.to_date(dt), today) == :lt
+
+    cond do
+      past? -> "Past"
+      role == :hosting -> "Hosting"
+      role == :waitlisted -> "Waitlist"
+      true -> "Going"
+    end
+  end
+
+  defp format_agenda_when(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%a %b %-d · %-I:%M %p")
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="calendar">
+      <div class="page-head">
+        <div>
+          <h1>My calendar</h1>
+          <p>
+            Huddlz you're hosting, attending, or watching from the waitlist — laid out across the month.
+          </p>
+        </div>
+      </div>
+
+      <div class="cal-toolbar">
+        <div class="cal-nav">
+          <.link
+            patch={month_path(shift_month(@focus_month, -1), @view_mode)}
+            class="cal-nav-btn"
+            aria-label="Previous month"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </.link>
+          <.link patch={month_path(first_of_month(@today), @view_mode)} class="cal-nav-today">
+            Today
+          </.link>
+          <.link
+            patch={month_path(shift_month(@focus_month, 1), @view_mode)}
+            class="cal-nav-btn"
+            aria-label="Next month"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="m9 6 6 6-6 6" />
+            </svg>
+          </.link>
+        </div>
+
+        <div class="cal-month-title">
+          <span class="cal-month-name">{format_month(@focus_month)}</span>
+          <span class="cal-month-count">({format_count(@in_month_count)})</span>
+        </div>
+
+        <div class="cal-view-tabs">
+          <.link
+            patch={month_path(@focus_month, :month)}
+            class={["scope-tab", @view_mode == :month && "is-active"]}
+          >
+            Month
+          </.link>
+          <.link
+            patch={month_path(@focus_month, :agenda)}
+            class={["scope-tab", @view_mode == :agenda && "is-active"]}
+          >
+            Agenda
+          </.link>
+        </div>
+      </div>
+
+      <%= if @view_mode == :month do %>
+        <.month_grid
+          focus_month={@focus_month}
+          grid_start={@grid_start}
+          entries_by_day={@entries_by_day}
+          today={@today}
+        />
+      <% else %>
+        <.agenda_view entries={@entries} today={@today} />
+      <% end %>
+
+      <div class="cal-legend">
+        <span class="cal-legend-item">
+          <span class="cal-legend-swatch" style="background:var(--cyan)"></span> Going
+        </span>
+        <span class="cal-legend-item">
+          <span class="cal-legend-swatch" style="background:var(--warn)"></span> Tentative / waitlist
+        </span>
+        <span class="cal-legend-item">
+          <span class="cal-legend-swatch" style="background:var(--muted)"></span> Past
+        </span>
+      </div>
+    </Layouts.v3_app>
+    """
+  end
+
+  attr :focus_month, Date, required: true
+  attr :grid_start, Date, required: true
+  attr :entries_by_day, :map, required: true
+  attr :today, Date, required: true
+
+  defp month_grid(assigns) do
+    ~H"""
+    <div class="panel" style="padding:0">
+      <div class="cal-grid">
+        <div class="cal-day-name">Sun</div>
+        <div class="cal-day-name">Mon</div>
+        <div class="cal-day-name">Tue</div>
+        <div class="cal-day-name">Wed</div>
+        <div class="cal-day-name">Thu</div>
+        <div class="cal-day-name">Fri</div>
+        <div class="cal-day-name">Sat</div>
+      </div>
+      <div class="cal-grid">
+        <%= for day <- days_in_grid(@grid_start) do %>
+          <div class={cell_class(day, @focus_month)}>
+            <span class={day_num_class(day, @today)}>{day.day}</span>
+            <%= for entry <- Map.get(@entries_by_day, day, []) do %>
+              <.link
+                navigate={huddl_path(entry)}
+                class={pill_class_for(entry, day, @focus_month, @today)}
+                title={entry.huddl.title}
+              >
+                {format_pill_label(entry)}
+              </.link>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp cell_class(day, focus_month) do
+    if day_in_focus?(day, focus_month), do: "cal-cell", else: "cal-cell out-of-month"
+  end
+
+  defp day_num_class(day, today) do
+    if Date.compare(day, today) == :eq, do: "cal-day-num is-today", else: "cal-day-num"
+  end
+
+  attr :entries, :list, required: true
+  attr :today, Date, required: true
+
+  defp agenda_view(assigns) do
+    sorted = agenda_entries(assigns.entries)
+    assigns = assign(assigns, :sorted, sorted)
+
+    ~H"""
+    <%= if @sorted == [] do %>
+      <p class="muted">Nothing on the calendar this month.</p>
+    <% else %>
+      <div class="panel">
+        <div class="row-list">
+          <.link
+            :for={entry <- @sorted}
+            navigate={huddl_path(entry)}
+            class="row"
+            style="grid-template-columns: 200px 1fr auto; text-decoration: none; padding: 14px 0"
+          >
+            <span class="meta">{format_agenda_when(entry.huddl.starts_at)}</span>
+            <span class="row-title">{entry.huddl.title}</span>
+            <.v3_pill variant={agenda_pill_variant(entry, @today)}>
+              {agenda_pill_label(entry, @today)}
+            </.v3_pill>
+          </.link>
+        </div>
+      </div>
+    <% end %>
+    """
+  end
+end

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -130,7 +130,7 @@ defmodule HuddlzWeb.CalendarLive do
 
   defp shift_month(date, delta) do
     total = date.year * 12 + (date.month - 1) + delta
-    Date.new!(div(total, 12), rem(total, 12) + 1, 1)
+    Date.new!(Integer.floor_div(total, 12), Integer.mod(total, 12) + 1, 1)
   end
 
   defp month_path(month, view) do
@@ -151,7 +151,7 @@ defmodule HuddlzWeb.CalendarLive do
   end
 
   defp format_month_param(%Date{year: y, month: m}) do
-    :io_lib.format("~4..0B-~2..0B", [y, m]) |> IO.iodata_to_binary()
+    "#{y}-#{String.pad_leading(to_string(m), 2, "0")}"
   end
 
   defp format_month(%Date{year: y, month: m}) do
@@ -194,8 +194,10 @@ defmodule HuddlzWeb.CalendarLive do
   defp huddl_path(%{huddl: %{id: id, group: %{slug: slug}}}),
     do: ~p"/groups/#{slug}/huddlz/#{id}"
 
-  defp agenda_entries(entries) do
-    Enum.sort_by(entries, fn %{huddl: %{starts_at: dt}} -> dt end, DateTime)
+  defp agenda_entries(entries, focus_month) do
+    entries
+    |> Enum.filter(fn %{huddl: h} -> in_focus_month?(h, focus_month) end)
+    |> Enum.sort_by(fn %{huddl: %{starts_at: dt}} -> dt end, DateTime)
   end
 
   defp agenda_pill_variant(%{role: role, huddl: %{starts_at: dt}}, %Date{} = today) do
@@ -308,7 +310,7 @@ defmodule HuddlzWeb.CalendarLive do
           today={@today}
         />
       <% else %>
-        <.agenda_view entries={@entries} today={@today} />
+        <.agenda_view entries={@entries} focus_month={@focus_month} today={@today} />
       <% end %>
 
       <div class="cal-legend">
@@ -372,10 +374,11 @@ defmodule HuddlzWeb.CalendarLive do
   end
 
   attr :entries, :list, required: true
+  attr :focus_month, Date, required: true
   attr :today, Date, required: true
 
   defp agenda_view(assigns) do
-    sorted = agenda_entries(assigns.entries)
+    sorted = agenda_entries(assigns.entries, assigns.focus_month)
     assigns = assign(assigns, :sorted, sorted)
 
     ~H"""

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -391,7 +391,7 @@ defmodule HuddlzWeb.CalendarLive do
             :for={entry <- @sorted}
             navigate={huddl_path(entry)}
             class="row"
-            style="grid-template-columns: 200px 1fr auto; text-decoration: none; padding: 14px 0"
+            style="grid-template-columns: 200px 1fr auto; text-decoration: none"
           >
             <span class="meta">{format_agenda_when(entry.huddl.starts_at)}</span>
             <span class="row-title">{entry.huddl.title}</span>

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -385,8 +385,8 @@ defmodule HuddlzWeb.CalendarLive do
     <%= if @sorted == [] do %>
       <p class="muted">Nothing on the calendar this month.</p>
     <% else %>
-      <div class="panel">
-        <div class="row-list">
+      <div class="panel" style="padding:0">
+        <div class="row-list" style="padding:6px 20px">
           <.link
             :for={entry <- @sorted}
             navigate={huddl_path(entry)}

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -211,7 +211,7 @@ defmodule HuddlzWeb.NotificationsLive do
         <p class="muted">{empty_message(@filter)}</p>
       <% else %>
         <div class="panel" style="padding:0">
-          <div class="row-list" style="padding:0 20px">
+          <div class="row-list" style="padding:6px 20px">
             <%= for notification <- @notifications do %>
               <.notification_row notification={notification} />
             <% end %>

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -90,6 +90,7 @@ defmodule HuddlzWeb.Router do
       live "/help", HelpLive, :index
       live "/my-huddlz", MyHuddlzLive, :index
       live "/my-groups", MyGroupsLive, :index
+      live "/calendar", CalendarLive, :index
       live "/notifications", NotificationsLive, :index
       live "/admin", AdminLive, :index
       live "/profile", ProfileLive, :index

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -1,0 +1,292 @@
+defmodule HuddlzWeb.CalendarLiveTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  setup do
+    host = generate(user(role: :user))
+    attendee = generate(user(role: :user))
+    public_group = generate(group(is_public: true, owner_id: host.id, actor: host))
+
+    %{host: host, attendee: attendee, public_group: public_group}
+  end
+
+  defp rsvp!(huddl, user, action) do
+    huddl
+    |> Ash.Changeset.for_update(action, %{}, actor: user)
+    |> Ash.update!()
+  end
+
+  defp create_huddl(host, group, opts) do
+    generate(
+      huddl(
+        Keyword.merge(
+          [
+            group_id: group.id,
+            creator_id: host.id,
+            is_private: false,
+            actor: host
+          ],
+          opts
+        )
+      )
+    )
+  end
+
+  defp create_past_huddl(host, group, opts) do
+    generate(
+      past_huddl(
+        Keyword.merge(
+          [
+            group_id: group.id,
+            creator_id: host.id,
+            is_private: false,
+            actor: host
+          ],
+          opts
+        )
+      )
+    )
+  end
+
+  describe "anonymous access" do
+    test "redirects to sign-in", %{conn: conn} do
+      conn
+      |> visit("/calendar")
+      |> assert_path("/sign-in")
+    end
+  end
+
+  describe "page chrome" do
+    test "renders v3 sidebar with Calendar active and v3 toolbar", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has("h1", text: "My calendar")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".sb-item.active", text: "My calendar")
+      |> assert_has(".cal-toolbar")
+      |> assert_has(".cal-nav-today", text: "Today")
+      |> assert_has(".cal-view-tabs .scope-tab.is-active", text: "Month")
+      |> assert_has(".cal-legend", text: "Going")
+    end
+
+    test "shows the current month name and 0 huddlz when empty", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(".cal-month-name", text: current_month_name())
+      |> assert_has(".cal-month-count", text: "0 huddlz")
+    end
+
+    test "month grid renders 7 day-name headers", %{conn: conn, attendee: attendee} do
+      session =
+        conn
+        |> login(attendee)
+        |> visit("/calendar")
+
+      for day <- ~w(Sun Mon Tue Wed Thu Fri Sat) do
+        assert_has(session, ".cal-day-name", text: day)
+      end
+    end
+  end
+
+  describe "month view — RSVP'd huddlz appear as cal-pills" do
+    test "attending future huddl appears as a cal-pill (Going)", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Going Show")
+      rsvp!(huddl, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(".cal-pill", text: "Going Show")
+    end
+
+    test "waitlisted huddl renders the tentative variant", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Sold Out", max_attendees: 1)
+
+      filler = generate(user(role: :user))
+      rsvp!(huddl, filler, :rsvp)
+
+      huddl = Ash.reload!(huddl)
+      rsvp!(huddl, attendee, :join_waitlist)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(".cal-pill.tentative", text: "Sold Out")
+    end
+
+    test "past attended huddl renders the past variant", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      past = create_past_huddl(host, public_group, title: "Old Workshop")
+      rsvp!(past, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(".cal-pill.past", text: "Old Workshop")
+    end
+
+    test "hosting (creator) appears even without an RSVP", %{
+      conn: conn,
+      host: host,
+      public_group: public_group
+    } do
+      _huddl = create_huddl(host, public_group, title: "I Am Hosting")
+
+      conn
+      |> login(host)
+      |> visit("/calendar")
+      |> assert_has(".cal-pill", text: "I Am Hosting")
+    end
+
+    test "does not leak another user's RSVP'd huddl", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      _theirs = create_huddl(host, public_group, title: "Stranger Show")
+      stranger = generate(user(role: :user))
+
+      huddl = create_huddl(host, public_group, title: "Stranger Show")
+      rsvp!(huddl, stranger, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> refute_has(".cal-pill", text: "Stranger Show")
+    end
+
+    test "month count reflects huddlz in the focus month", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      next = shift(Date.utc_today(), 1)
+      target_date = %{next | day: 15}
+      huddl = create_huddl(host, public_group, title: "Counted", date: target_date)
+      rsvp!(huddl, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?month=#{next_month_param(Date.utc_today())}")
+      |> assert_has(".cal-month-count", text: "1 huddl")
+    end
+
+    test "cal-pill links to the huddl detail page", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Linked")
+      rsvp!(huddl, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(~s(.cal-pill[href="/groups/#{public_group.slug}/huddlz/#{huddl.id}"]))
+    end
+  end
+
+  describe "month navigation" do
+    test "next-month link patches the URL with ?month=YYYY-MM", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      next = next_month_param(Date.utc_today())
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(~s(a.cal-nav-btn[href="/calendar?month=#{next}"]))
+    end
+
+    test "Today link returns to current month from a navigated state", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      next = next_month_param(Date.utc_today())
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?month=#{next}")
+      |> assert_has(~s(a.cal-nav-today[href="/calendar"]))
+    end
+
+    test "invalid ?month= falls back to current month", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/calendar?month=not-a-month")
+      |> assert_has(".cal-month-name", text: current_month_name())
+    end
+  end
+
+  describe "agenda view" do
+    test "?view=agenda activates the Agenda tab", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=agenda")
+      |> assert_has(".cal-view-tabs .scope-tab.is-active", text: "Agenda")
+      |> refute_has(".cal-grid")
+    end
+
+    test "agenda lists RSVP'd huddlz with title and pill", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Agenda Item")
+      rsvp!(huddl, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=agenda")
+      |> assert_has(".row .row-title", text: "Agenda Item")
+      |> assert_has(".pill", text: "Going")
+    end
+
+    test "empty agenda shows helpful copy", %{conn: conn, attendee: attendee} do
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=agenda")
+      |> assert_has("p", text: "Nothing on the calendar this month.")
+    end
+  end
+
+  defp current_month_name do
+    Date.utc_today() |> Calendar.strftime("%B %Y")
+  end
+
+  defp next_month_param(date) do
+    next = shift(date, 1)
+    :io_lib.format("~4..0B-~2..0B", [next.year, next.month]) |> IO.iodata_to_binary()
+  end
+
+  defp shift(date, delta) do
+    total = date.year * 12 + (date.month - 1) + delta
+    Date.new!(div(total, 12), rem(total, 12) + 1, 1)
+  end
+end

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -102,12 +102,12 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      huddl = create_huddl(host, public_group, title: "Going Show")
+      huddl = create_huddl(host, public_group, title: "Going Show", date: tomorrow())
       rsvp!(huddl, attendee, :rsvp)
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit(calendar_path_for(tomorrow()))
       |> assert_has(".cal-pill", text: "Going Show")
     end
 
@@ -117,7 +117,12 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      huddl = create_huddl(host, public_group, title: "Sold Out", max_attendees: 1)
+      huddl =
+        create_huddl(host, public_group,
+          title: "Sold Out",
+          max_attendees: 1,
+          date: tomorrow()
+        )
 
       filler = generate(user(role: :user))
       rsvp!(huddl, filler, :rsvp)
@@ -127,7 +132,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit(calendar_path_for(tomorrow()))
       |> assert_has(".cal-pill.tentative", text: "Sold Out")
     end
 
@@ -142,7 +147,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit(calendar_path_for(Date.add(Date.utc_today(), -2)))
       |> assert_has(".cal-pill.past", text: "Old Workshop")
     end
 
@@ -151,11 +156,11 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      _huddl = create_huddl(host, public_group, title: "I Am Hosting")
+      _huddl = create_huddl(host, public_group, title: "I Am Hosting", date: tomorrow())
 
       conn
       |> login(host)
-      |> visit("/calendar")
+      |> visit(calendar_path_for(tomorrow()))
       |> assert_has(".cal-pill", text: "I Am Hosting")
     end
 
@@ -165,15 +170,13 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      _theirs = create_huddl(host, public_group, title: "Stranger Show")
       stranger = generate(user(role: :user))
-
-      huddl = create_huddl(host, public_group, title: "Stranger Show")
+      huddl = create_huddl(host, public_group, title: "Stranger Show", date: tomorrow())
       rsvp!(huddl, stranger, :rsvp)
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit(calendar_path_for(tomorrow()))
       |> refute_has(".cal-pill", text: "Stranger Show")
     end
 
@@ -200,12 +203,12 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      huddl = create_huddl(host, public_group, title: "Linked")
+      huddl = create_huddl(host, public_group, title: "Linked", date: tomorrow())
       rsvp!(huddl, attendee, :rsvp)
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit(calendar_path_for(tomorrow()))
       |> assert_has(~s(.cal-pill[href="/groups/#{public_group.slug}/huddlz/#{huddl.id}"]))
     end
   end
@@ -258,12 +261,12 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      huddl = create_huddl(host, public_group, title: "Agenda Item")
+      huddl = create_huddl(host, public_group, title: "Agenda Item", date: tomorrow())
       rsvp!(huddl, attendee, :rsvp)
 
       conn
       |> login(attendee)
-      |> visit("/calendar?view=agenda")
+      |> visit(calendar_path_for(tomorrow(), view: "agenda"))
       |> assert_has(".row .row-title", text: "Agenda Item")
       |> assert_has(".pill", text: "Going")
     end
@@ -274,6 +277,21 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> visit("/calendar?view=agenda")
       |> assert_has("p", text: "Nothing on the calendar this month.")
     end
+  end
+
+  defp tomorrow, do: Date.add(Date.utc_today(), 1)
+
+  # Build a /calendar URL pinned to the month containing `date`, so the focus
+  # month always matches where the huddl actually lives (matters for agenda
+  # filtering and for past dates that may slip outside the default grid).
+  defp calendar_path_for(date, opts \\ []) do
+    month = "#{date.year}-#{String.pad_leading(to_string(date.month), 2, "0")}"
+    view = Keyword.get(opts, :view)
+
+    params =
+      if view, do: "?month=#{month}&view=#{view}", else: "?month=#{month}"
+
+    "/calendar" <> params
   end
 
   defp current_month_name do


### PR DESCRIPTION
## Summary

- New `/calendar` LiveView (member-facing) showing huddlz the signed-in user is hosting, attending, or waitlisted on
- Sunday-first 6-week month grid; `?month=YYYY-MM` and `?view=month|agenda` drive state
- `cal-pill` variants follow the v3 legend: cyan for going/hosting, warn for waitlist, muted for past

The sidebar already pointed at `/calendar` from PR-F2 — this lights up the route so the link resolves instead of 404'ing. Phase 2 (PR-2.4 in the migration plan).

## Test plan

- [x] `mix precommit` — 1290 tests, 0 failures, credo clean
- [x] LiveView tests cover: anonymous redirect, page chrome, month grid headers, RSVP variants (going/waitlist/past/hosting), scoping (no leaks), month nav, agenda toggle, agenda empty state
- [x] Browser smoke: month grid renders 42 cells, day names, pills with correct classes; prev/next/today nav links resolve to expected URLs; agenda view hides grid and lists huddlz with date/time/title/pill