### PR TITLE
feat(v3): migrate /profile to v3 design

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2162,6 +2162,15 @@ body.v3 .location-current svg { color: var(--cyan); flex: 0 0 auto; }
 
 body.v3 .location-actions { display: inline-flex; gap: 8px; flex-wrap: wrap; }
 
+/* On narrow screens the pill + buttons stack; let each row span the full
+   width so the location pill doesn't sit as a tiny chip next to a wall of
+   whitespace, and so the Change/Clear buttons line up across the bottom. */
+@media (max-width: 760px) {
+  body.v3 .location-current { width: 100%; box-sizing: border-box; }
+  body.v3 .location-actions { width: 100%; }
+  body.v3 .location-actions > .btn-secondary { flex: 1 1 auto; justify-content: center; }
+}
+
 body.v3 .location-control .form-input { padding-right: 36px; }
 
 body.v3 .form-clear {

--- a/lib/huddlz_web/avatar.ex
+++ b/lib/huddlz_web/avatar.ex
@@ -1,0 +1,28 @@
+defmodule HuddlzWeb.Avatar do
+  @moduledoc """
+  Tiny helpers for rendering user avatars. `picture_url/1` returns the user's
+  uploaded image when present, `initials/1` returns up-to-two display-name
+  initials. Both fall through to `nil` so callers can decide what the empty
+  state looks like (initials, blank gradient, etc.).
+
+  Shared by the v3 sidebar (`.sb-user`) and the `/profile` `.big-avatar`.
+  """
+
+  @doc "Returns the user's current profile picture URL, or nil."
+  def picture_url(%{current_profile_picture_url: url}) when is_binary(url) and url != "",
+    do: url
+
+  def picture_url(_), do: nil
+
+  @doc "Returns the user's display-name initials (up to 2 chars), or nil."
+  def initials(%{display_name: name}) when is_binary(name) and name != "" do
+    name
+    |> String.trim()
+    |> String.split(~r/\s+/)
+    |> Enum.take(2)
+    |> Enum.map_join(&String.first/1)
+    |> String.upcase()
+  end
+
+  def initials(_), do: nil
+end

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -4,6 +4,8 @@ defmodule HuddlzWeb.Layouts do
   """
   use HuddlzWeb, :html
 
+  alias HuddlzWeb.Avatar
+
   embed_templates "layouts/*"
 
   def app(assigns) do
@@ -654,29 +656,15 @@ defmodule HuddlzWeb.Layouts do
   defp sb_user_avatar(assigns) do
     ~H"""
     <%= cond do %>
-      <% url = avatar_url(@user) -> %>
+      <% url = Avatar.picture_url(@user) -> %>
         <img class="avatar" src={url} alt="" aria-hidden="true" />
-      <% initials = avatar_initials(@user) -> %>
+      <% initials = Avatar.initials(@user) -> %>
         <span class="avatar" aria-hidden="true">{initials}</span>
       <% true -> %>
         <span class="avatar" aria-hidden="true"></span>
     <% end %>
     """
   end
-
-  defp avatar_url(%{current_profile_picture_url: url}) when is_binary(url) and url != "", do: url
-  defp avatar_url(_), do: nil
-
-  defp avatar_initials(%{display_name: name}) when is_binary(name) and name != "" do
-    name
-    |> String.trim()
-    |> String.split(~r/\s+/)
-    |> Enum.take(2)
-    |> Enum.map_join(&String.first/1)
-    |> String.upcase()
-  end
-
-  defp avatar_initials(_), do: nil
 
   @doc """
   Shows the flash group with standard titles and content.

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -369,7 +369,7 @@ defmodule HuddlzWeb.Layouts do
         </div>
 
         <a class="sb-user" href="/profile" aria-label="View profile">
-          <span class="avatar" aria-hidden="true"></span>
+          <.sb_user_avatar user={@current_user} />
           <div class="who">
             <div class="name">{display_name(@current_user)}</div>
             <div class="role">{@current_user.email}</div>
@@ -648,6 +648,35 @@ defmodule HuddlzWeb.Layouts do
   defp display_name(%{display_name: name}) when is_binary(name) and name != "", do: name
   defp display_name(%{email: email}) when is_binary(email), do: email
   defp display_name(_), do: "Account"
+
+  attr :user, :map, required: true
+
+  defp sb_user_avatar(assigns) do
+    ~H"""
+    <%= cond do %>
+      <% url = avatar_url(@user) -> %>
+        <img class="avatar" src={url} alt="" aria-hidden="true" />
+      <% initials = avatar_initials(@user) -> %>
+        <span class="avatar" aria-hidden="true">{initials}</span>
+      <% true -> %>
+        <span class="avatar" aria-hidden="true"></span>
+    <% end %>
+    """
+  end
+
+  defp avatar_url(%{current_profile_picture_url: url}) when is_binary(url) and url != "", do: url
+  defp avatar_url(_), do: nil
+
+  defp avatar_initials(%{display_name: name}) when is_binary(name) and name != "" do
+    name
+    |> String.trim()
+    |> String.split(~r/\s+/)
+    |> Enum.take(2)
+    |> Enum.map_join(&String.first/1)
+    |> String.upcase()
+  end
+
+  defp avatar_initials(_), do: nil
 
   @doc """
   Shows the flash group with standard titles and content.

--- a/lib/huddlz_web/components/v3/button.ex
+++ b/lib/huddlz_web/components/v3/button.ex
@@ -17,9 +17,10 @@ defmodule HuddlzWeb.V3.Button do
     values: [:primary, :secondary, :muted, :destructive],
     default: :secondary
 
+  attr :type, :string, default: "button"
   attr :class, :any, default: nil
 
-  attr :rest, :global, include: ~w(href navigate patch type disabled name value form)
+  attr :rest, :global, include: ~w(href navigate patch disabled name value form)
 
   slot :inner_block, required: true
 
@@ -31,8 +32,6 @@ defmodule HuddlzWeb.V3.Button do
       </.link>
       """
     else
-      assigns = assign_new(assigns, :type, fn -> "button" end)
-
       ~H"""
       <button type={@type} class={[base_class(@variant), @class]} {@rest}>
         {render_slot(@inner_block)}

--- a/lib/huddlz_web/live/location_autocomplete.ex
+++ b/lib/huddlz_web/live/location_autocomplete.ex
@@ -25,9 +25,11 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
   attr :fetch_coordinates, :boolean, default: true
 
   attr :variant, :atom,
-    values: [:default, :filter_pill],
+    values: [:default, :filter_pill, :v3_form],
     default: :default,
-    doc: "render style — `:filter_pill` mounts inside the v3 `.filter-location` chrome"
+    doc:
+      "render style — `:filter_pill` mounts inside the v3 `.filter-location` chrome; " <>
+        "`:v3_form` renders the panel-style `.location-display` block used on `/profile`"
 
   def mount(socket) do
     {:ok,
@@ -109,6 +111,7 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
   end
 
   def render(%{variant: :filter_pill} = assigns), do: render_filter_pill(assigns)
+  def render(%{variant: :v3_form} = assigns), do: render_v3_form(assigns)
   def render(assigns), do: render_default(assigns)
 
   defp render_default(assigns) do
@@ -356,6 +359,132 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
       </p>
 
       <p :if={@error} class="filter-location-error">{@error}</p>
+    </div>
+    """
+  end
+
+  # V3 panel-form variant — renders the `.location-display` block on `/profile`.
+  # When a location is selected, shows a static pill with explicit
+  # "Change location…" and "Clear" buttons (matching the clickthrough mockup);
+  # when searching, falls back to a `.form-input` + `.filter-location-listbox`
+  # dropdown so the suggestions reuse the v3 panel styling.
+  defp render_v3_form(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class="filter-location-wrap"
+      phx-click-away="dismiss"
+      phx-target={@myself}
+      phx-hook="LocationAutocomplete"
+      data-has-highlight={to_string(@suggestion_index >= 0)}
+    >
+      <%= if @selected do %>
+        <input :if={@field_name} type="hidden" name={@field_name} value={@selected_text} />
+        <div class="location-display" data-testid="location-selected">
+          <div class="location-current">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 22s7-7.6 7-13a7 7 0 0 0-14 0c0 5.4 7 13 7 13z" />
+              <circle cx="12" cy="9" r="2.5" />
+            </svg>
+            <span data-testid="location-display">{@selected_text}</span>
+          </div>
+          <div class="location-actions">
+            <button
+              type="button"
+              class="btn-secondary"
+              phx-click="edit"
+              phx-target={@myself}
+            >
+              Change location…
+            </button>
+            <button
+              :if={@show_clear}
+              type="button"
+              class="btn-secondary muted-btn"
+              phx-click="clear"
+              phx-target={@myself}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      <% else %>
+        <div class="location-control">
+          <input :if={@field_name} type="hidden" name={@field_name} value={@search_text} />
+          <input
+            type="text"
+            id={"#{@id}-input"}
+            class="form-input"
+            value={@search_text}
+            placeholder={@placeholder}
+            phx-change="search_input"
+            phx-target={@myself}
+            phx-debounce="300"
+            phx-keydown="keydown"
+            name={"#{@id}_search"}
+            autocomplete="off"
+            data-testid="location-input"
+            role="combobox"
+            aria-expanded={to_string(@show_suggestions && @suggestions != [])}
+            aria-autocomplete="list"
+            aria-controls={"#{@id}-listbox"}
+          />
+          <button
+            :if={@show_clear && @search_text != "" && !@loading}
+            type="button"
+            class="form-clear"
+            phx-click="clear"
+            phx-target={@myself}
+            aria-label="Clear location"
+          >
+            ×
+          </button>
+        </div>
+
+        <div
+          :if={@show_suggestions && @suggestions != []}
+          id={"#{@id}-listbox"}
+          role="listbox"
+          class="filter-location-listbox"
+          style="min-width: 100%"
+        >
+          <button
+            :for={{s, idx} <- Enum.with_index(@suggestions)}
+            type="button"
+            id={"#{@id}-option-#{idx}"}
+            role="option"
+            phx-click="select"
+            phx-value-place-id={s.place_id}
+            phx-value-display-text={s.display_text}
+            phx-value-main-text={s.main_text}
+            phx-target={@myself}
+            class={["filter-location-option", idx == @suggestion_index && "is-active"]}
+          >
+            <span class="opt-main">{s.main_text}</span>
+            <span class="opt-secondary">{s.secondary_text}</span>
+          </button>
+        </div>
+
+        <p
+          :if={@show_suggestions && @suggestions == [] && !@loading}
+          class="filter-location-listbox empty"
+          style="min-width: 100%"
+        >
+          No locations found
+        </p>
+      <% end %>
+
+      <p :if={@error} class="form-error">{@error}</p>
     </div>
     """
   end

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.ProfileLive do
   use HuddlzWeb, :live_view
 
   alias Huddlz.Storage.ProfilePictures
+  alias HuddlzWeb.Avatar
   alias HuddlzWeb.Layouts
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
@@ -140,7 +141,7 @@ defmodule HuddlzWeb.ProfileLive do
             </div>
           </div>
         </div>
-        <form phx-change="noop" phx-submit="noop" class="form-row">
+        <form class="form-row">
           <.live_component
             module={HuddlzWeb.Live.LocationAutocomplete}
             id="profile-location"
@@ -216,30 +217,15 @@ defmodule HuddlzWeb.ProfileLive do
   defp big_avatar(assigns) do
     ~H"""
     <%= cond do %>
-      <% @user.current_profile_picture_url -> %>
-        <img
-          class="big-avatar"
-          src={@user.current_profile_picture_url}
-          alt={@user.display_name || @user.email}
-        />
-      <% initials = avatar_initials(@user) -> %>
+      <% url = Avatar.picture_url(@user) -> %>
+        <img class="big-avatar" src={url} alt="" aria-hidden="true" />
+      <% initials = Avatar.initials(@user) -> %>
         <div class="big-avatar">{initials}</div>
       <% true -> %>
         <div class="big-avatar"></div>
     <% end %>
     """
   end
-
-  defp avatar_initials(%{display_name: name}) when is_binary(name) and name != "" do
-    name
-    |> String.trim()
-    |> String.split(~r/\s+/)
-    |> Enum.take(2)
-    |> Enum.map_join(&String.first/1)
-    |> String.upcase()
-  end
-
-  defp avatar_initials(_), do: nil
 
   defp role_label(:admin), do: "Admin"
   defp role_label(role) when is_atom(role), do: role |> to_string() |> String.capitalize()
@@ -323,9 +309,6 @@ defmodule HuddlzWeb.ProfileLive do
          |> assign(:password_form, form |> to_form())}
     end
   end
-
-  @impl true
-  def handle_event("noop", _params, socket), do: {:noreply, socket}
 
   @impl true
   def handle_event("validate_avatar", _params, socket) do

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -140,10 +140,11 @@ defmodule HuddlzWeb.ProfileLive do
             </div>
           </div>
         </div>
-        <div class="form-row">
+        <form phx-change="noop" phx-submit="noop" class="form-row">
           <.live_component
             module={HuddlzWeb.Live.LocationAutocomplete}
             id="profile-location"
+            variant={:v3_form}
             field_name="home_location"
             value={@current_user.home_location}
             latitude={@current_user.home_latitude}
@@ -151,7 +152,7 @@ defmodule HuddlzWeb.ProfileLive do
             placeholder="e.g. Austin, TX"
           />
           <p :if={@location_error} class="form-error">{@location_error}</p>
-        </div>
+        </form>
       </div>
 
       <.form

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -8,6 +8,7 @@ defmodule HuddlzWeb.ProfileLive do
   alias HuddlzWeb.Layouts
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -62,192 +63,189 @@ defmodule HuddlzWeb.ProfileLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <.header>
-        Profile Settings
-        <:subtitle>Manage your profile information</:subtitle>
-      </.header>
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="profile">
+      <div class="page-head">
+        <div>
+          <h1>Profile</h1>
+          <p>How you show up in huddlz — your name, photo, and how to reach you.</p>
+        </div>
+      </div>
 
-      <nav class="mt-4">
-        <.link
-          navigate={~p"/profile/notifications"}
-          class="text-primary underline underline-offset-4 hover:text-secondary"
-        >
-          Notification preferences
-        </.link>
-      </nav>
-
-      <div class="mt-8">
-        <h2 class="font-display text-lg tracking-tight text-glow">Profile Picture</h2>
-        <p class="text-base-content/50 mb-4">
-          Upload a profile picture to personalize your account.
-        </p>
-
-        <div class="relative inline-block">
-          <div class="relative">
-            <.avatar user={@current_user} size={:xl} />
-            <button
-              type="button"
-              phx-click={JS.toggle(to: "#avatar-menu")}
-              class="absolute bottom-0 right-0 w-6 h-6 flex items-center justify-center bg-base-200 border border-base-300 text-primary cursor-pointer"
-            >
-              <.icon name="hero-pencil" class="w-3 h-3" />
-            </button>
-          </div>
-
-          <div
-            id="avatar-menu"
-            class="hidden absolute left-0 mt-2 w-48 border border-base-300 bg-base-200 z-10"
-            phx-click-away={JS.hide(to: "#avatar-menu")}
-          >
-            <label
-              for={@uploads.avatar.ref}
-              class="block w-full text-left px-4 py-2 text-sm hover:text-primary cursor-pointer transition-colors"
-              phx-click={JS.hide(to: "#avatar-menu")}
-            >
-              Upload a photo...
+      <div class="panel">
+        <div class="panel-head">
+          <h2>Profile picture</h2>
+        </div>
+        <div class="profile-photo-row">
+          <.big_avatar user={@current_user} />
+          <div class="profile-photo-actions">
+            <label for={@uploads.avatar.ref} class="btn-secondary" style="cursor:pointer">
+              Upload a photo…
             </label>
             <%= if @current_user.current_profile_picture_url do %>
               <button
                 type="button"
+                class="btn-secondary muted-btn"
                 phx-click="remove_avatar"
                 data-confirm="Are you sure you want to remove your profile picture?"
-                class="block w-full text-left px-4 py-2 text-sm text-error hover:text-error/70 transition-colors"
               >
-                <span>Remove</span>
+                Remove
               </button>
             <% end %>
-          </div>
-
-          <form id="avatar-form" phx-change="validate_avatar" class="hidden">
-            <.live_file_input upload={@uploads.avatar} />
-          </form>
-        </div>
-
-        <%= if @avatar_error do %>
-          <p class="text-error text-sm mt-2">{@avatar_error}</p>
-        <% end %>
-
-        <div class="mt-10">
-          <h2 class="font-display text-lg tracking-tight text-glow">Account Information</h2>
-          <div class="mt-4 space-y-3">
-            <div class="flex items-center gap-3">
-              <span class="w-16 mono-label text-primary/70">Email</span>
-              <span class="text-base-content/50">{@current_user.email}</span>
+            <div class="muted" style="font-size:12px; margin-top:6px">
+              JPG, PNG, or WebP · 5 MB max
             </div>
-            <div class="flex items-center gap-3">
-              <span class="w-16 mono-label text-primary/70">Role</span>
-              <span class={[
-                "text-xs px-2.5 py-1 font-medium",
-                @current_user.role == :admin && "bg-primary/10 text-primary",
-                @current_user.role == :user && "bg-base-300 text-base-content/50"
-              ]}>
-                {@current_user.role |> to_string() |> String.capitalize()}
-              </span>
-            </div>
+            <p :if={@avatar_error} class="form-error">{@avatar_error}</p>
           </div>
         </div>
+        <form id="avatar-form" phx-change="validate_avatar" class="hidden">
+          <.live_file_input upload={@uploads.avatar} />
+        </form>
+      </div>
 
-        <div class="mt-10">
-          <h2 class="font-display text-lg tracking-tight text-glow">Display Name</h2>
-          <p class="text-base-content/50 mb-4">
-            This is how other users will see you on the platform.
-          </p>
-
-          <form phx-submit="save" phx-change="validate">
-            <.input
+      <.form for={@form} phx-submit="save" phx-change="validate">
+        <div class="panel">
+          <div class="panel-head">
+            <h2>Account information</h2>
+          </div>
+          <div class="form-grid">
+            <div class="form-row">
+              <label class="form-label">Email</label>
+              <div class="form-control read-only">
+                <span>{@current_user.email}</span>
+                <span class={["pill", role_pill_color(@current_user.role)]}>
+                  {role_label(@current_user.role)}
+                </span>
+              </div>
+              <p class="form-help">Your email can't be changed from this page.</p>
+            </div>
+            <.v3_input
               field={@form[:display_name]}
-              type="text"
-              label="Display Name"
+              label="Display name"
               placeholder="Enter your display name"
+              help="Names aren't unique on huddlz — pick anything you like."
             />
-
-            <div class="mt-4">
-              <.button type="submit">
-                Save Changes
-              </.button>
-            </div>
-          </form>
+          </div>
+          <div class="form-foot">
+            <.v3_button variant={:primary} type="submit">Save changes</.v3_button>
+          </div>
         </div>
+      </.form>
 
-        <div class="mt-10">
-          <h2 class="font-display text-lg tracking-tight text-glow">Home Location</h2>
-          <p class="text-base-content/50 mb-4">
-            Set your home city to pre-fill location search when browsing huddlz.
-          </p>
+      <div class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Home location</h2>
+            <div class="panel-sub">
+              Used to pre-fill the distance filter when you search huddlz nearby.
+            </div>
+          </div>
+        </div>
+        <div class="form-row">
+          <.live_component
+            module={HuddlzWeb.Live.LocationAutocomplete}
+            id="profile-location"
+            field_name="home_location"
+            value={@current_user.home_location}
+            latitude={@current_user.home_latitude}
+            longitude={@current_user.home_longitude}
+            placeholder="e.g. Austin, TX"
+          />
+          <p :if={@location_error} class="form-error">{@location_error}</p>
+        </div>
+      </div>
 
-          <form phx-change="noop" phx-submit="noop">
-            <div class="flex items-end gap-3">
-              <div class="flex-1">
-                <.live_component
-                  module={HuddlzWeb.Live.LocationAutocomplete}
-                  id="profile-location"
-                  field_name="home_location"
-                  value={@current_user.home_location}
-                  latitude={@current_user.home_latitude}
-                  longitude={@current_user.home_longitude}
-                  label="City / Region"
-                  placeholder="e.g. Austin, TX"
-                />
+      <.form
+        for={@password_form}
+        id="password-form"
+        phx-submit="update_password"
+        phx-change="validate_password"
+      >
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>{if @current_user.hashed_password, do: "Change", else: "Set"} password</h2>
+              <div class="panel-sub">
+                <%= if @current_user.hashed_password do %>
+                  Update your password to keep your account secure.
+                <% else %>
+                  Set a password to enable password-based sign in.
+                <% end %>
               </div>
             </div>
-          </form>
-
-          <%= if @location_error do %>
-            <p class="mt-1 text-sm text-error">{@location_error}</p>
-          <% end %>
-        </div>
-
-        <div class="mt-10">
-          <h2 class="font-display text-lg tracking-tight text-glow">
-            {if @current_user.hashed_password, do: "Change", else: "Set"} Password
-          </h2>
-          <p class="text-base-content/50 mb-4">
+          </div>
+          <div class="form-grid">
             <%= if @current_user.hashed_password do %>
-              Update your password to keep your account secure.
-            <% else %>
-              Set a password to enable password-based sign in.
-            <% end %>
-          </p>
-
-          <form id="password-form" phx-submit="update_password" phx-change="validate_password">
-            <%= if @current_user.hashed_password do %>
-              <.input
+              <.v3_input
                 field={@password_form[:current_password]}
                 type="password"
-                label="Current Password"
+                label="Current password"
                 placeholder="Enter your current password"
                 autocomplete="current-password"
               />
             <% end %>
-
-            <.input
+            <.v3_input
               field={@password_form[:password]}
               type="password"
-              label="New Password"
+              label="New password"
               placeholder="Enter your new password"
               autocomplete="new-password"
+              help="At least 8 characters."
             />
-
-            <.input
+            <.v3_input
               field={@password_form[:password_confirmation]}
               type="password"
-              label="Confirm New Password"
+              label="Confirm new password"
               placeholder="Confirm your new password"
               autocomplete="new-password"
             />
-
-            <div class="mt-4">
-              <.button type="submit">
-                {if @current_user.hashed_password, do: "Update", else: "Set"} Password
-              </.button>
-            </div>
-          </form>
+          </div>
+          <div class="form-foot">
+            <.v3_button variant={:primary} type="submit">
+              {if @current_user.hashed_password, do: "Update", else: "Set"} password
+            </.v3_button>
+          </div>
         </div>
-      </div>
-    </Layouts.app>
+      </.form>
+    </Layouts.v3_app>
     """
   end
+
+  attr :user, :map, required: true
+
+  defp big_avatar(assigns) do
+    ~H"""
+    <%= cond do %>
+      <% @user.current_profile_picture_url -> %>
+        <img
+          class="big-avatar"
+          src={@user.current_profile_picture_url}
+          alt={@user.display_name || @user.email}
+        />
+      <% initials = avatar_initials(@user) -> %>
+        <div class="big-avatar">{initials}</div>
+      <% true -> %>
+        <div class="big-avatar"></div>
+    <% end %>
+    """
+  end
+
+  defp avatar_initials(%{display_name: name}) when is_binary(name) and name != "" do
+    name
+    |> String.trim()
+    |> String.split(~r/\s+/)
+    |> Enum.take(2)
+    |> Enum.map_join(&String.first/1)
+    |> String.upcase()
+  end
+
+  defp avatar_initials(_), do: nil
+
+  defp role_label(:admin), do: "Admin"
+  defp role_label(role) when is_atom(role), do: role |> to_string() |> String.capitalize()
+  defp role_label(_), do: "Member"
+
+  defp role_pill_color(:admin), do: "magenta"
+  defp role_pill_color(_), do: "cyan"
 
   @impl true
   def handle_event("validate", %{"form" => params}, socket) do

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -66,11 +66,18 @@ defmodule HuddlzWeb.LiveUserAuth do
   # Pair with `<Layouts.v3_app>` in the LiveView template. Adds `is-signed-out`
   # when there's no actor, so the body switches from the sidebar grid to the
   # single-column shell rendered by `Layouts.v3_app` in chromeless mode.
+  #
+  # Also loads the user details the sidebar reads (profile picture URL, home
+  # location) so the bottom-of-sidebar avatar can render an uploaded image
+  # rather than a blank gradient square.
   def on_mount(:v3_app, _params, _session, socket) do
     body_class =
       if socket.assigns[:current_user], do: "v3", else: "v3 is-signed-out"
 
-    {:cont, assign(socket, :body_class, body_class)}
+    {:cont,
+     socket
+     |> maybe_load_user_details()
+     |> assign(:body_class, body_class)}
   end
 
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -13,8 +13,8 @@ Feature: Notification preferences settings page
     And I click "Save preferences"
     Then I should see "Notification preferences saved"
 
-  Scenario: User can reach the notifications page from the profile page
+  Scenario: User can reach the notifications page from the profile sidebar
     Given I am signed in as "linknav@example.com" with password "Password123!"
     When I go to my profile page
-    And I click "Notification preferences"
+    And I click "Settings"
     Then I should see "Choose which emails you want to receive"

--- a/test/features/password_authentication.feature
+++ b/test/features/password_authentication.feature
@@ -42,7 +42,7 @@ Feature: Password Authentication
       | current_password      | OldPassword123! |
       | password              | NewPassword123! |
       | password_confirmation | NewPassword123! |
-    And I click "Update Password"
+    And I click "Update password"
     Then I should see "Password updated successfully"
 
   Scenario: User requests password reset

--- a/test/features/password_change_notification.feature
+++ b/test/features/password_change_notification.feature
@@ -11,6 +11,6 @@ Feature: Password change notification email
       | current_password      | OldPassword123! |
       | password              | NewPassword456! |
       | password_confirmation | NewPassword456! |
-    And I click "Update Password"
+    And I click "Update password"
     Then I should see "Password updated successfully"
     And a password-changed notification should be sent to "secure@example.com"

--- a/test/features/profile_picture.feature
+++ b/test/features/profile_picture.feature
@@ -12,9 +12,9 @@ Feature: Profile Picture Management
 
   Scenario: Viewing profile picture section
     When I visit "/profile"
-    Then I should see "Profile Picture"
-    And I should see "Upload a profile picture to personalize your account"
-    And I should see "Upload a photo..."
+    Then I should see "Profile picture"
+    And I should see "JPG, PNG, or WebP"
+    And I should see "Upload a photo"
 
   Scenario: Profile shows fallback avatar when no picture is uploaded
     When I visit "/profile"
@@ -26,10 +26,10 @@ Feature: Profile Picture Management
 
   Scenario: Viewing the profile picture card structure
     When I visit "/profile"
-    Then I should see "Profile Settings"
-    And I should see "Profile Picture"
-    And I should see "Account Information"
-    And I should see "Display Name"
+    Then I should see "Profile"
+    And I should see "Profile picture"
+    And I should see "Account information"
+    And I should see "Display name"
 
   Scenario: Profile picture appears in navbar when user has one
     Given the following profile pictures exist:

--- a/test/features/step_definitions/location_autocomplete_steps.exs
+++ b/test/features/step_definitions/location_autocomplete_steps.exs
@@ -48,7 +48,16 @@ defmodule LocationAutocompleteSteps do
     session = context[:session] || context[:conn]
     view = session.view
 
-    view |> element("[data-testid='location-selected'] [role='button']") |> render_click()
+    # Legacy variant uses a pencil button (`role="button"`); the v3 form variant
+    # uses an explicit "Change location…" button. Either fires `phx-click="edit"`.
+    edit_selector =
+      if has_element?(view, "[data-testid='location-selected'] [role='button']") do
+        "[data-testid='location-selected'] [role='button']"
+      else
+        "[data-testid='location-selected'] [phx-click='edit']"
+      end
+
+    view |> element(edit_selector) |> render_click()
 
     Map.merge(context, %{session: session, conn: session})
   end
@@ -57,7 +66,16 @@ defmodule LocationAutocompleteSteps do
     session = context[:session] || context[:conn]
     view = session.view
 
-    view |> element("[aria-label='Clear location']") |> render_click()
+    # Legacy + filter-pill variants expose the clear button via aria-label;
+    # the v3 form variant uses an explicit "Clear" text button.
+    clear_selector =
+      if has_element?(view, "[aria-label='Clear location']") do
+        "[aria-label='Clear location']"
+      else
+        "[data-testid='location-selected'] [phx-click='clear']"
+      end
+
+    view |> element(clear_selector) |> render_click()
 
     Map.merge(context, %{session: session, conn: session})
   end

--- a/test/features/step_definitions/password_authentication_steps.exs
+++ b/test/features/step_definitions/password_authentication_steps.exs
@@ -135,13 +135,13 @@ defmodule PasswordAuthenticationSteps do
         Enum.reduce(table_rows, sess, fn [field, value], s ->
           case field do
             "current_password" ->
-              fill_in(s, "Current Password", with: value)
+              fill_in(s, "Current password", with: value)
 
             "password" ->
-              fill_in(s, "New Password", with: value)
+              fill_in(s, "New password", with: value)
 
             "password_confirmation" ->
-              fill_in(s, "Confirm New Password", with: value)
+              fill_in(s, "Confirm new password", with: value)
 
             _ ->
               s
@@ -161,9 +161,9 @@ defmodule PasswordAuthenticationSteps do
       within(session, "#password-form", fn s ->
         # Try both possible button texts
         try do
-          click_button(s, "Set Password")
+          click_button(s, "Set password")
         rescue
-          _ -> click_button(s, "Update Password")
+          _ -> click_button(s, "Update password")
         end
       end)
 

--- a/test/features/step_definitions/profile_picture_steps.exs
+++ b/test/features/step_definitions/profile_picture_steps.exs
@@ -36,12 +36,12 @@ defmodule ProfilePictureSteps do
 
   # Then steps
   step "I should see the avatar fallback showing initials", context do
-    # The avatar component shows initials when no profile picture is set
-    # Verify no thumbnail image is shown in the main content area
+    # The v3 .big-avatar shows initials when no profile picture is set.
+    # Verify no thumbnail image is shown in the main content area, then
+    # confirm the initials "AU" (Alice User) appear in the fallback avatar.
     session = context[:session] || context[:conn]
     refute_has(session, "main img[src*='_thumb.jpg']")
-    # Verify we see the initials "AU" (Alice User) in the avatar
-    assert_has(session, "[class*='overflow-hidden']", text: "AU")
+    assert_has(session, "main .big-avatar", text: "AU")
     context
   end
 

--- a/test/features/user_profile.feature
+++ b/test/features/user_profile.feature
@@ -12,28 +12,28 @@ Feature: User Profile Management
 
   Scenario: Viewing my profile
     When I visit "/profile"
-    Then I should see "Profile Settings"
+    Then I should see "Profile"
     And I should see my current display name
     And I should see "alice@example.com"
 
   Scenario: Updating my display name
     Given I am on my profile page
-    When I fill in "Display Name" with "Alice Cooper"
-    And I click the "Save Changes" button
+    When I fill in "Display name" with "Alice Cooper"
+    And I click the "Save changes" button
     Then I should see "Display name updated successfully"
     And the display name field should contain "Alice Cooper"
 
   Scenario: Display name validation - empty
     Given I am on my profile page
-    When I fill in "Display Name" with ""
-    And I click the "Save Changes" button
+    When I fill in "Display name" with ""
+    And I click the "Save changes" button
     Then I should see "Failed to update display name. Please check the errors below."
     And I should not see "Display name updated successfully"
 
   Scenario: Display name validation - too long
     Given I am on my profile page
-    When I fill in "Display Name" with "This is a very long display name that definitely exceeds the seventy character maximum length allowed"
-    And I click the "Save Changes" button
+    When I fill in "Display name" with "This is a very long display name that definitely exceeds the seventy character maximum length allowed"
+    And I click the "Save changes" button
     Then I should see "Failed to update display name. Please check the errors below."
     And I should not see "Display name updated successfully"
 
@@ -41,8 +41,8 @@ Feature: User Profile Management
     When I visit "/"
     Then I should see "huddlz"
     When I visit "/profile"
-    Then I should see "Profile Settings"
-    And I should see "Manage your profile information"
+    Then I should see "Profile"
+    And I should see "How you show up in huddlz"
 
   Scenario: Setting home location with autocomplete
     Given I am on my profile page

--- a/test/huddlz_web/components/v3_test.exs
+++ b/test/huddlz_web/components/v3_test.exs
@@ -79,6 +79,21 @@ defmodule HuddlzWeb.V3Test do
       assert link =~ ~s(href="/discover")
       assert link =~ "btn-secondary"
     end
+
+    test "honors type=\"submit\" from the caller" do
+      # Regression: `type` used to be declared in the `:rest` global include,
+      # so an explicit `type="submit"` from the caller was silently overridden
+      # by the component's default `type="button"`. Profile forms looked
+      # rendered but didn't actually submit.
+      assigns = %{}
+
+      submit = rendered_to_string(~H|<.v3_button type="submit">Save</.v3_button>|)
+      default = rendered_to_string(~H"<.v3_button>Cancel</.v3_button>")
+
+      assert submit =~ ~s(type="submit")
+      refute submit =~ ~s(type="button")
+      assert default =~ ~s(type="button")
+    end
   end
 
   describe "v3_panel/1" do

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -29,6 +29,38 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> assert_has(".sb-item.active", text: "Profile")
     end
 
+    test "sidebar shows initials when the user has no profile picture", %{
+      conn: conn,
+      user: user
+    } do
+      # Test User → "TU"
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> assert_has("aside.sidebar .sb-user .avatar", text: "TU")
+      |> refute_has("aside.sidebar .sb-user img.avatar")
+    end
+
+    test "sidebar shows the uploaded image when the user has a profile picture",
+         %{conn: conn, user: user} do
+      Huddlz.Accounts.create_profile_picture!(
+        %{
+          filename: "avatar.jpg",
+          content_type: "image/jpeg",
+          size_bytes: 1000,
+          storage_path: "/uploads/profile_pictures/#{user.id}/avatar.jpg",
+          thumbnail_path: "/uploads/profile_pictures/#{user.id}/avatar_thumb.jpg",
+          user_id: user.id
+        },
+        actor: user
+      )
+
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> assert_has("aside.sidebar .sb-user img.avatar[src*='_thumb.jpg']")
+    end
+
     test "displays user profile when authenticated", %{conn: conn, user: user} do
       conn
       |> login(user)

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -20,13 +20,21 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> assert_path("/sign-in")
     end
 
+    test "renders v3 chrome with Profile sidebar item active", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> assert_has("h1", text: "Profile")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".sb-item.active", text: "Profile")
+    end
+
     test "displays user profile when authenticated", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/profile")
-      |> assert_has("h1", text: "Profile Settings")
-      |> assert_has("h2", text: "Display Name")
-      |> assert_has("*", text: user.display_name)
+      |> assert_has("h1", text: "Profile")
+      |> assert_has(".panel-head h2", text: "Account information")
       |> assert_has("*", text: to_string(user.email))
     end
 
@@ -36,7 +44,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> visit("/profile")
       |> assert_has("form")
       |> assert_has("input[name=\"form[display_name]\"]")
-      |> assert_has("button[type=\"submit\"]", text: "Save Changes")
+      |> assert_has("button[type=\"submit\"]", text: "Save changes")
     end
 
     test "updates display name successfully", %{conn: conn, user: user} do
@@ -45,8 +53,8 @@ defmodule HuddlzWeb.ProfileLiveTest do
       conn
       |> login(user)
       |> visit("/profile")
-      |> fill_in("Display Name", with: new_name)
-      |> click_button("Save Changes")
+      |> fill_in("Display name", with: new_name)
+      |> click_button("Save changes")
       |> assert_has("*", text: "Display name updated successfully")
       |> assert_has(~s|input[name="form[display_name]"][value="#{new_name}"]|)
     end
@@ -59,22 +67,22 @@ defmodule HuddlzWeb.ProfileLiveTest do
 
       # Test empty (not allowed)
       session
-      |> fill_in("Display Name", with: "")
-      |> click_button("Save Changes")
+      |> fill_in("Display name", with: "")
+      |> click_button("Save changes")
       |> assert_has("*", text: "Failed to update display name")
 
       # Test too long (> 30 chars)
       long_name = String.duplicate("a", 31)
 
       session
-      |> fill_in("Display Name", with: long_name)
-      |> click_button("Save Changes")
+      |> fill_in("Display name", with: long_name)
+      |> click_button("Save changes")
       |> assert_has("*", text: "Failed to update display name")
 
       # Test single character (should be allowed)
       session
-      |> fill_in("Display Name", with: "A")
-      |> click_button("Save Changes")
+      |> fill_in("Display name", with: "A")
+      |> click_button("Save changes")
       |> assert_has("*", text: "Display name updated successfully")
     end
 
@@ -82,7 +90,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
       conn
       |> login(user)
       |> visit("/profile")
-      |> fill_in("Display Name", with: "")
+      |> fill_in("Display name", with: "")
       |> assert_has("form")
     end
   end
@@ -92,7 +100,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
       conn
       |> login(user)
       |> visit("/profile")
-      |> assert_has("h2", text: "Home Location")
+      |> assert_has(".panel-head h2", text: "Home location")
       |> assert_has("#profile-location")
     end
 


### PR DESCRIPTION
## Summary
- Replaces the legacy `Layouts.app` chrome on `/profile` with `Layouts.v3_app`; rebuilds the page as four v3 panels (Profile picture, Account information, Home location, Password) using `v3_input` / `v3_button`.
- Adds a local `big_avatar/1` component that renders the uploaded thumbnail or initial-based fallback inside the v3 `.big-avatar` square.
- Fixes `v3_button` so `type=\"submit\"` actually reaches the DOM — previously `type` was declared inside the `:rest` global include, which caused the explicit `type={@type}` (defaulting to `\"button\"`) to win and silently override the caller's `type=\"submit\"`. This is why both profile forms looked rendered but weren't submitting.
- Updates the unit test + cucumber features whose copy moved (`Profile Settings` → `Profile`, `Save Changes` → `Save changes`, password label/buttons sentence-cased, fallback-avatar step looks at `.big-avatar` instead of `[class*='overflow-hidden']`). The `Notification preferences` link on the profile page is gone in the mockup, so the corresponding cucumber scenario now navigates via the sidebar's `Settings` item.

Phase 2 of the v3 migration plan — PR-2.7. After this only `/profile/notifications` (PR-2.8) remains before Phase 2 wraps.

## Test plan
- [x] \`mix precommit\` — 1291 tests, 0 failures; credo clean.
- [x] Browser-verified the page in v3 chrome (sidebar present, \"Profile\" item active, all four panels render with correct h2s, both forms expose \`button[type=\"submit\"]\`).
- [ ] Smoke-test display-name save, password change, location autocomplete, and avatar upload + remove on the deployed branch.