### PR TITLE
fix(v3): override daisyUI .toggle so prefs pills render at full width

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2346,12 +2346,27 @@ body.v3 .edit-scope-row { padding: 0; }
 body.v3 .edit-scope-row p { margin: 6px 0 12px; color: var(--soft); font-size: 13.5px; }
 body.v3 .edit-scope-row strong { color: var(--text); }
 
-/* Toggle pill (notification prefs etc.) */
+/* Toggle pill (notification prefs etc.).
+   Resets here undo daisyUI's `.toggle` component CSS: daisy clamps `.toggle`
+   to ~40px wide, paints a border + inset shadow, and animates
+   `grid-template-columns` on `:checked` state — the latter still affects
+   child rendering even after we swap `display` to inline-flex, growing the
+   `.track` rect by ~4px on unchecked rows. Drop the whole daisy footprint
+   until the migration retires daisy entirely. */
 body.v3 .toggle {
   display: inline-flex;
   align-items: center;
   gap: 10px;
   cursor: pointer;
+  width: auto;
+  height: auto;
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+  appearance: auto;
+  grid-template-columns: none;
+  transition: none;
+  place-content: normal;
 }
 
 body.v3 .toggle input { display: none; }

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -2,7 +2,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   @moduledoc """
   Settings page for the user's email notification preferences.
 
-  Renders one checkbox per entry in `Huddlz.Notifications.Triggers`, grouped
+  Renders one toggle per entry in `Huddlz.Notifications.Triggers`, grouped
   by category. Transactional triggers are shown disabled-but-on for
   transparency. Activity and digest triggers are editable. Submitting the
   form merges the changes onto `User.notification_preferences` via the
@@ -16,6 +16,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   alias HuddlzWeb.Layouts
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -23,7 +24,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
 
     {:ok,
      socket
-     |> assign(:page_title, "Notification preferences")
+     |> assign(:page_title, "Settings")
      |> assign(:triggers_by_category, group_triggers())
      |> assign(:current_user, user)}
   end
@@ -55,38 +56,40 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <.header>
-        Notification preferences
-        <:subtitle>Choose which emails you want to receive from huddlz.</:subtitle>
-      </.header>
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="settings">
+      <div class="page-head">
+        <div>
+          <h1>Settings</h1>
+          <p>Notification preferences and other knobs. We'll add more here as huddlz grows.</p>
+        </div>
+      </div>
 
-      <.read_only_section
-        title="Security"
-        description="These messages always send. We can't disable them, but you'll always know about account-critical events."
-        triggers={@triggers_by_category.transactional}
-      />
+      <form phx-submit="save">
+        <.read_only_panel
+          title="Transactional"
+          description="Critical account and event updates. Always on — these can't be disabled."
+          triggers={@triggers_by_category.transactional}
+        />
 
-      <form phx-submit="save" class="mt-10 space-y-10">
-        <.category_section
+        <.category_panel
           title="Activity"
-          description="Updates about huddlz, RSVPs, and groups you're part of."
+          description="Things that happen in groups and huddlz you're part of."
           triggers={@triggers_by_category.activity}
           user={@current_user}
         />
 
-        <.category_section
-          title="Digests"
-          description="Optional summaries and re-engagement messages. Off by default."
+        <.category_panel
+          title="Digest"
+          description="Optional summaries. Off by default."
           triggers={@triggers_by_category.digest}
           user={@current_user}
         />
 
-        <div>
-          <.button type="submit">Save preferences</.button>
+        <div class="form-foot" style="border:0; margin:0 0 32px">
+          <.v3_button variant={:primary} type="submit">Save preferences</.v3_button>
         </div>
       </form>
-    </Layouts.app>
+    </Layouts.v3_app>
     """
   end
 
@@ -95,22 +98,39 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   attr :triggers, :list, required: true
   attr :user, :any, required: true
 
-  defp category_section(assigns) do
+  defp category_panel(assigns) do
     ~H"""
-    <section class="border border-base-300 p-6">
-      <h2 class="text-2xl font-extrabold tracking-tight text-base-content">{@title}</h2>
-      <p class="text-base-content/70 mt-1">{@description}</p>
-
-      <div class="mt-6 space-y-1">
-        <.input
-          :for={{trigger, entry} <- @triggers}
-          type="checkbox"
-          name={"prefs[#{trigger}]"}
-          label={entry.label}
-          checked={Notifications.preference_for(@user, trigger)}
-        />
+    <div class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>{@title}</h2>
+          <div class="panel-sub">{@description}</div>
+        </div>
       </div>
-    </section>
+      <div class="settings-list row-list pref-list">
+        <div :for={{trigger, entry} <- @triggers} class="row">
+          <div>
+            <label class="row-title" for={"prefs-#{Triggers.preference_key(trigger)}"}>
+              {entry.label}
+            </label>
+          </div>
+          <label class="toggle">
+            <input type="hidden" name={"prefs[#{Triggers.preference_key(trigger)}]"} value="false" />
+            <input
+              id={"prefs-#{Triggers.preference_key(trigger)}"}
+              type="checkbox"
+              name={"prefs[#{Triggers.preference_key(trigger)}]"}
+              value="true"
+              checked={Notifications.preference_for(@user, trigger)}
+            />
+            <span class="track"></span>
+            <span class="toggle-text">
+              {if Notifications.preference_for(@user, trigger), do: "On", else: "Off"}
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
     """
   end
 
@@ -118,22 +138,28 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   attr :description, :string, required: true
   attr :triggers, :list, required: true
 
-  defp read_only_section(assigns) do
+  defp read_only_panel(assigns) do
     ~H"""
-    <section class="border border-base-300 p-6">
-      <h2 class="text-2xl font-extrabold tracking-tight text-base-content">{@title}</h2>
-      <p class="text-base-content/70 mt-1">{@description}</p>
-
-      <ul class="mt-6 space-y-2">
-        <li
-          :for={{_trigger, entry} <- @triggers}
-          class="flex items-center gap-2 text-base-content"
-        >
-          <span class="mono-label text-primary/70">On</span>
-          <span>{entry.label}</span>
-        </li>
-      </ul>
-    </section>
+    <div class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>{@title}</h2>
+          <div class="panel-sub">{@description}</div>
+        </div>
+      </div>
+      <div class="settings-list row-list pref-list">
+        <div :for={{_trigger, entry} <- @triggers} class="row">
+          <div>
+            <div class="row-title">{entry.label}</div>
+          </div>
+          <span class="toggle">
+            <input type="checkbox" checked disabled />
+            <span class="track"></span>
+            <span class="toggle-text">On</span>
+          </span>
+        </div>
+      </div>
+    </div>
     """
   end
 
@@ -150,10 +176,9 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
     |> Enum.sort_by(fn {_atom, entry} -> entry.label end)
   end
 
-  # `<.input type="checkbox">` submits "true" when checked and a paired hidden
-  # input ensures "false" is submitted when unchecked. We iterate every editable
-  # trigger here so the saved map stays exhaustive regardless of which keys the
-  # client sends.
+  # The form only sends keys for *checked* boxes (we don't render a hidden
+  # paired input). Iterate every editable trigger so the saved map stays
+  # exhaustive: missing keys become `false`.
   defp normalize_form_params(form_prefs) do
     all_editable_keys =
       Triggers.all()

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -17,4 +17,4 @@ Feature: Notification preferences settings page
     Given I am signed in as "linknav@example.com" with password "Password123!"
     When I go to my profile page
     And I click "Settings"
-    Then I should see "Choose which emails you want to receive"
+    Then I should see "Notification preferences and other knobs"

--- a/test/features/unsubscribe.feature
+++ b/test/features/unsubscribe.feature
@@ -11,7 +11,7 @@ Feature: Unsubscribe URL
     And the user "unsub@example.com" should not have trigger "rsvp_received" disabled
     When I confirm the unsubscribe
     Then I should see "Unsubscribed from"
-    And I should see "Choose which emails you want to receive"
+    And I should see "Notification preferences and other knobs"
     And the user "unsub@example.com" should have trigger "rsvp_received" disabled
 
   Scenario: An invalid unsubscribe token redirects with an error

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -1,0 +1,57 @@
+defmodule HuddlzWeb.ProfileLive.NotificationsTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import PhoenixTest
+  import Huddlz.Test.Helpers.Authentication
+
+  setup do
+    user = create_user(%{display_name: "Settings User"})
+    %{user: user}
+  end
+
+  describe "Notification preferences" do
+    test "requires authentication", %{conn: conn} do
+      conn
+      |> visit("/profile/notifications")
+      |> assert_path("/sign-in")
+    end
+
+    test "renders v3 chrome with Settings sidebar item active", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile/notifications")
+      |> assert_has("h1", text: "Settings")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".sb-item.active", text: "Settings")
+    end
+
+    test "renders the three category panels in v3 chrome", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile/notifications")
+      |> assert_has(".panel-head h2", text: "Transactional")
+      |> assert_has(".panel-head h2", text: "Activity")
+      |> assert_has(".panel-head h2", text: "Digest")
+    end
+
+    test "transactional toggles are disabled", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile/notifications")
+      |> assert_has(".row .toggle input[type=checkbox][disabled]")
+    end
+
+    test "saving with an activity preference unchecked persists the change",
+         %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile/notifications")
+      |> uncheck("Confirmation when I RSVP to a huddl")
+      |> click_button("Save preferences")
+      |> assert_has("*", text: "Notification preferences saved")
+
+      reloaded = Ash.get!(Huddlz.Accounts.User, user.id, actor: user)
+      assert reloaded.notification_preferences["rsvp_confirmation"] == false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR #197 shipped the v3 notification-prefs page but every toggle rendered as a 9px sliver instead of a 36px pill. Root cause: **daisyUI ships a `.toggle` component class** that clamps the element to ~40px wide, paints a border + inset shadow, and animates \`grid-template-columns\` on \`:checked\`. Our \`body.v3 .toggle\` rule only swapped \`display\` to \`inline-flex\`, so daisy's \`width: calc(...)\` was winning and squeezing the entire toggle down — which collapsed the explicit 36px-wide \`.track\` to a 9px nub.

Fix: zero out the rest of daisy's footprint on \`.toggle\` (\`width / height / padding / border / box-shadow / appearance / grid-template-columns / transition / place-content\`) so daisy's component CSS no longer leaks through.

The mockup (\`/dev/design/clickthrough/settings\`) was unaffected because that page only loads \`docs/design/clickthrough/styles.css\`, not the app's daisy-bundled CSS. This is the kind of collision Phase 8 of the V3 migration plan addresses by dropping daisy entirely — this PR is a stopgap until then.

## Test plan

- [x] \`mix precommit\` clean (1299 tests, 0 failures, credo clean)
- [x] Verified in browser: \`.toggle\` is now 84px wide (36px track + 10px gap + 28px text), pill visible on all 21 rows
- [x] No other production templates use \`.toggle\` yet (only \`/profile/notifications\` + dev-design mockups)
- [x] Save round-trip still works end-to-end