### PR TITLE
feat(v3): rename sidebar Explore nav item to Discover

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -330,7 +330,7 @@ defmodule HuddlzWeb.Layouts do
         <nav class="sb-nav">
           <a class={["sb-item", @active == "discover" && "active"]} href="/discover">
             <.v3_nav_icon name="search" />
-            <span class="label">Explore</span>
+            <span class="label">Discover</span>
           </a>
           <a class={["sb-item", @active == "my-huddlz" && "active"]} href="/my-huddlz">
             <.v3_nav_icon name="ticket" />

--- a/lib/huddlz_web/controllers/dev_design_html.ex
+++ b/lib/huddlz_web/controllers/dev_design_html.ex
@@ -59,7 +59,7 @@ defmodule HuddlzWeb.DevDesignHTML do
                 >
                   <circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" />
                 </svg>
-                <span class="label">Explore</span>
+                <span class="label">Discover</span>
               </a>
               <a
                 class={["sb-item", @active == "my-huddlz" && "active"]}


### PR DESCRIPTION
## Summary

- Sidebar label \"Explore\" → \"Discover\" so the nav text matches the route (`/discover`).
- Same swap in the clickthrough mockup (`dev_design_html.ex`) so the design source stays in sync.

## Test plan

- [x] \`mix precommit\` clean (1299 tests, credo clean)
- [x] Manual check on /discover — sidebar shows \"Discover\" and highlights when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)