### PR TITLE
feat(v3): migrate /groups/new to v3 chrome

### DIFF
--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -19,15 +19,13 @@ defmodule HuddlzWeb.GroupLive.New do
   alias Huddlz.Storage.GroupImages
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.Live.Helpers.ImageUploadPipeline
-  alias HuddlzWeb.Live.Helpers.ModalLocationHelpers
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(_params, _session, socket) do
-    # Check if user can create groups
     if Ash.can?({Group, :create_group}, socket.assigns.current_user) do
-      # Create a new changeset for the form
       form =
         AshPhoenix.Form.for_create(Group, :create_group,
           actor: socket.assigns.current_user,
@@ -42,7 +40,6 @@ defmodule HuddlzWeb.GroupLive.New do
        |> assign(:pending_image_id, nil)
        |> assign(:pending_preview_url, nil)
        |> assign(:selected_location_data, nil)
-       |> ModalLocationHelpers.init()
        |> assign(:upload_processing, false)
        |> allow_upload(:group_image,
          accept: ~w(.jpg .jpeg .png .webp),
@@ -57,17 +54,6 @@ defmodule HuddlzWeb.GroupLive.New do
        |> put_flash(:error, "You need to be logged in to create groups")
        |> redirect(to: ~p"/discover?#{[scope: "groups"]}")}
     end
-  end
-
-  @impl true
-  def handle_params(_params, _uri, socket) do
-    socket =
-      case socket.assigns.live_action do
-        :new_location -> ModalLocationHelpers.clear(socket)
-        _ -> socket
-      end
-
-    {:noreply, socket}
   end
 
   defp handle_upload_progress(:group_image, entry, socket) do
@@ -136,34 +122,9 @@ defmodule HuddlzWeb.GroupLive.New do
   end
 
   @impl true
-  def handle_event("clear_location", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:selected_location_data, nil)
-     |> apply_group_location_to_form("")}
-  end
-
-  @impl true
-  def handle_event("select_modal_location", _params, socket) do
-    location_data = %{
-      display_text: socket.assigns.modal_location_address,
-      latitude: socket.assigns.modal_location_lat,
-      longitude: socket.assigns.modal_location_lng
-    }
-
-    {:noreply,
-     socket
-     |> assign(:selected_location_data, location_data)
-     |> apply_group_location_to_form(location_data.display_text)
-     |> push_patch(to: ~p"/groups/new")}
-  end
-
-  @impl true
   def handle_event("save", params, socket) do
-    # Extract form params, handling both wrapped and unwrapped formats
     form_params = Map.get(params, "form", params)
 
-    # Add the current user as the owner and inject location from modal selection
     params_with_owner =
       form_params
       |> Map.put("owner_id", socket.assigns.current_user.id)
@@ -177,7 +138,6 @@ defmodule HuddlzWeb.GroupLive.New do
            before_submit: prepare_source_with_coordinates(socket.assigns.selected_location_data)
          ) do
       {:ok, group} ->
-        # Assign pending image to the new group if one was uploaded
         assign_pending_image_to_group(socket, group)
 
         {:noreply,
@@ -191,13 +151,25 @@ defmodule HuddlzWeb.GroupLive.New do
   end
 
   @impl true
-  def handle_info({:location_selected, "modal-location-autocomplete", payload}, socket) do
-    {:noreply, ModalLocationHelpers.apply_selected(socket, payload)}
+  def handle_info({:location_selected, "group-location", payload}, socket) do
+    location_data = %{
+      display_text: payload.display_text,
+      latitude: payload.latitude,
+      longitude: payload.longitude
+    }
+
+    {:noreply,
+     socket
+     |> assign(:selected_location_data, location_data)
+     |> apply_group_location_to_form(location_data.display_text)}
   end
 
   @impl true
-  def handle_info({:location_cleared, "modal-location-autocomplete"}, socket) do
-    {:noreply, ModalLocationHelpers.clear(socket)}
+  def handle_info({:location_cleared, "group-location"}, socket) do
+    {:noreply,
+     socket
+     |> assign(:selected_location_data, nil)
+     |> apply_group_location_to_form("")}
   end
 
   defp assign_pending_image_to_group(socket, group) do
@@ -217,205 +189,182 @@ defmodule HuddlzWeb.GroupLive.New do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <.header>
-        Create a New Group
-        <:subtitle>Create a group to organize huddlz and connect with others</:subtitle>
-      </.header>
-
-      <form id="group-form" phx-change="validate" phx-submit="save" class="space-y-6">
-        <.input field={@form[:name]} type="text" label="Group Name" autocomplete="off" required />
-
-        <div class="border border-base-300 p-4 bg-base-200/50">
-          <p class="text-sm text-base-content/60">
-            Your group will be available at:
-          </p>
-          <p class="font-mono text-sm mt-1 break-all">
-            {url(~p"/groups/#{@form[:slug].value || "..."}")}
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="my-groups">
+      <div class="page-head">
+        <div>
+          <h1>Create a group</h1>
+          <p>
+            Groups are where huddlz live. Set the name, decide who can see it, and you can invite members or schedule your first huddl in a minute.
           </p>
         </div>
+      </div>
 
-        <.input field={@form[:description]} type="textarea" label="Description" />
-
-        <div>
-          <label class="mono-label text-primary/70 mb-1.5 block">Location</label>
-          <%= if @selected_location_data do %>
-            <div class="flex items-center h-10 pl-6 border-0 border-b border-primary/50 bg-transparent group relative">
-              <.icon
-                name="hero-map-pin"
-                class="absolute left-0 top-1/2 -translate-y-1/2 w-4 h-4 text-primary"
+      <.form for={@form} id="group-form" phx-change="validate" phx-submit="save">
+        <div class="panel">
+          <div class="panel-head">
+            <h2>The basics</h2>
+          </div>
+          <div class="form-grid">
+            <.v3_input
+              field={@form[:name]}
+              label="Group name"
+              placeholder="e.g. Phoenix Elixir Meetup"
+              autocomplete="off"
+              help={"3–100 characters. Your group lives at #{url(~p"/groups/#{@form[:slug].value || "your-group"}")}"}
+            />
+            <.v3_textarea
+              field={@form[:description]}
+              label="Description"
+              placeholder="Tell people what your group is about, what huddlz to expect, and who should join."
+              help="Up to 5,000 characters."
+            />
+            <div class="form-row">
+              <label class="form-label" for="group-location-input">Location</label>
+              <.live_component
+                module={HuddlzWeb.Live.LocationAutocomplete}
+                id="group-location"
+                variant={:v3_form}
+                field_name="form[location]"
+                value={@form[:location].value}
+                latitude={@selected_location_data && @selected_location_data.latitude}
+                longitude={@selected_location_data && @selected_location_data.longitude}
+                placeholder="Search for a city"
+                types={["locality", "sublocality", "administrative_area_level_2"]}
+                fetch_coordinates={true}
+                show_clear={true}
               />
-              <.link
-                patch={~p"/groups/new/locations/new"}
-                class="flex items-center flex-1 min-w-0 cursor-pointer"
-              >
-                <span class="text-sm text-base-content truncate flex-1">
-                  {@selected_location_data.display_text}
-                </span>
-                <.icon
-                  name="hero-pencil"
-                  class="w-3.5 h-3.5 ml-2 text-transparent group-hover:text-primary/50 transition-colors"
-                />
-              </.link>
-              <button
-                type="button"
-                phx-click="clear_location"
-                class="ml-2 text-base-content/40 hover:text-error transition-colors"
-              >
-                <.icon name="hero-x-mark" class="w-4 h-4" />
-              </button>
+              <p class="form-help">
+                Optional. Helps people find your group when they search nearby.
+              </p>
             </div>
-          <% else %>
-            <.link
-              patch={~p"/groups/new/locations/new"}
-              class="flex items-center h-10 pl-6 border-0 border-b border-base-300 bg-transparent hover:border-primary/50 transition-colors relative"
-            >
-              <.icon
-                name="hero-map-pin"
-                class="absolute left-0 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/40"
-              />
-              <span class="text-sm text-base-content/50">Search for a city or region...</span>
-            </.link>
-          <% end %>
+          </div>
         </div>
 
-        <div>
-          <label class="mono-label text-primary/70 mb-2 block">
-            Group Image
-          </label>
-          <p class="text-base-content/50 text-sm mb-3">
-            Upload a banner image for your group (16:9 ratio recommended).
-          </p>
-
-          <div
-            class="border border-dashed border-base-300 p-4 text-center hover:border-primary transition-colors"
-            phx-drop-target={@uploads.group_image.ref}
-          >
-            <.live_file_input upload={@uploads.group_image} class="hidden" />
-            <label for={@uploads.group_image.ref} class="cursor-pointer flex flex-col items-center">
-              <.icon name="hero-photo" class="w-8 h-8 text-base-content/50 mb-2" />
-              <span class="text-sm text-base-content/50">
-                Click to upload or drag and drop
-              </span>
-              <span class="text-xs text-base-content/50 mt-1">
-                JPG, PNG, or WebP (max 5MB)
-              </span>
-            </label>
+        <div class="panel">
+          <div class="panel-head">
+            <h2>Cover image</h2>
           </div>
 
-          <%= if @image_error do %>
-            <p class="text-error text-sm mt-2">{@image_error}</p>
-          <% end %>
-
           <%= if @pending_preview_url do %>
-            <div class="mt-3 flex items-center gap-3 p-3 bg-base-200">
-              <img src={@pending_preview_url} class="w-32 aspect-video object-cover" alt="Preview" />
-              <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium text-success flex items-center gap-1">
-                  <.icon name="hero-check-circle" class="w-4 h-4" /> Image uploaded
-                </p>
-              </div>
-              <button
-                type="button"
-                phx-click="cancel_pending_image"
-                class="p-1 hover:bg-base-300 text-base-content/50 hover:text-base-content transition-colors"
+            <div class="image-preview">
+              <div
+                class="card-cover"
+                style={"height:140px; background-image: url('#{@pending_preview_url}')"}
               >
-                <.icon name="hero-x-mark" class="w-4 h-4" />
-              </button>
+              </div>
+              <div
+                class="muted"
+                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
+              >
+                <span>Image uploaded · ready to publish.</span>
+                <.v3_button variant={:muted} type="button" phx-click="cancel_pending_image">
+                  Remove
+                </.v3_button>
+              </div>
             </div>
           <% else %>
-            <%= for entry <- @uploads.group_image.entries do %>
-              <div class="mt-3 flex items-center gap-3 p-3 bg-base-200">
-                <.live_img_preview entry={entry} class="w-32 aspect-video object-cover" />
-                <div class="flex-1 min-w-0">
-                  <p class="text-sm font-medium truncate">{entry.client_name}</p>
-                  <div class="w-full bg-base-300 h-1.5 mt-1">
-                    <div
-                      class="bg-primary h-1.5 transition-all"
-                      style={"width: #{entry.progress}%"}
-                    >
-                    </div>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  phx-click="cancel_image_upload"
-                  phx-value-ref={entry.ref}
-                  class="p-1 hover:bg-base-300 text-base-content/50 hover:text-base-content transition-colors"
+            <div class="upload-zone" phx-drop-target={@uploads.group_image.ref}>
+              <div class="upload-icon">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
                 >
-                  <.icon name="hero-x-mark" class="w-4 h-4" />
-                </button>
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <circle cx="9" cy="9" r="2" />
+                  <path d="m21 15-5-5L5 21" />
+                </svg>
+              </div>
+              <.live_file_input upload={@uploads.group_image} class="hidden" />
+              <label for={@uploads.group_image.ref} class="upload-prompt">
+                Drop a 16:9 image, or <span class="upload-link">browse</span>
+              </label>
+              <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max</div>
+            </div>
+
+            <%= for entry <- @uploads.group_image.entries do %>
+              <div class="image-preview" style="margin-top:12px">
+                <.live_img_preview entry={entry} class="card-cover-img" />
+                <div
+                  class="muted"
+                  style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
+                >
+                  <span>{entry.client_name} · {entry.progress}%</span>
+                  <.v3_button
+                    variant={:muted}
+                    type="button"
+                    phx-click="cancel_image_upload"
+                    phx-value-ref={entry.ref}
+                  >
+                    Cancel
+                  </.v3_button>
+                </div>
               </div>
 
               <%= for err <- upload_errors(@uploads.group_image, entry) do %>
-                <p class="text-error text-sm mt-1">{upload_error_to_string(err)}</p>
+                <p class="form-error">{upload_error_to_string(err)}</p>
               <% end %>
             <% end %>
           <% end %>
 
+          <p :if={@image_error} class="form-error">{@image_error}</p>
+
           <%= for err <- upload_errors(@uploads.group_image) do %>
-            <p class="text-error text-sm mt-2">{upload_error_to_string(err)}</p>
+            <p class="form-error">{upload_error_to_string(err)}</p>
           <% end %>
         </div>
 
-        <div>
-          <label class="mono-label text-primary/70 mb-2 block">
-            Privacy
-          </label>
-          <.input
-            field={@form[:is_public]}
-            type="checkbox"
-            label="Public group (visible to everyone)"
-          />
-          <p class="text-sm text-base-content/50">
-            Public groups are visible to all users. Private groups are only visible to members.
-          </p>
-        </div>
-
-        <div class="flex gap-4">
-          <.button type="submit" phx-disable-with="Creating...">Create Group</.button>
-          <.link
-            navigate={~p"/discover?#{[scope: "groups"]}"}
-            class="px-6 py-2 text-sm font-medium border border-base-300 hover:border-primary/30 transition-colors"
-          >
-            Cancel
-          </.link>
-        </div>
-      </form>
-
-      <.modal
-        :if={@live_action == :new_location}
-        id="new-location-modal"
-        show
-        on_cancel={JS.patch(~p"/groups/new")}
-      >
-        <h2 class="font-display text-xl tracking-tight text-glow mb-6">Set Location</h2>
-
-        <form phx-submit="select_modal_location">
-          <.live_component
-            module={HuddlzWeb.Live.LocationAutocomplete}
-            id="modal-location-autocomplete"
-            label="Search for a city or region"
-            placeholder="Search for a city or region..."
-            types={["locality", "sublocality", "administrative_area_level_2"]}
-            fetch_coordinates={true}
-            show_clear={true}
-          />
-
-          <div class="mt-6 flex gap-4">
-            <.button type="submit" disabled={is_nil(@modal_location_address)}>
-              Use This Location
-            </.button>
-            <.link
-              patch={~p"/groups/new"}
-              class="px-6 py-2 text-sm font-medium border border-base-300 hover:border-primary/30 transition-colors"
-            >
-              Cancel
-            </.link>
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Visibility</h2>
+              <div class="panel-sub">
+                Public groups are findable in Discover. Private groups are only visible to members.
+              </div>
+            </div>
           </div>
-        </form>
-      </.modal>
-    </Layouts.app>
+          <div class="settings-list row-list pref-list">
+            <div class="row">
+              <div>
+                <label class="row-title" for="group-is-public">Public group</label>
+                <div class="row-desc">
+                  Anyone can find and join this group. Huddlz are visible without signing in.
+                </div>
+              </div>
+              <label class="toggle">
+                <input type="hidden" name={@form[:is_public].name} value="false" />
+                <input
+                  id="group-is-public"
+                  type="checkbox"
+                  name={@form[:is_public].name}
+                  value="true"
+                  checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_public].value)}
+                />
+                <span class="track"></span>
+                <span class="toggle-text">
+                  {if Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_public].value),
+                    do: "On",
+                    else: "Off"}
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-foot" style="border:0; margin:0">
+          <.v3_button variant={:primary} type="submit" phx-disable-with="Creating…">
+            Create group
+          </.v3_button>
+          <.v3_button variant={:secondary} navigate={~p"/my-groups"}>Cancel</.v3_button>
+        </div>
+      </.form>
+    </Layouts.v3_app>
     """
   end
 end

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -210,8 +210,13 @@ defmodule HuddlzWeb.GroupLive.New do
               label="Group name"
               placeholder="e.g. Phoenix Elixir Meetup"
               autocomplete="off"
-              help={"3–100 characters. Your group lives at #{url(~p"/groups/#{@form[:slug].value || "your-group"}")}"}
+              help="3–100 characters."
             />
+            <div class="form-row">
+              <div class="form-help">
+                URL: {url(~p"/groups/#{@form[:slug].value || "..."}")}
+              </div>
+            </div>
             <.v3_textarea
               field={@form[:description]}
               label="Description"
@@ -245,8 +250,10 @@ defmodule HuddlzWeb.GroupLive.New do
             <h2>Cover image</h2>
           </div>
 
+          <.live_file_input upload={@uploads.group_image} class="hidden" />
+
           <%= if @pending_preview_url do %>
-            <div class="image-preview">
+            <div class="image-preview" phx-drop-target={@uploads.group_image.ref}>
               <div
                 class="card-cover"
                 style={"height:140px; background-image: url('#{@pending_preview_url}')"}
@@ -257,9 +264,14 @@ defmodule HuddlzWeb.GroupLive.New do
                 style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
               >
                 <span>Image uploaded · ready to publish.</span>
-                <.v3_button variant={:muted} type="button" phx-click="cancel_pending_image">
-                  Remove
-                </.v3_button>
+                <div style="display:flex; gap:8px">
+                  <label for={@uploads.group_image.ref} class="btn-secondary" style="cursor:pointer">
+                    Replace
+                  </label>
+                  <.v3_button variant={:muted} type="button" phx-click="cancel_pending_image">
+                    Remove
+                  </.v3_button>
+                </div>
               </div>
             </div>
           <% else %>
@@ -281,7 +293,6 @@ defmodule HuddlzWeb.GroupLive.New do
                   <path d="m21 15-5-5L5 21" />
                 </svg>
               </div>
-              <.live_file_input upload={@uploads.group_image} class="hidden" />
               <label for={@uploads.group_image.ref} class="upload-prompt">
                 Drop a 16:9 image, or <span class="upload-link">browse</span>
               </label>

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -107,7 +107,6 @@ defmodule HuddlzWeb.Router do
       live "/organize/members", OrganizeLive, :members
 
       # Group routes
-      live "/groups/new/locations/new", GroupLive.New, :new_location
       live "/groups/new", GroupLive.New, :new
       live "/groups/:slug/edit/locations/new", GroupLive.Edit, :new_location
       live "/groups/:slug/edit", GroupLive.Edit, :edit

--- a/test/features/global_footer.feature
+++ b/test/features/global_footer.feature
@@ -5,8 +5,12 @@ Feature: Global Footer
   So that I can find supporting pages without hunting for them
 
   Scenario: Footer surfaces grouped columns and the tagline
-    Given I am signed in as "footer.user@example.com" with password "Password123!"
-    When I visit "/groups/new"
+    Given the following users exist:
+      | email                       | role |
+      | footer.user@example.com     | user |
+    And a public group "Footer Group" exists with owner "footer.user@example.com"
+    And I am signed in as "footer.user@example.com"
+    When I visit the group page for "Footer Group"
     Then the footer should show the huddlz brand block
     And the footer should expose the Product, Help, Legal, and Open columns
     And the footer should link to GitHub and the API docs

--- a/test/features/global_header.feature
+++ b/test/features/global_header.feature
@@ -5,8 +5,12 @@ Feature: Global Header
   So that I can find huddlz from anywhere and start organizing without hunting through menus
 
   Scenario: Header chrome is visible on legacy pages
-    Given I am signed in as "header.user@example.com" with password "Password123!"
-    When I visit "/groups/new"
+    Given the following users exist:
+      | email                       | role |
+      | header.user@example.com     | user |
+    And a public group "Header Group" exists with owner "header.user@example.com"
+    And I am signed in as "header.user@example.com"
+    When I visit the group page for "Header Group"
     Then the header should show the huddlz brand
     And the header should expose a global search form posting q to /discover
     And the header should expose an Organize link to /organize
@@ -22,6 +26,10 @@ Feature: Global Header
     Then I should see huddlz matching "Elixir"
 
   Scenario: Signed-in user sees the redesigned account menu on legacy pages
-    Given I am signed in as "menu.user@example.com" with password "Password123!"
-    When I visit "/groups/new"
+    Given the following users exist:
+      | email                     | role |
+      | menu.user@example.com     | user |
+    And a public group "Menu Group" exists with owner "menu.user@example.com"
+    And I am signed in as "menu.user@example.com"
+    When I visit the group page for "Menu Group"
     Then the account menu should expose the member, organizer, and account links

--- a/test/features/group_image.feature
+++ b/test/features/group_image.feature
@@ -16,29 +16,28 @@ Feature: Group Image Management
   Scenario: Owner can see image upload area when creating a group
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    Then I should see "Group Image"
-    And I should see "Upload a banner image for your group"
-    And I should see "Click to upload or drag and drop"
-    And I should see "JPG, PNG, or WebP (max 5MB)"
+    Then I should see "Cover image"
+    And I should see "Drop a 16:9 image"
+    And I should see "JPG, PNG, WebP · 5 MB max"
 
   Scenario: Creating a group without an image
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    And I fill in "Group Name" with "No Image Group"
+    And I fill in "Group name" with "No Image Group"
     And I fill in "Description" with "A group without an image"
-    And I check "Public group (visible to everyone)"
-    And I click "Create Group"
+    And I check "Public group"
+    And I click "Create group"
     Then I should see "Group created successfully"
     And I should see "No Image Group"
 
   Scenario: Creating a group with an image upload
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    And I fill in "Group Name" with "Image Test Group"
+    And I fill in "Group name" with "Image Test Group"
     And I fill in "Description" with "A group with an image"
-    And I upload "test/fixtures/test_image.jpg" to "Group Image"
+    And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
-    When I click "Create Group"
+    When I click "Create group"
     Then I should see "Group created successfully"
     And I should see "Image Test Group"
     And the group "Image Test Group" should have an image
@@ -46,22 +45,22 @@ Feature: Group Image Management
   Scenario: Canceling a pending image before saving group
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    And I fill in "Group Name" with "Cancel Image Group"
-    And I upload "test/fixtures/test_image.jpg" to "Group Image"
+    And I fill in "Group name" with "Cancel Image Group"
+    And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
     When I cancel the pending image
     Then I should not see "Image uploaded"
-    When I click "Create Group"
+    When I click "Create group"
     Then I should see "Group created successfully"
     And the group "Cancel Image Group" should not have an image
 
   Scenario: Re-uploading replaces the pending image
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    And I fill in "Group Name" with "Replace Image Group"
-    And I upload "test/fixtures/test_image.jpg" to "Group Image"
+    And I fill in "Group name" with "Replace Image Group"
+    And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
-    When I upload "test/fixtures/test_image.jpg" to "Group Image"
+    When I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
     And there should be only one pending image for the current user
 
@@ -151,16 +150,16 @@ Feature: Group Image Management
   Scenario: Form validation errors preserve pending image
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    And I upload "test/fixtures/test_image.jpg" to "Group Image"
+    And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
-    When I click "Create Group"
+    When I click "Create group"
     Then I should see "is required"
     And I should see "Image uploaded"
 
   Scenario: Navigating away leaves orphaned pending image for cleanup
     Given I am signed in as "owner@example.com"
     When I visit "/groups/new"
-    And I upload "test/fixtures/test_image.jpg" to "Group Image"
+    And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
     When I visit "/my-groups"
     Then there should be an orphaned pending image

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -14,13 +14,13 @@ Feature: Group Management
   Scenario: Creating a public group as a verified user
     Given I am signed in as "verified@example.com"
     When I visit "/groups/new"
-    Then I should see "Create a New Group"
+    Then I should see "Create a group"
     When I fill in the following:
-      | Group Name  | Tech Enthusiasts           |
+      | Group name  | Tech Enthusiasts           |
       | Description | A group for tech lovers    |
       | Location    | San Francisco, CA          |
-    And I check "Public group (visible to everyone)"
-    And I click "Create Group"
+    And I check "Public group"
+    And I click "Create group"
     Then I should see "Group created successfully"
     And I should see "Tech Enthusiasts"
     And I should see "A group for tech lovers"
@@ -29,10 +29,10 @@ Feature: Group Management
     Given I am signed in as "admin@example.com"
     When I visit "/groups/new"
     When I fill in the following:
-      | Group Name  | Secret Society |
+      | Group name  | Secret Society |
       | Description | Private group  |
-    And I uncheck "Public group (visible to everyone)"
-    And I click "Create Group"
+    And I uncheck "Public group"
+    And I click "Create group"
     Then I should see "Group created successfully"
     And I should see "Secret Society"
     And I should see "Private"
@@ -40,8 +40,7 @@ Feature: Group Management
   Scenario: Regular users can create groups
     Given I am signed in as "regular@example.com"
     When I visit "/groups/new"
-    Then I should see "New Group"
-    And I should see "Create a New Group"
+    Then I should see "Create a group"
 
   Scenario: Viewing a public group as a visitor
     Given a public group "Book Club" exists with owner "verified@example.com"
@@ -78,5 +77,5 @@ Feature: Group Management
   Scenario: Group name is required
     Given I am signed in as "verified@example.com"
     When I visit "/groups/new"
-    And I click "Create Group"
-    Then I should see an error on the "Group Name" field
+    And I click "Create group"
+    Then I should see an error on the "Group name" field

--- a/test/features/profile_picture.feature
+++ b/test/features/profile_picture.feature
@@ -32,14 +32,16 @@ Feature: Profile Picture Management
     And I should see "Display name"
 
   Scenario: Profile picture appears in navbar when user has one
-    Given the following profile pictures exist:
+    Given a public group "Avatar Group" exists with owner "alice@example.com"
+    And the following profile pictures exist:
       | user_email          | storage_path                                      |
       | alice@example.com   | /uploads/profile_pictures/alice/avatar.jpg        |
-    When I visit "/groups/new"
+    When I visit the group page for "Avatar Group"
     Then I should see the navbar avatar with image
 
   Scenario: Navbar shows initials when user has no profile picture
-    When I visit "/groups/new"
+    Given a public group "Initials Group" exists with owner "alice@example.com"
+    When I visit the group page for "Initials Group"
     Then I should see the navbar avatar with initials "AU"
 
   Scenario: Profile picture appears in group members section

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -63,16 +63,21 @@ defmodule GroupManagementSteps do
           "Location" ->
             view = session.view
 
-            modal_path =
+            {component_id, needs_modal_submit?} =
               if editing_group,
-                do: "/groups/#{editing_group.slug}/edit/locations/new",
-                else: "/groups/new/locations/new"
+                do: {"modal-location-autocomplete", true},
+                else: {"group-location", false}
 
-            Phoenix.LiveViewTest.render_patch(view, modal_path)
+            if needs_modal_submit? do
+              Phoenix.LiveViewTest.render_patch(
+                view,
+                "/groups/#{editing_group.slug}/edit/locations/new"
+              )
+            end
 
             send(
               view.pid,
-              {:location_selected, "modal-location-autocomplete",
+              {:location_selected, component_id,
                %{
                  place_id: "test_place_id",
                  display_text: value,
@@ -83,7 +88,10 @@ defmodule GroupManagementSteps do
             )
 
             render(view)
-            Phoenix.LiveViewTest.render_submit(view, "select_modal_location", %{})
+
+            if needs_modal_submit? do
+              Phoenix.LiveViewTest.render_submit(view, "select_modal_location", %{})
+            end
 
             session
 

--- a/test/huddlz_web/live/group_live_image_test.exs
+++ b/test/huddlz_web/live/group_live_image_test.exs
@@ -27,10 +27,10 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         |> login(owner)
         |> live(~p"/groups/new")
 
-      assert has_element?(view, "label", "Group Image")
-      assert has_element?(view, "*", "Upload a banner image")
-      assert has_element?(view, "*", "Click to upload or drag and drop")
-      assert has_element?(view, "*", "JPG, PNG, or WebP (max 5MB)")
+      assert has_element?(view, ".panel-head h2", "Cover image")
+      assert has_element?(view, ".upload-zone")
+      assert has_element?(view, "*", "Drop a 16:9 image")
+      assert has_element?(view, "*", "JPG, PNG, WebP · 5 MB max")
     end
 
     test "creates group without image", %{conn: conn, owner: owner} do

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -16,23 +16,26 @@ defmodule HuddlzWeb.GroupLiveTest do
       %{admin: admin, verified: verified, regular: regular}
     end
 
-    test "renders form for users", %{conn: conn, verified: verified} do
+    test "renders v3 shell with form panels", %{conn: conn, verified: verified} do
       conn
       |> login(verified)
       |> visit(~p"/groups/new")
-      |> assert_has("h1", text: "Create a New Group")
-      |> assert_has("label", text: "Group Name")
-      |> assert_has("label", text: "Description")
-      |> assert_has("label", text: "Location")
-      |> assert_has("label", text: "Group Image")
-      |> assert_has("label", text: "Privacy")
+      |> assert_has("aside.sidebar")
+      |> assert_has("h1", text: "Create a group")
+      |> assert_has(".panel .panel-head h2", text: "The basics")
+      |> assert_has(".panel .panel-head h2", text: "Cover image")
+      |> assert_has(".panel .panel-head h2", text: "Visibility")
+      |> assert_has("label.form-label", text: "Group name")
+      |> assert_has("label.form-label", text: "Description")
+      |> assert_has("label.form-label", text: "Location")
+      |> assert_has("label.row-title", text: "Public group")
     end
 
     test "allows all users to create groups", %{conn: conn, regular: regular} do
       conn
       |> login(regular)
       |> visit(~p"/groups/new")
-      |> assert_has("h1", text: "Create a New Group")
+      |> assert_has("h1", text: "Create a group")
     end
 
     test "creates group with valid data", %{conn: conn, verified: verified} do
@@ -40,18 +43,15 @@ defmodule HuddlzWeb.GroupLiveTest do
         conn
         |> login(verified)
         |> visit(~p"/groups/new")
-        |> fill_in("Group Name", with: "Test Group")
+        |> fill_in("Group name", with: "Test Group")
         |> fill_in("Description", with: "A test group")
-        |> check("Public group (visible to everyone)")
+        |> check("Public group")
 
-      # Simulate location selection via modal
       view = session.view
-
-      Phoenix.LiveViewTest.render_patch(view, ~p"/groups/new/locations/new")
 
       send(
         view.pid,
-        {:location_selected, "modal-location-autocomplete",
+        {:location_selected, "group-location",
          %{
            place_id: "test_place_id",
            display_text: "Test City, TX, USA",
@@ -62,12 +62,10 @@ defmodule HuddlzWeb.GroupLiveTest do
       )
 
       Phoenix.LiveViewTest.render(view)
-      Phoenix.LiveViewTest.render_submit(view, "select_modal_location", %{})
 
       session
-      |> click_button("Create Group")
+      |> click_button("Create group")
 
-      # Verify group was created
       group =
         Group
         |> Ash.Query.filter(name: "Test Group")
@@ -82,9 +80,9 @@ defmodule HuddlzWeb.GroupLiveTest do
       conn
       |> login(verified)
       |> visit(~p"/groups/new")
-      |> fill_in("Group Name", with: "")
+      |> fill_in("Group name", with: "")
       |> fill_in("Description", with: "Missing name")
-      |> click_button("Create Group")
+      |> click_button("Create group")
       |> assert_has("p", text: "is required")
     end
 
@@ -92,8 +90,7 @@ defmodule HuddlzWeb.GroupLiveTest do
       conn
       |> login(verified)
       |> visit(~p"/groups/new")
-      |> fill_in("Group Name", with: "ab")
-      # PhoenixTest triggers phx-change automatically when filling fields
+      |> fill_in("Group name", with: "ab")
       |> assert_has("p", text: "length must be greater than or equal to")
     end
   end


### PR DESCRIPTION
## Summary
- Wraps `/groups/new` in `<Layouts.v3_app>` and rebuilds the form with v3 panel/form-grid primitives (`v3_input`, `v3_textarea`, `v3_button`).
- Replaces the modal-based location autocomplete with an inline `:v3_form` `LocationAutocomplete` (matching `/profile`); drops the `/groups/new/locations/new` route + `ModalLocationHelpers` usage.
- Restyles the cover-image upload zone with the v3 mockup's `.upload-zone` / `.image-preview` classes, including a Replace label that retriggers the existing upload pipeline (keeping the existing image-processing flow per the V3 plan).
- Swaps the daisy `Public group` checkbox for the v3 toggle row.
- Repoints three legacy-chrome feature scenarios (`global_footer`, `global_header`, `profile_picture` navbar) off `/groups/new` to a still-legacy `/groups/:slug` show page.

This is Phase 3 PR-3.2 in the V3 migration plan.

## Test plan
- [x] `mix precommit` — 1257 tests pass; credo clean.
- [x] Browser smoke: `/groups/new` renders v3 chrome with sidebar, three panels, slug URL updates live as the name field changes.