### PR TITLE
fix(profile-picture): route avatar URL through storage adapter

### DIFF
--- a/lib/huddlz_web/avatar.ex
+++ b/lib/huddlz_web/avatar.ex
@@ -8,9 +8,11 @@ defmodule HuddlzWeb.Avatar do
   Shared by the v3 sidebar (`.sb-user`) and the `/profile` `.big-avatar`.
   """
 
+  alias Huddlz.Storage.ProfilePictures
+
   @doc "Returns the user's current profile picture URL, or nil."
-  def picture_url(%{current_profile_picture_url: url}) when is_binary(url) and url != "",
-    do: url
+  def picture_url(%{current_profile_picture_url: path}) when is_binary(path) and path != "",
+    do: ProfilePictures.url(path)
 
   def picture_url(_), do: nil
 


### PR DESCRIPTION
## Summary
- `current_profile_picture_url` is an aggregate that returns a raw storage path (`/uploads/profile_pictures/<user>/<uuid>_thumb.jpg`), not a public URL.
- In #196's review pass, `core_components.ex`'s `get_avatar_url/1` was extracted into `HuddlzWeb.Avatar.picture_url/1` and accidentally lost the `ProfilePictures.url/1` wrapping — so the v3 sidebar and `/profile`'s big avatar started rendering the storage path as-is.
- In dev with the Local adapter this is invisible: `priv/static/uploads/...` is served by `Plug.Static` at the matching URL. In production with the S3 adapter, files live on Tigris (`https://<bucket>.<endpoint>/...`); the browser was resolving the raw path against `huddlz.com` and getting 404s for everyone's avatar.

## Test plan
- [x] `mix test test/features/profile_picture.feature.exs test/huddlz_web/live/profile_live_test.exs` (149 tests, 0 failures)
- [x] `mix test` full suite passes (1257 tests, 0 failures)
- [ ] In production, hard-refresh `/profile` and any page using the v3 sidebar — the avatar should load from the Tigris bucket URL instead of `huddlz.com/uploads/...`