### PR TITLE
feat(v3): migrate /groups/:slug/huddlz/:id to v3 chrome

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1350,6 +1350,8 @@ body.v3 .rsvp-banner {
 
 body.v3 .rsvp-banner.cyan { color: var(--cyan); border-color: rgba(24, 203, 212, 0.4); background: var(--cyan-soft); }
 body.v3 .rsvp-banner.warn { color: var(--warn); border-color: rgba(246, 193, 119, 0.35); background: rgba(246, 193, 119, 0.08); }
+body.v3 .rsvp-banner.magenta { color: var(--magenta); border-color: rgba(232, 79, 180, 0.35); background: rgba(232, 79, 180, 0.08); }
+body.v3 .rsvp-banner.muted { color: var(--muted); }
 body.v3 .rsvp-banner svg { flex: 0 0 auto; }
 
 body.v3 .virtual-hint {
@@ -1369,6 +1371,38 @@ body.v3 .btn-secondary.virtual-link {
 }
 
 body.v3 .btn-secondary.virtual-link:hover { border-color: var(--cyan); }
+
+/* Stretch RSVP-state buttons to fill the aside */
+body.v3 .rsvp-state { margin-top: 18px; display: flex; flex-direction: column; gap: 10px; }
+body.v3 .rsvp-state .btn-primary,
+body.v3 .rsvp-state .btn-secondary { width: 100%; justify-content: center; }
+body.v3 .rsvp-state .rsvp-banner { width: 100%; }
+
+/* Inline "Join virtually" link inside .facts .value */
+body.v3 .facts .value .virtual-link-text { color: var(--cyan); font-weight: 700; }
+body.v3 .facts .value .virtual-link-text:hover { text-decoration: underline; }
+body.v3 .facts .value .muted { color: var(--muted); font-weight: 500; font-size: 12px; }
+
+/* Magenta-warn destructive button (delete huddl) */
+body.v3 .btn-secondary.destructive-btn { color: var(--magenta); border-color: rgba(232, 79, 180, 0.4); }
+body.v3 .btn-secondary.destructive-btn:hover { color: var(--magenta); border-color: var(--magenta); }
+
+/* "Organized by" row in huddl-side */
+body.v3 .creator-row { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+
+/* Cancelled-hero strikethrough on title */
+body.v3 .hero.is-cancelled .hero-content h1 {
+  text-decoration: line-through;
+  text-decoration-color: rgba(232, 79, 180, 0.45);
+}
+
+/* Eyebrow color variants for huddl status */
+body.v3 .eyebrow.eyebrow-warn { color: var(--warn); }
+body.v3 .eyebrow.eyebrow-muted { color: var(--muted); opacity: 0.85; }
+body.v3 .eyebrow.eyebrow-magenta { color: var(--magenta); }
+
+/* Spacing between hero meta segments and separators */
+body.v3 .hero-content .meta .meta-sep { color: var(--muted); margin: 0 4px; }
 
 /* ─────────────────────────────────────────  CALENDAR  ────────── */
 body.v3 .cal-toolbar {

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -10,6 +10,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
   alias HuddlzWeb.MetaHelpers
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -54,222 +55,337 @@ defmodule HuddlzWeb.HuddlLive.Show do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <.header>
-        {@huddl.title}
-        <:subtitle>
-          <%= if @huddl.is_private do %>
-            <span class="text-xs px-2.5 py-1 bg-base-300 text-base-content/50 font-medium">
-              Private
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active="discover">
+      <div class={["hero", status_hero_class(@huddl.status)]}>
+        <img
+          :if={@huddl.display_image_url}
+          class="hero-img"
+          src={HuddlImages.url(@huddl.display_image_url)}
+          alt={@huddl.title}
+        />
+        <div class="hero-content">
+          <span class={["eyebrow", status_eyebrow_class(@huddl.status)]}>
+            {hero_eyebrow(@huddl)}
+          </span>
+          <h1>{@huddl.title}</h1>
+          <div class="meta">
+            <span :for={{segment, idx} <- Enum.with_index(hero_meta_segments(@huddl))}>
+              <%= if idx > 0 do %>
+                <span class="meta-sep">·</span>
+              <% end %>
+              <span>{segment}</span>
             </span>
-          <% end %>
-        </:subtitle>
-        <:actions>
-          <%= if @can_edit_huddl do %>
-            <.link
-              navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}/edit"}
-              class="inline-flex items-center gap-1.5 text-sm font-medium text-base-content/50 hover:text-base-content transition-colors"
-            >
-              <.icon name="hero-pencil" class="h-4 w-4" /> Edit Huddl
-            </.link>
-          <% end %>
-          <%= if @can_delete_huddl do %>
-            <.button
-              phx-click="delete_huddl"
-              data-confirm="Are you sure you want to delete this huddl?"
-              variant="danger"
-            >
-              <.icon name="hero-trash" class="h-4 w-4" /> Delete Huddl
-            </.button>
-          <% end %>
-          <%= if @current_user && @huddl.status == :upcoming do %>
-            <%= case @attendance do %>
-              <% :attending -> %>
-                <div class="flex items-center gap-4">
-                  <div class="text-success font-semibold">
-                    <.icon name="hero-check-circle" class="h-5 w-5 inline" /> You're attending!
-                  </div>
-                  <button
-                    phx-click="cancel_rsvp"
-                    phx-disable-with="Cancelling..."
-                    class="px-3 py-1.5 text-xs font-medium bg-error/10 text-error hover:bg-error/20 transition-colors"
-                  >
-                    Cancel RSVP
-                  </button>
-                </div>
-              <% :waitlisted -> %>
-                <div class="flex items-center gap-4">
-                  <div class="text-warning font-semibold">
-                    <.icon name="hero-clock" class="h-5 w-5 inline" />
-                    On waitlist ({@waitlist_position} of {@huddl.waitlist_count})
-                  </div>
-                  <button
-                    phx-click="leave_waitlist"
-                    phx-disable-with="Leaving..."
-                    class="px-3 py-1.5 text-xs font-medium bg-error/10 text-error hover:bg-error/20 transition-colors"
-                  >
-                    Leave Waitlist
-                  </button>
-                </div>
-              <% :none -> %>
-                <%= if event_full?(@huddl) do %>
-                  <.button phx-click="join_waitlist">
-                    Huddl Full — Join Waitlist
-                  </.button>
-                <% else %>
-                  <.button phx-click="rsvp">
-                    RSVP to this huddl
-                  </.button>
-                <% end %>
-            <% end %>
-          <% end %>
-        </:actions>
-      </.header>
+          </div>
+        </div>
+      </div>
 
-      <div class="mt-8">
-        <div class="mb-6">
-          <%= if @huddl.display_image_url do %>
-            <div class="border border-base-300 overflow-hidden">
-              <img
-                src={HuddlImages.url(@huddl.display_image_url)}
-                alt={@huddl.title}
-                class="w-full aspect-video object-cover"
-              />
-            </div>
+      <div class="huddl-frame">
+        <div class="huddl-intro prose">
+          <%= if @huddl.description do %>
+            <p :for={paragraph <- description_paragraphs(@huddl.description)}>{paragraph}</p>
           <% else %>
-            <div class="w-full aspect-video bg-base-100 border border-base-300 overflow-hidden flex items-center justify-center">
-              <span class="text-4xl font-bold text-base-content/40 text-center px-8 line-clamp-2">
-                {@huddl.title}
-              </span>
-            </div>
+            <p>No description provided.</p>
           <% end %>
         </div>
 
-        <p class="text-base-content/60">
-          {@huddl.description || "No description provided."}
-        </p>
+        <aside class="huddl-side">
+          <h3>RSVP</h3>
 
-        <%= if @huddl.max_attendees do %>
-          <div class="mt-6 border border-base-300 p-4">
-            <div class="flex items-center justify-between gap-3 text-sm">
-              <span class="font-medium flex items-center gap-2">
-                <.icon name="hero-user-group" class="h-4 w-4" />
-                {capacity_label(@huddl)}
-              </span>
-              <span class={capacity_status_class(@huddl)}>
-                {capacity_status(@huddl)}
-              </span>
-            </div>
-            <div class="mt-3 h-2 bg-base-200 overflow-hidden">
-              <div class="h-full bg-primary" style={"width: #{capacity_percent(@huddl)}%"}></div>
+          <ul class="facts">
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="9" /><path d="M12 6v6l4 2" />
+              </svg>
+              <div>
+                <div class="label">When</div>
+                <div class="value">{format_fact_when(@huddl)}</div>
+              </div>
+            </li>
+
+            <li :if={@huddl.event_type in [:in_person, :hybrid] && @huddl.physical_location}>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" />
+                <circle cx="12" cy="10" r="3" />
+              </svg>
+              <div>
+                <div class="label">Where</div>
+                <div class="value">{@huddl.physical_location}</div>
+              </div>
+            </li>
+
+            <li :if={@huddl.event_type in [:virtual, :hybrid]}>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
+              </svg>
+              <div>
+                <div class="label">Virtual access</div>
+                <div class="value">
+                  <%= cond do %>
+                    <% @huddl.status == :completed -> %>
+                      <span class="muted">Link expired</span>
+                    <% @huddl.visible_virtual_link -> %>
+                      <a class="virtual-link-text" href={@huddl.visible_virtual_link} target="_blank">
+                        Join virtually
+                      </a>
+                    <% @current_user -> %>
+                      <span class="muted">Virtual link available after RSVP</span>
+                    <% true -> %>
+                      <span class="muted">Sign in and RSVP to get virtual link</span>
+                  <% end %>
+                </div>
+              </div>
+            </li>
+
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M17 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                <circle cx="9.5" cy="7" r="4" />
+              </svg>
+              <div>
+                <div class="label">{capacity_fact_label(@huddl)}</div>
+                <div class="value">{format_fact_capacity(@huddl)}</div>
+              </div>
+            </li>
+          </ul>
+
+          <div :if={@huddl.max_attendees} class={["bar", capacity_bar_class(@huddl)]}>
+            <span style={"width:#{capacity_percent(@huddl)}%"}></span>
+          </div>
+
+          <div class="rsvp-state">
+            {render_rsvp_state(assigns)}
+          </div>
+
+          <div :if={@can_edit_huddl || @can_delete_huddl} class="huddl-side-section">
+            <h3>Organize</h3>
+            <div class="side-actions">
+              <.v3_button
+                :if={@can_edit_huddl}
+                variant={:secondary}
+                navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}/edit"}
+              >
+                Edit huddl
+              </.v3_button>
+              <.v3_button
+                :if={@can_delete_huddl}
+                variant={:destructive}
+                phx-click="delete_huddl"
+                data-confirm="Are you sure you want to delete this huddl?"
+              >
+                Delete huddl
+              </.v3_button>
             </div>
           </div>
-        <% end %>
 
-        <dl class="mt-6">
-          <div class="flex items-start gap-3 py-3">
-            <dt class="w-32 shrink-0 font-medium text-base-content/50">Status</dt>
-            <dd class={["flex items-center gap-2", status_text_class(@huddl.status)]}>
-              <.icon name={status_icon(@huddl.status)} class="h-4 w-4" />
-              {humanize(@huddl.status)}
-            </dd>
-          </div>
-
-          <div class="flex items-start gap-3 py-3">
-            <dt class="w-32 shrink-0 font-medium text-base-content/50">Type</dt>
-            <dd class="flex items-center gap-2">
-              <.icon name={type_detail_icon(@huddl.event_type)} class="h-4 w-4" />
-              {humanize(@huddl.event_type)}
-            </dd>
-          </div>
-
-          <div class="flex items-start gap-3 py-3">
-            <dt class="w-32 shrink-0 font-medium text-base-content/50">When</dt>
-            <dd class="flex items-center gap-2">
-              <.icon name="hero-calendar" class="h-4 w-4" />
-              {format_datetime(@huddl.starts_at)}
-              <%= if @huddl.ends_at do %>
-                - {format_time_only(@huddl.ends_at)}
-              <% end %>
-            </dd>
-          </div>
-
-          <%= if @huddl.event_type in [:in_person, :hybrid] && @huddl.physical_location do %>
-            <div class="flex items-start gap-3 py-3">
-              <dt class="w-32 shrink-0 font-medium text-base-content/50">Where</dt>
-              <dd class="flex items-center gap-2">
-                <.icon name="hero-map-pin" class="h-4 w-4" />
-                {@huddl.physical_location}
-              </dd>
-            </div>
-          <% end %>
-
-          <%= if @huddl.event_type in [:virtual, :hybrid] do %>
-            <div class="flex items-start gap-3 py-3">
-              <dt class="w-32 shrink-0 font-medium text-base-content/50">Virtual Access</dt>
-              <dd class="flex items-center gap-2">
-                <.icon name="hero-video-camera" class="h-4 w-4" />
-                <%= cond do %>
-                  <% @huddl.status == :completed -> %>
-                    <span class="text-base-content/50">Link expired</span>
-                  <% @huddl.visible_virtual_link -> %>
-                    <a
-                      href={@huddl.visible_virtual_link}
-                      target="_blank"
-                      class="text-primary hover:underline font-medium"
-                    >
-                      Join virtually
-                    </a>
-                  <% @current_user -> %>
-                    <span class="text-base-content/50">
-                      Virtual link available after RSVP
-                    </span>
-                  <% true -> %>
-                    <span class="text-base-content/50">
-                      Sign in and RSVP to get virtual link
-                    </span>
-                <% end %>
-              </dd>
-            </div>
-          <% end %>
-
-          <%= if @huddl.status != :completed do %>
-            <div class="flex items-start gap-3 py-3">
-              <dt class="w-32 shrink-0 font-medium text-base-content/50">Attendance</dt>
-              <dd class="flex items-center gap-2">
-                <.icon name="hero-user-group" class="h-4 w-4" />
-                <%= if @huddl.rsvp_count == 0 do %>
-                  Be the first to RSVP!
-                <% else %>
-                  {@huddl.rsvp_count} {if @huddl.rsvp_count == 1, do: "person", else: "people"} attending
-                <% end %>
-              </dd>
-            </div>
-          <% else %>
-            <div class="flex items-start gap-3 py-3">
-              <dt class="w-32 shrink-0 font-medium text-base-content/50">Attended</dt>
-              <dd class="flex items-center gap-2">
-                <.icon name="hero-user-group" class="h-4 w-4" />
-                <%= if @huddl.rsvp_count == 0 do %>
-                  No one attended
-                <% else %>
-                  {@huddl.rsvp_count} {if @huddl.rsvp_count == 1, do: "person", else: "people"} attended
-                <% end %>
-              </dd>
-            </div>
-          <% end %>
-
-          <div class="flex items-start gap-3 py-3">
-            <dt class="w-32 shrink-0 font-medium text-base-content/50">Organized by</dt>
-            <dd class="flex items-center gap-2">
+          <div class="huddl-side-section">
+            <h3>Organized by</h3>
+            <div class="creator-row">
               <.avatar user={@huddl.creator} size={:sm} />
-              {@huddl.creator.display_name || @huddl.creator.email}
-            </dd>
+              <span>{@huddl.creator.display_name || @huddl.creator.email}</span>
+            </div>
           </div>
-        </dl>
+        </aside>
       </div>
-    </Layouts.app>
+    </Layouts.v3_app>
     """
+  end
+
+  defp render_rsvp_state(%{huddl: %{status: status}} = assigns)
+       when status in [:completed, :cancelled] do
+    ~H"""
+    <div class={["rsvp-banner", status_banner_class(@huddl.status)]}>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <%= if @huddl.status == :cancelled do %>
+          <circle cx="12" cy="12" r="9" /><path d="M15 9l-6 6M9 9l6 6" />
+        <% else %>
+          <path d="M5 13l4 4L19 7" />
+        <% end %>
+      </svg>
+      <span>{status_banner_text(@huddl.status)}</span>
+    </div>
+    """
+  end
+
+  defp render_rsvp_state(%{current_user: nil} = assigns) do
+    ~H"""
+    <.v3_button variant={:primary} navigate={~p"/sign-in"} class="rsvp-cta">
+      Sign in to RSVP
+    </.v3_button>
+    """
+  end
+
+  defp render_rsvp_state(%{attendance: :attending} = assigns) do
+    ~H"""
+    <div class="rsvp-banner cyan">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M5 13l4 4L19 7" />
+      </svg>
+      <span>You're attending</span>
+    </div>
+    <a
+      :if={@huddl.visible_virtual_link}
+      class="btn-secondary virtual-link"
+      href={@huddl.visible_virtual_link}
+      target="_blank"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
+      </svg>
+      Join the online room
+    </a>
+    <.v3_button
+      variant={:muted}
+      phx-click="cancel_rsvp"
+      phx-disable-with="Cancelling..."
+      class="rsvp-cta"
+    >
+      Cancel RSVP
+    </.v3_button>
+    """
+  end
+
+  defp render_rsvp_state(%{attendance: :waitlisted} = assigns) do
+    ~H"""
+    <div class="rsvp-banner warn">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" />
+      </svg>
+      <span>On waitlist · #{@waitlist_position} of {@huddl.waitlist_count}</span>
+    </div>
+    <.v3_button
+      variant={:muted}
+      phx-click="leave_waitlist"
+      phx-disable-with="Leaving..."
+      class="rsvp-cta"
+    >
+      Leave waitlist
+    </.v3_button>
+    """
+  end
+
+  defp render_rsvp_state(assigns) do
+    if event_full?(assigns.huddl) do
+      ~H"""
+      <div class="rsvp-banner warn">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" />
+        </svg>
+        <span>This huddl is full</span>
+      </div>
+      <.v3_button variant={:primary} phx-click="join_waitlist" class="rsvp-cta">
+        Join waitlist
+      </.v3_button>
+      """
+    else
+      ~H"""
+      <.v3_button
+        variant={:primary}
+        phx-click="rsvp"
+        phx-disable-with="RSVPing..."
+        class="rsvp-cta"
+      >
+        RSVP to this huddl
+      </.v3_button>
+      <div :if={@huddl.event_type in [:virtual, :hybrid]} class="virtual-hint">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
+        </svg>
+        <span>Online link visible after you RSVP.</span>
+      </div>
+      """
+    end
   end
 
   @impl true
@@ -439,28 +555,138 @@ defmodule HuddlzWeb.HuddlLive.Show do
     end
   end
 
-  defp format_datetime(datetime) do
-    Calendar.strftime(datetime, "%B %d, %Y at %I:%M %p")
+  defp hero_eyebrow(huddl) do
+    "#{event_type_label(huddl.event_type)} · #{status_label(huddl.status)}"
+  end
+
+  defp event_type_label(:in_person), do: "In-person huddl"
+  defp event_type_label(:virtual), do: "Online huddl"
+  defp event_type_label(:hybrid), do: "Hybrid huddl"
+  defp event_type_label(_), do: "Huddl"
+
+  defp status_label(:upcoming), do: "Upcoming"
+  defp status_label(:in_progress), do: "Happening now"
+  defp status_label(:completed), do: "Completed"
+  defp status_label(:cancelled), do: "Cancelled"
+  defp status_label(other), do: to_string(other) |> String.capitalize()
+
+  defp status_hero_class(:cancelled), do: "is-cancelled"
+  defp status_hero_class(_), do: nil
+
+  defp status_eyebrow_class(:in_progress), do: "eyebrow-warn"
+  defp status_eyebrow_class(:completed), do: "eyebrow-muted"
+  defp status_eyebrow_class(:cancelled), do: "eyebrow-magenta"
+  defp status_eyebrow_class(_), do: nil
+
+  defp status_banner_class(:completed), do: "muted"
+  defp status_banner_class(:cancelled), do: "magenta"
+
+  defp status_banner_text(:completed), do: "This huddl has ended"
+  defp status_banner_text(:cancelled), do: "This huddl was cancelled"
+
+  defp hero_meta_segments(huddl) do
+    [
+      huddl.group.name,
+      hero_when_segment(huddl),
+      hero_location_segment(huddl)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp hero_when_segment(%{status: :in_progress} = huddl) do
+    if huddl.ends_at do
+      "Started #{format_time_only(huddl.starts_at)} · ends #{format_time_only(huddl.ends_at)}"
+    else
+      "Started #{format_time_only(huddl.starts_at)}"
+    end
+  end
+
+  defp hero_when_segment(%{status: :cancelled} = huddl) do
+    "Was scheduled for #{format_short_date(huddl.starts_at)}"
+  end
+
+  defp hero_when_segment(%{status: :completed} = huddl) do
+    "#{format_short_date(huddl.starts_at)} · #{huddl.rsvp_count} attended"
+  end
+
+  defp hero_when_segment(huddl) do
+    "#{format_short_date(huddl.starts_at)} · #{format_time_only(huddl.starts_at)}"
+  end
+
+  defp hero_location_segment(%{event_type: :hybrid, physical_location: loc}) when is_binary(loc),
+    do: "#{loc} · & online"
+
+  defp hero_location_segment(%{event_type: :in_person, physical_location: loc})
+       when is_binary(loc),
+       do: loc
+
+  defp hero_location_segment(%{event_type: :virtual}), do: "Online"
+  defp hero_location_segment(_), do: nil
+
+  defp format_fact_when(huddl) do
+    cond do
+      huddl.ends_at && same_day?(huddl.starts_at, huddl.ends_at) ->
+        "#{format_short_date(huddl.starts_at)} · #{format_time_only(huddl.starts_at)} – #{format_time_only(huddl.ends_at)} UTC"
+
+      huddl.ends_at ->
+        "#{format_short_date(huddl.starts_at)} #{format_time_only(huddl.starts_at)} → #{format_short_date(huddl.ends_at)} #{format_time_only(huddl.ends_at)} UTC"
+
+      true ->
+        "#{format_short_date(huddl.starts_at)} · #{format_time_only(huddl.starts_at)} UTC"
+    end
+  end
+
+  defp same_day?(%DateTime{} = a, %DateTime{} = b),
+    do: DateTime.to_date(a) == DateTime.to_date(b)
+
+  defp capacity_fact_label(%{status: :completed}), do: "Attended"
+  defp capacity_fact_label(_), do: "Capacity"
+
+  defp format_fact_capacity(%{status: :completed} = huddl) do
+    case huddl.rsvp_count do
+      0 -> "No one attended"
+      1 -> "1 person attended"
+      n -> "#{n} people attended"
+    end
+  end
+
+  defp format_fact_capacity(%{rsvp_count: 0, max_attendees: nil}), do: "Be the first to RSVP!"
+
+  defp format_fact_capacity(%{rsvp_count: count, max_attendees: nil}),
+    do: "#{count} #{person_label(count)} attending"
+
+  defp format_fact_capacity(%{max_attendees: max} = huddl) when is_integer(max) and max > 0 do
+    base = "#{huddl.rsvp_count}/#{max} spots filled · #{capacity_status(huddl)}"
+
+    case huddl.waitlist_count do
+      n when is_integer(n) and n > 0 -> "#{base} · #{n} waitlisted"
+      _ -> base
+    end
+  end
+
+  defp person_label(1), do: "person"
+  defp person_label(_), do: "people"
+
+  defp capacity_bar_class(huddl) do
+    cond do
+      event_full?(huddl) -> "warn"
+      capacity_percent(huddl) >= 80 -> "warn"
+      true -> nil
+    end
+  end
+
+  defp description_paragraphs(text) do
+    text
+    |> String.split(~r/\r?\n\r?\n/, trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp format_short_date(datetime) do
+    Calendar.strftime(datetime, "%a, %b %-d")
   end
 
   defp format_time_only(datetime) do
-    Calendar.strftime(datetime, "%I:%M %p")
+    Calendar.strftime(datetime, "%-I:%M %p")
   end
-
-  defp status_text_class(:upcoming), do: "text-primary"
-  defp status_text_class(:in_progress), do: "text-success"
-  defp status_text_class(:completed), do: "text-base-content/50"
-  defp status_text_class(:cancelled), do: "text-error"
-  defp status_text_class(_), do: ""
-
-  defp status_icon(:upcoming), do: "hero-clock"
-  defp status_icon(:in_progress), do: "hero-play-circle"
-  defp status_icon(:completed), do: "hero-check-circle"
-  defp status_icon(:cancelled), do: "hero-x-circle"
-  defp status_icon(_), do: "hero-question-mark-circle"
-
-  defp type_detail_icon(:in_person), do: "hero-map-pin"
-  defp type_detail_icon(:virtual), do: "hero-video-camera"
-  defp type_detail_icon(:hybrid), do: "hero-globe-alt"
-  defp type_detail_icon(_), do: "hero-calendar"
 end

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -148,7 +148,12 @@ defmodule HuddlzWeb.HuddlLive.Show do
                     <% @huddl.status == :completed -> %>
                       <span class="muted">Link expired</span>
                     <% @huddl.visible_virtual_link -> %>
-                      <a class="virtual-link-text" href={@huddl.visible_virtual_link} target="_blank">
+                      <a
+                        class="virtual-link-text"
+                        href={@huddl.visible_virtual_link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
                         Join virtually
                       </a>
                     <% @current_user -> %>
@@ -279,6 +284,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
       class="btn-secondary virtual-link"
       href={@huddl.visible_virtual_link}
       target="_blank"
+      rel="noopener noreferrer"
     >
       <svg
         width="14"

--- a/test/features/delete_huddl.feature
+++ b/test/features/delete_huddl.feature
@@ -16,12 +16,12 @@ Feature: Delete Huddl
   Scenario: Owner deletes an in-person huddl
     Given I am signed in as "owner@example.com"
     When I visit the "Future Workshop" huddl page
-    Then I should see "Delete Huddl"
-    When I click "Delete Huddl"
+    Then I should see "Delete huddl"
+    When I click "Delete huddl"
     Then I should be redirected to the "Tech Meetup" group page
     And I should see "Huddl deleted successfully!"
 
   Scenario: Non-owner cannot delete a huddl
     Given I am signed in as "non_owner@example.com"
     When I visit the "Future Workshop" huddl page
-    Then I should not see "Delete Huddl"
+    Then I should not see "Delete huddl"

--- a/test/features/rsvp_cancellation.feature
+++ b/test/features/rsvp_cancellation.feature
@@ -29,14 +29,14 @@ Feature: RSVP Cancellation
     
     When I click "RSVP to this huddl"
     Then I should see "Successfully RSVPed to this huddl!"
-    And I should see "You're attending!"
+    And I should see "You're attending"
     And I should see "Cancel RSVP"
     And I should see "1 person attending"
     
     When I click "Cancel RSVP"
     Then I should see "RSVP cancelled successfully"
     And I should see "RSVP to this huddl"
-    And I should not see "You're attending!"
+    And I should not see "You're attending"
     And I should see "Be the first to RSVP!"
 
   Scenario: User can RSVP again after cancelling
@@ -48,7 +48,7 @@ Feature: RSVP Cancellation
     
     When I click "RSVP to this huddl"
     Then I should see "Successfully RSVPed to this huddl!"
-    And I should see "You're attending!"
+    And I should see "You're attending"
     And I should see "1 person attending"
 
   Scenario: Multiple users can manage their RSVPs independently
@@ -65,7 +65,7 @@ Feature: RSVP Cancellation
     When I log out
     And I am logged in as "member@example.com"
     And I visit the "Virtual Code Review" huddl page
-    Then I should see "You're attending!"
+    Then I should see "You're attending"
     And I should see "1 person attending"
 
   Scenario: Cannot cancel RSVP for past events

--- a/test/features/waitlist.feature
+++ b/test/features/waitlist.feature
@@ -23,13 +23,13 @@ Feature: Waitlist
   Scenario: User joins the waitlist when the huddl is full
     Given I am logged in as "hopeful@example.com"
     When I visit the "Capped Code Review" huddl page
-    Then I should see "Huddl Full"
-    And I should see "Join Waitlist"
+    Then I should see "This huddl is full"
+    And I should see "Join waitlist"
 
-    When I click "Huddl Full — Join Waitlist"
+    When I click "Join waitlist"
     Then I should see "Added to the waitlist"
     And I should see "On waitlist"
-    And I should see "Leave Waitlist"
+    And I should see "Leave waitlist"
 
   Scenario: User leaves the waitlist
     Given I am logged in as "hopeful@example.com"
@@ -37,9 +37,9 @@ Feature: Waitlist
     When I visit the "Capped Code Review" huddl page
     Then I should see "On waitlist"
 
-    When I click "Leave Waitlist"
+    When I click "Leave waitlist"
     Then I should see "Removed from the waitlist"
-    And I should see "Join Waitlist"
+    And I should see "Join waitlist"
     And I should not see "On waitlist"
 
   Scenario: User is promoted when an attendee cancels
@@ -47,5 +47,5 @@ Feature: Waitlist
     And I have joined the waitlist for "Capped Code Review"
     When "member@example.com" cancels their RSVP to "Capped Code Review"
     And I visit the "Capped Code Review" huddl page
-    Then I should see "You're attending!"
+    Then I should see "You're attending"
     And I should not see "On waitlist"

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -597,6 +597,66 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has(".eyebrow", text: "In-person huddl")
       |> assert_has(".eyebrow", text: "Happening now")
     end
+
+    test "shows completed banner and 'attended' copy for past huddlz", %{
+      conn: conn,
+      member: member,
+      owner: owner,
+      group: group
+    } do
+      completed_huddl =
+        generate(
+          past_huddl(
+            title: "Wrapped-up workshop",
+            description: "Already happened",
+            starts_at: DateTime.add(DateTime.utc_now(), -2, :day),
+            ends_at: DateTime.add(DateTime.utc_now(), -1, :day),
+            event_type: :virtual,
+            virtual_link: "https://zoom.us/j/old",
+            is_private: false,
+            group_id: group.id,
+            creator_id: owner.id
+          )
+        )
+
+      conn
+      |> login(member)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{completed_huddl.id}")
+      |> assert_has(".eyebrow", text: "Completed")
+      |> assert_has(".rsvp-banner.muted", text: "This huddl has ended")
+      |> assert_has(".facts .label", text: "Attended")
+      |> assert_has(".facts .value .muted", text: "Link expired")
+      |> refute_has("button", text: "RSVP to this huddl")
+      |> refute_has("button", text: "Cancel RSVP")
+    end
+
+    test "hides Organize section from non-owners", %{
+      conn: conn,
+      member: member,
+      group: group,
+      huddl: huddl
+    } do
+      # "Organized by" is always shown; assert the Organize action stack is gone instead.
+      conn
+      |> login(member)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> refute_has("a", text: "Edit huddl")
+      |> refute_has("button", text: "Delete huddl")
+    end
+
+    test "shows Organize section with edit and delete for owner", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> assert_has(".huddl-side-section h3", text: "Organize")
+      |> assert_has("a", text: "Edit huddl")
+      |> assert_has("button", text: "Delete huddl")
+    end
   end
 
   defp create_verified_user do

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -73,19 +73,25 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       }
     end
 
-    test "displays huddl details", %{conn: conn, group: group, huddl: huddl} do
+    test "renders v3 chrome with hero and huddl-frame", %{
+      conn: conn,
+      member: member,
+      group: group,
+      huddl: huddl
+    } do
       conn
+      |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
-      |> assert_has("h1", text: huddl.title)
-      |> assert_has("p", text: huddl.description)
-      |> assert_has("dd", text: "Virtual")
-      |> assert_has("dd", text: "Be the first to RSVP!")
-    end
-
-    test "renders detail hero in 16:9 aspect ratio", %{conn: conn, group: group, huddl: huddl} do
-      conn
-      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
-      |> assert_has("[class*='aspect-video']")
+      |> assert_has("aside.sidebar")
+      |> assert_has(".hero h1", text: huddl.title)
+      |> assert_has(".hero .eyebrow", text: "Online huddl")
+      |> assert_has(".hero .eyebrow", text: "Upcoming")
+      |> assert_has(".huddl-frame .huddl-intro.prose p", text: huddl.description)
+      |> assert_has("aside.huddl-side h3", text: "RSVP")
+      |> assert_has(".facts .label", text: "When")
+      |> assert_has(".facts .label", text: "Virtual access")
+      |> assert_has(".facts .label", text: "Capacity")
+      |> assert_has(".facts .value", text: "Be the first to RSVP!")
     end
 
     test "renders rich link preview metadata", %{conn: conn, group: group, huddl: huddl} do
@@ -172,14 +178,14 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
       |> assert_has("button", text: "RSVP to this huddl")
-      |> refute_has("div.text-success", text: "You're attending!")
+      |> refute_has(".rsvp-banner.cyan", text: "You're attending")
       # Click RSVP button
       |> click_button("RSVP to this huddl")
       # Check UI updates after RSVP
-      |> assert_has("div.text-success", text: "You're attending!")
+      |> assert_has(".rsvp-banner.cyan", text: "You're attending")
       |> refute_has("button", text: "RSVP to this huddl")
       # Should show 1 person attending
-      |> assert_has("dd", text: "1 person attending")
+      |> assert_has(".facts .value", text: "1 person attending")
     end
 
     test "shows virtual link after RSVP", %{
@@ -192,12 +198,12 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
       # Before RSVP, virtual link is not visible
-      |> assert_has("span", text: "Virtual link available after RSVP")
+      |> assert_has(".facts .value .muted", text: "Virtual link available after RSVP")
       |> refute_has("a", text: "Join virtually")
       # RSVP
       |> click_button("RSVP to this huddl")
       # After RSVP, virtual link is visible
-      |> assert_has("a", text: "Join virtually")
+      |> assert_has("a.virtual-link-text", text: "Join virtually")
     end
 
     test "prevents duplicate RSVPs", %{conn: conn, member: member, group: group, huddl: huddl} do
@@ -211,9 +217,9 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{updated_huddl.id}")
       # Should already show as attending
-      |> assert_has("div.text-success", text: "You're attending!")
+      |> assert_has(".rsvp-banner.cyan", text: "You're attending")
       |> refute_has("button", text: "RSVP to this huddl")
-      |> assert_has("dd", text: "1 person attending")
+      |> assert_has(".facts .value", text: "1 person attending")
     end
 
     test "shows correct attendee count with multiple RSVPs", %{
@@ -231,10 +237,10 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
-      |> assert_has("dd", text: "1 person attending")
+      |> assert_has(".facts .value", text: "1 person attending")
       # Member RSVPs
       |> click_button("RSVP to this huddl")
-      |> assert_has("dd", text: "2 people attending")
+      |> assert_has(".facts .value", text: "2 people attending")
     end
 
     test "shows capacity status for limited huddls", %{
@@ -256,8 +262,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{limited_huddl.id}")
-      |> assert_has("span", text: "1/2 spots filled")
-      |> assert_has("span", text: "Filling up")
+      |> assert_has(".facts .value", text: "1/2 spots filled")
+      |> assert_has(".facts .value", text: "Filling up")
       |> assert_has("button", text: "RSVP to this huddl")
     end
 
@@ -283,8 +289,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{capped.id}")
-      |> assert_has("span", text: "4/5 spots filled")
-      |> assert_has("span", text: "Almost full")
+      |> assert_has(".facts .value", text: "4/5 spots filled")
+      |> assert_has(".facts .value", text: "Almost full")
       |> assert_has("button", text: "RSVP to this huddl")
     end
 
@@ -307,9 +313,10 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{full_huddl.id}")
-      |> assert_has("div", text: "Huddl Full")
-      |> assert_has("span", text: "1/1 spots filled")
+      |> assert_has(".rsvp-banner.warn", text: "This huddl is full")
+      |> assert_has(".facts .value", text: "1/1 spots filled")
       |> refute_has("button", text: "RSVP to this huddl")
+      |> assert_has("button", text: "Join waitlist")
     end
 
     test "non-authenticated users see sign-in prompt for virtual link", %{
@@ -319,8 +326,9 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
     } do
       conn
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
-      |> assert_has("span", text: "Sign in and RSVP to get virtual link")
+      |> assert_has(".facts .value .muted", text: "Sign in and RSVP to get virtual link")
       |> refute_has("button", text: "RSVP to this huddl")
+      |> assert_has("a", text: "Sign in to RSVP")
     end
 
     test "handles different event types correctly", %{conn: conn, owner: owner, group: group} do
@@ -348,8 +356,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{in_person_huddl.id}")
-      |> assert_has("dd", text: "123 Main St, City")
-      |> refute_has("dt", text: "Virtual Access")
+      |> assert_has(".facts .value", text: "123 Main St, City")
+      |> refute_has(".facts .label", text: "Virtual access")
 
       # Create hybrid huddl
       hybrid_huddl =
@@ -376,12 +384,12 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{hybrid_huddl.id}")
-      |> assert_has("dd", text: "Conference Room A")
-      |> assert_has("dt", text: "Virtual Access")
-      |> assert_has("span", text: "Virtual link available after RSVP")
+      |> assert_has(".facts .value", text: "Conference Room A")
+      |> assert_has(".facts .label", text: "Virtual access")
+      |> assert_has(".facts .value .muted", text: "Virtual link available after RSVP")
       # RSVP to see virtual link
       |> click_button("RSVP to this huddl")
-      |> assert_has("a", text: "Join virtually")
+      |> assert_has("a.virtual-link-text", text: "Join virtually")
     end
 
     test "cannot access private huddl without membership", %{
@@ -452,7 +460,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has("button", text: "Cancel RSVP")
       |> refute_has("button", text: "RSVP to this huddl")
       # Should still show attending status
-      |> assert_has("div.text-success", text: "You're attending!")
+      |> assert_has(".rsvp-banner.cyan", text: "You're attending")
     end
 
     test "Cancel RSVP button only shows for upcoming huddls", %{
@@ -489,7 +497,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> refute_has("button", text: "Cancel RSVP")
       |> refute_has("button", text: "RSVP to this huddl")
       # But should still show attended status for past event
-      |> assert_has("dd", text: "1 person attended")
+      |> assert_has(".facts .value", text: "1 person attended")
     end
 
     test "handles cancel_rsvp event successfully", %{
@@ -510,10 +518,10 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> click_button("Cancel RSVP")
       # Check UI updates after cancel
       |> assert_has("button", text: "RSVP to this huddl")
-      |> refute_has("div.text-success", text: "You're attending!")
+      |> refute_has(".rsvp-banner.cyan", text: "You're attending")
       |> refute_has("button", text: "Cancel RSVP")
       # Should show 0 people attending
-      |> assert_has("dd", text: "Be the first to RSVP!")
+      |> assert_has(".facts .value", text: "Be the first to RSVP!")
     end
 
     test "cancel_rsvp updates attendee count correctly", %{
@@ -536,11 +544,11 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
-      |> assert_has("dd", text: "2 people attending")
+      |> assert_has(".facts .value", text: "2 people attending")
       # Member cancels their RSVP
       |> click_button("Cancel RSVP")
       # Should show 1 person attending (owner still RSVPed)
-      |> assert_has("dd", text: "1 person attending")
+      |> assert_has(".facts .value", text: "1 person attending")
     end
 
     test "can RSVP again after cancelling", %{
@@ -562,8 +570,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       # RSVP again
       |> click_button("RSVP to this huddl")
       # Check UI updates after second RSVP
-      |> assert_has("div.text-success", text: "You're attending!")
-      |> assert_has("dd", text: "1 person attending")
+      |> assert_has(".rsvp-banner.cyan", text: "You're attending")
+      |> assert_has(".facts .value", text: "1 person attending")
     end
 
     test "rendering type and status correctly", %{conn: conn, owner: owner, group: group} do
@@ -586,8 +594,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       conn
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{in_person_huddl.id}")
-      |> assert_has("dd", text: "In progress")
-      |> assert_has("dd", text: "In person")
+      |> assert_has(".eyebrow", text: "In-person huddl")
+      |> assert_has(".eyebrow", text: "Happening now")
     end
   end
 

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -306,7 +306,8 @@ defmodule Huddlz.Generator do
         physical_location: "123 Main St, Anytown, USA",
         is_private: false,
         huddl_template_id: nil,
-        is_recurring: false
+        is_recurring: false,
+        max_attendees: nil
       ],
       overrides: opts,
       actor: actor


### PR DESCRIPTION
## Summary

- Migrates the huddl detail page (`/groups/:slug/huddlz/:id`) from the legacy `Layouts.app` header/dl shell to the v3 `.hero` + `.huddl-frame` layout from `clickthrough_huddl.html.heex` (PR-4.1 in the v3 plan).
- Renders six RSVP-state variants (anonymous, RSVP, waitlist, attending, on waitlist, completed/cancelled) matching the mockup, plus an "Organize" section for owner edit/delete and a creator row.
- Patches an unrelated latent test-data bug: `Ash.Generator.changeset_generator` was auto-filling `max_attendees` with a random integer, which was previously invisible because the legacy detail page didn't derive copy from the cap.

## Commits

1. `test: default huddl generator max_attendees to nil` — stand-alone generator fix; unlimited huddlz now actually unlimited.
2. `feat(v3): migrate /groups/:slug/huddlz/:id to v3 chrome` — full page rewrite, CSS for the new variants (`.rsvp-banner.magenta`/`.muted`, `.rsvp-state` stretch rules, `.virtual-link-text`, `.destructive-btn`, `.creator-row`, eyebrow status modifiers), and updated tests/features.

## Out of scope

- `/groups/:slug/huddlz/new` and `/.../edit` (PR-4.2 / 4.3) — still gated on the recurring-mockup update.

## Test plan

- [x] `mix precommit` clean (1258 tests, 0 failures, no credo issues)
- [x] Browser-verified four states on `/groups/.../huddlz/...`:
  - Upcoming hybrid huddl, currently attending — eyebrow "Hybrid huddl · Upcoming", "You're attending" banner, "Join the online room" + "Cancel RSVP"
  - Upcoming in-person huddl, no RSVP yet — RSVP button, "Be the first to RSVP!" capacity fact
  - Completed past huddl — muted banner "This huddl has ended"
- [x] All existing `show_test.exs`, `rsvp_cancellation.feature`, `waitlist.feature`, and `delete_huddl.feature` scenarios still pass under the new chrome