### PR TITLE
feat(v3): migrate /organize overview to v3 chrome

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -344,6 +344,47 @@ defmodule HuddlzWeb.Layouts do
             <.v3_nav_icon name="calendar" />
             <span class="label">My calendar</span>
           </a>
+          <a
+            class={["sb-item", String.starts_with?(@active || "", "organize") && "active"]}
+            href="/organize"
+          >
+            <.v3_nav_icon name="grid" />
+            <span class="label">Organize</span>
+          </a>
+          <%= if String.starts_with?(@active || "", "organize") do %>
+            <div class="sb-sub">
+              <a
+                class={["sb-sub-item", @active == "organize" && "active"]}
+                href="/organize"
+              >
+                Overview
+              </a>
+              <a
+                class={["sb-sub-item", @active == "organize-groups" && "active"]}
+                href="/organize/groups"
+              >
+                Groups
+              </a>
+              <a
+                class={["sb-sub-item", @active == "organize-huddlz" && "active"]}
+                href="/organize/huddlz"
+              >
+                Huddlz
+              </a>
+              <a
+                class={["sb-sub-item", @active == "organize-attendees" && "active"]}
+                href="/organize/attendees"
+              >
+                Attendees
+              </a>
+              <a
+                class={["sb-sub-item", @active == "organize-members" && "active"]}
+                href="/organize/members"
+              >
+                Members
+              </a>
+            </div>
+          <% end %>
         </nav>
 
         <div class="sb-account">
@@ -611,6 +652,33 @@ defmodule HuddlzWeb.Layouts do
       stroke-linejoin="round"
     >
       <path d="M12 3 4 6v6c0 5 3.5 8.5 8 9 4.5-.5 8-4 8-9V6l-8-3z" />
+    </svg>
+    """
+  end
+
+  defp v3_nav_icon(%{name: "grid"} = assigns) do
+    ~H"""
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect x="3" y="3" width="7" height="7" rx="1" /><rect
+        x="14"
+        y="3"
+        width="7"
+        height="7"
+        rx="1"
+      /><rect x="3" y="14" width="7" height="7" rx="1" /><rect
+        x="14"
+        y="14"
+        width="7"
+        height="7"
+        rx="1"
+      />
     </svg>
     """
   end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -5,8 +5,6 @@ defmodule HuddlzWeb.OrganizeLive do
   """
   use HuddlzWeb, :live_view
 
-  import HuddlzWeb.OrganizeLive.Components
-
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
   alias HuddlzWeb.Layouts
@@ -17,6 +15,7 @@ defmodule HuddlzWeb.OrganizeLive do
   @member_role_order [:owner, :organizer, :member]
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -173,40 +172,38 @@ defmodule HuddlzWeb.OrganizeLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <.workspace_chrome active={@active} current_user={@current_user}>
-        <%= case @active do %>
-          <% :overview -> %>
-            <.overview_tab
-              owned_groups={@owned_groups}
-              upcoming_huddlz={@upcoming_huddlz}
-              upcoming_count={@upcoming_count}
-              open_rsvps={@open_rsvps}
-            />
-          <% :groups -> %>
-            <.groups_tab groups={@groups_list} />
-          <% :huddlz -> %>
-            <.huddlz_tab
-              huddlz={@huddlz_list}
-              filter={@huddlz_filter}
-              owned_groups={@owned_groups}
-            />
-          <% :attendees -> %>
-            <.attendees_tab
-              huddlz={@attendees_huddlz}
-              selected={@selected_huddl}
-              attendees={@selected_attendees}
-              waitlist={@selected_waitlist}
-            />
-          <% :members -> %>
-            <.members_tab
-              groups={@members_groups}
-              selected={@selected_group}
-              members={@selected_members}
-            />
-        <% end %>
-      </.workspace_chrome>
-    </Layouts.app>
+    <Layouts.v3_app flash={@flash} current_user={@current_user} active={active_key(@active)}>
+      <%= case @active do %>
+        <% :overview -> %>
+          <.overview_tab
+            owned_groups={@owned_groups}
+            upcoming_huddlz={@upcoming_huddlz}
+            upcoming_count={@upcoming_count}
+            open_rsvps={@open_rsvps}
+          />
+        <% :groups -> %>
+          <.groups_tab groups={@groups_list} />
+        <% :huddlz -> %>
+          <.huddlz_tab
+            huddlz={@huddlz_list}
+            filter={@huddlz_filter}
+            owned_groups={@owned_groups}
+          />
+        <% :attendees -> %>
+          <.attendees_tab
+            huddlz={@attendees_huddlz}
+            selected={@selected_huddl}
+            attendees={@selected_attendees}
+            waitlist={@selected_waitlist}
+          />
+        <% :members -> %>
+          <.members_tab
+            groups={@members_groups}
+            selected={@selected_group}
+            members={@selected_members}
+          />
+      <% end %>
+    </Layouts.v3_app>
     """
   end
 
@@ -218,112 +215,103 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :open_rsvps, :integer, required: true
 
   defp overview_tab(assigns) do
-    assigns = assign(assigns, :preview_limit, @upcoming_preview_limit)
+    members_total = Enum.reduce(assigns.owned_groups, 0, &(&1.member_count + &2))
+
+    assigns =
+      assigns
+      |> assign(:preview_limit, @upcoming_preview_limit)
+      |> assign(:members_total, members_total)
 
     ~H"""
-    <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <div class="page-head">
       <div>
-        <span class="mono-label text-primary/70">// Overview</span>
-        <h1 class="text-3xl font-extrabold tracking-tight text-base-content mt-2">
-          Organizer workspace.
-        </h1>
-        <p class="mt-2 text-base-content/60 max-w-2xl">
-          A scannable summary of the huddlz and groups you run.
-        </p>
+        <h1>Organizer workspace</h1>
+        <p>A scannable summary of the huddlz and groups you run.</p>
       </div>
-      <div class="flex flex-wrap gap-2">
-        <.button navigate={~p"/groups/new"}>Create group</.button>
-        <.button variant="primary" navigate={create_huddl_path(@owned_groups)}>
-          Create huddl
-        </.button>
+      <div :if={@owned_groups != []} class="actions">
+        <a class="btn-secondary" href={~p"/groups/new"}>Create group</a>
+        <a class="btn-primary" href={create_huddl_path(@owned_groups)}>+ Create huddl</a>
       </div>
-    </header>
+    </div>
 
     <%= if @owned_groups == [] do %>
-      <.empty_state />
+      <div class="panel">
+        <div class="panel-head">
+          <h2>Get started</h2>
+        </div>
+        <p class="muted">
+          You don't organize any groups yet. Create a group to start hosting huddlz —
+          once you have one, this overview fills in with upcoming huddlz, RSVP totals,
+          and quick actions.
+        </p>
+        <div style="margin-top:16px">
+          <a class="btn-primary" href={~p"/groups/new"}>Create your first group</a>
+        </div>
+      </div>
     <% else %>
-      <section class="grid gap-4 sm:grid-cols-3" aria-label="Workspace metrics">
-        <.metric_tile label="Upcoming huddlz" value={@upcoming_count} />
-        <.metric_tile label="Open RSVPs" value={@open_rsvps} />
-        <.metric_tile label="Groups managed" value={length(@owned_groups)} />
-      </section>
+      <div class="kpis">
+        <div class="kpi">
+          <div class="label">Members</div>
+          <div class="value">{@members_total}</div>
+          <div class="delta muted">Across {group_count_label(length(@owned_groups))}</div>
+        </div>
+        <div class="kpi">
+          <div class="label">Upcoming</div>
+          <div class="value">{@upcoming_count}</div>
+          <div class="delta muted">Huddlz scheduled</div>
+        </div>
+        <div class="kpi">
+          <div class="label">Open RSVPs</div>
+          <div class="value">{@open_rsvps}</div>
+          <div class="delta muted">Across upcoming huddlz</div>
+        </div>
+        <div class="kpi">
+          <div class="label">Groups managed</div>
+          <div class="value">{length(@owned_groups)}</div>
+          <div class="delta muted">Owned by you</div>
+        </div>
+      </div>
 
-      <section>
-        <div class="flex items-baseline justify-between gap-2">
-          <h2 class="text-lg font-extrabold tracking-tight text-base-content flex items-baseline gap-3">
-            <span class="mono-label text-primary/70">// Upcoming huddlz</span>
-            <span class="text-sm font-body font-normal text-base-content/40">
-              ({@upcoming_count})
-            </span>
-          </h2>
+      <div class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Upcoming huddlz</h2>
+            <div class="panel-sub">Next on the calendar across your groups</div>
+          </div>
           <.link
             :if={@upcoming_count > @preview_limit}
             navigate={~p"/organize/huddlz"}
-            class="text-xs font-bold text-primary hover:underline"
+            class="pill"
           >
-            View all →
+            View all
           </.link>
         </div>
 
         <%= if @upcoming_huddlz == [] do %>
-          <.surface_panel variant="dashed" class="p-8 mt-4 text-center text-base-content/50">
-            No upcoming huddlz right now. Create one to get started.
-          </.surface_panel>
+          <p class="muted">No upcoming huddlz right now. Create one to get started.</p>
         <% else %>
-          <.surface_panel tag="ul" class="mt-4 divide-y divide-base-300">
-            <%= for huddl <- Enum.take(@upcoming_huddlz, @preview_limit) do %>
-              <li class="flex items-center justify-between gap-4 px-5 py-4">
-                <div class="min-w-0">
-                  <.link
-                    navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}
-                    class="text-base font-extrabold tracking-tight text-base-content hover:text-primary transition-colors block truncate"
-                  >
+          <div class="row-list">
+            <div
+              :for={huddl <- Enum.take(@upcoming_huddlz, @preview_limit)}
+              class="row"
+              style="grid-template-columns:1fr auto"
+            >
+              <div>
+                <div class="row-title">
+                  <.link navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}>
                     {huddl.title}
                   </.link>
-                  <p class="text-xs text-base-content/60 mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
-                    <span>{format_starts_at(huddl.starts_at)}</span>
-                    <span class="text-base-content/30">·</span>
-                    <span>{huddl.group.name}</span>
-                  </p>
                 </div>
-                <.huddl_badge variant="cyan" class="flex-shrink-0">
-                  {rsvp_label(huddl.rsvp_count)}
-                </.huddl_badge>
-              </li>
-            <% end %>
-          </.surface_panel>
+                <div class="meta">
+                  {format_starts_at(huddl.starts_at)} · {huddl.group.name}
+                </div>
+              </div>
+              <span class="pill">{rsvp_label(huddl.rsvp_count)}</span>
+            </div>
+          </div>
         <% end %>
-      </section>
+      </div>
     <% end %>
-    """
-  end
-
-  attr :label, :string, required: true
-  attr :value, :integer, required: true
-
-  defp metric_tile(assigns) do
-    ~H"""
-    <.surface_panel class="p-6">
-      <span class="mono-label text-primary/70">// {@label}</span>
-      <p class="text-3xl font-extrabold tracking-tight text-base-content mt-2">{@value}</p>
-    </.surface_panel>
-    """
-  end
-
-  defp empty_state(assigns) do
-    ~H"""
-    <.surface_panel class="p-8">
-      <span class="mono-label text-primary/70">// Get started</span>
-      <h2 class="text-xl font-extrabold tracking-tight text-base-content mt-2">
-        You don't organize any groups yet.
-      </h2>
-      <p class="mt-2 text-sm text-base-content/60 max-w-xl">
-        Create a group to start hosting huddlz. Once you have a group, this overview will fill in with upcoming huddlz, RSVP totals, and quick actions.
-      </p>
-      <.button variant="primary" navigate={~p"/groups/new"} class="mt-4">
-        Create your first group
-      </.button>
-    </.surface_panel>
     """
   end
 
@@ -1016,4 +1004,13 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp format_starts_at(_), do: ""
+
+  defp active_key(:overview), do: "organize"
+  defp active_key(:groups), do: "organize-groups"
+  defp active_key(:huddlz), do: "organize-huddlz"
+  defp active_key(:attendees), do: "organize-attendees"
+  defp active_key(:members), do: "organize-members"
+
+  defp group_count_label(1), do: "1 group"
+  defp group_count_label(n), do: "#{n} groups"
 end

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -19,13 +19,12 @@ Feature: Organizer workspace
   Scenario: Signed-in user with no groups sees the empty-state CTA
     Given I am signed in as "host@example.com"
     When I visit "/organize"
-    Then I should see "Organizer workspace."
-    And I should see "// Workspace"
-    And I should see "// Get started"
+    Then I should see "Organizer workspace"
+    And I should see "Get started"
     And I should see "You don't organize any groups yet."
     And I should see "Create your first group"
-    And I should not see "// Upcoming huddlz"
-    And I should not see "// Open RSVPs"
+    And I should not see "Upcoming huddlz"
+    And I should not see "Open RSVPs"
 
   Scenario: Sidebar lists every workspace tab
     Given I am signed in as "host@example.com"
@@ -46,9 +45,9 @@ Feature: Organizer workspace
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
     And I am signed in as "host@example.com"
     When I visit "/organize"
-    Then I should see "// Upcoming huddlz"
-    And I should see "// Open RSVPs"
-    And I should see "// Groups managed"
+    Then I should see "Upcoming huddlz"
+    And I should see "Open RSVPs"
+    And I should see "Groups managed"
     And I should see "No upcoming huddlz right now. Create one to get started."
 
   Scenario: Owner sees their upcoming huddl on the Overview
@@ -56,7 +55,7 @@ Feature: Organizer workspace
     And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
     And I am signed in as "host@example.com"
     When I visit "/organize"
-    Then I should see "// Upcoming huddlz"
+    Then I should see "Upcoming huddlz"
     And I should see "Synthwave Night"
     And I should see "Cyberpunk Builders"
 
@@ -66,7 +65,7 @@ Feature: Organizer workspace
     And "attendee@example.com" has RSVPed to "Synthwave Night"
     And I am signed in as "host@example.com"
     When I visit "/organize"
-    Then I should see "// Open RSVPs"
+    Then I should see "Open RSVPs"
     And I should see "1 RSVP"
 
   Scenario: Groups tab shows the empty state when the actor owns no groups


### PR DESCRIPTION
## Summary

PR-5.2 of the V3 design migration. Wraps `OrganizeLive` in `Layouts.v3_app` and adds an "Organize" sidebar entry to the v3 shell with sub-items (Overview, Groups, Huddlz, Attendees, Members) that expand when the active key starts with `organize`.

The Overview tab is fully restyled to v3 vocabulary:
- `page-head` (h1 + description + actions)
- `kpis` grid: Members, Upcoming, Open RSVPs, Groups managed
- `panel` + `row-list` for upcoming huddlz preview

Show-up rate is intentionally omitted from KPIs — needs attendance check-in (filed as a separate concern in the migration plan).

The Groups, Huddlz, Attendees, and Members tabs keep their current legacy daisy-styled inner content for now. They render inside the v3 shell (so v3 sidebar/topbar wrap them) and will be restyled tab-by-tab in PR-5.3 through 5.6.

`workspace_chrome` (the previous in-page sub-sidebar) is no longer used by `OrganizeLive`. It stays alive only for `HuddlLive.New`'s `:workspace_new` action, which gets retired in Phase 4 when workspace mode is removed.

## Test plan

- [x] `mix precommit` clean (1 doctest, 1255 tests, 0 failures; credo clean)
- [x] Browser check: `/organize` renders with v3 shell, sidebar's Organize item active with sub-items expanded, KPI tiles + Upcoming huddlz panel render
- [x] Browser check: `/organize/groups` keeps the legacy inner content but renders inside the v3 shell with the correct active sub-item
- [x] Browser check: `/discover` (non-organize page) still renders normally with the new Organize entry inactive