### PR TITLE
fix(v3): scope organize sidebar to actually-organized groups; centralize admin check

### DIFF
--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -582,6 +582,16 @@ defmodule Huddlz.Accounts.User do
     end
   end
 
+  calculations do
+    calculate :is_admin, :boolean, expr(role == :admin) do
+      description """
+      Single expression for "this user is an admin". Use this — instead of
+      a fresh `role == :admin` check — in expressions and code so the rule
+      stays in one place if admin semantics ever broaden.
+      """
+    end
+  end
+
   aggregates do
     first :current_profile_picture_url, :profile_pictures, :thumbnail_path do
       description "Returns the thumbnail path of the user's current profile picture"
@@ -593,6 +603,19 @@ defmodule Huddlz.Accounts.User do
   identities do
     identity :unique_email, [:email]
   end
+
+  @doc """
+  True when the given user has the `:admin` role. Nil-safe so callers can
+  pass `current_user` directly without a separate nil guard.
+
+  Reads the `:is_admin` calculation when it has been loaded; falls back to
+  inspecting `:role` directly so callers that haven't loaded the calc
+  (e.g. policies handing us a raw actor) still get a correct answer.
+  """
+  def admin?(%{is_admin: true}), do: true
+  def admin?(%{is_admin: false}), do: false
+  def admin?(%{role: :admin}), do: true
+  def admin?(_), do: false
 
   defp enqueue_email_changed(user, previous_email, audience) do
     payload = %{"audience" => audience, "old_email" => previous_email}

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -114,16 +114,19 @@ defmodule Huddlz.Communities.Group do
 
     read :get_organizable do
       description """
-      Groups the current actor can manage in the organizer workspace. Returns
-      groups they own, are an :organizer GroupMember of, or — for admins —
-      every group. Sorted alphabetically by name.
+      Groups the actor actually organizes — they own the group, or are an
+      `:organizer` GroupMember of it. Sorted alphabetically by name.
+
+      Admins are not auto-included via this action; the admin bypass for
+      managing a specific group lives in `OrganizeLive`'s per-slug auth
+      check, not in the list query, so the sidebar/picker stay scoped to
+      groups the actor truly organizes.
       """
 
       pagination offset?: true, countable: true, required?: false, default_limit: 50
 
       filter expr(
-               ^actor(:role) == :admin or
-                 owner_id == ^actor(:id) or
+               owner_id == ^actor(:id) or
                  exists(group_members, user_id == ^actor(:id) and role == :organizer)
              )
     end

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -4,6 +4,7 @@ defmodule HuddlzWeb.Layouts do
   """
   use HuddlzWeb, :html
 
+  alias Huddlz.Accounts.User
   alias HuddlzWeb.Avatar
 
   embed_templates "layouts/*"
@@ -119,7 +120,7 @@ defmodule HuddlzWeb.Layouts do
                       Profile &amp; preferences
                     </a>
                   </li>
-                  <%= if @current_user.role == :admin do %>
+                  <%= if User.admin?(@current_user) do %>
                     <li>
                       <a
                         href="/admin"
@@ -416,7 +417,7 @@ defmodule HuddlzWeb.Layouts do
             <.v3_nav_icon name="help" />
             <span class="label">Help</span>
           </a>
-          <%= if @current_user && @current_user.role == :admin do %>
+          <%= if User.admin?(@current_user) do %>
             <a class={["sb-item", @active == "admin" && "active"]} href="/admin">
               <.v3_nav_icon name="shield" />
               <span class="label">Admin</span>

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -13,6 +13,7 @@ defmodule HuddlzWeb.OrganizeLive do
   """
   use HuddlzWeb, :live_view
 
+  alias Huddlz.Accounts.User
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
   alias HuddlzWeb.Layouts
@@ -116,13 +117,16 @@ defmodule HuddlzWeb.OrganizeLive do
     end
   end
 
-  defp organizable_by?(_group, %{role: :admin}), do: true
   defp organizable_by?(%{owner_id: owner_id}, %{id: actor_id}) when owner_id == actor_id, do: true
 
   defp organizable_by?(group, user) do
-    case Communities.get_membership_in_group(group.id, actor: user) do
-      {:ok, %{role: :organizer}} -> true
-      _ -> false
+    if User.admin?(user) do
+      true
+    else
+      case Communities.get_membership_in_group(group.id, actor: user) do
+        {:ok, %{role: :organizer}} -> true
+        _ -> false
+      end
     end
   end
 

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -85,7 +85,13 @@ defmodule HuddlzWeb.LiveUserAuth do
        when not is_nil(user) do
     case Ash.load(
            user,
-           [:current_profile_picture_url, :home_location, :home_latitude, :home_longitude],
+           [
+             :current_profile_picture_url,
+             :home_location,
+             :home_latitude,
+             :home_longitude,
+             :is_admin
+           ],
            actor: user
          ) do
       {:ok, loaded_user} -> assign(socket, :current_user, loaded_user)

--- a/test/huddlz/communities/group_test.exs
+++ b/test/huddlz/communities/group_test.exs
@@ -358,6 +358,82 @@ defmodule Huddlz.Communities.GroupTest do
     end
   end
 
+  describe "get_organizable" do
+    # Regression: admins used to be auto-included here via a `role == :admin`
+    # filter clause, which flooded the v3 sidebar with every group in the DB.
+    # The admin override now lives in OrganizeLive's per-slug auth helper, not
+    # in the list query — so this action returns only groups the actor truly
+    # organizes, even for admins.
+
+    test "returns groups the actor owns" do
+      owner = generate(user(role: :user))
+      mine = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+      _theirs = generate(group(is_public: true))
+
+      result = Communities.get_organizable_groups!(actor: owner)
+
+      assert Enum.map(result, & &1.id) == [mine.id]
+    end
+
+    test "returns groups the actor is an :organizer member of" do
+      owner = generate(user(role: :user))
+      co = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: co.id,
+          role: "organizer",
+          actor: owner
+        )
+      )
+
+      result = Communities.get_organizable_groups!(actor: co)
+
+      assert Enum.map(result, & &1.id) == [group.id]
+    end
+
+    test "does NOT auto-include every group for admins" do
+      admin = generate(user(role: :admin))
+      _strangers_group = generate(group(is_public: true))
+
+      result = Communities.get_organizable_groups!(actor: admin)
+
+      assert result == [],
+             "admins should only see groups they actually organize in this list, not every group in the DB"
+    end
+
+    test "admins still see groups they organize themselves" do
+      admin = generate(user(role: :admin))
+      mine = generate(group(is_public: true, owner_id: admin.id, actor: admin))
+      _strangers_group = generate(group(is_public: true))
+
+      result = Communities.get_organizable_groups!(actor: admin)
+
+      assert Enum.map(result, & &1.id) == [mine.id]
+    end
+
+    test "excludes groups where the actor is only a :member" do
+      owner = generate(user(role: :user))
+      member = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: member.id,
+          role: "member",
+          actor: owner
+        )
+      )
+
+      result = Communities.get_organizable_groups!(actor: member)
+
+      assert result == []
+    end
+  end
+
   describe "attribute constraints" do
     test "rejects description over 5000 characters" do
       owner = generate(user())


### PR DESCRIPTION
## Summary

- **Bug fix:** admins were seeing every group in the v3 sidebar (and on the `/organize` picker), because `Group.:get_organizable` bypassed the filter for the admin role. Dropping that bypass scopes the list to groups the actor truly organizes. Admins keep their override for opening any group's workspace — the bypass lives in `OrganizeLive.load_group/2`'s per-slug auth check, not the list query.
- **Refactor:** centralize the \"is admin?\" check via a `:is_admin` calculation on `User` (`expr(role == :admin)`) plus a nil-safe `User.admin?/1` predicate. `LiveUserAuth` loads the calc onto `current_user` so both layouts can call `User.admin?(@current_user)` instead of inlining `role == :admin`.

Tracked follow-up: #212 — fold the remaining 11 `actor_attribute_equals(:role, :admin)` policy bypasses and 2 Elixir pattern matches onto the new calc so the rule lives in exactly one expression.

## Test plan

- [x] `mix precommit` clean (1243 tests, credo clean)
- [x] Verified in browser as an admin user — sidebar `sb-orgs` now lists only owned/organized groups, and the Admin link still renders in the account section.
- [x] Verified admins can still open `/organize/:slug` for a group they don't organize directly.