### PR TITLE
feat(v3): migrate /groups/:slug/huddlz/new to v3 chrome (PR-4.2)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2167,6 +2167,16 @@ body.v3 .form-input, body.v3 .form-textarea, body.v3 .form-select {
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
+body.v3 .form-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 32px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23b7c1c3' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px;
+}
+
 body.v3 .form-input:focus, body.v3 .form-textarea:focus, body.v3 .form-select:focus {
   border-color: var(--cyan);
   box-shadow: 0 0 0 3px var(--cyan-soft);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2207,6 +2207,19 @@ body.v3 .form-foot {
   gap: 10px;
 }
 
+/* No top border or gap — for foots stacked under their own panel/form. */
+body.v3 .form-foot.is-flush {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+/* Flex columns inside .form-row-inline. The basis values match the
+   clickthrough mockup's inline date/time/duration trio. */
+body.v3 .form-col-sm { flex: 1 1 140px; }
+body.v3 .form-col-md { flex: 1 1 180px; }
+body.v3 .form-col-lg { flex: 1 1 220px; }
+
 body.v3 .location-control {
   position: relative;
   display: flex;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2490,8 +2490,11 @@ body.v3 .toggle .track {
   height: 20px;
   border-radius: 999px;
   background: var(--line-strong);
-  transition: background 120ms ease;
+  border: 1px solid var(--soft);
+  transition: background 120ms ease, border-color 120ms ease;
 }
+
+body.v3 .toggle input:checked + .track { border-color: var(--cyan); }
 
 body.v3 .toggle .track::after {
   content: "";

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2469,12 +2469,15 @@ body.v3 .edit-scope-row strong { color: var(--text); }
 body.v3 .toggle {
   display: inline-flex;
   align-items: center;
+  align-self: flex-start;
   gap: 10px;
   cursor: pointer;
   width: auto;
   height: auto;
   padding: 0;
   border: 0;
+  background: transparent;
+  color: var(--soft);
   box-shadow: none;
   appearance: auto;
   grid-template-columns: none;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2506,10 +2506,10 @@ body.v3 .toggle input:checked + .track { border-color: var(--cyan); }
 body.v3 .toggle .track::after {
   content: "";
   position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 16px;
-  height: 16px;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: #f0fafa;
   transition: transform 120ms ease;
@@ -2520,7 +2520,7 @@ body.v3 .toggle input:checked + .track {
   box-shadow: 0 0 12px rgba(24, 203, 212, 0.4);
 }
 
-body.v3 .toggle input:checked + .track::after { transform: translateX(16px); }
+body.v3 .toggle input:checked + .track::after { transform: translateX(14px); }
 
 body.v3 .toggle input:disabled + .track {
   opacity: 0.5;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2491,9 +2491,13 @@ body.v3 .toggle .track {
   position: relative;
   width: 36px;
   height: 20px;
+  flex: 0 0 36px;
   border-radius: 999px;
   background: var(--line-strong);
   border: 1px solid var(--soft);
+  padding: 0;
+  opacity: 1;
+  rotate: 0deg;
   transition: background 120ms ease, border-color 120ms ease;
 }
 

--- a/lib/huddlz_web/components/v3/input.ex
+++ b/lib/huddlz_web/components/v3/input.ex
@@ -132,6 +132,28 @@ defmodule HuddlzWeb.V3.Input do
     """
   end
 
+  attr :field, FormField, required: true, doc: "form field whose errors to render"
+
+  @doc """
+  Renders `<p class="form-error">` lines for a form field whose markup isn't
+  produced by `v3_input/v3_textarea/v3_select` (e.g. an inline raw input or a
+  radio-card group). Hidden until the field has been touched (`used_input?/1`).
+  """
+  def v3_field_errors(%{field: %FormField{} = field} = assigns) do
+    errors =
+      if Phoenix.Component.used_input?(field) do
+        Enum.map(field.errors, &translate_error/1)
+      else
+        []
+      end
+
+    assigns = Phoenix.Component.assign(assigns, :errors, errors)
+
+    ~H"""
+    <p :for={msg <- @errors} class="form-error">{msg}</p>
+    """
+  end
+
   defp translate_error({msg, opts}) do
     Enum.reduce(opts, msg, fn {key, value}, acc ->
       String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -5,7 +5,6 @@ defmodule HuddlzWeb.HuddlLive.New do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.HuddlLive.FormHelpers
-  import HuddlzWeb.HuddlLive.FormComponent
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
   alias Huddlz.Communities
@@ -16,6 +15,7 @@ defmodule HuddlzWeb.HuddlLive.New do
   alias HuddlzWeb.Live.Helpers.ModalLocationHelpers
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
+  on_mount {HuddlzWeb.LiveUserAuth, :v3_app}
 
   @impl true
   def mount(%{"group_slug" => group_slug}, _session, socket) do
@@ -84,7 +84,7 @@ defmodule HuddlzWeb.HuddlLive.New do
       )
 
     socket
-    |> assign(:page_title, "Create New Huddl")
+    |> assign(:page_title, "Schedule a huddl")
     |> assign(:group, group)
     |> assign(:form, to_form(form))
     |> assign(:show_virtual_link, false)
@@ -151,35 +151,379 @@ defmodule HuddlzWeb.HuddlLive.New do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_user={@current_user}>
-      <.link
-        navigate={~p"/groups/#{@group.slug}"}
-        class="text-sm font-semibold leading-6 hover:underline"
-      >
-        <.icon name="hero-arrow-left" class="h-3 w-3" /> Back to {@group.name}
-      </.link>
+    <Layouts.v3_app
+      flash={@flash}
+      current_user={@current_user}
+      sidebar_owned_groups={@sidebar_owned_groups}
+      active="my-groups"
+    >
+      <div class="page-head">
+        <div>
+          <h1>Schedule a huddl</h1>
+          <p>
+            Creating a huddl for <strong>{@group.name}</strong>. Members get an email when you publish.
+          </p>
+        </div>
+      </div>
 
-      <.header>
-        Create New Huddl
-        <:subtitle>
-          Creating a huddl for <span class="font-semibold">{@group.name}</span>
-        </:subtitle>
-      </.header>
+      <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save">
+        <div class="panel">
+          <div class="panel-head">
+            <h2>The basics</h2>
+          </div>
+          <div class="form-grid">
+            <.v3_input
+              field={@form[:title]}
+              label="Title"
+              placeholder="e.g. Ash Framework workshop"
+              autocomplete="off"
+            />
+            <.v3_textarea
+              field={@form[:description]}
+              label="Description"
+              rows="4"
+              placeholder="What you'll do, what to bring, who it's for."
+            />
+          </div>
+        </div>
 
-      <.create_huddl_form_body
-        form={@form}
-        group={@group}
-        group_locations={@group_locations}
-        selected_location={@selected_location}
-        show_physical_location={@show_physical_location}
-        show_virtual_link={@show_virtual_link}
-        calculated_end_time={@calculated_end_time}
-        uploads={@uploads}
-        image_error={@image_error}
-        pending_preview_url={@pending_preview_url}
-        new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
-        cancel_path={~p"/groups/#{@group.slug}"}
-      />
+        <div class="panel">
+          <div class="panel-head">
+            <h2>Format</h2>
+          </div>
+          <div class="event-type-grid">
+            <.event_type_option
+              field={@form[:event_type]}
+              value="in_person"
+              title="In person"
+              desc="Single physical location."
+            >
+              <:icon>
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
+                    cx="12"
+                    cy="10"
+                    r="3"
+                  />
+                </svg>
+              </:icon>
+            </.event_type_option>
+            <.event_type_option
+              field={@form[:event_type]}
+              value="virtual"
+              title="Virtual"
+              desc="Online only — no physical address."
+            >
+              <:icon>
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
+                </svg>
+              </:icon>
+            </.event_type_option>
+            <.event_type_option
+              field={@form[:event_type]}
+              value="hybrid"
+              title="Hybrid"
+              desc="In-person plus an online stream."
+            >
+              <:icon>
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
+                    cx="12"
+                    cy="10"
+                    r="3"
+                  /><path d="m22 22-2-2" />
+                </svg>
+              </:icon>
+            </.event_type_option>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h2>When</h2>
+          </div>
+          <div class="form-grid">
+            <div class="form-row form-row-inline">
+              <div style="flex:1 1 180px">
+                <label class="form-label" for={@form[:date].id}>Date</label>
+                <input
+                  type="date"
+                  id={@form[:date].id}
+                  name={@form[:date].name}
+                  value={@form[:date].value}
+                  min={Date.utc_today() |> Date.to_iso8601()}
+                  class="form-input"
+                />
+                <.field_errors field={@form[:date]} />
+              </div>
+              <div style="flex:1 1 140px">
+                <label class="form-label" for={@form[:start_time].id}>Start time</label>
+                <input
+                  type="time"
+                  id={@form[:start_time].id}
+                  name={@form[:start_time].name}
+                  value={@form[:start_time].value}
+                  class="form-input"
+                />
+                <.field_errors field={@form[:start_time]} />
+              </div>
+              <div style="flex:1 1 140px">
+                <label class="form-label" for={@form[:duration_minutes].id}>Duration</label>
+                <select
+                  id={@form[:duration_minutes].id}
+                  name={@form[:duration_minutes].name}
+                  class="form-select"
+                >
+                  <option value="">Select duration…</option>
+                  <%= for {label, mins} <- duration_options() do %>
+                    <option value={mins} selected={to_string(@form[:duration_minutes].value) == mins}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+                <.field_errors field={@form[:duration_minutes]} />
+              </div>
+            </div>
+
+            <p :if={@calculated_end_time} class="form-help" style="margin-top:-4px">
+              Ends at: <strong>{@calculated_end_time}</strong>
+            </p>
+
+            <div class="form-row">
+              <label class="toggle">
+                <input type="hidden" name={@form[:is_recurring].name} value="false" />
+                <input
+                  id={@form[:is_recurring].id}
+                  type="checkbox"
+                  name={@form[:is_recurring].name}
+                  value="true"
+                  checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_recurring].value)}
+                />
+                <span class="track"></span>
+                <span class="toggle-text">Recurring huddl</span>
+              </label>
+              <p class="form-help">Repeats on a schedule until you stop it.</p>
+            </div>
+
+            <%= if Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_recurring].value) do %>
+              <div class="form-row form-row-inline">
+                <div style="flex:1 1 200px">
+                  <label class="form-label" for={@form[:frequency].id}>Frequency</label>
+                  <select
+                    id={@form[:frequency].id}
+                    name={@form[:frequency].name}
+                    class="form-select"
+                    required
+                  >
+                    <option value="weekly" selected={to_string(@form[:frequency].value) == "weekly"}>
+                      Weekly
+                    </option>
+                    <option value="monthly" selected={to_string(@form[:frequency].value) == "monthly"}>
+                      Monthly
+                    </option>
+                  </select>
+                </div>
+                <div style="flex:1 1 200px">
+                  <label class="form-label" for={@form[:repeat_until].id}>Repeat until</label>
+                  <input
+                    type="date"
+                    id={@form[:repeat_until].id}
+                    name={@form[:repeat_until].name}
+                    value={@form[:repeat_until].value}
+                    class="form-input"
+                    required
+                  />
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h2>Where</h2>
+          </div>
+          <div class="form-grid">
+            <%= if @show_physical_location do %>
+              <div class="form-row">
+                <.live_component
+                  module={HuddlzWeb.Live.SavedLocationPicker}
+                  id="saved-location-picker"
+                  group_locations={@group_locations}
+                  selected_location={@selected_location}
+                  new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
+                />
+              </div>
+            <% end %>
+
+            <%= if @show_virtual_link do %>
+              <.v3_input
+                field={@form[:virtual_link]}
+                type="url"
+                label="Online link"
+                placeholder="https://meet.example.com/..."
+                help="Only attendees see this link."
+              />
+            <% end %>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h2>Capacity &amp; visibility</h2>
+          </div>
+          <div class="form-grid">
+            <.v3_input
+              field={@form[:max_attendees]}
+              type="number"
+              label="Max attendees"
+              min="1"
+              placeholder="No limit"
+              help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
+            />
+
+            <%= if @group.is_public do %>
+              <div class="form-row">
+                <label class="toggle">
+                  <input type="hidden" name={@form[:is_private].name} value="false" />
+                  <input
+                    id={@form[:is_private].id}
+                    type="checkbox"
+                    name={@form[:is_private].name}
+                    value="true"
+                    checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_private].value)}
+                  />
+                  <span class="track"></span>
+                  <span class="toggle-text">Members only</span>
+                </label>
+                <p class="form-help">
+                  Only group members can RSVP. Useful for private workshops or socials.
+                </p>
+              </div>
+            <% else %>
+              <p class="form-help">
+                <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
+                This will be a private huddl (private groups can only create private huddlz).
+              </p>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h2>Cover image</h2>
+          </div>
+
+          <.live_file_input upload={@uploads.huddl_image} class="hidden" />
+
+          <%= if @pending_preview_url do %>
+            <div class="image-preview" phx-drop-target={@uploads.huddl_image.ref}>
+              <div
+                class="card-cover"
+                style={"background-image: url('#{@pending_preview_url}')"}
+              >
+              </div>
+              <div
+                class="muted"
+                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
+              >
+                <span>Image uploaded · ready to publish.</span>
+                <div style="display:flex; gap:8px">
+                  <label for={@uploads.huddl_image.ref} class="btn-secondary" style="cursor:pointer">
+                    Replace
+                  </label>
+                  <.v3_button variant={:muted} type="button" phx-click="cancel_pending_image">
+                    Remove
+                  </.v3_button>
+                </div>
+              </div>
+            </div>
+          <% else %>
+            <div class="upload-zone" phx-drop-target={@uploads.huddl_image.ref}>
+              <div class="upload-icon">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
+                </svg>
+              </div>
+              <label for={@uploads.huddl_image.ref} class="upload-prompt">
+                Drop a 16:9 image, or <span class="upload-link">browse</span>
+              </label>
+              <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max · optional</div>
+            </div>
+
+            <%= for entry <- @uploads.huddl_image.entries do %>
+              <div class="image-preview" style="margin-top:12px">
+                <div class="card-cover">
+                  <.live_img_preview entry={entry} class="card-cover-img" />
+                </div>
+                <div
+                  class="muted"
+                  style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
+                >
+                  <span>{entry.client_name} · {entry.progress}%</span>
+                  <.v3_button
+                    variant={:muted}
+                    type="button"
+                    phx-click="cancel_image_upload"
+                    phx-value-ref={entry.ref}
+                  >
+                    Cancel
+                  </.v3_button>
+                </div>
+              </div>
+
+              <%= for err <- upload_errors(@uploads.huddl_image, entry) do %>
+                <p class="form-error">{upload_error_to_string(err)}</p>
+              <% end %>
+            <% end %>
+          <% end %>
+
+          <p :if={@image_error} class="form-error">{@image_error}</p>
+
+          <%= for err <- upload_errors(@uploads.huddl_image) do %>
+            <p class="form-error">{upload_error_to_string(err)}</p>
+          <% end %>
+        </div>
+
+        <div class="form-foot" style="border:0; margin:0">
+          <.v3_button variant={:primary} type="submit" phx-disable-with="Scheduling…">
+            Schedule huddl
+          </.v3_button>
+          <.v3_button variant={:secondary} navigate={~p"/groups/#{@group.slug}"}>Cancel</.v3_button>
+        </div>
+      </.form>
 
       <.modal
         :if={@live_action == :new_location}
@@ -201,8 +545,8 @@ defmodule HuddlzWeb.HuddlLive.New do
           />
 
           <div class="mt-4">
-            <label class="mono-label text-primary/70 mb-1.5 block" for="location-name-input">
-              Location Name (optional)
+            <label class="form-label" for="location-name-input">
+              Location name (optional)
             </label>
             <input
               type="text"
@@ -211,177 +555,90 @@ defmodule HuddlzWeb.HuddlLive.New do
               value={@modal_location_name}
               phx-debounce="100"
               placeholder="e.g., Community Center"
-              class="w-full h-10 border-0 border-b border-base-300 bg-transparent focus:border-primary focus:ring-0 focus:outline-none text-base-content text-sm"
+              class="form-input"
             />
           </div>
 
-          <div class="mt-6 flex gap-4">
-            <.button type="submit" disabled={is_nil(@modal_location_address)}>
-              Save Address
-            </.button>
-            <.link
-              patch={~p"/groups/#{@group.slug}/huddlz/new"}
-              class="px-6 py-2 text-sm font-medium border border-base-300 hover:border-primary/30 transition-colors"
-            >
+          <div class="form-foot" style="border:0; margin-top:18px">
+            <.v3_button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
+              Save address
+            </.v3_button>
+            <.v3_button variant={:secondary} patch={~p"/groups/#{@group.slug}/huddlz/new"}>
               Cancel
-            </.link>
+            </.v3_button>
           </div>
         </form>
       </.modal>
-    </Layouts.app>
+    </Layouts.v3_app>
     """
   end
 
-  attr :form, :any, required: true
-  attr :group, :map, required: true
-  attr :group_locations, :list, required: true
-  attr :selected_location, :any, required: true
-  attr :show_physical_location, :boolean, required: true
-  attr :show_virtual_link, :boolean, required: true
-  attr :calculated_end_time, :string, default: nil
-  attr :uploads, :map, required: true
-  attr :image_error, :any, default: nil
-  attr :pending_preview_url, :any, default: nil
-  attr :new_location_path, :string, required: true
-  attr :cancel_path, :string, required: true
+  attr :field, Phoenix.HTML.FormField, required: true
+  attr :value, :string, required: true
+  attr :title, :string, required: true
+  attr :desc, :string, required: true
+  slot :icon, required: true
 
-  defp create_huddl_form_body(assigns) do
+  defp event_type_option(assigns) do
+    radio_id = "event-type-#{assigns.value}"
+    assigns = Phoenix.Component.assign(assigns, :radio_id, radio_id)
+
     ~H"""
-    <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save" class="space-y-6">
-      <.huddl_form_fields
-        form={@form}
-        show_physical_location={@show_physical_location}
-        show_virtual_link={@show_virtual_link}
-        calculated_end_time={@calculated_end_time}
-        is_public={@group.is_public}
-        group_locations={@group_locations}
-        selected_location={@selected_location}
-        new_location_path={@new_location_path}
-      >
-        <:image_section>
-          <div>
-            <label class="mono-label text-primary/70 mb-2 block">
-              Huddl Image
-            </label>
-            <p class="text-base-content/50 text-sm mb-3">
-              Upload a banner image for this huddl (16:9 ratio recommended). If none is provided, the group image will be used.
-            </p>
-
-            <div
-              class="border border-dashed border-base-300 p-4 text-center hover:border-primary transition-colors"
-              phx-drop-target={@uploads.huddl_image.ref}
-            >
-              <.live_file_input upload={@uploads.huddl_image} class="hidden" />
-              <label
-                for={@uploads.huddl_image.ref}
-                class="cursor-pointer flex flex-col items-center"
-              >
-                <.icon name="hero-photo" class="w-8 h-8 text-base-content/50 mb-2" />
-                <span class="text-sm text-base-content/50">
-                  Click to upload or drag and drop
-                </span>
-                <span class="text-xs text-base-content/50 mt-1">
-                  JPG, PNG, or WebP (max 5MB)
-                </span>
-              </label>
-            </div>
-
-            <%= if @image_error do %>
-              <p class="text-error text-sm mt-2">{@image_error}</p>
-            <% end %>
-
-            <%= if @pending_preview_url do %>
-              <div class="mt-3 flex items-center gap-3 p-3 bg-base-200">
-                <img
-                  src={@pending_preview_url}
-                  class="w-32 aspect-video object-cover"
-                  alt="Preview"
-                />
-                <div class="flex-1 min-w-0">
-                  <p class="text-sm font-medium text-success flex items-center gap-1">
-                    <.icon name="hero-check-circle" class="w-4 h-4" /> Image uploaded
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  phx-click="cancel_pending_image"
-                  class="p-1 hover:bg-base-300 text-base-content/50 hover:text-base-content transition-colors"
-                >
-                  <.icon name="hero-x-mark" class="w-4 h-4" />
-                </button>
-              </div>
-            <% else %>
-              <%= for entry <- @uploads.huddl_image.entries do %>
-                <div class="mt-3 flex items-center gap-3 p-3 bg-base-200">
-                  <.live_img_preview entry={entry} class="w-32 aspect-video object-cover" />
-                  <div class="flex-1 min-w-0">
-                    <p class="text-sm font-medium truncate">{entry.client_name}</p>
-                    <div class="w-full bg-base-300 h-1.5 mt-1">
-                      <div
-                        class="bg-primary h-1.5 transition-all"
-                        style={"width: #{entry.progress}%"}
-                      >
-                      </div>
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    phx-click="cancel_image_upload"
-                    phx-value-ref={entry.ref}
-                    class="p-1 hover:bg-base-300 text-base-content/50 hover:text-base-content transition-colors"
-                  >
-                    <.icon name="hero-x-mark" class="w-4 h-4" />
-                  </button>
-                </div>
-
-                <%= for err <- upload_errors(@uploads.huddl_image, entry) do %>
-                  <p class="text-error text-sm mt-1">{upload_error_to_string(err)}</p>
-                <% end %>
-              <% end %>
-            <% end %>
-
-            <%= for err <- upload_errors(@uploads.huddl_image) do %>
-              <p class="text-error text-sm mt-2">{upload_error_to_string(err)}</p>
-            <% end %>
-          </div>
-        </:image_section>
-
-        <:recurring_section>
-          <.input field={@form[:is_recurring]} type="checkbox" label="Make this a recurring huddl" />
-
-          <%= if @form[:is_recurring].value do %>
-            <div class="grid gap-4 sm:grid-cols-2">
-              <.input
-                field={@form[:frequency]}
-                type="select"
-                label="Frequency"
-                options={[
-                  {"Weekly", "weekly"},
-                  {"Monthly", "monthly"}
-                ]}
-                required
-              />
-              <.input field={@form[:repeat_until]} type="date" label="Repeat Until" required />
-            </div>
-          <% end %>
-        </:recurring_section>
-
-        <:actions>
-          <div class="flex gap-4">
-            <.button type="submit" phx-disable-with="Creating...">
-              Create Huddl
-            </.button>
-            <.link
-              navigate={@cancel_path}
-              class="px-6 py-2 text-sm font-medium border border-base-300 hover:border-primary/30 transition-colors"
-            >
-              Cancel
-            </.link>
-          </div>
-        </:actions>
-      </.huddl_form_fields>
-    </.form>
+    <label for={@radio_id} class="sr-only">{@title}</label>
+    <label
+      for={@radio_id}
+      class={["event-type-option", to_string(@field.value) == @value && "is-active"]}
+    >
+      <input
+        id={@radio_id}
+        type="radio"
+        name={@field.name}
+        value={@value}
+        checked={to_string(@field.value) == @value}
+      />
+      <div class="event-type-icon">{render_slot(@icon)}</div>
+      <div>
+        <div class="event-type-title">{@title}</div>
+        <div class="event-type-desc">{@desc}</div>
+      </div>
+    </label>
     """
+  end
+
+  attr :field, Phoenix.HTML.FormField, required: true
+
+  defp field_errors(assigns) do
+    errors =
+      if Phoenix.Component.used_input?(assigns.field) do
+        Enum.map(assigns.field.errors, &translate_field_error/1)
+      else
+        []
+      end
+
+    assigns = Phoenix.Component.assign(assigns, :errors, errors)
+
+    ~H"""
+    <p :for={msg <- @errors} class="form-error">{msg}</p>
+    """
+  end
+
+  defp translate_field_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
+
+  defp duration_options do
+    [
+      {"30 minutes", "30"},
+      {"1 hour", "60"},
+      {"1.5 hours", "90"},
+      {"2 hours", "120"},
+      {"2.5 hours", "150"},
+      {"3 hours", "180"},
+      {"4 hours", "240"},
+      {"6 hours", "360"}
+    ]
   end
 
   @impl true

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -258,6 +258,7 @@ defmodule HuddlzWeb.HuddlLive.New do
               </:icon>
             </.event_type_option>
           </div>
+          <.v3_field_errors field={@form[:event_type]} />
         </div>
 
         <div class="panel">
@@ -266,48 +267,28 @@ defmodule HuddlzWeb.HuddlLive.New do
           </div>
           <div class="form-grid">
             <div class="form-row form-row-inline">
-              <div style="flex:1 1 180px">
-                <label class="form-label" for={@form[:date].id}>Date</label>
-                <input
+              <div class="form-col-md">
+                <.v3_input
+                  field={@form[:date]}
                   type="date"
-                  id={@form[:date].id}
-                  name={@form[:date].name}
-                  value={@form[:date].value}
+                  label="Date"
                   min={Date.utc_today() |> Date.to_iso8601()}
-                  class="form-input"
                 />
-                <.field_errors field={@form[:date]} />
               </div>
-              <div style="flex:1 1 140px">
-                <label class="form-label" for={@form[:start_time].id}>Start time</label>
-                <input
-                  type="time"
-                  id={@form[:start_time].id}
-                  name={@form[:start_time].name}
-                  value={@form[:start_time].value}
-                  class="form-input"
+              <div class="form-col-sm">
+                <.v3_input field={@form[:start_time]} type="time" label="Start time" />
+              </div>
+              <div class="form-col-sm">
+                <.v3_select
+                  field={@form[:duration_minutes]}
+                  label="Duration"
+                  prompt="Select duration…"
+                  options={duration_options()}
                 />
-                <.field_errors field={@form[:start_time]} />
-              </div>
-              <div style="flex:1 1 140px">
-                <label class="form-label" for={@form[:duration_minutes].id}>Duration</label>
-                <select
-                  id={@form[:duration_minutes].id}
-                  name={@form[:duration_minutes].name}
-                  class="form-select"
-                >
-                  <option value="">Select duration…</option>
-                  <%= for {label, mins} <- duration_options() do %>
-                    <option value={mins} selected={to_string(@form[:duration_minutes].value) == mins}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-                <.field_errors field={@form[:duration_minutes]} />
               </div>
             </div>
 
-            <p :if={@calculated_end_time} class="form-help" style="margin-top:-4px">
+            <p :if={@calculated_end_time} class="form-help">
               Ends at: <strong>{@calculated_end_time}</strong>
             </p>
 
@@ -329,30 +310,19 @@ defmodule HuddlzWeb.HuddlLive.New do
 
             <%= if Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_recurring].value) do %>
               <div class="form-row form-row-inline">
-                <div style="flex:1 1 200px">
-                  <label class="form-label" for={@form[:frequency].id}>Frequency</label>
-                  <select
-                    id={@form[:frequency].id}
-                    name={@form[:frequency].name}
-                    class="form-select"
+                <div class="form-col-md">
+                  <.v3_select
+                    field={@form[:frequency]}
+                    label="Frequency"
+                    options={[{"Weekly", "weekly"}, {"Monthly", "monthly"}]}
                     required
-                  >
-                    <option value="weekly" selected={to_string(@form[:frequency].value) == "weekly"}>
-                      Weekly
-                    </option>
-                    <option value="monthly" selected={to_string(@form[:frequency].value) == "monthly"}>
-                      Monthly
-                    </option>
-                  </select>
+                  />
                 </div>
-                <div style="flex:1 1 200px">
-                  <label class="form-label" for={@form[:repeat_until].id}>Repeat until</label>
-                  <input
+                <div class="form-col-md">
+                  <.v3_input
+                    field={@form[:repeat_until]}
                     type="date"
-                    id={@form[:repeat_until].id}
-                    name={@form[:repeat_until].name}
-                    value={@form[:repeat_until].value}
-                    class="form-input"
+                    label="Repeat until"
                     required
                   />
                 </div>
@@ -517,7 +487,7 @@ defmodule HuddlzWeb.HuddlLive.New do
           <% end %>
         </div>
 
-        <div class="form-foot" style="border:0; margin:0">
+        <div class="form-foot is-flush">
           <.v3_button variant={:primary} type="submit" phx-disable-with="Scheduling…">
             Schedule huddl
           </.v3_button>
@@ -559,7 +529,7 @@ defmodule HuddlzWeb.HuddlLive.New do
             />
           </div>
 
-          <div class="form-foot" style="border:0; margin-top:18px">
+          <div class="form-foot is-flush" style="margin-top:18px">
             <.v3_button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
               Save address
             </.v3_button>
@@ -603,29 +573,6 @@ defmodule HuddlzWeb.HuddlLive.New do
       </div>
     </label>
     """
-  end
-
-  attr :field, Phoenix.HTML.FormField, required: true
-
-  defp field_errors(assigns) do
-    errors =
-      if Phoenix.Component.used_input?(assigns.field) do
-        Enum.map(assigns.field.errors, &translate_field_error/1)
-      else
-        []
-      end
-
-    assigns = Phoenix.Component.assign(assigns, :errors, errors)
-
-    ~H"""
-    <p :for={msg <- @errors} class="form-error">{msg}</p>
-    """
-  end
-
-  defp translate_field_error({msg, opts}) do
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
   end
 
   defp duration_options do

--- a/test/features/create_huddl.feature
+++ b/test/features/create_huddl.feature
@@ -63,7 +63,7 @@ Feature: Create Huddl
     Then I should see a "Create Huddl" button
     When I click "Create Huddl"
     Then I should be on the new huddl page for "Tech Meetup"
-    When I check "Make this a recurring huddl"
+    When I check "Recurring huddl"
     When I fill in the huddl form with:
       | Field             | Value                       |
       | Title             | Monthly Tech Talk           |
@@ -83,7 +83,7 @@ Feature: Create Huddl
     Then I should see a "Create Huddl" button
     When I click "Create Huddl"
     Then I should be on the new huddl page for "Tech Meetup"
-    When I check "Make this a recurring huddl"
+    When I check "Recurring huddl"
     When I fill in the huddl form with:
       | Field             | Value                       |
       | Title             | Weekly Tech Talk            |
@@ -101,15 +101,15 @@ Feature: Create Huddl
     Given I am signed in as "owner@example.com"
     When I visit the new huddl page for "Tech Meetup"
     Then I should see "Physical Location" field
-    And I should not see "Virtual Meeting Link" field
-    When I select "Hybrid (Both In-Person and Virtual)" from "Huddl Type"
+    And I should not see "Online link" field
+    When I choose "Hybrid"
     Then I should see "Physical Location" field
-    And I should see "Virtual Meeting Link" field
+    And I should see "Online link" field
 
   Scenario: Private groups create private huddls only
     Given I am signed in as "owner@example.com"
     When I visit the new huddl page for "Private Group"
-    Then I should not see a checkbox for "Make this a private huddl"
+    Then I should not see a checkbox for "Members only"
     And I should see "This will be a private huddl"
     When I fill in the huddl form with:
       | Field             | Value                        |

--- a/test/features/step_definitions/create_huddl_steps.exs
+++ b/test/features/step_definitions/create_huddl_steps.exs
@@ -131,7 +131,7 @@ defmodule CreateHuddlSteps do
     # Check if we're on the new huddl page or got redirected
     has_form =
       try do
-        assert_has(session, "*", text: "Create New Huddl")
+        assert_has(session, "*", text: "Schedule a huddl")
         true
       rescue
         _ -> false
@@ -171,7 +171,7 @@ defmodule CreateHuddlSteps do
 
   step "I should be on the new huddl page for {string}", %{args: [group_name]} = context do
     session = context[:session] || context[:conn]
-    assert_has(session, "*", text: "Create New Huddl")
+    assert_has(session, "*", text: "Schedule a huddl")
     assert_has(session, "*", text: group_name)
     context
   end
@@ -263,13 +263,13 @@ defmodule CreateHuddlSteps do
       if form_data["event_type"] do
         event_type_label =
           case form_data["event_type"] do
-            "in_person" -> "In-Person"
+            "in_person" -> "In person"
             "virtual" -> "Virtual"
-            "hybrid" -> "Hybrid (Both In-Person and Virtual)"
-            _ -> "In-Person"
+            "hybrid" -> "Hybrid"
+            _ -> "In person"
           end
 
-        select(session, "Huddl Type", option: event_type_label, exact: false)
+        choose(session, event_type_label)
       else
         session
       end
@@ -308,13 +308,13 @@ defmodule CreateHuddlSteps do
             session
 
           "virtual_link" ->
-            fill_in(session, "Virtual Meeting Link", with: value, exact: false)
+            fill_in(session, "Online link", with: value, exact: false)
 
           "date" ->
             fill_in(session, "Date", with: value, exact: false)
 
           "start_time" ->
-            fill_in(session, "Start Time", with: value, exact: false)
+            fill_in(session, "Start time", with: value, exact: false)
 
           "duration_minutes" ->
             select(session, "Duration", option: format_duration_option(value), exact: false)
@@ -330,7 +330,7 @@ defmodule CreateHuddlSteps do
             select(session, "Frequency", option: value, exact: false)
 
           "repeat_until" ->
-            fill_in(session, "Repeat Until", with: value, exact: false)
+            fill_in(session, "Repeat until", with: value, exact: false)
 
           # Already handled above
           "event_type" ->
@@ -342,14 +342,14 @@ defmodule CreateHuddlSteps do
       end)
 
     # Submit the form
-    session = click_button(session, "Create Huddl")
+    session = click_button(session, "Schedule huddl")
 
     Map.merge(context, %{session: session, conn: session})
   end
 
   step "I submit the form without filling it", context do
     session = context[:session] || context[:conn]
-    session = click_button(session, "Create Huddl")
+    session = click_button(session, "Schedule huddl")
     Map.merge(context, %{session: session, conn: session})
   end
 
@@ -410,7 +410,7 @@ defmodule CreateHuddlSteps do
 
   step "I should remain on the new huddl page", context do
     session = context[:session] || context[:conn]
-    assert_has(session, "*", text: "Create New Huddl")
+    assert_has(session, "*", text: "Schedule a huddl")
     context
   end
 

--- a/test/features/step_definitions/shared_ui_steps.exs
+++ b/test/features/step_definitions/shared_ui_steps.exs
@@ -146,6 +146,13 @@ defmodule SharedUISteps do
     Map.merge(context, %{session: session, conn: session})
   end
 
+  step "I choose {string}", %{args: [option]} = context do
+    session = context[:session] || context[:conn]
+    session = choose(session, option)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
   # Button presence checks
   step "the {string} button should be visible", %{args: [button_text]} = context do
     session = context[:session] || context[:conn]

--- a/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
@@ -27,10 +27,9 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         |> login(owner)
         |> live(~p"/groups/#{group.slug}/huddlz/new")
 
-      assert has_element?(view, "label", "Huddl Image")
-      assert has_element?(view, "*", "Upload a banner image")
-      assert has_element?(view, "*", "Click to upload or drag and drop")
-      assert has_element?(view, "*", "JPG, PNG, or WebP (max 5MB)")
+      assert has_element?(view, "h2", "Cover image")
+      assert has_element?(view, "*", "Drop a 16:9 image")
+      assert has_element?(view, "*", "JPG, PNG, WebP")
     end
 
     test "creates huddl without image", %{conn: conn, owner: owner, group: group} do

--- a/test/huddlz_web/live/huddl_live/new_location_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_location_test.exs
@@ -51,7 +51,7 @@ defmodule HuddlzWeb.HuddlLive.NewLocationTest do
         |> live(~p"/groups/#{group.slug}/huddlz/new/locations/new")
 
       # Save button should be disabled initially
-      assert has_element?(view, "button[disabled]", "Save Address")
+      assert has_element?(view, "button[disabled]", "Save address")
     end
 
     test "selecting an address enables save and pre-populates name", %{
@@ -83,7 +83,7 @@ defmodule HuddlzWeb.HuddlLive.NewLocationTest do
       assert html =~ "Austin Convention Center"
 
       # Save button should no longer be disabled
-      refute has_element?(view, "button[disabled]", "Save Address")
+      refute has_element?(view, "button[disabled]", "Save address")
     end
 
     test "saving creates location and returns to huddl form", %{

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -47,7 +47,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
 
-      assert_has(session, "h1", text: "Create New Huddl")
+      assert_has(session, "h1", text: "Schedule a huddl")
       assert_has(session, "#huddl-form")
 
       # The group name should be somewhere on the page
@@ -65,7 +65,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> login(organizer)
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
 
-      assert_has(session, "h1", text: "Create New Huddl")
+      assert_has(session, "h1", text: "Schedule a huddl")
       assert_has(session, "#huddl-form")
 
       # The group name should be somewhere on the page
@@ -153,7 +153,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       assert_has(session, "input[name='form[date]'][type='date']")
       assert_has(session, "input[name='form[start_time]']")
       assert_has(session, "select[name='form[duration_minutes]']")
-      assert_has(session, "select[name='form[event_type]']")
+      assert_has(session, "input[name='form[event_type]'][type='radio']")
     end
 
     test "shows 16:9 ratio guidance for cover image", %{
@@ -166,7 +166,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
 
-      assert_has(session, "p", text: "16:9 ratio recommended")
+      assert_has(session, "*", text: "Drop a 16:9 image")
     end
 
     test "shows is_private checkbox for public groups", %{
@@ -180,7 +180,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
 
       assert_has(session, "input[name='form[is_private]'][type='checkbox']")
-      assert session.conn.resp_body =~ "Make this a private huddl"
+      assert session.conn.resp_body =~ "Members only"
     end
 
     test "shows private huddl notice for private groups", %{
@@ -220,7 +220,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/huddlz/new")
       # Change to virtual
-      |> select("Huddl Type", option: "Virtual", exact: false)
+      |> choose("Virtual")
       |> refute_has("#saved-location-picker")
       |> assert_has("input[name='form[virtual_link]']")
     end
@@ -230,7 +230,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/huddlz/new")
       # Change to hybrid
-      |> select("Huddl Type", option: "Hybrid (Both In-Person and Virtual)", exact: false)
+      |> choose("Hybrid")
       |> assert_has("#saved-location-picker")
       |> assert_has("input[name='form[virtual_link]']")
     end
@@ -255,13 +255,13 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> fill_in("Title", with: "Test Huddl")
         |> fill_in("Description", with: "A test huddl description")
         |> fill_in("Date", with: date)
-        |> fill_in("Start Time", with: time)
+        |> fill_in("Start time", with: time)
         |> select("Duration", option: "2 hours")
 
       # Set physical location through autocomplete component
       select_physical_location(session.view, "123 Main St")
 
-      session = click_button(session, "Create Huddl")
+      session = click_button(session, "Schedule huddl")
 
       # Should redirect to group page
       assert_path(session, ~p"/groups/#{group.slug}")
@@ -295,14 +295,14 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> fill_in("Title", with: "Capped Huddl")
         |> fill_in("Description", with: "Limited seats")
         |> fill_in("Date", with: date)
-        |> fill_in("Start Time", with: "14:30")
+        |> fill_in("Start time", with: "14:30")
         |> select("Duration", option: "2 hours")
-        |> fill_in("Max Attendees", with: "5")
+        |> fill_in("Max attendees", with: "5")
 
       select_physical_location(session.view, "123 Main St")
 
       session
-      |> click_button("Create Huddl")
+      |> click_button("Schedule huddl")
       |> assert_path(~p"/groups/#{group.slug}")
 
       huddl =
@@ -330,14 +330,14 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> login(owner)
         |> visit(~p"/groups/#{private_group.slug}/huddlz/new")
         # First change to virtual to show the virtual_link field
-        |> select("Huddl Type", option: "Virtual", exact: false)
+        |> choose("Virtual")
         |> fill_in("Title", with: "Private Group Huddl")
         |> fill_in("Description", with: "A huddl in a private group")
         |> fill_in("Date", with: date)
-        |> fill_in("Start Time", with: time)
+        |> fill_in("Start time", with: time)
         |> select("Duration", option: "2 hours")
-        |> fill_in("Virtual Meeting Link", with: "https://zoom.us/j/123456789")
-        |> click_button("Create Huddl")
+        |> fill_in("Online link", with: "https://zoom.us/j/123456789")
+        |> click_button("Schedule huddl")
 
       # Should redirect to group page
       assert_path(session, ~p"/groups/#{private_group.slug}")
@@ -358,13 +358,13 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
         # Try to submit without filling required fields
-        |> click_button("Create Huddl")
+        |> click_button("Schedule huddl")
 
       # Should still be on the same page
       assert_path(session, ~p"/groups/#{group.slug}/huddlz/new")
 
-      # Should show validation error (checking for error class on input)
-      assert_has(session, "input.border-error")
+      # Should show validation error
+      assert_has(session, "p.form-error")
     end
 
     test "selecting a saved location preserves other form fields", %{
@@ -392,7 +392,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
         |> fill_in("Title", with: "My New Huddl")
         |> fill_in("Date", with: tomorrow)
-        |> fill_in("Start Time", with: "15:00")
+        |> fill_in("Start time", with: "15:00")
         |> select("Duration", option: "2 hours")
 
       view = session.view
@@ -428,8 +428,8 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         # Clear the field to trigger validation
         |> fill_in("Title", with: "")
 
-      # Check for validation error class on the input
-      assert_has(session, "input#form_title.border-error")
+      # Check for validation error displayed below the input
+      assert_has(session, "p.form-error")
     end
   end
 
@@ -450,12 +450,12 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
         |> fill_in("Title", with: "Test Huddl")
         |> fill_in("Date", with: date)
-        |> fill_in("Start Time", with: "14:30")
+        |> fill_in("Start time", with: "14:30")
         |> select("Duration", option: "1 hour")
 
       select_physical_location(session.view, "123 Main St")
 
-      session = click_button(session, "Create Huddl")
+      session = click_button(session, "Schedule huddl")
 
       # Should still be on the same page with error
       assert_path(session, ~p"/groups/#{group.slug}/huddlz/new")
@@ -479,12 +479,12 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> fill_in("Title", with: "Test Huddl with Manual Time")
         |> fill_in("Date", with: date)
         # Enter a time that's not on a 15-minute increment
-        |> fill_in("Start Time", with: "09:47")
+        |> fill_in("Start time", with: "09:47")
         |> select("Duration", option: "1 hour")
 
       select_physical_location(session.view, "123 Main St")
 
-      session = click_button(session, "Create Huddl")
+      session = click_button(session, "Schedule huddl")
 
       # Should redirect to group page (successful creation)
       assert_path(session, ~p"/groups/#{group.slug}")
@@ -509,7 +509,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
         |> fill_in("Title", with: "Test Duration Calculation")
         |> fill_in("Date", with: date)
-        |> fill_in("Start Time", with: "15:00")
+        |> fill_in("Start time", with: "15:00")
         |> select("Duration", option: "1.5 hours")
 
       select_physical_location(session.view, "123 Main St")
@@ -517,7 +517,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       # Check that end time is displayed on the form
       assert session.conn.resp_body =~ "Ends at:"
 
-      session = click_button(session, "Create Huddl")
+      session = click_button(session, "Schedule huddl")
 
       # Should redirect to group page
       assert_path(session, ~p"/groups/#{group.slug}")
@@ -547,12 +547,12 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
         |> fill_in("Title", with: "Test Day Boundary")
         |> fill_in("Date", with: date)
-        |> fill_in("Start Time", with: "23:00")
+        |> fill_in("Start time", with: "23:00")
         |> select("Duration", option: "6 hours")
 
       select_physical_location(session.view, "123 Main St")
 
-      session = click_button(session, "Create Huddl")
+      session = click_button(session, "Schedule huddl")
 
       # Should redirect to group page
       assert_path(session, ~p"/groups/#{group.slug}")

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -363,8 +363,8 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       # Should still be on the same page
       assert_path(session, ~p"/groups/#{group.slug}/huddlz/new")
 
-      # Should show validation error
-      assert_has(session, "p.form-error")
+      # Should show validation error attached to the empty title field
+      assert_has(session, "input#form_title + p.form-error")
     end
 
     test "selecting a saved location preserves other form fields", %{
@@ -428,8 +428,8 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         # Clear the field to trigger validation
         |> fill_in("Title", with: "")
 
-      # Check for validation error displayed below the input
-      assert_has(session, "p.form-error")
+      # Check that the validation error renders in the same form-row as the title input
+      assert_has(session, "input#form_title + p.form-error")
     end
   end
 


### PR DESCRIPTION
## Summary

- Migrate the new-huddl form to `Layouts.v3_app` with v3 panels and primitives. Form layout is rebuilt inline; the existing `HuddlLive.FormComponent.huddl_form_fields` stays put because the edit form (PR-4.3) still depends on it.
- Drop the broken `padding: 0`-from-preflight on `.form-select` (was 22px tall next to 43px inputs) by setting `appearance: none` and supplying a SVG chevron. Affects every v3 select.
- Bump the unchecked toggle track to a `var(--soft)` border so the pill is visible against the panel background (also affected `group/new` and any future toggle).
- Update tests + feature steps + step defs for the new vocabulary: "Schedule huddl" submit, "Members only" toggle, radio-card event types ("In person / Virtual / Hybrid"), "Online link" instead of "Virtual Meeting Link", "Recurring huddl" toggle.

Net: one of the last three pages still on `Layouts.app` is now on v3. Remaining: `huddl_live/edit.ex` (PR-4.3) and `group_live/locations.ex` (PR-3.5, blocked on mockup).

## Test plan

- [x] `mix precommit` — 1250 tests / 0 failures, credo clean, formatter clean
- [x] Page renders in browser at `/groups/<slug>/huddlz/new` with v3 sidebar/topbar, panels, working toggles, working radio cards
- [x] Duration select and adjacent date/time inputs all render at 43px tall (verified)
- [x] Unchecked recurring toggle has a visible border in the off state (verified)
- [ ] Manual: submit a huddl end-to-end (happy path tested by feature scenarios)