### PR TITLE
fix(organize): drop redundant owned-groups query on /organize index

### DIFF
--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -15,10 +15,9 @@ defmodule HuddlzWeb.OrganizeLive do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities
-  alias Huddlz.Storage.GroupImages
   alias HuddlzWeb.Layouts
 
-  @group_loads [:current_image_url, :member_count]
+  @group_loads [:member_count]
   @huddl_loads [:rsvp_count, :status, :group]
   @upcoming_loads [:rsvp_count, :group]
   @member_role_order [:owner, :organizer, :member]
@@ -56,7 +55,7 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp load_action(socket, :index, _params, user) do
-    owned_groups = load_owned_groups(user)
+    owned_groups = Ash.load!(socket.assigns.sidebar_owned_groups, @group_loads, actor: user)
 
     socket
     |> assign(:group, nil)
@@ -97,14 +96,6 @@ defmodule HuddlzWeb.OrganizeLive do
   defp load_section(socket, :members, group, user) do
     members = list_group_members(group, user)
     assign(socket, :members, members)
-  end
-
-  defp load_owned_groups(user) do
-    Communities.get_organizable_groups!(
-      actor: user,
-      load: @group_loads,
-      query: [sort: [name: :asc]]
-    )
   end
 
   defp load_group(slug, user) do
@@ -446,10 +437,7 @@ defmodule HuddlzWeb.OrganizeLive do
       @member_role_order
       |> Enum.map(fn role -> {role, Enum.filter(assigns.members, &(&1.role == role))} end)
 
-    assigns =
-      assigns
-      |> assign(:grouped, grouped)
-      |> assign(:cover_url, cover_url(assigns.group))
+    assigns = assign(assigns, :grouped, grouped)
 
     ~H"""
     <div class="page-head">
@@ -502,11 +490,6 @@ defmodule HuddlzWeb.OrganizeLive do
     </div>
     """
   end
-
-  defp cover_url(%{current_image_url: url}) when is_binary(url) and url != "",
-    do: GroupImages.url(url)
-
-  defp cover_url(_), do: nil
 
   defp role_heading(:owner), do: "Owner"
   defp role_heading(:organizer), do: "Co-organizers"

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -42,6 +42,13 @@ Feature: Organizer workspace
     Then I should see "You don't organize any groups yet."
     And I should not see "Phoenix Devs"
 
+  Scenario: /organize picker lists owned groups alphabetically by name
+    Given a public group "Synth Society" exists with owner "host@example.com"
+    And a public group "Cyberpunk Builders" exists with owner "host@example.com"
+    And I am signed in as "host@example.com"
+    When I visit "/organize"
+    Then the picker should list "Cyberpunk Builders" before "Synth Society"
+
   Scenario: Sidebar shows each owned group with sub-tabs when active
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
     And a public group "Synth Society" exists with owner "host@example.com"

--- a/test/features/step_definitions/organize_workspace_steps.exs
+++ b/test/features/step_definitions/organize_workspace_steps.exs
@@ -56,6 +56,17 @@ defmodule OrganizeWorkspaceSteps do
     context
   end
 
+  step "the picker should list {string} before {string}",
+       %{args: [first, second]} = context do
+    session = context[:session] || context[:conn]
+
+    session
+    |> assert_has("a.row .row-title", text: first, at: 1)
+    |> assert_has("a.row .row-title", text: second, at: 2)
+
+    context
+  end
+
   defp lookup_group(name) do
     Huddlz.Communities.Group
     |> Ash.Query.filter(name: name)


### PR DESCRIPTION
## Summary
- `/organize` (picker) was firing a near-duplicate `get_organizable_groups!` after `LiveUserAuth.on_mount(:app)` had already loaded the same set for the sidebar. Reuse the sidebar list and `Ash.load` the extra `:member_count` onto it.
- Drop `:current_image_url` from `@group_loads`. `picker_view/1` never rendered it, and the `:cover_url` assign that `members_view` was computing from it was never referenced in the template either — so the helper and `Huddlz.Storage.GroupImages` alias come out with it.

Net: one DB query removed per index render, plus a small chunk of dead code gone.

## Test plan
- [x] `mix precommit` clean (1245 tests pass, credo clean)
- [ ] Manual: load `/organize` while signed in as an organizer; confirm the picker still renders group rows with name, member count, and visibility pill, and that the sidebar still lists owned groups
- [ ] Manual: visit `/organize/:group_slug` (overview, huddlz, members) and confirm nothing regresses — `member_count` still loaded for the per-group views

Closes #210