### PR TITLE
fix(huddl-edit): drop stale is_recurring param seed

### DIFF
--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -121,7 +121,6 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   defp maybe_add_recurring_params(params, huddl) do
     if huddl.huddl_template_id do
       Map.merge(params, %{
-        "is_recurring" => "true",
         "repeat_until" => huddl.huddl_template.repeat_until,
         "frequency" => to_string(huddl.huddl_template.frequency)
       })


### PR DESCRIPTION
## Summary
- `Huddlz.Communities.Huddl`'s `:update` action doesn't accept `is_recurring`, so the seeded `"true"` in `maybe_add_recurring_params/2` was silently dropped by Ash
- The chip-group (`edit_type_value(@form) == "all"`) drives the frequency/repeat-until input visibility on edit now, leaving the param with no consumer
- Drops the one dead line; `repeat_until` and `frequency` seeds are kept since the update action still accepts them

## Test plan
- [x] `mix precommit` clean (compile, format, credo, 1245 tests)

Closes #219