### PR TITLE
Centralize identity/role checks in Ash policies

### DIFF
--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -440,7 +440,23 @@ defmodule Huddlz.Accounts.User do
       authorize_if always()
     end
 
+    # Self-role-change is forbidden for everyone, including admins. This
+    # regular policy runs before the admin bypass below — and because the
+    # bypass excludes :update_role, admins are subject to it. Without this,
+    # an admin could demote themselves and lock /admin out; `Ash.can?` would
+    # also report self-edits as allowed, so UIs couldn't pre-disable the
+    # control.
+    policy action(:update_role) do
+      description "Admins can change anyone's role except their own"
+      forbid_if expr(id == ^actor(:id))
+      authorize_if actor_attribute_equals(:role, :admin)
+    end
+
+    # Broad admin bypass — applies to everything EXCEPT :update_role, which
+    # is gated by the regular policy above so admins are not exempt from the
+    # self-role-change block.
     bypass actor_attribute_equals(:role, :admin) do
+      forbid_if action(:update_role)
       authorize_if always()
     end
 

--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -51,6 +51,7 @@ defmodule Huddlz.Communities do
       define :get_joined_groups, action: :get_joined
       define :my_groups, action: :my_groups, args: [{:optional, :relationship}]
       define :get_by_slug, action: :get_by_slug, args: [:slug]
+      define :get_group_for_organize, action: :get_for_organize, args: [:slug], get?: true
 
       define :update_details,
         action: :update_details,

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -178,6 +178,23 @@ defmodule Huddlz.Communities.Group do
       filter expr(slug == ^arg(:slug))
     end
 
+    read :get_for_organize do
+      description """
+      Get a group by slug, but only when the actor can manage it as an
+      organizer — they own the group, are an `:organizer` GroupMember, or are
+      an admin (via the resource-level admin bypass). Drives `OrganizeLive`'s
+      per-slug auth check; nil result means "not organizable by this actor."
+      """
+
+      get? true
+
+      argument :slug, :string do
+        allow_nil? false
+      end
+
+      filter expr(slug == ^arg(:slug))
+    end
+
     update :update_details do
       description "Update group details"
       accept [:name, :description, :location, :is_public, :slug]
@@ -244,6 +261,14 @@ defmodule Huddlz.Communities.Group do
       # Explicitly forbid users that are not the owner
       forbid_unless relates_to_actor_via(:owner)
       authorize_if relates_to_actor_via(:owner)
+    end
+
+    # Owner or :organizer member can open the per-group organizer workspace.
+    # Admins are covered by the bypass at the top of this block.
+    policy action(:get_for_organize) do
+      description "Owner or :organizer member can manage this group as an organizer"
+      authorize_if expr(owner_id == ^actor(:id))
+      authorize_if expr(exists(group_members, user_id == ^actor(:id) and role == :organizer))
     end
 
     # Anyone can read public groups, owner and members can read private groups

--- a/lib/huddlz_web/live/admin_live.ex
+++ b/lib/huddlz_web/live/admin_live.ex
@@ -123,9 +123,7 @@ defmodule HuddlzWeb.AdminLive do
                     <span class={["pill", role_pill_variant(user.role)]}>{user.role}</span>
                   </td>
                   <td data-label="Actions">
-                    <%= if user.id == @current_user.id do %>
-                      <span class="muted">You</span>
-                    <% else %>
+                    <%= if Ash.can?({user, :update_role}, @current_user) do %>
                       <form phx-submit="update_role" class="role-form">
                         <input type="hidden" name="user_id" value={user.id} />
                         <select name="role" class="form-select">
@@ -134,6 +132,8 @@ defmodule HuddlzWeb.AdminLive do
                         </select>
                         <button type="submit" class="btn-primary">Update</button>
                       </form>
+                    <% else %>
+                      <span class="muted">You</span>
                     <% end %>
                   </td>
                 </tr>

--- a/lib/huddlz_web/live/admin_live.ex
+++ b/lib/huddlz_web/live/admin_live.ex
@@ -7,7 +7,7 @@ defmodule HuddlzWeb.AdminLive do
   alias Huddlz.Accounts
   alias HuddlzWeb.Layouts
 
-  on_mount {HuddlzWeb.LiveUserAuth, role_required: :admin}
+  on_mount {HuddlzWeb.LiveUserAuth, :admin_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
 
   @impl true

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -13,7 +13,6 @@ defmodule HuddlzWeb.OrganizeLive do
   """
   use HuddlzWeb, :live_view
 
-  alias Huddlz.Accounts.User
   alias Huddlz.Communities
   alias HuddlzWeb.Layouts
 
@@ -99,25 +98,9 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp load_group(slug, user) do
-    case Communities.get_by_slug(slug, actor: user, load: @group_loads) do
-      {:ok, %{} = group} ->
-        if organizable_by?(group, user), do: {:ok, group}, else: :error
-
-      _ ->
-        :error
-    end
-  end
-
-  defp organizable_by?(%{owner_id: owner_id}, %{id: actor_id}) when owner_id == actor_id, do: true
-
-  defp organizable_by?(group, user) do
-    if User.admin?(user) do
-      true
-    else
-      case Communities.get_membership_in_group(group.id, actor: user) do
-        {:ok, %{role: :organizer}} -> true
-        _ -> false
-      end
+    case Communities.get_group_for_organize(slug, actor: user, load: @group_loads) do
+      {:ok, %Huddlz.Communities.Group{} = group} -> {:ok, group}
+      _ -> :error
     end
   end
 

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -7,6 +7,7 @@ defmodule HuddlzWeb.LiveUserAuth do
   use HuddlzWeb, :verified_routes
 
   alias AshAuthentication.Phoenix.LiveSession
+  alias Huddlz.Accounts.User
 
   # This is used for nested liveviews to fetch the current user.
   # To use, place the following at the top of that liveview:
@@ -48,10 +49,12 @@ defmodule HuddlzWeb.LiveUserAuth do
     end
   end
 
-  def on_mount([role_required: role_required], _params, _session, socket) do
-    current_user = socket.assigns[:current_user]
-
-    if current_user && current_user.role == role_required do
+  # Gate a LiveView on admin-only access. The "is this user an admin?" rule
+  # lives on the User resource (`User.admin?/1` + the `:is_admin` calculation),
+  # so this hook stays in sync with the policy bypass that uses the same role
+  # check on every Ash action.
+  def on_mount(:admin_required, _params, _session, socket) do
+    if User.admin?(socket.assigns[:current_user]) do
       {:cont, socket}
     else
       {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}

--- a/test/huddlz/accounts/admin_authorization_test.exs
+++ b/test/huddlz/accounts/admin_authorization_test.exs
@@ -68,5 +68,21 @@ defmodule Huddlz.Accounts.AdminAuthorizationTest do
       assert {:ok, demoted} = Accounts.update_role(other_admin, :user, actor: admin)
       assert demoted.role == :user
     end
+
+    test "Ash.can? rejects self-role-change at the record level", %{admin: admin} do
+      # Drives the AdminLive UI gate: the self-edit form is hidden via
+      # `Ash.can?({user, :update_role}, current_user)`. If this slips back to
+      # true, admins would render an Update button on their own row that the
+      # action's validate would then reject — confusing footgun.
+      refute Ash.can?({admin, :update_role}, admin)
+    end
+
+    test "Ash.can? allows record-level update on other admins", %{admin: admin} do
+      # Counterpart to the self-block: the scoped admin bypass must still
+      # authorize when the target isn't the actor.
+      other = generate(user(role: :admin))
+
+      assert Ash.can?({other, :update_role}, admin)
+    end
   end
 end

--- a/test/huddlz/communities/group_test.exs
+++ b/test/huddlz/communities/group_test.exs
@@ -434,6 +434,102 @@ defmodule Huddlz.Communities.GroupTest do
     end
   end
 
+  describe "get_for_organize" do
+    # Backs the per-slug auth check in OrganizeLive: succeeds when the actor
+    # can manage the group (owner, :organizer member, or admin via the
+    # resource-level bypass), and returns NotFound otherwise — the action is
+    # `get? true`, so policy-filtered rows surface as `Ash.Error.Query.NotFound`
+    # under the default `not_found_error?: true`. The LiveView treats both
+    # success-with-wrong-shape and error as "not organizable".
+
+    test "owner gets their group" do
+      owner = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      assert {:ok, %Group{id: id}} =
+               Communities.get_group_for_organize(group.slug, actor: owner)
+
+      assert id == group.id
+    end
+
+    test ":organizer member gets the group" do
+      owner = generate(user(role: :user))
+      co = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: co.id,
+          role: "organizer",
+          actor: owner
+        )
+      )
+
+      assert {:ok, %Group{id: id}} =
+               Communities.get_group_for_organize(group.slug, actor: co)
+
+      assert id == group.id
+    end
+
+    test "regular :member is excluded" do
+      owner = generate(user(role: :user))
+      member = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: member.id,
+          role: "member",
+          actor: owner
+        )
+      )
+
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Query.NotFound{}]}} =
+               Communities.get_group_for_organize(group.slug, actor: member)
+    end
+
+    test "non-member of a public group is excluded" do
+      owner = generate(user(role: :user))
+      stranger = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Query.NotFound{}]}} =
+               Communities.get_group_for_organize(group.slug, actor: stranger)
+    end
+
+    test "non-member of a private group is excluded" do
+      owner = generate(user(role: :user))
+      stranger = generate(user(role: :user))
+      group = generate(group(is_public: false, owner_id: owner.id, actor: owner))
+
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Query.NotFound{}]}} =
+               Communities.get_group_for_organize(group.slug, actor: stranger)
+    end
+
+    test "admin can open any group's slug via the resource-level bypass" do
+      # Mirrors the action's docstring: admins are not auto-included in the
+      # picker (`:get_organizable`), but the per-slug check intentionally lets
+      # an admin into any group's organizer workspace.
+      admin = generate(user(role: :admin))
+      owner = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+      assert {:ok, %Group{id: id}} =
+               Communities.get_group_for_organize(group.slug, actor: admin)
+
+      assert id == group.id
+    end
+
+    test "unknown slug returns NotFound" do
+      actor = generate(user(role: :user))
+
+      assert {:error, %Ash.Error.Invalid{errors: [%Ash.Error.Query.NotFound{}]}} =
+               Communities.get_group_for_organize("no-such-slug", actor: actor)
+    end
+  end
+
   describe "attribute constraints" do
     test "rejects description over 5000 characters" do
       owner = generate(user())


### PR DESCRIPTION
## Summary

Move three permission checks out of LiveViews and into the Ash policy layer so every entry point (LiveView, GraphQL, JSON:API, future MCP tools) inherits the same rules.

- **Admin mount gate** — replace `role_required: :admin` with a dedicated `:admin_required` hook that delegates to `User.admin?/1` (the existing helper backed by the `:is_admin` calculation).
- **Organizer workspace** — new `Group.:get_for_organize` read action whose policy authorizes owner OR `:organizer` GroupMember (admins via the resource-level bypass). `OrganizeLive`'s imperative `organizable_by?/2` helper is gone.
- **Admin self-role-change** — the `forbid_if expr(id == ^actor(:id))` rule moves from a `validate` (which can't be queried by `Ash.can?`) into a regular `policy action(:update_role)` that runs ahead of the broad admin bypass. The AdminLive template now uses `Ash.can?` instead of an inline `user.id == @current_user.id` check; the action's `validate` stays as defense-in-depth for `authorize?: false` callers.

Three commits, one per fix. `mix precommit` clean (1255 tests).

## Test plan

- [x] `mix precommit` passes (1255 tests, 0 failures, credo clean)
- [x] New tests pin the policy contract:
  - `Ash.can?({admin_record, :update_role}, admin_record)` returns false
  - `Ash.can?({other_admin, :update_role}, admin)` returns true
  - `Group.:get_for_organize` covers owner / organizer / regular member / non-member of public group / non-member of private group / admin bypass / unknown slug
- [ ] Manual smoke: `/admin` still redirects non-admins; admins see all rows but no Update form on their own row; `/organize/<slug>` accessible to owner, organizer, and admin; private-group owner can still open it