### PR TITLE
refactor(huddl-form): extract shared event-type + duration primitives

### DIFF
--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -9,11 +9,19 @@ defmodule HuddlzWeb.Components.HuddlForm do
 
   <.input type="select" options={duration_options()} ... />
   ```
-
-  `event_type_option/1` is also exported so a form that needs a divergent
-  layout can assemble its own grid without forking the wrapper.
   """
   use Phoenix.Component
+
+  @duration_options [
+    {"30 minutes", "30"},
+    {"1 hour", "60"},
+    {"1.5 hours", "90"},
+    {"2 hours", "120"},
+    {"2.5 hours", "150"},
+    {"3 hours", "180"},
+    {"4 hours", "240"},
+    {"6 hours", "360"}
+  ]
 
   attr :field, Phoenix.HTML.FormField, required: true
   attr :value, :string, required: true
@@ -21,7 +29,7 @@ defmodule HuddlzWeb.Components.HuddlForm do
   attr :desc, :string, required: true
   slot :icon, required: true
 
-  def event_type_option(assigns) do
+  defp event_type_option(assigns) do
     radio_id = "event-type-#{assigns.value}"
     assigns = assign(assigns, :radio_id, radio_id)
 
@@ -121,16 +129,5 @@ defmodule HuddlzWeb.Components.HuddlForm do
     """
   end
 
-  def duration_options do
-    [
-      {"30 minutes", "30"},
-      {"1 hour", "60"},
-      {"1.5 hours", "90"},
-      {"2 hours", "120"},
-      {"2.5 hours", "150"},
-      {"3 hours", "180"},
-      {"4 hours", "240"},
-      {"6 hours", "360"}
-    ]
-  end
+  def duration_options, do: @duration_options
 end

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -1,0 +1,136 @@
+defmodule HuddlzWeb.Components.HuddlForm do
+  @moduledoc """
+  Presentation primitives shared by the huddl create and edit forms:
+  the event-type radio cards and the duration select options.
+
+  ```
+  <.event_type_grid field={@form[:event_type]} />
+  <.field_errors field={@form[:event_type]} />
+
+  <.input type="select" options={duration_options()} ... />
+  ```
+
+  `event_type_option/1` is also exported so a form that needs a divergent
+  layout can assemble its own grid without forking the wrapper.
+  """
+  use Phoenix.Component
+
+  attr :field, Phoenix.HTML.FormField, required: true
+  attr :value, :string, required: true
+  attr :title, :string, required: true
+  attr :desc, :string, required: true
+  slot :icon, required: true
+
+  def event_type_option(assigns) do
+    radio_id = "event-type-#{assigns.value}"
+    assigns = assign(assigns, :radio_id, radio_id)
+
+    ~H"""
+    <label for={@radio_id} class="sr-only">{@title}</label>
+    <label
+      for={@radio_id}
+      class={["event-type-option", to_string(@field.value) == @value && "is-active"]}
+    >
+      <input
+        id={@radio_id}
+        type="radio"
+        name={@field.name}
+        value={@value}
+        checked={to_string(@field.value) == @value}
+      />
+      <div class="event-type-icon">{render_slot(@icon)}</div>
+      <div>
+        <div class="event-type-title">{@title}</div>
+        <div class="event-type-desc">{@desc}</div>
+      </div>
+    </label>
+    """
+  end
+
+  attr :field, Phoenix.HTML.FormField, required: true
+
+  def event_type_grid(assigns) do
+    ~H"""
+    <div class="event-type-grid">
+      <.event_type_option
+        field={@field}
+        value="in_person"
+        title="In person"
+        desc="Single physical location."
+      >
+        <:icon>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
+              cx="12"
+              cy="10"
+              r="3"
+            />
+          </svg>
+        </:icon>
+      </.event_type_option>
+      <.event_type_option
+        field={@field}
+        value="virtual"
+        title="Virtual"
+        desc="Online only — no physical address."
+      >
+        <:icon>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
+          </svg>
+        </:icon>
+      </.event_type_option>
+      <.event_type_option
+        field={@field}
+        value="hybrid"
+        title="Hybrid"
+        desc="In-person plus an online stream."
+      >
+        <:icon>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
+              cx="12"
+              cy="10"
+              r="3"
+            /><path d="m22 22-2-2" />
+          </svg>
+        </:icon>
+      </.event_type_option>
+    </div>
+    """
+  end
+
+  def duration_options do
+    [
+      {"30 minutes", "30"},
+      {"1 hour", "60"},
+      {"1.5 hours", "90"},
+      {"2 hours", "120"},
+      {"2.5 hours", "150"},
+      {"3 hours", "180"},
+      {"4 hours", "240"},
+      {"6 hours", "360"}
+    ]
+  end
+end

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -4,6 +4,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Components.HuddlForm
   import HuddlzWeb.HuddlLive.FormHelpers
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
@@ -259,73 +260,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
           <div class="panel-head">
             <h2>Format</h2>
           </div>
-          <div class="event-type-grid">
-            <.event_type_option
-              field={@form[:event_type]}
-              value="in_person"
-              title="In person"
-              desc="Single physical location."
-            >
-              <:icon>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
-                    cx="12"
-                    cy="10"
-                    r="3"
-                  />
-                </svg>
-              </:icon>
-            </.event_type_option>
-            <.event_type_option
-              field={@form[:event_type]}
-              value="virtual"
-              title="Virtual"
-              desc="Online only — no physical address."
-            >
-              <:icon>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
-                </svg>
-              </:icon>
-            </.event_type_option>
-            <.event_type_option
-              field={@form[:event_type]}
-              value="hybrid"
-              title="Hybrid"
-              desc="In-person plus an online stream."
-            >
-              <:icon>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
-                    cx="12"
-                    cy="10"
-                    r="3"
-                  /><path d="m22 22-2-2" />
-                </svg>
-              </:icon>
-            </.event_type_option>
-          </div>
+          <.event_type_grid field={@form[:event_type]} />
           <.field_errors field={@form[:event_type]} />
         </div>
 
@@ -580,38 +515,6 @@ defmodule HuddlzWeb.HuddlLive.Edit do
     """
   end
 
-  attr :field, Phoenix.HTML.FormField, required: true
-  attr :value, :string, required: true
-  attr :title, :string, required: true
-  attr :desc, :string, required: true
-  slot :icon, required: true
-
-  defp event_type_option(assigns) do
-    radio_id = "event-type-#{assigns.value}"
-    assigns = Phoenix.Component.assign(assigns, :radio_id, radio_id)
-
-    ~H"""
-    <label for={@radio_id} class="sr-only">{@title}</label>
-    <label
-      for={@radio_id}
-      class={["event-type-option", to_string(@field.value) == @value && "is-active"]}
-    >
-      <input
-        id={@radio_id}
-        type="radio"
-        name={@field.name}
-        value={@value}
-        checked={to_string(@field.value) == @value}
-      />
-      <div class="event-type-icon">{render_slot(@icon)}</div>
-      <div>
-        <div class="event-type-title">{@title}</div>
-        <div class="event-type-desc">{@desc}</div>
-      </div>
-    </label>
-    """
-  end
-
   attr :pending_preview_url, :string, default: nil
   attr :huddl, :map, required: true
   attr :upload_ref, :string, required: true
@@ -671,19 +574,6 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   end
 
   defp image_preview(assigns), do: ~H""
-
-  defp duration_options do
-    [
-      {"30 minutes", "30"},
-      {"1 hour", "60"},
-      {"1.5 hours", "90"},
-      {"2 hours", "120"},
-      {"2.5 hours", "150"},
-      {"3 hours", "180"},
-      {"4 hours", "240"},
-      {"6 hours", "360"}
-    ]
-  end
 
   defp edit_type_value(form) do
     case AshPhoenix.Form.value(form.source, :edit_type) do

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -4,6 +4,7 @@ defmodule HuddlzWeb.HuddlLive.New do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Components.HuddlForm
   import HuddlzWeb.HuddlLive.FormHelpers
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
@@ -191,73 +192,7 @@ defmodule HuddlzWeb.HuddlLive.New do
           <div class="panel-head">
             <h2>Format</h2>
           </div>
-          <div class="event-type-grid">
-            <.event_type_option
-              field={@form[:event_type]}
-              value="in_person"
-              title="In person"
-              desc="Single physical location."
-            >
-              <:icon>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
-                    cx="12"
-                    cy="10"
-                    r="3"
-                  />
-                </svg>
-              </:icon>
-            </.event_type_option>
-            <.event_type_option
-              field={@form[:event_type]}
-              value="virtual"
-              title="Virtual"
-              desc="Online only — no physical address."
-            >
-              <:icon>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
-                </svg>
-              </:icon>
-            </.event_type_option>
-            <.event_type_option
-              field={@form[:event_type]}
-              value="hybrid"
-              title="Hybrid"
-              desc="In-person plus an online stream."
-            >
-              <:icon>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
-                    cx="12"
-                    cy="10"
-                    r="3"
-                  /><path d="m22 22-2-2" />
-                </svg>
-              </:icon>
-            </.event_type_option>
-          </div>
+          <.event_type_grid field={@form[:event_type]} />
           <.field_errors field={@form[:event_type]} />
         </div>
 
@@ -546,51 +481,6 @@ defmodule HuddlzWeb.HuddlLive.New do
       </.modal>
     </Layouts.app>
     """
-  end
-
-  attr :field, Phoenix.HTML.FormField, required: true
-  attr :value, :string, required: true
-  attr :title, :string, required: true
-  attr :desc, :string, required: true
-  slot :icon, required: true
-
-  defp event_type_option(assigns) do
-    radio_id = "event-type-#{assigns.value}"
-    assigns = Phoenix.Component.assign(assigns, :radio_id, radio_id)
-
-    ~H"""
-    <label for={@radio_id} class="sr-only">{@title}</label>
-    <label
-      for={@radio_id}
-      class={["event-type-option", to_string(@field.value) == @value && "is-active"]}
-    >
-      <input
-        id={@radio_id}
-        type="radio"
-        name={@field.name}
-        value={@value}
-        checked={to_string(@field.value) == @value}
-      />
-      <div class="event-type-icon">{render_slot(@icon)}</div>
-      <div>
-        <div class="event-type-title">{@title}</div>
-        <div class="event-type-desc">{@desc}</div>
-      </div>
-    </label>
-    """
-  end
-
-  defp duration_options do
-    [
-      {"30 minutes", "30"},
-      {"1 hour", "60"},
-      {"1.5 hours", "90"},
-      {"2 hours", "120"},
-      {"2.5 hours", "150"},
-      {"3 hours", "180"},
-      {"4 hours", "240"},
-      {"6 hours", "360"}
-    ]
   end
 
   @impl true


### PR DESCRIPTION
## Summary

- New `HuddlzWeb.Components.HuddlForm` module owns the radio-card vocabulary and duration list shared by `HuddlLive.New` and `HuddlLive.Edit`.
- `<.event_type_grid field={...} />` replaces 66 lines of byte-identical inline SVG markup in each form. `event_type_option/1` is kept public so a future divergent form can assemble its own grid without forking the wrapper.
- `duration_options/0` graduates from a private def in each LiveView to a public helper on the new module.
- Net: -84 lines across the two LiveViews + new component.

Closes #218.

## Test plan

- [x] `mix precommit` (1255 tests, credo clean)
- [ ] Manual: `/groups/:slug/huddlz/new` — Format panel renders all three cards, selection updates `is-active` chip, duration select still populates
- [ ] Manual: `/groups/:slug/huddlz/:id/edit` — same checks; existing event_type is reflected on load