### PR TITLE
fix(organize): neutralize organize workspace not-found flash

### DIFF
--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -71,7 +71,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
       :error ->
         socket
-        |> put_flash(:error, "You don't organize that group.")
+        |> put_flash(:error, "That group doesn't exist, or you don't organize it.")
         |> push_navigate(to: ~p"/organize")
     end
   end

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -64,7 +64,13 @@ Feature: Organizer workspace
     Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
     And I am signed in as "host@example.com"
     When I visit "/organize/phoenix-devs"
-    Then I should see "You don't organize that group."
+    Then I should see "That group doesn't exist, or you don't organize it."
+    And I should see "You don't organize any groups yet."
+
+  Scenario: Visiting an unknown group slug redirects back to the picker with the same flash
+    Given I am signed in as "host@example.com"
+    When I visit "/organize/no-such-group"
+    Then I should see "That group doesn't exist, or you don't organize it."
     And I should see "You don't organize any groups yet."
 
   Scenario: A co-organizer can open the workspace for a group they help run
@@ -77,7 +83,7 @@ Feature: Organizer workspace
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
-    And I should not see "You don't organize that group."
+    And I should not see "That group doesn't exist, or you don't organize it."
 
   Scenario: An admin can open the workspace for any group
     Given the following users exist:
@@ -87,7 +93,7 @@ Feature: Organizer workspace
     And I am signed in as "admin@example.com"
     When I visit "/organize/phoenix-devs"
     Then I should see "Phoenix Devs"
-    And I should not see "You don't organize that group."
+    And I should not see "That group doesn't exist, or you don't organize it."
 
   Scenario: Group overview shows zeroed KPIs and empty upcoming list
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"


### PR DESCRIPTION
## Summary
- `OrganizeLive`'s redirect flash used to say "You don't organize that group." for *both* unknown slugs and policy-filtered groups. Since the move to the `:get_for_organize` action (4ad25e5), Ash intentionally collapses 404 and 403 into a single `Ash.Error.Query.NotFound` (to avoid leaking the existence of private groups), so the old copy misled users who simply mistyped a slug.
- Reworded to "That group doesn't exist, or you don't organize it." — honest about both cases without distinguishing them.
- Added a feature scenario that exercises the unknown-slug path so the unified message stays put.

Closes #211.

## Test plan
- [x] `mix precommit` (1256 tests, 0 failures, credo clean)
- [ ] Manual: sign in, visit `/organize/no-such-group` → see neutral flash; visit a public group owned by someone else → same flash