### PR TITLE
refactor(notifications): share helpers across senders

### DIFF
--- a/lib/huddlz/notifications/senders/changed_fields.ex
+++ b/lib/huddlz/notifications/senders/changed_fields.ex
@@ -1,0 +1,20 @@
+defmodule Huddlz.Notifications.Senders.ChangedFields do
+  @moduledoc """
+  Renders the `changed_fields` payload list as a human-readable
+  summary for huddl-update emails.
+  """
+
+  @spec summary(map()) :: String.t()
+  def summary(%{"changed_fields" => fields}) when is_list(fields) and fields != [] do
+    Enum.map_join(fields, ", ", &humanize/1)
+  end
+
+  def summary(_), do: "huddl details"
+
+  defp humanize("title"), do: "the title"
+  defp humanize("starts_at"), do: "the start time"
+  defp humanize("ends_at"), do: "the end time"
+  defp humanize("physical_location"), do: "the location"
+  defp humanize("virtual_link"), do: "the virtual link"
+  defp humanize(other) when is_binary(other), do: other
+end

--- a/lib/huddlz/notifications/senders/group_member_added.ex
+++ b/lib/huddlz/notifications/senders/group_member_added.ex
@@ -15,19 +15,19 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
     safe_name = HtmlEscape.escape(user.display_name)
     safe_group = HtmlEscape.escape(group_name(payload))
-    group_url = group_url(payload)
+    group_url = Urls.group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_member_added)
 
@@ -55,7 +55,4 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")
 end

--- a/lib/huddlz/notifications/senders/group_member_joined.ex
+++ b/lib/huddlz/notifications/senders/group_member_joined.ex
@@ -16,20 +16,20 @@ defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
     safe_name = HtmlEscape.escape(user.display_name)
     safe_group = HtmlEscape.escape(group_name(payload))
     safe_joiner = HtmlEscape.escape(joiner_display_name(payload))
-    group_url = group_url(payload)
+    group_url = Urls.group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_member_joined)
 
@@ -59,7 +59,4 @@ defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
 
   defp joiner_display_name(%{"joiner_display_name" => name}) when is_binary(name), do: name
   defp joiner_display_name(_), do: "Someone"
-
-  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")
 end

--- a/lib/huddlz/notifications/senders/group_ownership_transferred.ex
+++ b/lib/huddlz/notifications/senders/group_ownership_transferred.ex
@@ -20,12 +20,12 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -41,7 +41,7 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
     safe_name = HtmlEscape.escape(user.display_name)
     safe_group = HtmlEscape.escape(group_name(payload))
     safe_new_owner = HtmlEscape.escape(payload["new_owner_display_name"] || "another member")
-    group_url = group_url(payload)
+    group_url = Urls.group_url(payload)
 
     new()
     |> from(Mailer.from())
@@ -73,7 +73,7 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
     safe_prev_owner =
       HtmlEscape.escape(payload["previous_owner_display_name"] || "the previous owner")
 
-    group_url = group_url(payload)
+    group_url = Urls.group_url(payload)
 
     new()
     |> from(Mailer.from())
@@ -101,7 +101,4 @@ defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "the group"
-
-  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")
 end

--- a/lib/huddlz/notifications/senders/group_role_changed.ex
+++ b/lib/huddlz/notifications/senders/group_role_changed.ex
@@ -16,13 +16,13 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -30,7 +30,7 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
     safe_group = HtmlEscape.escape(group_name(payload))
     safe_prev = HtmlEscape.escape(role_label(role_value(payload, "previous_role")))
     safe_new = HtmlEscape.escape(role_label(role_value(payload, "new_role")))
-    group_url = group_url(payload)
+    group_url = Urls.group_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :group_role_changed)
 
@@ -59,9 +59,6 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "the group"
-
-  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")
 
   defp role_value(payload, key) do
     case Map.get(payload, key) do

--- a/lib/huddlz/notifications/senders/huddl_cancelled.ex
+++ b/lib/huddlz/notifications/senders/huddl_cancelled.ex
@@ -17,13 +17,13 @@ defmodule Huddlz.Notifications.Senders.HuddlCancelled do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -39,7 +39,7 @@ defmodule Huddlz.Notifications.Senders.HuddlCancelled do
       )
 
     safe_when = HtmlEscape.escape(when_text)
-    group_url = group_url(payload)
+    group_url = Urls.group_url(payload)
 
     new()
     |> from(Mailer.from())
@@ -75,7 +75,4 @@ defmodule Huddlz.Notifications.Senders.HuddlCancelled do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")
 end

--- a/lib/huddlz/notifications/senders/huddl_new.ex
+++ b/lib/huddlz/notifications/senders/huddl_new.ex
@@ -18,7 +18,6 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
@@ -26,6 +25,7 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -41,7 +41,7 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
       )
 
     safe_when = HtmlEscape.escape(when_text)
-    huddl_url = huddl_url(payload)
+    huddl_url = Urls.huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :huddl_new)
 
@@ -74,12 +74,4 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
-       when is_binary(slug) and is_binary(id) do
-    url(~p"/groups/#{slug}/huddlz/#{id}")
-  end
-
-  defp huddl_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp huddl_url(_), do: url(~p"/discover")
 end

--- a/lib/huddlz/notifications/senders/huddl_series_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_series_updated.ex
@@ -16,7 +16,6 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
@@ -25,6 +24,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
   alias Huddlz.Notifications.Senders.ChangedFields
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -41,7 +41,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
     safe_when = HtmlEscape.escape(when_text)
     safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
-    huddl_url = huddl_url(payload)
+    huddl_url = Urls.huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :huddl_series_updated)
 
@@ -86,12 +86,4 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
-       when is_binary(slug) and is_binary(id) do
-    url(~p"/groups/#{slug}/huddlz/#{id}")
-  end
-
-  defp huddl_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp huddl_url(_), do: url(~p"/discover")
 end

--- a/lib/huddlz/notifications/senders/huddl_series_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_series_updated.ex
@@ -22,6 +22,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
   alias Huddlz.Mailer
   alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.ChangedFields
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
@@ -39,7 +40,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
       )
 
     safe_when = HtmlEscape.escape(when_text)
-    safe_changed = HtmlEscape.escape(changed_summary(payload))
+    safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
     huddl_url = huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :huddl_series_updated)
@@ -69,7 +70,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
     The recurring huddl series in "#{group_name(payload)}" has been updated.
 
-    What changed: #{changed_summary(payload)}.
+    What changed: #{ChangedFields.summary(payload)}.
 
     Your next upcoming instance, "#{huddl_title(payload)}", is now scheduled for
     #{when_text}. See it at #{huddl_url}.
@@ -93,17 +94,4 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
   defp huddl_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
   defp huddl_url(_), do: url(~p"/discover")
-
-  defp changed_summary(%{"changed_fields" => fields}) when is_list(fields) and fields != [] do
-    Enum.map_join(fields, ", ", &humanize_field/1)
-  end
-
-  defp changed_summary(_), do: "huddl details"
-
-  defp humanize_field("title"), do: "the title"
-  defp humanize_field("starts_at"), do: "the start time"
-  defp humanize_field("ends_at"), do: "the end time"
-  defp humanize_field("physical_location"), do: "the location"
-  defp humanize_field("virtual_link"), do: "the virtual link"
-  defp humanize_field(other) when is_binary(other), do: other
 end

--- a/lib/huddlz/notifications/senders/huddl_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_updated.ex
@@ -16,7 +16,6 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
@@ -25,6 +24,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
   alias Huddlz.Notifications.Senders.ChangedFields
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -41,7 +41,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
 
     safe_when = HtmlEscape.escape(when_text)
     safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
-    huddl_url = huddl_url(payload)
+    huddl_url = Urls.huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :huddl_updated)
 
@@ -79,12 +79,4 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
-
-  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
-       when is_binary(slug) and is_binary(id) do
-    url(~p"/groups/#{slug}/huddlz/#{id}")
-  end
-
-  defp huddl_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
-  defp huddl_url(_), do: url(~p"/discover")
 end

--- a/lib/huddlz/notifications/senders/huddl_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_updated.ex
@@ -22,6 +22,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
   alias Huddlz.Mailer
   alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Senders.ChangedFields
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
 
@@ -39,7 +40,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
       )
 
     safe_when = HtmlEscape.escape(when_text)
-    safe_changed = HtmlEscape.escape(changed_summary(payload))
+    safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
     huddl_url = huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :huddl_updated)
@@ -65,7 +66,7 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
 
     The huddl "#{huddl_title(payload)}" in "#{group_name(payload)}" has been updated.
 
-    What changed: #{changed_summary(payload)}.
+    What changed: #{ChangedFields.summary(payload)}.
 
     It is currently scheduled for #{when_text}. See the latest details at
     #{huddl_url}.
@@ -86,17 +87,4 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
 
   defp huddl_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
   defp huddl_url(_), do: url(~p"/discover")
-
-  defp changed_summary(%{"changed_fields" => fields}) when is_list(fields) and fields != [] do
-    Enum.map_join(fields, ", ", &humanize_field/1)
-  end
-
-  defp changed_summary(_), do: "huddl details"
-
-  defp humanize_field("title"), do: "the title"
-  defp humanize_field("starts_at"), do: "the start time"
-  defp humanize_field("ends_at"), do: "the end time"
-  defp humanize_field("physical_location"), do: "the location"
-  defp humanize_field("virtual_link"), do: "the virtual link"
-  defp humanize_field(other) when is_binary(other), do: other
 end

--- a/lib/huddlz/notifications/senders/rsvp_cancelled.ex
+++ b/lib/huddlz/notifications/senders/rsvp_cancelled.ex
@@ -18,13 +18,13 @@ defmodule Huddlz.Notifications.Senders.RsvpCancelled do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -32,7 +32,7 @@ defmodule Huddlz.Notifications.Senders.RsvpCancelled do
     safe_title = HtmlEscape.escape(huddl_title(payload))
     safe_group = HtmlEscape.escape(group_name(payload))
     safe_rsvper = HtmlEscape.escape(rsvper_display_name(payload))
-    huddl_url = huddl_url(payload)
+    huddl_url = Urls.huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :rsvp_cancelled)
 
@@ -69,10 +69,4 @@ defmodule Huddlz.Notifications.Senders.RsvpCancelled do
 
   defp rsvper_display_name(%{"rsvper_display_name" => name}) when is_binary(name), do: name
   defp rsvper_display_name(_), do: "Someone"
-
-  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
-       when is_binary(slug) and is_binary(id),
-       do: url(~p"/groups/#{slug}/huddlz/#{id}")
-
-  defp huddl_url(_), do: url(~p"/discover")
 end

--- a/lib/huddlz/notifications/senders/rsvp_received.ex
+++ b/lib/huddlz/notifications/senders/rsvp_received.ex
@@ -17,13 +17,13 @@ defmodule Huddlz.Notifications.Senders.RsvpReceived do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
   import Swoosh.Email
 
   alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
@@ -31,7 +31,7 @@ defmodule Huddlz.Notifications.Senders.RsvpReceived do
     safe_title = HtmlEscape.escape(huddl_title(payload))
     safe_group = HtmlEscape.escape(group_name(payload))
     safe_rsvper = HtmlEscape.escape(rsvper_display_name(payload))
-    huddl_url = huddl_url(payload)
+    huddl_url = Urls.huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :rsvp_received)
 
@@ -66,10 +66,4 @@ defmodule Huddlz.Notifications.Senders.RsvpReceived do
 
   defp rsvper_display_name(%{"rsvper_display_name" => name}) when is_binary(name), do: name
   defp rsvper_display_name(_), do: "Someone"
-
-  defp huddl_url(%{"group_slug" => slug, "huddl_id" => id})
-       when is_binary(slug) and is_binary(id),
-       do: url(~p"/groups/#{slug}/huddlz/#{id}")
-
-  defp huddl_url(_), do: url(~p"/discover")
 end

--- a/lib/huddlz/notifications/senders/urls.ex
+++ b/lib/huddlz/notifications/senders/urls.ex
@@ -1,0 +1,13 @@
+defmodule Huddlz.Notifications.Senders.Urls do
+  @moduledoc """
+  Shared URL builders for notification payloads. Falls back to a
+  sensible browse-by destination when payload keys are missing so
+  emails always link somewhere useful.
+  """
+
+  use HuddlzWeb, :verified_routes
+
+  @spec group_url(map()) :: String.t()
+  def group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
+  def group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")
+end

--- a/lib/huddlz/notifications/senders/urls.ex
+++ b/lib/huddlz/notifications/senders/urls.ex
@@ -7,6 +7,15 @@ defmodule Huddlz.Notifications.Senders.Urls do
 
   use HuddlzWeb, :verified_routes
 
+  @spec huddl_url(map()) :: String.t()
+  def huddl_url(%{"group_slug" => slug, "huddl_id" => id})
+      when is_binary(slug) and is_binary(id) do
+    url(~p"/groups/#{slug}/huddlz/#{id}")
+  end
+
+  def huddl_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
+  def huddl_url(_), do: url(~p"/discover")
+
   @spec group_url(map()) :: String.t()
   def group_url(%{"group_slug" => slug}) when is_binary(slug), do: url(~p"/groups/#{slug}")
   def group_url(_), do: url(~p"/discover?#{[scope: "groups"]}")


### PR DESCRIPTION
## Summary

Three atomic refactors that pull duplicated helpers out of the per-sender modules in `lib/huddlz/notifications/senders/`.

- **ChangedFields** — `humanize_field`/`changed_summary` were byte-identical in `huddl_updated.ex` and `huddl_series_updated.ex`; now both delegate to `Huddlz.Notifications.Senders.ChangedFields.summary/1`.
- **Urls.group_url/1** — five senders (`group_member_added`, `group_member_joined`, `group_role_changed`, `group_ownership_transferred`, `huddl_cancelled`) had identical 2-clause defps.
- **Urls.huddl_url/1** — five senders (`huddl_new`, `huddl_updated`, `huddl_series_updated`, `rsvp_received`, `rsvp_cancelled`) had near-identical defps; harmonized to the 3-clause version. The only behavior delta: `rsvp_received`/`rsvp_cancelled` now fall back to `/groups/{slug}` instead of `/discover` when payload has `group_slug` but no `huddl_id` — that combo violates the senders' documented payload contracts so it shouldn't happen.

Net: 10 senders touched, 2 new tiny modules, `use HuddlzWeb, :verified_routes` dropped from 9 senders (no `~p` callsites left outside `Urls`).

## Test plan

- [x] `mix precommit` clean at each commit boundary (compile + format + credo + full suite, 1286 tests)
- [ ] Manual spot-check of one notification render (e.g. `RsvpReceived`) — links resolve to the expected URL