### PR TITLE
refactor(organize): rename co-organizers to organizers in UI copy

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -306,7 +306,7 @@ defmodule Huddlz.Communities.Huddl do
 
     read :huddlz_for_organizer do
       description """
-      Huddlz across every group the actor owns or co-organizes.
+      Huddlz across every group the actor owns or organizes.
 
       Note: this is intentionally broader than `Group.get_by_owner` (owner-only).
       The Workspace Groups + Members tabs still scope to owned groups; if those

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -466,7 +466,7 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp role_heading(:owner), do: "Owner"
-  defp role_heading(:organizer), do: "Co-organizers"
+  defp role_heading(:organizer), do: "Organizers"
   defp role_heading(:member), do: "Members"
 
   defp role_label(:owner), do: "Owner"
@@ -478,7 +478,7 @@ defmodule HuddlzWeb.OrganizeLive do
   defp role_pill_class(_), do: nil
 
   defp role_empty_copy(:organizer),
-    do: "No co-organizers yet. Promote a member to organizer to share the load."
+    do: "No organizers yet. Promote a member to organizer to share the load."
 
   defp role_empty_copy(:member), do: "Nobody has joined yet."
   defp role_empty_copy(_), do: ""

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -73,13 +73,13 @@ Feature: Organizer workspace
     Then I should see "That group doesn't exist, or you don't organize it."
     And I should see "You don't organize any groups yet."
 
-  Scenario: A co-organizer can open the workspace for a group they help run
+  Scenario: An organizer can open the workspace for a group they help run
     Given the following users exist:
       | email                  | role     | display_name |
-      | co.organizer@example.com | verified | Co Organizer |
+      | organizer@example.com | verified | Group Organizer |
     And a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And "co.organizer@example.com" is an organizer of "Cyberpunk Builders"
-    And I am signed in as "co.organizer@example.com"
+    And "organizer@example.com" is an organizer of "Cyberpunk Builders"
+    And I am signed in as "organizer@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
@@ -179,7 +179,7 @@ Feature: Organizer workspace
     When I visit "/organize/cyberpunk-builders/members"
     Then I should see "Owner"
     And I should see "Members"
-    And I should see "Co-organizers"
+    And I should see "Organizers"
     And I should see "Host User"
     And I should see "Attendee"
-    And I should see "No co-organizers yet. Promote a member to organizer to share the load."
+    And I should see "No organizers yet. Promote a member to organizer to share the load."


### PR DESCRIPTION
## Summary
- Drop the "co-organizers" label across the organize workspace — the role is just **organizer** everywhere now (Members tab heading + empty-state copy).
- Update the matching Cucumber scenario assertions and fixture identifiers, plus the `Huddl.huddlz_for_organizer` action description for consistency.

## Test plan
- [x] `mix test --include feature` — 1286 tests pass
- [x] Browser-verified `/organize/<slug>/members` shows "Organizers" / "No organizers yet…" (no "Co-organizers" anywhere)