### PR TITLE
refactor(organize): drop owner-role count in members view

### DIFF
--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -444,7 +444,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <div class="role-section">
           <div class="role-section-head">
             <h3>{role_heading(role)}</h3>
-            <span class="muted count">({length(rows)})</span>
+            <span :if={role != :owner} class="muted count">({length(rows)})</span>
           </div>
           <%= if rows == [] do %>
             <p class="muted role-section-empty">{role_empty_copy(role)}</p>


### PR DESCRIPTION
## Summary
- Owner role is single-occupant by design, so the trailing `(1)` next to the **Owner** heading on the organize members view was visual noise.
- Suppresses the count span only for the owner section; organizer and member sections still show their counts.

## Test plan
- [x] `mix precommit` (1286 tests, credo clean)
- [ ] Visit `/organize/<slug>/members` and confirm the Owner heading no longer renders `(1)`, while Organizers and Members sections still show counts.