### PR TITLE
fix: security & Ash-policy hardening

### DIFF
--- a/lib/huddlz/communities/group/changes/add_owner_as_member.ex
+++ b/lib/huddlz/communities/group/changes/add_owner_as_member.ex
@@ -14,11 +14,10 @@ defmodule Huddlz.Communities.Group.Changes.AddOwnerAsMember do
 
       Huddlz.Communities.GroupMember
       |> Ash.Changeset.for_create(
-        :add_member,
+        :add_owner,
         %{
           group_id: group.id,
-          user_id: group.owner_id,
-          role: "owner"
+          user_id: group.owner_id
         },
         actor: actor
       )

--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -93,10 +93,9 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
     case fetch_membership(group_id, user_id) do
       nil ->
         GroupMember
-        |> Ash.Changeset.for_create(:add_member, %{
+        |> Ash.Changeset.for_create(:add_owner, %{
           group_id: group_id,
-          user_id: user_id,
-          role: "owner"
+          user_id: user_id
         })
         |> Ash.create(authorize?: false)
         |> ok_or_error()

--- a/lib/huddlz/communities/group_location.ex
+++ b/lib/huddlz/communities/group_location.ex
@@ -77,8 +77,12 @@ defmodule Huddlz.Communities.GroupLocation do
       authorize_if Huddlz.Communities.Huddl.Checks.GroupOwnerOrOrganizer
     end
 
+    # Locations belong to a group. Mirror the Group read policy so a private
+    # group's saved meeting addresses are only visible to its members, while
+    # public groups' locations stay readable by anyone (including anonymous).
     policy action_type(:read) do
-      authorize_if always()
+      authorize_if expr(group.is_public == true)
+      authorize_if relates_to_actor_via([:group, :members])
     end
 
     policy action_type([:update, :destroy]) do

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -80,9 +80,48 @@ defmodule Huddlz.Communities.GroupMember do
         default "member"
       end
 
+      # The :owner role is never settable through this action — owners are
+      # minted only by group creation and Group.:transfer_ownership (via the
+      # internal :add_owner action). This mirrors :change_role, which also
+      # refuses :owner.
+      validate fn changeset, _context ->
+        case Ash.Changeset.get_argument(changeset, :role) do
+          role when role in ["member", "organizer"] ->
+            :ok
+
+          _ ->
+            {:error,
+             field: :role,
+             message:
+               "must be \"member\" or \"organizer\" (use transfer_ownership to set the owner)"}
+        end
+      end
+
       change manage_relationship(:group_id, :group, type: :append)
       change manage_relationship(:user_id, :user, type: :append)
       change set_attribute(:role, arg(:role))
+      change Huddlz.Communities.GroupMember.Changes.NotifyAdded
+    end
+
+    create :add_owner do
+      description """
+      Internal helper used by group creation and Group.:transfer_ownership to
+      add the owner as an :owner member. Always forbidden by policy — callers
+      must pass `authorize?: false`. Owner promotion otherwise only happens via
+      Group.:transfer_ownership.
+      """
+
+      argument :group_id, :uuid do
+        allow_nil? false
+      end
+
+      argument :user_id, :uuid do
+        allow_nil? false
+      end
+
+      change manage_relationship(:group_id, :group, type: :append)
+      change manage_relationship(:user_id, :user, type: :append)
+      change set_attribute(:role, :owner)
       change Huddlz.Communities.GroupMember.Changes.NotifyAdded
     end
 
@@ -198,11 +237,19 @@ defmodule Huddlz.Communities.GroupMember do
       authorize_if always()
     end
 
-    # Only group owners can add members (custom check for create)
+    # Owners may add members or organizers; organizers may add regular
+    # members only. Granting the organizer role is owner-only (mirroring
+    # :change_role), so an organizer cannot escalate a confederate — or
+    # themselves — into the organizer tier.
     policy action(:add_member) do
-      # Only the owner or an organizer (must be verified) can add members
       authorize_if GroupOwner
+      forbid_if expr(^arg(:role) == "organizer")
       authorize_if GroupOrganizer
+    end
+
+    # Internal-only — must be called with `authorize?: false`.
+    policy action(:add_owner) do
+      forbid_if always()
     end
 
     # Group owners can remove members

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -114,7 +114,6 @@ defmodule Huddlz.Communities.Huddl do
         :is_private,
         :thumbnail_url,
         :max_attendees,
-        :creator_id,
         :group_id,
         :huddl_template_id
       ]
@@ -136,6 +135,7 @@ defmodule Huddlz.Communities.Huddl do
       argument :provided_longitude, :float, allow_nil?: true, public?: false
 
       validate Huddlz.Communities.Huddl.Validations.FutureDateValidation
+      change Huddlz.Communities.Huddl.Changes.SetCreatorToActor
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.AddHuddlTemplate

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -627,6 +627,11 @@ defmodule Huddlz.Communities.Huddl do
       calculation expr(is_private == false and group.is_public == true)
     end
 
+    calculate :at_capacity, :boolean do
+      description "Whether the huddl has reached max_attendees (no open seats remain)"
+      calculation expr(not is_nil(max_attendees) and rsvp_count >= max_attendees)
+    end
+
     calculate :display_image_url, :string do
       description "Returns huddl's image, falling back to group image if none"
       calculation Huddlz.Communities.Huddl.Calculations.DisplayImageUrl

--- a/lib/huddlz/communities/huddl/changes/cancel_rsvp.ex
+++ b/lib/huddlz/communities/huddl/changes/cancel_rsvp.ex
@@ -9,40 +9,63 @@ defmodule Huddlz.Communities.Huddl.Changes.CancelRsvp do
   (`PromoteFromWaitlist`, `NotifyRsvpCancelled`) can no-op for waitlist
   withdrawals. Sets `:waitlist_left` when a waitlist row was destroyed
   so the LiveView flash message can distinguish the two cases.
+
+  Concurrency: runs inside a `before_action` hook and locks the huddl row
+  `FOR UPDATE` before freeing the seat. `:rsvp` and `:join_waitlist` take
+  the same lock, so a cancellation (and the waitlist promotion that follows
+  it) serializes with concurrent RSVP attempts and cannot overbook. The
+  destroy must happen inside the action transaction — doing it in the
+  `change/3` body would commit the freed seat before the lock is held.
   """
   use Ash.Resource.Change
+
+  alias Huddlz.Communities.{Huddl, HuddlAttendee}
 
   require Ash.Query
 
   def change(changeset, _opts, %{actor: %{id: user_id}}) when not is_nil(user_id) do
-    huddl_id = changeset.data.id
+    Ash.Changeset.before_action(changeset, &cancel(&1, user_id))
+  end
 
-    existing =
-      Huddlz.Communities.HuddlAttendee
-      |> Ash.Query.for_read(:check_rsvp, %{huddl_id: huddl_id}, actor: %{id: user_id})
-      |> Ash.read_one(authorize?: false)
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.add_error(changeset, "An actor is required to cancel an RSVP")
+  end
 
-    case existing do
+  defp cancel(cs, user_id) do
+    # Lock the huddl row up front so the freed seat and any waitlist
+    # promotion serialize against concurrent RSVP/waitlist transactions.
+    lock_huddl!(cs.data.id)
+
+    case fetch_existing(cs.data.id, user_id) do
       {:ok, nil} ->
-        changeset
+        cs
 
       {:ok, %{waitlisted_at: nil} = attendee} ->
         Ash.destroy!(attendee, authorize?: false)
         # Load-bearing: NotifyRsvpCancelled and PromoteFromWaitlist skip
         # when this flag is absent — pure waitlist withdrawals don't
         # free a seat or warrant an organizer email.
-        Ash.Changeset.put_context(changeset, :rsvp_cancelled, true)
+        Ash.Changeset.put_context(cs, :rsvp_cancelled, true)
 
       {:ok, %{waitlisted_at: %DateTime{}} = attendee} ->
         Ash.destroy!(attendee, authorize?: false)
-        Ash.Changeset.put_context(changeset, :waitlist_left, true)
+        Ash.Changeset.put_context(cs, :waitlist_left, true)
 
       {:error, error} ->
-        Ash.Changeset.add_error(changeset, error)
+        Ash.Changeset.add_error(cs, error)
     end
   end
 
-  def change(changeset, _opts, _context) do
-    Ash.Changeset.add_error(changeset, "An actor is required to cancel an RSVP")
+  defp lock_huddl!(huddl_id) do
+    Huddl
+    |> Ash.Query.filter(id == ^huddl_id)
+    |> Ash.Query.lock("FOR UPDATE")
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp fetch_existing(huddl_id, user_id) do
+    HuddlAttendee
+    |> Ash.Query.for_read(:check_rsvp, %{huddl_id: huddl_id}, actor: %{id: user_id})
+    |> Ash.read_one(authorize?: false)
   end
 end

--- a/lib/huddlz/communities/huddl/changes/join_waitlist.ex
+++ b/lib/huddlz/communities/huddl/changes/join_waitlist.ex
@@ -27,7 +27,7 @@ defmodule Huddlz.Communities.Huddl.Changes.JoinWaitlist do
       is_nil(huddl.max_attendees) ->
         Ash.Changeset.add_error(cs, "This huddl has no capacity limit; RSVP directly")
 
-      not at_capacity?(huddl) ->
+      not huddl.at_capacity ->
         Ash.Changeset.add_error(cs, "This huddl still has open spots; RSVP directly")
 
       true ->
@@ -51,7 +51,7 @@ defmodule Huddlz.Communities.Huddl.Changes.JoinWaitlist do
     Huddl
     |> Ash.Query.filter(id == ^huddl_id)
     |> Ash.Query.lock("FOR UPDATE")
-    |> Ash.Query.load(:rsvp_count)
+    |> Ash.Query.load(:at_capacity)
     |> Ash.read_one!(authorize?: false)
   end
 
@@ -60,7 +60,4 @@ defmodule Huddlz.Communities.Huddl.Changes.JoinWaitlist do
     |> Ash.Query.for_read(:check_rsvp, %{huddl_id: huddl_id}, actor: %{id: user_id})
     |> Ash.read_one(authorize?: false)
   end
-
-  defp at_capacity?(%{max_attendees: nil}), do: false
-  defp at_capacity?(%{max_attendees: max, rsvp_count: count}), do: count >= max
 end

--- a/lib/huddlz/communities/huddl/changes/promote_from_waitlist.ex
+++ b/lib/huddlz/communities/huddl/changes/promote_from_waitlist.ex
@@ -15,7 +15,7 @@ defmodule Huddlz.Communities.Huddl.Changes.PromoteFromWaitlist do
 
   use Ash.Resource.Change
 
-  alias Huddlz.Communities.HuddlAttendee
+  alias Huddlz.Communities.{Huddl, HuddlAttendee}
 
   require Ash.Query
 
@@ -32,17 +32,34 @@ defmodule Huddlz.Communities.Huddl.Changes.PromoteFromWaitlist do
   end
 
   defp do_promote(cs) do
-    case fetch_oldest_waitlist_entry(cs.data.id) do
-      nil ->
-        cs
+    # Re-affirm the FOR UPDATE lock CancelRsvp already holds and read the
+    # current count so we never promote past capacity (defensive — the cancel
+    # that triggered this freed exactly one seat).
+    huddl = lock_huddl!(cs.data.id)
 
-      attendee ->
-        attendee
-        |> Ash.Changeset.for_update(:promote_from_waitlist)
-        |> Ash.update!(authorize?: false)
+    if huddl.at_capacity do
+      cs
+    else
+      case fetch_oldest_waitlist_entry(cs.data.id) do
+        nil ->
+          cs
 
-        Ash.Changeset.put_context(cs, :promoted_user_id, attendee.user_id)
+        attendee ->
+          attendee
+          |> Ash.Changeset.for_update(:promote_from_waitlist)
+          |> Ash.update!(authorize?: false)
+
+          Ash.Changeset.put_context(cs, :promoted_user_id, attendee.user_id)
+      end
     end
+  end
+
+  defp lock_huddl!(huddl_id) do
+    Huddl
+    |> Ash.Query.filter(id == ^huddl_id)
+    |> Ash.Query.lock("FOR UPDATE")
+    |> Ash.Query.load(:at_capacity)
+    |> Ash.read_one!(authorize?: false)
   end
 
   defp fetch_oldest_waitlist_entry(huddl_id) do

--- a/lib/huddlz/communities/huddl/changes/rsvp.ex
+++ b/lib/huddlz/communities/huddl/changes/rsvp.ex
@@ -31,7 +31,7 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
   end
 
   defp claim_or_reject(cs, huddl, user_id) do
-    if at_capacity?(huddl) do
+    if huddl.at_capacity do
       Ash.Changeset.add_error(cs, "This huddl is full")
     else
       create_rsvp!(huddl.id, user_id)
@@ -45,7 +45,7 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
     Huddl
     |> Ash.Query.filter(id == ^huddl_id)
     |> Ash.Query.lock("FOR UPDATE")
-    |> Ash.Query.load(:rsvp_count)
+    |> Ash.Query.load(:at_capacity)
     |> Ash.read_one!(authorize?: false)
   end
 
@@ -54,9 +54,6 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
     |> Ash.Query.for_read(:check_rsvp, %{huddl_id: huddl_id}, actor: %{id: user_id})
     |> Ash.read_one(authorize?: false)
   end
-
-  defp at_capacity?(%{max_attendees: nil}), do: false
-  defp at_capacity?(%{max_attendees: max, rsvp_count: count}), do: count >= max
 
   defp create_rsvp!(huddl_id, user_id) do
     HuddlAttendee

--- a/lib/huddlz/communities/huddl/changes/set_creator_to_actor.ex
+++ b/lib/huddlz/communities/huddl/changes/set_creator_to_actor.ex
@@ -1,0 +1,32 @@
+defmodule Huddlz.Communities.Huddl.Changes.SetCreatorToActor do
+  @moduledoc """
+  Forces `creator_id` to the acting user so huddl authorship cannot be
+  spoofed through the action input — `creator_id` is not an accepted
+  attribute on `:create`, the creator is always the actor.
+
+  Implemented as a `before_action` hook (rather than the builtin
+  `relate_actor/1`) so the actor lookup is deferred until after Ash has
+  propagated `actor:` from either `for_create` opts or `Ash.create/2` opts
+  to the changeset's private context.
+
+  When no actor is present — internal seeding and recurring-series
+  generation that run with `authorize?: false` and set `creator_id`
+  directly via `force_change_attribute/3` — the existing `creator_id` is
+  left untouched so a generated series inherits its parent's creator.
+  """
+
+  use Ash.Resource.Change
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.before_action(changeset, fn cs ->
+      case cs.context[:private][:actor] do
+        %{id: id} when is_binary(id) ->
+          Ash.Changeset.force_change_attribute(cs, :creator_id, id)
+
+        _ ->
+          cs
+      end
+    end)
+  end
+end

--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -37,10 +37,14 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
           physical_location: huddl.physical_location,
           is_private: huddl.is_private,
           thumbnail_url: huddl.thumbnail_url,
-          creator_id: huddl.creator_id,
           group_id: huddl.group_id,
           huddl_template_id: huddl_template.id
         })
+        # creator_id is not an accepted input — the :create action derives it
+        # from the actor. This internal, actorless generation sets it directly
+        # so each instance inherits the parent huddl's creator (SetCreatorToActor
+        # leaves it untouched when no actor is present).
+        |> Ash.Changeset.force_change_attribute(:creator_id, huddl.creator_id)
         |> Ash.create!(authorize?: false)
 
       generate_huddlz_from_template(huddl_template, new_huddl, count + 1)

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -77,7 +77,6 @@ defmodule HuddlzWeb.HuddlLive.New do
         actor: user,
         params: %{
           "group_id" => group.id,
-          "creator_id" => user.id,
           "date" => Date.to_iso8601(tomorrow),
           "start_time" => Time.to_iso8601(default_time) |> String.slice(0..4),
           "duration_minutes" => "60"
@@ -519,7 +518,6 @@ defmodule HuddlzWeb.HuddlLive.New do
     params =
       params
       |> Map.put("group_id", socket.assigns.group.id)
-      |> Map.put("creator_id", socket.assigns.current_user.id)
       |> inject_saved_location_params(socket.assigns[:selected_location])
 
     case AshPhoenix.Form.submit(socket.assigns.form,

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -5,6 +5,14 @@ defmodule HuddlzWeb.Router do
 
   import AshAuthentication.Plug.Helpers
 
+  # Bound total GraphQL query cost. Resource relationships aren't exposed as
+  # GraphQL fields, so deep nesting isn't possible — this caps query *breadth*,
+  # chiefly alias amplification (N aliased list queries -> N DB queries) from an
+  # anonymous client. A list query costs ~3 and legitimate requests are shallow
+  # (a handful of fields), so 100 leaves ample headroom while blocking alias
+  # floods. Tune as the schema grows.
+  @graphql_max_complexity 100
+
   pipeline :graphql do
     plug :load_from_bearer
     plug :set_actor, :user
@@ -35,9 +43,14 @@ defmodule HuddlzWeb.Router do
     forward "/playground", Absinthe.Plug.GraphiQL,
       schema: Module.concat(["HuddlzWeb.GraphqlSchema"]),
       socket: Module.concat(["HuddlzWeb.GraphqlSocket"]),
-      interface: :playground
+      interface: :playground,
+      analyze_complexity: true,
+      max_complexity: @graphql_max_complexity
 
-    forward "/", Absinthe.Plug, schema: Module.concat(["HuddlzWeb.GraphqlSchema"])
+    forward "/", Absinthe.Plug,
+      schema: Module.concat(["HuddlzWeb.GraphqlSchema"]),
+      analyze_complexity: true,
+      max_complexity: @graphql_max_complexity
   end
 
   scope "/api/json" do

--- a/test/huddlz/communities/group_location_test.exs
+++ b/test/huddlz/communities/group_location_test.exs
@@ -214,6 +214,75 @@ defmodule Huddlz.Communities.GroupLocationTest do
 
       assert length(locations) == 1
     end
+
+    test "anonymous user can read a public group's locations" do
+      owner = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+      generate(group_location(group_id: group.id, name: "Public Location", actor: owner))
+
+      {:ok, locations} =
+        GroupLocation
+        |> Ash.Query.for_read(:by_group, %{group_id: group.id})
+        |> Ash.read(actor: nil)
+
+      assert length(locations) == 1
+    end
+
+    test "non-member cannot read a private group's locations" do
+      owner = generate(user(role: :user))
+      outsider = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: false, actor: owner))
+      generate(group_location(group_id: group.id, name: "Secret HQ", actor: owner))
+
+      {:ok, locations} =
+        GroupLocation
+        |> Ash.Query.for_read(:by_group, %{group_id: group.id})
+        |> Ash.read(actor: outsider)
+
+      assert locations == []
+    end
+
+    test "anonymous user cannot read a private group's locations" do
+      owner = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: false, actor: owner))
+      generate(group_location(group_id: group.id, name: "Secret HQ", actor: owner))
+
+      {:ok, locations} =
+        GroupLocation
+        |> Ash.Query.for_read(:by_group, %{group_id: group.id})
+        |> Ash.read(actor: nil)
+
+      assert locations == []
+    end
+
+    test "member can read a private group's locations" do
+      owner = generate(user(role: :user))
+      member = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: false, actor: owner))
+      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+      generate(group_location(group_id: group.id, name: "Members Only", actor: owner))
+
+      {:ok, locations} =
+        GroupLocation
+        |> Ash.Query.for_read(:by_group, %{group_id: group.id})
+        |> Ash.read(actor: member)
+
+      assert length(locations) == 1
+      assert hd(locations).name == "Members Only"
+    end
+
+    test "owner can read their private group's locations" do
+      owner = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: false, actor: owner))
+      generate(group_location(group_id: group.id, name: "HQ", actor: owner))
+
+      {:ok, locations} =
+        GroupLocation
+        |> Ash.Query.for_read(:by_group, %{group_id: group.id})
+        |> Ash.read(actor: owner)
+
+      assert length(locations) == 1
+    end
   end
 
   describe "group_location update" do

--- a/test/huddlz/communities/group_member_test.exs
+++ b/test/huddlz/communities/group_member_test.exs
@@ -441,4 +441,128 @@ defmodule Huddlz.Communities.GroupMemberTest do
       assert private_result == []
     end
   end
+
+  describe "add_member role hardening" do
+    setup do
+      owner = generate(user(role: :user))
+      organizer = generate(user(role: :user))
+      target = generate(user(role: :user))
+
+      group = generate(group(is_public: true, actor: owner))
+
+      # Owner promotes `organizer` to the organizer role
+      {:ok, _} =
+        GroupMember
+        |> Ash.Changeset.for_create(:add_member, %{
+          group_id: group.id,
+          user_id: organizer.id,
+          role: :organizer
+        })
+        |> Ash.create(actor: owner)
+
+      {:ok, %{owner: owner, organizer: organizer, target: target, group: group}}
+    end
+
+    test "owner cannot mint an :owner membership via add_member", %{
+      owner: owner,
+      target: target,
+      group: group
+    } do
+      assert {:error, %Ash.Error.Invalid{}} =
+               GroupMember
+               |> Ash.Changeset.for_create(:add_member, %{
+                 group_id: group.id,
+                 user_id: target.id,
+                 role: :owner
+               })
+               |> Ash.create(actor: owner)
+    end
+
+    test "organizer cannot mint an :owner membership via add_member", %{
+      organizer: organizer,
+      target: target,
+      group: group
+    } do
+      assert {:error, %Ash.Error.Invalid{}} =
+               GroupMember
+               |> Ash.Changeset.for_create(:add_member, %{
+                 group_id: group.id,
+                 user_id: target.id,
+                 role: :owner
+               })
+               |> Ash.create(actor: organizer)
+    end
+
+    test "organizer cannot grant the organizer role (owner-only)", %{
+      organizer: organizer,
+      target: target,
+      group: group
+    } do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               GroupMember
+               |> Ash.Changeset.for_create(:add_member, %{
+                 group_id: group.id,
+                 user_id: target.id,
+                 role: :organizer
+               })
+               |> Ash.create(actor: organizer)
+    end
+
+    test "organizer can add a regular member", %{
+      organizer: organizer,
+      target: target,
+      group: group
+    } do
+      assert {:ok, membership} =
+               GroupMember
+               |> Ash.Changeset.for_create(:add_member, %{
+                 group_id: group.id,
+                 user_id: target.id,
+                 role: :member
+               })
+               |> Ash.create(actor: organizer)
+
+      assert membership.role == :member
+    end
+
+    test "owner can still grant the organizer role", %{
+      owner: owner,
+      target: target,
+      group: group
+    } do
+      assert {:ok, membership} =
+               GroupMember
+               |> Ash.Changeset.for_create(:add_member, %{
+                 group_id: group.id,
+                 user_id: target.id,
+                 role: :organizer
+               })
+               |> Ash.create(actor: owner)
+
+      assert membership.role == :organizer
+    end
+
+    test "group creation adds the owner as an :owner member", %{owner: owner, group: group} do
+      owner_membership =
+        GroupMember
+        |> Ash.Query.filter(group_id == ^group.id and user_id == ^owner.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert owner_membership.role == :owner
+    end
+
+    test ":add_owner is forbidden through the authorized API", %{
+      owner: owner,
+      target: target,
+      group: group
+    } do
+      assert {:error, %Ash.Error.Forbidden{}} =
+               GroupMember
+               |> Ash.Changeset.for_create(:add_owner, %{
+                 group_id: group.id,
+                 user_id: target.id
+               })
+               |> Ash.create(actor: owner)
+    end
+  end
 end

--- a/test/huddlz/communities/huddl/changes/apply_provided_coordinates_test.exs
+++ b/test/huddlz/communities/huddl/changes/apply_provided_coordinates_test.exs
@@ -37,8 +37,7 @@ defmodule Huddlz.Communities.Huddl.Changes.ApplyProvidedCoordinatesTest do
                  duration_minutes: 60,
                  event_type: :in_person,
                  physical_location: "100 Main St, Austin, TX",
-                 group_id: group.id,
-                 creator_id: owner.id
+                 group_id: group.id
                })
                |> Ash.create(actor: owner)
 
@@ -62,8 +61,7 @@ defmodule Huddlz.Communities.Huddl.Changes.ApplyProvidedCoordinatesTest do
                  duration_minutes: 60,
                  event_type: :in_person,
                  physical_location: "456 Oak Ave, Dallas, TX",
-                 group_id: group.id,
-                 creator_id: owner.id
+                 group_id: group.id
                })
                |> Ash.create(actor: owner)
 
@@ -89,8 +87,7 @@ defmodule Huddlz.Communities.Huddl.Changes.ApplyProvidedCoordinatesTest do
                  duration_minutes: 60,
                  event_type: :in_person,
                  physical_location: "789 Elm St, Houston, TX",
-                 group_id: group.id,
-                 creator_id: owner.id
+                 group_id: group.id
                })
                |> Ash.create(actor: owner)
 

--- a/test/huddlz/communities/huddl_access_control_test.exs
+++ b/test/huddlz/communities/huddl_access_control_test.exs
@@ -46,8 +46,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.add(2, :hour),
                    event_type: :in_person,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: owner.id
+                   group_id: group.id
                  },
                  actor: owner
                )
@@ -70,8 +69,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.add(2, :hour),
                    event_type: :virtual,
                    virtual_link: "https://zoom.us/j/123456",
-                   group_id: group.id,
-                   creator_id: organizer.id
+                   group_id: group.id
                  },
                  actor: organizer
                )
@@ -92,8 +90,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.add(2, :hour),
                    event_type: :in_person,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: member.id
+                   group_id: group.id
                  },
                  actor: member
                )
@@ -112,8 +109,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.add(2, :hour),
                    event_type: :in_person,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: non_member.id
+                   group_id: group.id
                  },
                  actor: non_member
                )
@@ -132,8 +128,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.add(2, :hour),
                    event_type: :in_person,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: admin.id
+                   group_id: group.id
                  },
                  actor: admin
                )
@@ -161,8 +156,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    physical_location: "123 Main St",
                    # Explicitly set to false
                    is_private: false,
-                   group_id: private_group.id,
-                   creator_id: owner.id
+                   group_id: private_group.id
                  },
                  actor: owner
                )
@@ -189,8 +183,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    event_type: :in_person,
                    physical_location: "123 Main St",
                    is_private: false,
-                   group_id: public_group.id,
-                   creator_id: owner.id
+                   group_id: public_group.id
                  },
                  actor: owner
                )
@@ -211,8 +204,7 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                    event_type: :in_person,
                    physical_location: "123 Main St",
                    is_private: true,
-                   group_id: public_group.id,
-                   creator_id: owner.id
+                   group_id: public_group.id
                  },
                  actor: owner
                )
@@ -486,7 +478,6 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                  event_type: :virtual,
                  starts_at: DateTime.add(DateTime.utc_now(), 7, :day),
                  ends_at: DateTime.add(DateTime.utc_now(), 7 * 24 * 3600 + 3600, :second),
-                 creator_id: owner.id,
                  group_id: group.id
                })
                |> Ash.create(actor: owner)
@@ -503,7 +494,6 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                  event_type: :in_person,
                  starts_at: DateTime.add(DateTime.utc_now(), 7, :day),
                  ends_at: DateTime.add(DateTime.utc_now(), 7 * 24 * 3600 + 3600, :second),
-                 creator_id: owner.id,
                  group_id: group.id
                })
                |> Ash.create(actor: owner)
@@ -520,7 +510,6 @@ defmodule Huddlz.Communities.HuddlAccessControlTest do
                  event_type: :virtual,
                  starts_at: DateTime.add(DateTime.utc_now(), 7, :day),
                  ends_at: DateTime.add(DateTime.utc_now(), 7 * 24 * 3600 + 3600, :second),
-                 creator_id: owner.id,
                  group_id: group.id
                })
                |> Ash.create(actor: owner)

--- a/test/huddlz/communities/huddl_permissions_edge_cases_test.exs
+++ b/test/huddlz/communities/huddl_permissions_edge_cases_test.exs
@@ -57,8 +57,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :in_person,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: user.id
+                   group_id: group.id
                  },
                  actor: user
                )
@@ -77,8 +76,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :virtual,
                    virtual_link: "https://zoom.us/j/organizer",
-                   group_id: group.id,
-                   creator_id: user.id
+                   group_id: group.id
                  },
                  actor: user
                )
@@ -99,12 +97,54 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :in_person,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: user.id
+                   group_id: group.id
                  },
                  actor: user
                )
                |> Ash.create()
+    end
+
+    test "rejects a supplied creator_id (not an accepted input)", %{
+      owner: owner,
+      outsider: outsider,
+      public_group: group
+    } do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Huddl
+               |> Ash.Changeset.for_create(
+                 :create,
+                 %{
+                   title: "Spoof Attempt",
+                   starts_at: DateTime.utc_now() |> DateTime.add(1, :day),
+                   ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
+                   event_type: :virtual,
+                   virtual_link: "https://zoom.us/j/spoof",
+                   group_id: group.id,
+                   creator_id: outsider.id
+                 },
+                 actor: owner
+               )
+               |> Ash.create()
+    end
+
+    test "derives the creator from the actor", %{owner: owner, public_group: group} do
+      assert {:ok, huddl} =
+               Huddl
+               |> Ash.Changeset.for_create(
+                 :create,
+                 %{
+                   title: "Authored Huddl",
+                   starts_at: DateTime.utc_now() |> DateTime.add(1, :day),
+                   ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
+                   event_type: :virtual,
+                   virtual_link: "https://zoom.us/j/authored",
+                   group_id: group.id
+                 },
+                 actor: owner
+               )
+               |> Ash.create()
+
+      assert huddl.creator_id == owner.id
     end
 
     test "private group only allows owner or organizer to create huddl", %{
@@ -126,8 +166,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :in_person,
                    physical_location: "Secret Place",
-                   group_id: group.id,
-                   creator_id: owner.id
+                   group_id: group.id
                  },
                  actor: owner
                )
@@ -145,8 +184,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :in_person,
                    physical_location: "Secret Place",
-                   group_id: group.id,
-                   creator_id: organizer.id
+                   group_id: group.id
                  },
                  actor: organizer
                )
@@ -164,8 +202,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :in_person,
                    physical_location: "Secret Place",
-                   group_id: group.id,
-                   creator_id: member.id
+                   group_id: group.id
                  },
                  actor: member
                )
@@ -183,8 +220,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :in_person,
                    physical_location: "Secret Place",
-                   group_id: group.id,
-                   creator_id: outsider.id
+                   group_id: group.id
                  },
                  actor: outsider
                )
@@ -205,8 +241,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
             ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
             event_type: :in_person,
             physical_location: "123 Main St",
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -232,8 +267,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
             ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
             event_type: :in_person,
             physical_location: "123 Main St",
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -263,8 +297,7 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                    ends_at: DateTime.utc_now() |> DateTime.add(2, :day),
                    event_type: :hybrid,
                    physical_location: "123 Main St",
-                   group_id: group.id,
-                   creator_id: user.id
+                   group_id: group.id
                  },
                  actor: user
                )

--- a/test/huddlz/communities/huddl_rsvp_edge_cases_test.exs
+++ b/test/huddlz/communities/huddl_rsvp_edge_cases_test.exs
@@ -62,8 +62,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/concurrent",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -116,8 +115,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/startingsoon",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -154,8 +152,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/counttest",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -203,8 +200,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/admintest",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )

--- a/test/huddlz/communities/huddl_rsvp_test.exs
+++ b/test/huddlz/communities/huddl_rsvp_test.exs
@@ -54,8 +54,7 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/123456",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -231,7 +230,6 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
             virtual_link: "https://zoom.us/j/999",
             is_private: false,
             group_id: group.id,
-            creator_id: owner.id,
             max_attendees: 1
           },
           actor: owner
@@ -406,8 +404,7 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
             event_type: :in_person,
             physical_location: "Secret Location",
             is_private: true,
-            group_id: private_group.id,
-            creator_id: owner.id
+            group_id: private_group.id
           },
           actor: owner
         )
@@ -469,8 +466,7 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/123456",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -672,8 +668,7 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/123456",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )

--- a/test/huddlz/communities/huddl_waitlist_test.exs
+++ b/test/huddlz/communities/huddl_waitlist_test.exs
@@ -333,6 +333,73 @@ defmodule Huddlz.Communities.HuddlWaitlistTest do
     end
   end
 
+  describe "at_capacity calculation" do
+    setup do
+      owner = generate(user(role: :user))
+      member = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+      generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+      %{owner: owner, member: member, group: group}
+    end
+
+    test "is false when rsvp_count is below max_attendees", %{owner: owner, group: group} do
+      huddl = capped_huddl(owner, group, 2)
+      assert load_at_capacity(huddl) == false
+    end
+
+    test "is true once rsvp_count reaches max_attendees", %{
+      owner: owner,
+      member: member,
+      group: group
+    } do
+      huddl = capped_huddl(owner, group, 1)
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
+      |> Ash.update!()
+
+      assert load_at_capacity(huddl) == true
+    end
+
+    test "is false for an uncapped huddl regardless of rsvp_count", %{
+      owner: owner,
+      member: member,
+      group: group
+    } do
+      huddl = capped_huddl(owner, group, nil)
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
+      |> Ash.update!()
+
+      assert load_at_capacity(huddl) == false
+    end
+  end
+
+  defp capped_huddl(owner, group, max_attendees) do
+    Huddl
+    |> Ash.Changeset.for_create(
+      :create,
+      %{
+        title: "Capacity Calc Huddl",
+        description: "x",
+        starts_at: DateTime.add(DateTime.utc_now(), 1, :day),
+        ends_at: DateTime.add(DateTime.utc_now(), 2, :day),
+        event_type: :virtual,
+        virtual_link: "https://zoom.us/j/cap",
+        is_private: false,
+        group_id: group.id,
+        max_attendees: max_attendees
+      },
+      actor: owner
+    )
+    |> Ash.create!()
+  end
+
+  defp load_at_capacity(huddl) do
+    huddl |> Ash.reload!() |> Ash.load!(:at_capacity, authorize?: false) |> Map.get(:at_capacity)
+  end
+
   defp setup_group_and_capped_huddl(_) do
     owner = generate(user(role: :user))
     member = generate(user(role: :user))

--- a/test/huddlz/communities/huddl_waitlist_test.exs
+++ b/test/huddlz/communities/huddl_waitlist_test.exs
@@ -65,8 +65,7 @@ defmodule Huddlz.Communities.HuddlWaitlistTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/000",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -372,7 +371,6 @@ defmodule Huddlz.Communities.HuddlWaitlistTest do
           virtual_link: "https://zoom.us/j/123456",
           is_private: false,
           group_id: group.id,
-          creator_id: owner.id,
           max_attendees: 1
         },
         actor: owner

--- a/test/huddlz/geocoding/geocode_change_test.exs
+++ b/test/huddlz/geocoding/geocode_change_test.exs
@@ -148,7 +148,6 @@ defmodule Huddlz.Geocoding.GeocodeChangeTest do
             date: future_date,
             start_time: ~T[14:00:00],
             duration_minutes: 60,
-            creator_id: owner.id,
             group_id: group.id
           },
           actor: owner

--- a/test/huddlz_web/api/end_to_end_test.exs
+++ b/test/huddlz_web/api/end_to_end_test.exs
@@ -69,7 +69,6 @@ defmodule HuddlzWeb.Api.EndToEndTest do
           date: Date.add(Date.utc_today(), 7),
           start_time: ~T[14:00:00],
           duration_minutes: 60,
-          creator_id: user_id,
           group_id: group_id,
           event_type: :in_person,
           physical_location: "123 Test St",

--- a/test/huddlz_web/graphql_test.exs
+++ b/test/huddlz_web/graphql_test.exs
@@ -25,11 +25,7 @@ defmodule HuddlzWeb.GraphqlTest do
       %{owner: owner, group: group, huddl: huddl}
     end
 
-    test "unauthenticated create mutation returns error", %{
-      conn: conn,
-      group: group,
-      owner: owner
-    } do
+    test "unauthenticated create mutation returns error", %{conn: conn, group: group} do
       starts_at =
         DateTime.utc_now()
         |> DateTime.add(7, :day)
@@ -60,7 +56,6 @@ defmodule HuddlzWeb.GraphqlTest do
           eventType: "in_person",
           physicalLocation: "123 Main St",
           groupId: group.id,
-          creatorId: owner.id,
           startsAt: starts_at,
           endsAt: ends_at
         }
@@ -114,7 +109,6 @@ defmodule HuddlzWeb.GraphqlTest do
           eventType: "in_person",
           physicalLocation: "456 Oak Ave",
           groupId: group.id,
-          creatorId: owner.id,
           startsAt: starts_at,
           endsAt: ends_at
         }

--- a/test/huddlz_web/graphql_test.exs
+++ b/test/huddlz_web/graphql_test.exs
@@ -148,5 +148,23 @@ defmodule HuddlzWeb.GraphqlTest do
       assert is_list(results)
       assert Enum.any?(results, fn r -> r["id"] == huddl.id end)
     end
+
+    test "rejects an overly complex query", %{conn: conn} do
+      # Each searchHuddlz costs 3; 100 aliased copies far exceed max_complexity,
+      # blocking unauthenticated alias-amplification queries.
+      aliased =
+        Enum.map_join(1..100, " ", fn i -> "a#{i}: searchHuddlz { results { id } }" end)
+
+      query = "query { #{aliased} }"
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/gql", Jason.encode!(%{query: query}))
+
+      body = json_response(conn, 200)
+      assert body["errors"] != nil
+      assert Enum.any?(body["errors"], fn e -> e["message"] =~ "too complex" end)
+    end
   end
 end

--- a/test/huddlz_web/json_api_test.exs
+++ b/test/huddlz_web/json_api_test.exs
@@ -25,7 +25,7 @@ defmodule HuddlzWeb.JsonApiTest do
       %{owner: owner, group: group, huddl: huddl}
     end
 
-    test "unauthenticated POST returns error", %{conn: conn, group: group, owner: owner} do
+    test "unauthenticated POST returns error", %{conn: conn, group: group} do
       starts_at =
         DateTime.utc_now()
         |> DateTime.add(7, :day)
@@ -46,7 +46,6 @@ defmodule HuddlzWeb.JsonApiTest do
             physical_location: "123 Main St",
             starts_at: starts_at,
             ends_at: ends_at,
-            creator_id: owner.id,
             group_id: group.id
           }
         }
@@ -84,7 +83,6 @@ defmodule HuddlzWeb.JsonApiTest do
             physical_location: "456 Oak Ave",
             starts_at: starts_at,
             ends_at: ends_at,
-            creator_id: owner.id,
             group_id: group.id
           }
         }

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -57,8 +57,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
             event_type: :virtual,
             virtual_link: "https://zoom.us/j/123456789",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -152,8 +151,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
             event_type: :in_person,
             physical_location: "123 Main St",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -346,8 +344,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
             event_type: :in_person,
             physical_location: "123 Main St, City",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -374,8 +371,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
             physical_location: "Conference Room A",
             virtual_link: "https://meet.example.com/hybrid",
             is_private: false,
-            group_id: group.id,
-            creator_id: owner.id
+            group_id: group.id
           },
           actor: owner
         )
@@ -425,8 +421,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
             event_type: :in_person,
             physical_location: "Secret Location",
             is_private: true,
-            group_id: private_group.id,
-            creator_id: owner.id
+            group_id: private_group.id
           },
           actor: owner
         )

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -257,17 +257,17 @@ defmodule Huddlz.Generator do
   Create a huddl with random data.
   """
   def huddl(opts \\ []) do
-    actor =
-      opts[:actor] ||
-        once(:default_actor, fn ->
-          generate(user(role: opts[:actor_role] || :user))
-        end)
-
     creator_id =
       opts[:creator_id] ||
         once(:default_creator_id, fn ->
           generate(user(role: :user)).id
         end)
+
+    # creator_id is no longer an accepted input — the :create action derives
+    # the creator from the actor. Author the huddl as the requested creator by
+    # using them as the actor (unless an explicit actor is given).
+    actor =
+      opts[:actor] || Ash.get!(User, creator_id, authorize?: false)
 
     group_id =
       opts[:group_id] ||
@@ -300,7 +300,6 @@ defmodule Huddlz.Generator do
         start_time: start_time,
         duration_minutes: duration_minutes,
         thumbnail_url: thumbnail_url,
-        creator_id: creator_id,
         group_id: group_id,
         event_type: :in_person,
         physical_location: "123 Main St, Anytown, USA",


### PR DESCRIPTION
## Security & Ash-policy hardening

Fixes the high/medium findings from a security + Ash-policy review. Each commit is one finding, ships with its tests, and leaves `mix precommit` clean. Authorship was kept actor-driven throughout (no `creator_id`/`owner_id` args).

### Findings fixed

- **`add_member` privilege escalation** (`fix(group-member)`) — the `:add_member` action accepted an unconstrained `role`, so any owner *or organizer* could mint `:owner`/`:organizer` membership rows via GraphQL/JSON:API. Now validated to `[:member, :organizer]`, organizers can grant only `:member`, and the owner self-add/transfer paths use a new internal `:add_owner` action (`forbid_if always()`).

- **Private-group location leak** (`fix(group-location)`) — `GroupLocation` reads were `authorize_if always()`, so an unauthenticated caller could fetch any private group's saved street addresses + GPS. Now gated by group visibility (public group **or** member), mirroring the `Group` read policy. Public-group locations stay public, so discovery is unaffected.

- **Capacity overbooking race** (`fix(huddl)` lock) — `:cancel_rsvp` destroyed the attendee in the `change/3` body (outside the action transaction) and the waitlist promotion took no lock, so cancel/promote never serialized against concurrent RSVPs. Now both run in a `before_action` that takes the same `FOR UPDATE` lock as `:rsvp`/`:join_waitlist`, with a capacity re-check before promoting. Also extracts the duplicated `at_capacity?` helper into a declarative `:at_capacity` calculation on `Huddl`.

- **Huddl creator spoofing** (`fix(huddl)` creator) — `:create` accepted `creator_id` and the policy never checked it against the actor. `creator_id` is removed from the action input entirely; a `SetCreatorToActor` change derives it from the actor (mirroring `Group`'s `SetOwnerToActor`). Internal/seed paths set it directly.

- **Unbounded GraphQL queries** (`fix(graphql)`) — the public `/gql` endpoint had no complexity analysis. Added `analyze_complexity: true, max_complexity: 100`. (Relationships aren't exposed as GraphQL fields, so deep nesting isn't possible; this bounds query breadth / alias amplification.)

### Notes / not in this PR

- The GraphQL playground, introspection, and JSON:API SwaggerUI are intentionally public (API-first / agent-consumable), so they were left exposed.
- Lower-severity hardening items from the review (auth-endpoint rate limiting, image content-type validation, libvips pixel cap, session `Secure` flag, `EditRecurringHuddlz` actorless read, etc.) are deferred to follow-ups.

All ~1300 tests pass with `mix precommit` clean at every commit.
