### PR TITLE
Low-severity security hardening (4 fixes)

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,6 +9,10 @@ config :huddlz, HuddlzWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   force_ssl: [rewrite_on: [:x_forwarded_proto], hsts: true]
 
+# Only transmit the session cookie over HTTPS (read by the endpoint's
+# @session_options). Dev/test leave this unset so cookies work over http.
+config :huddlz, :session, secure: true
+
 # Configures Swoosh API Client
 config :swoosh, api_client: Swoosh.ApiClient.Req
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -40,6 +40,11 @@ config :huddlz, :storage, adapter: Huddlz.Storage.Local
 config :huddlz, :geocoding, adapter: Huddlz.MockGeocoding
 config :huddlz, :places, adapter: Huddlz.MockPlaces
 config :huddlz, geocoding_req_plug: {Req.Test, Huddlz.Geocoding.Google}
+config :huddlz, places_req_plug: {Req.Test, Huddlz.Places.Google}
+# Real Google adapters read this key for request headers; the configured
+# MockGeocoding/MockPlaces adapters mean live code never sends it, but the
+# *_req_plug-backed adapter tests need a non-nil value.
+config :huddlz, :google_maps, api_key: "test-google-maps-key"
 config :huddlz, Huddlz.Repo, pool: Ecto.Adapters.SQL.Sandbox
 config :huddlz, :sql_sandbox?, true
 

--- a/lib/huddlz/places/google.ex
+++ b/lib/huddlz/places/google.ex
@@ -22,13 +22,17 @@ defmodule Huddlz.Places.Google do
 
     body = if types != [], do: Map.put(body, :includedPrimaryTypes, types), else: body
 
-    case Req.post(@autocomplete_url,
-           json: body,
-           headers: [
-             {"X-Goog-Api-Key", api_key()},
-             {"Content-Type", "application/json"}
-           ]
-         ) do
+    opts =
+      [
+        json: body,
+        redirect: false,
+        headers: [
+          {"X-Goog-Api-Key", api_key()},
+          {"Content-Type", "application/json"}
+        ]
+      ] ++ req_test_options()
+
+    case Req.post(@autocomplete_url, opts) do
       {:ok, %{status: 200, body: %{"suggestions" => suggestions}}} ->
         {:ok, parse_suggestions(suggestions)}
 
@@ -49,13 +53,17 @@ defmodule Huddlz.Places.Google do
   def place_details(place_id, session_token) when is_binary(place_id) do
     url = "https://places.googleapis.com/v1/places/#{place_id}"
 
-    case Req.get(url,
-           headers: [
-             {"X-Goog-Api-Key", api_key()},
-             {"X-Goog-FieldMask", "location"}
-           ],
-           params: [sessionToken: session_token]
-         ) do
+    opts =
+      [
+        redirect: false,
+        headers: [
+          {"X-Goog-Api-Key", api_key()},
+          {"X-Goog-FieldMask", "location"}
+        ],
+        params: [sessionToken: session_token]
+      ] ++ req_test_options()
+
+    case Req.get(url, opts) do
       {:ok, %{status: 200, body: %{"location" => %{"latitude" => lat, "longitude" => lng}}}} ->
         {:ok, %{latitude: lat, longitude: lng}}
 
@@ -87,5 +95,17 @@ defmodule Huddlz.Places.Google do
 
   defp api_key do
     Application.get_env(:huddlz, :google_maps)[:api_key]
+  end
+
+  # These are direct calls to Google's Places host, which never legitimately
+  # redirects. `redirect: false` is set on both requests so the
+  # X-Goog-Api-Key header can't be forwarded to another host if a 3xx is ever
+  # returned (Req's cross-host credential stripping only covers `authorization`,
+  # not arbitrary custom headers).
+  defp req_test_options do
+    case Application.get_env(:huddlz, :places_req_plug) do
+      nil -> []
+      plug -> [plug: plug]
+    end
   end
 end

--- a/lib/huddlz/storage/group_images.ex
+++ b/lib/huddlz/storage/group_images.ex
@@ -27,6 +27,7 @@ defmodule Huddlz.Storage.GroupImages do
   """
   def store(source_path, original_filename, content_type, group_id) do
     with :ok <- validate_extension(original_filename),
+         :ok <- validate_file_type(content_type),
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),
@@ -56,6 +57,7 @@ defmodule Huddlz.Storage.GroupImages do
   """
   def store_pending(source_path, original_filename, content_type) do
     with :ok <- validate_extension(original_filename),
+         :ok <- validate_file_type(content_type),
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),

--- a/lib/huddlz/storage/huddl_images.ex
+++ b/lib/huddlz/storage/huddl_images.ex
@@ -27,6 +27,7 @@ defmodule Huddlz.Storage.HuddlImages do
   """
   def store(source_path, original_filename, content_type, huddl_id) do
     with :ok <- validate_extension(original_filename),
+         :ok <- validate_file_type(content_type),
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),
@@ -56,6 +57,7 @@ defmodule Huddlz.Storage.HuddlImages do
   """
   def store_pending(source_path, original_filename, content_type) do
     with :ok <- validate_extension(original_filename),
+         :ok <- validate_file_type(content_type),
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),

--- a/lib/huddlz/storage/profile_pictures.ex
+++ b/lib/huddlz/storage/profile_pictures.ex
@@ -24,6 +24,7 @@ defmodule Huddlz.Storage.ProfilePictures do
   """
   def store(source_path, original_filename, content_type, user_id) do
     with :ok <- validate_extension(original_filename),
+         :ok <- validate_file_type(content_type),
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),

--- a/lib/huddlz_web/endpoint.ex
+++ b/lib/huddlz_web/endpoint.ex
@@ -5,11 +5,16 @@ defmodule HuddlzWeb.Endpoint do
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
+  # `secure: true` keeps the session cookie off plaintext HTTP. It is only set
+  # in production (dev/test run over http); force_ssl + HSTS already redirect
+  # http→https there, and this closes the first-request window before HSTS is
+  # honored by the browser.
   @session_options [
     store: :cookie,
     key: "_huddlz_key",
     signing_salt: "QBw0kYUu",
-    same_site: "Lax"
+    same_site: "Lax",
+    secure: Application.compile_env(:huddlz, [:session, :secure], false)
   ]
 
   socket "/live", Phoenix.LiveView.Socket,

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -391,7 +391,7 @@ defmodule HuddlzWeb.GroupLive.Show do
   end
 
   def handle_event("change_past_page", %{"page" => page_str}, socket) do
-    page = String.to_integer(page_str)
+    page = parse_page(page_str)
 
     {past_huddlz, total_pages} =
       get_past_group_huddlz_paginated(
@@ -547,6 +547,21 @@ defmodule HuddlzWeb.GroupLive.Show do
 
     {page_result.results, total_pages}
   end
+
+  # Mirrors the clamped parser the other pagination LiveViews use, so a
+  # crafted non-numeric "page" value over the socket can't crash the process.
+  defp parse_page(nil), do: 1
+  defp parse_page(""), do: 1
+
+  defp parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  defp parse_page(val) when is_integer(val) and val >= 1, do: val
+  defp parse_page(_), do: 1
 
   defp role_pill(%{can_edit_group: true}), do: "Owner"
   defp role_pill(%{is_member: true}), do: "Joined"

--- a/test/huddlz/places/google_test.exs
+++ b/test/huddlz/places/google_test.exs
@@ -1,0 +1,83 @@
+defmodule Huddlz.Places.GoogleTest do
+  use ExUnit.Case, async: true
+
+  alias Huddlz.Places.Google
+
+  describe "autocomplete/3" do
+    test "returns parsed suggestions" do
+      Req.Test.stub(Google, fn conn ->
+        Req.Test.json(conn, %{
+          "suggestions" => [
+            %{
+              "placePrediction" => %{
+                "placeId" => "place-123",
+                "text" => %{"text" => "Austin, TX, USA"},
+                "structuredFormat" => %{
+                  "mainText" => %{"text" => "Austin"},
+                  "secondaryText" => %{"text" => "TX, USA"}
+                }
+              }
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, [suggestion]} = Google.autocomplete("Austin", "session-token", [])
+      assert suggestion.place_id == "place-123"
+      assert suggestion.main_text == "Austin"
+      assert suggestion.display_text == "Austin, TX, USA"
+    end
+  end
+
+  describe "place_details/2" do
+    test "returns coordinates" do
+      Req.Test.stub(Google, fn conn ->
+        Req.Test.json(conn, %{"location" => %{"latitude" => 30.2672, "longitude" => -97.7431}})
+      end)
+
+      assert {:ok, %{latitude: 30.2672, longitude: -97.7431}} =
+               Google.place_details("place-123", "session-token")
+    end
+  end
+
+  describe "redirect handling" do
+    test "place_details does not follow a cross-host redirect" do
+      test_pid = self()
+
+      Req.Test.stub(Google, fn conn ->
+        send(test_pid, {:requested_host, conn.host})
+
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://evil.example.com/steal")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      # With redirect: false the 3xx is surfaced as-is rather than followed.
+      assert {:error, {:api_error, 302, _}} =
+               Google.place_details("place-123", "session-token")
+
+      # The Places host was contacted exactly once and the redirect target was
+      # never requested — so the X-Goog-Api-Key header never left Google's domain.
+      assert_received {:requested_host, "places.googleapis.com"}
+      refute_received {:requested_host, "evil.example.com"}
+    end
+
+    test "autocomplete does not follow a cross-host redirect" do
+      test_pid = self()
+
+      Req.Test.stub(Google, fn conn ->
+        send(test_pid, {:requested_host, conn.host})
+
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://evil.example.com/steal")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      assert {:error, {:api_error, 302, _}} =
+               Google.autocomplete("Austin", "session-token", [])
+
+      assert_received {:requested_host, "places.googleapis.com"}
+      refute_received {:requested_host, "evil.example.com"}
+    end
+  end
+end

--- a/test/huddlz/storage_test.exs
+++ b/test/huddlz/storage_test.exs
@@ -131,6 +131,18 @@ defmodule Huddlz.StorageTest do
                ProfilePictures.store(temp_path, "avatar.gif", "image/gif", user_id)
     end
 
+    test "store/4 rejects a disallowed content type even with a valid extension", %{
+      test_id: test_id,
+      user_id: user_id
+    } do
+      temp_path = Path.join(System.tmp_dir!(), "upload_#{test_id}.png")
+      File.write!(temp_path, "not really an image")
+      on_exit(fn -> File.rm(temp_path) end)
+
+      assert {:error, "Invalid file type. Allowed: JPG, PNG, WebP"} =
+               ProfilePictures.store(temp_path, "avatar.png", "text/html", user_id)
+    end
+
     test "store/4 rejects files that are too large", %{test_id: test_id, user_id: user_id} do
       temp_path = Path.join(System.tmp_dir!(), "upload_#{test_id}.png")
       # Create a file larger than 5MB
@@ -192,6 +204,52 @@ defmodule Huddlz.StorageTest do
       # 5MB = 5 * 1024 * 1024 = 5,242,880 bytes
       assert {:error, _} = ProfilePictures.validate_file_size(5_242_881)
       assert {:error, _} = ProfilePictures.validate_file_size(10_000_000)
+    end
+  end
+
+  # The content-type allowlist runs before the file is read/decoded, so a
+  # bogus content type is rejected regardless of the bytes on disk. These
+  # cover that the allowlist is wired into every store entry point (it was
+  # previously dead code, leaving the client-supplied content type trusted).
+  describe "Storage.HuddlImages content-type allowlist" do
+    alias Huddlz.Storage.HuddlImages
+
+    setup do
+      temp_path = Path.join(System.tmp_dir!(), "huddl_#{:rand.uniform(999_999)}.png")
+      File.write!(temp_path, "not really an image")
+      on_exit(fn -> File.rm(temp_path) end)
+      {:ok, temp_path: temp_path}
+    end
+
+    test "store/4 rejects a disallowed content type", %{temp_path: temp_path} do
+      assert {:error, "Invalid file type. Allowed: JPG, PNG, WebP"} =
+               HuddlImages.store(temp_path, "banner.png", "text/html", "huddl-1")
+    end
+
+    test "store_pending/3 rejects a disallowed content type", %{temp_path: temp_path} do
+      assert {:error, "Invalid file type. Allowed: JPG, PNG, WebP"} =
+               HuddlImages.store_pending(temp_path, "banner.png", "application/pdf")
+    end
+  end
+
+  describe "Storage.GroupImages content-type allowlist" do
+    alias Huddlz.Storage.GroupImages
+
+    setup do
+      temp_path = Path.join(System.tmp_dir!(), "group_#{:rand.uniform(999_999)}.png")
+      File.write!(temp_path, "not really an image")
+      on_exit(fn -> File.rm(temp_path) end)
+      {:ok, temp_path: temp_path}
+    end
+
+    test "store/4 rejects a disallowed content type", %{temp_path: temp_path} do
+      assert {:error, "Invalid file type. Allowed: JPG, PNG, WebP"} =
+               GroupImages.store(temp_path, "banner.png", "text/html", "group-1")
+    end
+
+    test "store_pending/3 rejects a disallowed content type", %{temp_path: temp_path} do
+      assert {:error, "Invalid file type. Allowed: JPG, PNG, WebP"} =
+               GroupImages.store_pending(temp_path, "banner.png", "application/pdf")
     end
   end
 end

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -210,6 +210,23 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       refute has_element?(view, "h3", "Past Event 20")
     end
 
+    test "ignores a non-numeric page value instead of crashing", %{conn: conn, group: group} do
+      {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
+
+      # Switch to past events tab and move off page 1 so the fallback is observable.
+      view |> element("button", "Past") |> render_click()
+      view |> element("button", "2") |> render_click()
+      assert has_element?(view, "button.page-num.is-active", "2")
+
+      # A crafted socket event with a non-numeric page must not crash the
+      # LiveView; it falls back to page 1. String.to_integer/1 would have
+      # raised ArgumentError here and dropped the process.
+      html = render_hook(view, "change_past_page", %{"page" => "not-a-number"})
+
+      assert html =~ "Past Event 1"
+      assert has_element?(view, "button.page-num.is-active", "1")
+    end
+
     test "shows no past events message when group has no past events", %{conn: conn, user: user} do
       # Create a new group with no past events
       new_group = generate(group(owner_id: user.id, is_public: true, actor: user))

--- a/test/huddlz_web/session_cookie_test.exs
+++ b/test/huddlz_web/session_cookie_test.exs
@@ -1,0 +1,11 @@
+defmodule HuddlzWeb.SessionCookieTest do
+  # Guards the session cookie's `secure` flag wiring. `secure: true` is set
+  # only in production (config/prod.exs); if it ever leaked into the base or
+  # test config the cookie would stop being sent over http and local dev /
+  # the test suite's session-based auth would silently break.
+  use ExUnit.Case, async: true
+
+  test "the session cookie is not forced secure outside production" do
+    refute get_in(Application.get_env(:huddlz, :session) || [], [:secure])
+  end
+end


### PR DESCRIPTION
## Summary

A small batch of low-severity hardening fixes from the audit's "🟡 Low / hardening" tier. Each is its own atomic commit with tests; `mix precommit` is clean (1335 tests, credo strict).

These were the cheap, high-value items. Two audit findings were **consciously dropped** from this batch (see below).

## What's here

**`fix(group-show): clamp past-page param instead of crashing`**
`change_past_page` ran `String.to_integer/1` on the client-supplied `page` value, so a crafted non-numeric value pushed over the socket raised `ArgumentError` and dropped the LiveView. Now reuses the clamped `parse_page/1` pattern the other four pagination LiveViews already use. (Self-inflicted crash only — low severity, but it was the lone outlier among five handlers.)

**`fix(places): stop following cross-host redirects on Google calls`**
The Places autocomplete/details requests sent `X-Goog-Api-Key` as a custom header with Req's default redirect behavior. Req only strips the `authorization` header on untrusted cross-host redirects, not arbitrary custom headers, so a 3xx from Google's host to another host would have forwarded the key. Set `redirect: false` on both calls (these hit a fixed Google host that never legitimately redirects). Tests assert a cross-host redirect is never followed. *(No SSRF — the host is hardcoded — and Google doesn't actually redirect today, so this is latent defense-in-depth.)*

**`feat(security): mark the session cookie secure in production`**
The session cookie had no `secure` flag. Sourced from compile-time config (default `false`), set `true` only in `config/prod.exs` so dev/test on http are unaffected. `force_ssl` + HSTS already mitigate the realistic case; this closes the pre-HSTS first-request window. Guard test prevents `secure: true` leaking into dev/test config.

**`fix(storage): enforce the content-type allowlist on uploads`**
Each storage module defined `validate_file_type/1` but never called it — the client-supplied content type was trusted and forced onto the record (and the S3 object's content-type header); only the extension was checked. Now called in the `store`/`store_pending` `with`-chains of all three modules, before the file is read, so it covers API uploads too (not just the LiveView accept list). *(Bounded today by server-side JPEG thumbnailing + libvips decode; this is hygiene that hardens the API entry point.)*

## Deliberately dropped from this batch

- **`Ash.get(GroupImage)` without `actor:`** — dropped entirely. On closer inspection even the consistency argument is hollow: the GroupImage read policy is `authorize_if always()`, so passing `actor:` adds zero protection. Pure churn.
- **User `:email` field policy (hide from non-self/non-admin)** — **deferred to its own PR.** This is latent (no API path exposes another user's email today) and turned out to be **not** a small change. Adding `field_policies` forces all-fields authorization, and more importantly Ash re-authorizes a *mutation's result* via the primary `:read` action while filter checks (`id == ^actor(:id)`) don't resolve on an in-memory mutation result — so a register/`change_email` result is indistinguishable from a cross-user browse `:read` at field-policy time. Doing it correctly needs auth-controller `authorize?: false` on register/sign-in, a fix to the `change_email` notice hook, and several direct-call test updates. Worth doing, but as a focused change in auth code — not bundled into hardening.

## Also not in this batch (bigger, separate)
The audit's `#2` (libvips megapixel cap) and `#7` (per-user API-key cap) are real but a notch larger; left for follow-ups.
