### PR TITLE
ci: run dev setup and seeds against a fresh database

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -110,3 +110,72 @@ jobs:
     # Customize this step as desired.
     - name: Check Linting
       run: mix credo --strict
+
+  # Run the dev onboarding flow (`mix ecto.setup`: create, migrate, seeds.exs,
+  # dev_seeds.exs) against a fresh database. The seed scripts call resource
+  # actions directly and refuse to run in MIX_ENV=test, so the test suite
+  # can't catch them drifting from the actions they call — this job can.
+  seeds:
+    services:
+      db:
+        image: postgis/postgis:17-3.5
+        ports: ['5432:5432']
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    runs-on: ubuntu-latest
+    name: Seed on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    env:
+      MIX_ENV: dev
+    strategy:
+      matrix:
+        otp: ['29.0.1']
+        elixir: ['1.20.0']
+    steps:
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{matrix.otp}}
+        elixir-version: ${{matrix.elixir}}
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # The example file works as-is: the placeholder Google Maps key makes
+    # geocoding fail soft (warning + nil coordinates), which is exactly what
+    # a fresh contributor without real credentials experiences.
+    - name: Setup dev environment
+      run: cp .dev.env.example .dev.env
+
+    - name: Cache deps
+      id: cache-deps
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-elixir-deps
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ env.cache-name }}-
+
+    - name: Cache compiled build
+      id: cache-build
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-compiled-dev-build
+      with:
+        path: _build
+        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ env.cache-name }}-
+
+    - name: Install dependencies
+      run: mix deps.get
+
+    - name: Create, migrate, and seed the database
+      run: mix ecto.setup


### PR DESCRIPTION
## Summary

Adds a `seeds` CI job that runs the real dev onboarding flow — `mix ecto.setup` (create, migrate, `seeds.exs`, `dev_seeds.exs`) — against a fresh Postgres on every push/PR.

## Why

The seed scripts call resource actions directly but refuse to run in `MIX_ENV=test` (their fixed emails collide with test fixtures), so the test suite structurally cannot catch them drifting from the actions they call. The `owner_id`/`creator_id` breakage fixed in #243 sat unnoticed on main for weeks until a contributor hit it during onboarding. This job turns that class of breakage into a red check.

## Notes

- Uses `.dev.env.example` as-is. The placeholder Google Maps key makes geocoding fail soft (warning + nil coordinates), which matches what a fresh contributor without real credentials experiences.
- Job-level `MIX_ENV: dev` overrides the workflow-level `test` env.
- Dev `_build` gets its own cache key (`cache-compiled-dev-build`); the deps cache is shared with the test job since deps are env-independent.

## Test plan

- [x] Validated the exact CI path locally: copied `.dev.env.example` over a scratch DB URL and ran `MIX_ENV=dev mix ecto.setup` — seeds completed (4 groups, 43 huddlz), geocoding warned and continued
- [ ] The `seeds` job on this PR is the live verification