### PR TITLE
Quick wins: button pending states, API timeouts, job dedupe, policy cleanup

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -456,23 +456,9 @@ defmodule Huddlz.Communities.Huddl do
       authorize_if always()
     end
 
-    # RSVP policies
-    policy action(:rsvp) do
-      description "Users can RSVP to huddlz they have access to"
-      authorize_if expr(is_private == false and group.is_public == true)
-      authorize_if expr(exists(group.members, id == ^actor(:id)))
-    end
-
-    # Cancel RSVP policies (also covers leaving the waitlist)
-    policy action(:cancel_rsvp) do
-      description "Users can cancel their own RSVPs or leave the waitlist"
-      authorize_if expr(is_private == false and group.is_public == true)
-      authorize_if expr(exists(group.members, id == ^actor(:id)))
-    end
-
-    # Waitlist join policy mirrors RSVP visibility
-    policy action(:join_waitlist) do
-      description "Users can join the waitlist for huddlz they have access to"
+    # RSVP, cancellation, and waitlist all share the same visibility rule
+    policy action([:rsvp, :cancel_rsvp, :join_waitlist]) do
+      description "Users can manage their attendance on huddlz they have access to"
       authorize_if expr(is_private == false and group.is_public == true)
       authorize_if expr(exists(group.members, id == ^actor(:id)))
     end

--- a/lib/huddlz/geocoding/google.ex
+++ b/lib/huddlz/geocoding/google.ex
@@ -7,6 +7,11 @@ defmodule Huddlz.Geocoding.Google do
 
   @geocoding_url "https://maps.googleapis.com/maps/api/geocode/json"
 
+  # Geocoding runs in the request path; cap how long a slow Google response
+  # can hold a connection, and don't let Req's default retry-with-backoff
+  # multiply that wait.
+  @req_options [receive_timeout: :timer.seconds(5), retry: false]
+
   @accepted_types ~w(
     street_address route premise subpremise
     locality sublocality neighborhood postal_code
@@ -34,7 +39,7 @@ defmodule Huddlz.Geocoding.Google do
   end
 
   defp fetch_coordinates(address, key) do
-    opts = [params: [address: address, key: key]] ++ req_test_options()
+    opts = [params: [address: address, key: key]] ++ @req_options ++ req_test_options()
     Req.get(@geocoding_url, opts)
   end
 

--- a/lib/huddlz/notifications/deliver_worker.ex
+++ b/lib/huddlz/notifications/deliver_worker.ex
@@ -13,9 +13,15 @@ defmodule Huddlz.Notifications.DeliverWorker do
   Delivery failures retry with the worker's default exponential backoff.
   Skipped or unknown-user jobs return `{:cancel, reason}` so they don't
   retry.
+
+  Jobs with identical args enqueued within a minute are deduplicated —
+  an accidental double-enqueue would otherwise email the user twice.
   """
 
-  use Oban.Worker, queue: :notifications, max_attempts: 5
+  use Oban.Worker,
+    queue: :notifications,
+    max_attempts: 5,
+    unique: [period: 60]
 
   alias Huddlz.Accounts.User
   alias Huddlz.Notifications

--- a/lib/huddlz/places/google.ex
+++ b/lib/huddlz/places/google.ex
@@ -7,6 +7,11 @@ defmodule Huddlz.Places.Google do
 
   @autocomplete_url "https://places.googleapis.com/v1/places:autocomplete"
 
+  # Autocomplete fires per keystroke from LiveView; cap how long a slow
+  # Google response can hold a connection, and don't let Req's default
+  # retry-with-backoff multiply that wait.
+  @req_options [receive_timeout: :timer.seconds(5), retry: false]
+
   @impl true
   def autocomplete(query, _session_token, _opts) when is_binary(query) and byte_size(query) < 2 do
     {:ok, []}
@@ -30,7 +35,7 @@ defmodule Huddlz.Places.Google do
           {"X-Goog-Api-Key", api_key()},
           {"Content-Type", "application/json"}
         ]
-      ] ++ req_test_options()
+      ] ++ @req_options ++ req_test_options()
 
     case Req.post(@autocomplete_url, opts) do
       {:ok, %{status: 200, body: %{"suggestions" => suggestions}}} ->
@@ -61,7 +66,7 @@ defmodule Huddlz.Places.Google do
           {"X-Goog-FieldMask", "location"}
         ],
         params: [sessionToken: session_token]
-      ] ++ req_test_options()
+      ] ++ @req_options ++ req_test_options()
 
     case Req.get(url, opts) do
       {:ok, %{status: 200, body: %{"location" => %{"latitude" => lat, "longitude" => lng}}}} ->

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -223,6 +223,7 @@ defmodule HuddlzWeb.GroupLive.Show do
                 :if={!@is_member and @can_join_group}
                 variant={:primary}
                 phx-click="join_group"
+                phx-disable-with="Joining..."
               >
                 Join Group
               </.button>
@@ -230,6 +231,7 @@ defmodule HuddlzWeb.GroupLive.Show do
                 :if={@can_leave_group}
                 variant={:muted}
                 phx-click="leave_group"
+                phx-disable-with="Leaving..."
                 data-confirm="Are you sure you want to leave this group?"
               >
                 Leave Group

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -365,7 +365,12 @@ defmodule HuddlzWeb.HuddlLive.Show do
         </svg>
         <span>This huddl is full</span>
       </div>
-      <.button variant={:primary} phx-click="join_waitlist" class="rsvp-cta">
+      <.button
+        variant={:primary}
+        phx-click="join_waitlist"
+        phx-disable-with="Joining waitlist..."
+        class="rsvp-cta"
+      >
         Join waitlist
       </.button>
       """

--- a/test/huddlz/geocoding/google_test.exs
+++ b/test/huddlz/geocoding/google_test.exs
@@ -120,6 +120,21 @@ defmodule Huddlz.Geocoding.GoogleTest do
       assert {:error, {:api_error, "REQUEST_DENIED"}} = Google.geocode("Austin, TX")
     end
 
+    test "returns request_failed without retrying when the request times out" do
+      test_pid = self()
+
+      Req.Test.stub(Google, fn conn ->
+        send(test_pid, :request_attempted)
+        Req.Test.transport_error(conn, :timeout)
+      end)
+
+      assert {:error, {:request_failed, %Req.TransportError{reason: :timeout}}} =
+               Google.geocode("Austin, TX")
+
+      assert_received :request_attempted
+      refute_received :request_attempted
+    end
+
     test "rejects empty address" do
       assert {:error, :invalid_address} = Google.geocode("")
     end

--- a/test/huddlz/notifications/deliver_worker_test.exs
+++ b/test/huddlz/notifications/deliver_worker_test.exs
@@ -23,6 +23,27 @@ defmodule Huddlz.Notifications.DeliverWorkerTest do
       )
     end
 
+    test "deduplicates identical jobs enqueued in quick succession" do
+      user = generate(user(confirmed_at: DateTime.utc_now()))
+
+      assert {:ok, %Oban.Job{conflict?: false}} = Notifications.deliver(user, :password_changed)
+      assert {:ok, %Oban.Job{conflict?: true}} = Notifications.deliver(user, :password_changed)
+
+      assert [_only_job] = all_enqueued(worker: DeliverWorker)
+    end
+
+    test "does not deduplicate jobs with different payloads" do
+      user = generate(user(confirmed_at: DateTime.utc_now()))
+
+      assert {:ok, %Oban.Job{conflict?: false}} =
+               Notifications.deliver(user, :password_changed, %{"source" => "a"})
+
+      assert {:ok, %Oban.Job{conflict?: false}} =
+               Notifications.deliver(user, :password_changed, %{"source" => "b"})
+
+      assert [_, _] = all_enqueued(worker: DeliverWorker)
+    end
+
     test "raises on unknown triggers up front rather than after enqueue" do
       user = generate(user())
 

--- a/test/huddlz/places/google_test.exs
+++ b/test/huddlz/places/google_test.exs
@@ -27,6 +27,21 @@ defmodule Huddlz.Places.GoogleTest do
       assert suggestion.main_text == "Austin"
       assert suggestion.display_text == "Austin, TX, USA"
     end
+
+    test "returns request_failed without retrying when the request times out" do
+      test_pid = self()
+
+      Req.Test.stub(Google, fn conn ->
+        send(test_pid, :request_attempted)
+        Req.Test.transport_error(conn, :timeout)
+      end)
+
+      assert {:error, {:request_failed, %Req.TransportError{reason: :timeout}}} =
+               Google.autocomplete("Austin", "session-token", [])
+
+      assert_received :request_attempted
+      refute_received :request_attempted
+    end
   end
 
   describe "place_details/2" do
@@ -37,6 +52,21 @@ defmodule Huddlz.Places.GoogleTest do
 
       assert {:ok, %{latitude: 30.2672, longitude: -97.7431}} =
                Google.place_details("place-123", "session-token")
+    end
+
+    test "returns request_failed without retrying when the request times out" do
+      test_pid = self()
+
+      Req.Test.stub(Google, fn conn ->
+        send(test_pid, :request_attempted)
+        Req.Test.transport_error(conn, :timeout)
+      end)
+
+      assert {:error, {:request_failed, %Req.TransportError{reason: :timeout}}} =
+               Google.place_details("place-123", "session-token")
+
+      assert_received :request_attempted
+      refute_received :request_attempted
     end
   end
 

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -1,0 +1,54 @@
+defmodule HuddlzWeb.GroupLive.ShowTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import Huddlz.Test.Helpers.Authentication
+
+  describe "membership action buttons" do
+    setup do
+      owner = generate(user(role: :user))
+
+      group =
+        generate(
+          group(
+            owner_id: owner.id,
+            is_public: true,
+            name: "Membership Test Group",
+            actor: owner
+          )
+        )
+
+      %{owner: owner, group: group}
+    end
+
+    test "join button shows a pending state while submitting", %{conn: conn, group: group} do
+      visitor = generate(user(role: :user))
+
+      conn
+      |> login(visitor)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("button[phx-disable-with='Joining...']", text: "Join Group")
+    end
+
+    test "leave button shows a pending state while submitting", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      member = generate(user(role: :user))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: member.id,
+          role: :member,
+          actor: owner
+        )
+      )
+
+      conn
+      |> login(member)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("button[phx-disable-with='Leaving...']", text: "Leave Group")
+    end
+  end
+end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -314,7 +314,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has(".rsvp-banner.warn", text: "This huddl is full")
       |> assert_has(".facts .value", text: "1/1 spots filled")
       |> refute_has("button", text: "RSVP to this huddl")
-      |> assert_has("button", text: "Join waitlist")
+      |> assert_has("button[phx-disable-with='Joining waitlist...']", text: "Join waitlist")
     end
 
     test "non-authenticated users see sign-in prompt for virtual link", %{


### PR DESCRIPTION
Four small, independent fixes from a codebase review.

## Changes

**fix(ux): add pending states to join, leave, and waitlist buttons**
- Join Group and Leave Group buttons now show feedback while submitting (`phx-disable-with`), matching the existing RSVP button pattern
- Join waitlist button gets the same treatment
- Prevents double-clicks on slow connections
- New `group_live/show_test.exs` covers both membership buttons; waitlist assertion extended

**fix(external): bound Google API requests to a single 5s attempt**
- Geocoding and Places calls run in the request path with no explicit timeout, so a slow Google response could hold a connection for Req's default 30s per attempt
- Req's default retry policy would also retry timed-out GETs 3x with backoff, multiplying the worst case to ~20s+; retries are disabled since these are interactive calls where failing fast is correct
- On timeout, behavior degrades gracefully as before: saves proceed with nil coordinates (logged), autocomplete shows "Location search is currently unavailable."
- New transport-error tests assert a single attempt and the `{:request_failed, _}` error shape for all three call sites

**fix(notifications): deduplicate identical delivery jobs**
- `DeliverWorker` had no Oban uniqueness constraint, so an accidental double-enqueue would email the user twice
- Jobs with identical args now dedupe within a 60s window; distinct payloads still enqueue separately

**refactor(communities): consolidate duplicate RSVP policies**
- `:rsvp`, `:cancel_rsvp`, and `:join_waitlist` had three byte-identical policies; merged into one `policy action([...])` block so the shared visibility rule lives in one place (net -14 lines)

## Testing

`mix precommit` clean at every commit boundary: 1343 tests passed, credo found no issues.