### PR TITLE
Show validation errors on huddl and group locations

### DIFF
--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -133,15 +133,16 @@ defmodule HuddlzWeb.Components.Input do
   end
 
   attr :field, FormField, required: true, doc: "form field whose errors to render"
+  attr :always_show, :boolean, default: false
 
   @doc """
   Renders `<p class="form-error">` lines for a form field whose markup isn't
   produced by `input/textarea/select` (e.g. an inline raw input or a
-  radio-card group). Hidden until the field has been touched (`used_input?/1`).
+  radio-card group). Hidden until the field has been touched (`used_input?/1`) or always_show is set.
   """
   def field_errors(%{field: %FormField{} = field} = assigns) do
     errors =
-      if Phoenix.Component.used_input?(field) do
+      if assigns.always_show || Phoenix.Component.used_input?(field) do
         Enum.map(field.errors, &translate_error/1)
       else
         []

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -301,6 +301,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
                 fetch_coordinates={true}
                 show_clear={true}
               />
+              <.field_errors field={@form[:location]} always_show={true} />
               <p class="form-help">
                 Optional. Helps people find your group when they search nearby.
               </p>

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -243,6 +243,7 @@ defmodule HuddlzWeb.GroupLive.New do
                 fetch_coordinates={true}
                 show_clear={true}
               />
+              <.field_errors field={@form[:location]} always_show={true} />
               <p class="form-help">
                 Optional. Helps people find your group when they search nearby.
               </p>

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -394,6 +394,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
                     ~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit/locations/new"
                   }
                 />
+                <.field_errors field={@form[:physical_location]} always_show={true} />
               </div>
             <% end %>
 

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -279,6 +279,7 @@ defmodule HuddlzWeb.HuddlLive.New do
                   selected_location={@selected_location}
                   new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
                 />
+                <.field_errors field={@form[:physical_location]} always_show={true} />
               </div>
             <% end %>
 

--- a/test/huddlz_web/live/group_live/edit_test.exs
+++ b/test/huddlz_web/live/group_live/edit_test.exs
@@ -109,6 +109,36 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> assert_has("h1", text: "Test Group")
     end
 
+    test "shows location error when submitting with a location that is too long", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/edit")
+
+      send(
+        session.view.pid,
+        {:location_selected, "group-location",
+         %{
+           place_id: "test_place_id",
+           display_text: String.duplicate("x", 501),
+           main_text: "Too Long",
+           latitude: 30.27,
+           longitude: -97.74
+         }}
+      )
+
+      Phoenix.LiveViewTest.render(session.view)
+
+      session
+      |> click_button("Save Changes")
+      |> assert_path(~p"/groups/#{group.slug}/edit")
+      |> assert_has("p.form-error", text: "length must be less than or equal to 500")
+    end
+
     test "cancel button returns to group page", %{conn: conn, owner: owner, group: group} do
       conn
       |> login(owner)

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -93,6 +93,37 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> fill_in("Group name", with: "ab")
       |> assert_has("p", text: "length must be greater than or equal to")
     end
+
+    test "shows location error when submitting with a location that is too long", %{
+      conn: conn,
+      verified: verified
+    } do
+      session =
+        conn
+        |> login(verified)
+        |> visit(~p"/groups/new")
+        |> fill_in("Group name", with: "Test Group")
+        |> fill_in("Description", with: "A test group description")
+
+      send(
+        session.view.pid,
+        {:location_selected, "group-location",
+         %{
+           place_id: "test_place_id",
+           display_text: String.duplicate("x", 501),
+           main_text: "Too Long",
+           latitude: 30.27,
+           longitude: -97.74
+         }}
+      )
+
+      Phoenix.LiveViewTest.render(session.view)
+
+      session
+      |> click_button("Create group")
+      |> assert_path(~p"/groups/new")
+      |> assert_has("p.form-error", text: "length must be less than or equal to 500")
+    end
   end
 
   describe "Show" do

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -367,6 +367,26 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       assert_has(session, "input#form_title + p.form-error")
     end
 
+    test "shows physical location error when submitting in-person huddl without a location", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      tomorrow = Date.utc_today() |> Date.add(1) |> Date.to_iso8601()
+
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/new")
+      |> fill_in("Title", with: "Test Huddl")
+      |> fill_in("Date", with: tomorrow)
+      |> fill_in("Start time", with: "14:00")
+      |> select("Duration", option: "1 hour")
+      # Leave event type as in-person (default), no location selected
+      |> click_button("Schedule huddl")
+      |> assert_path(~p"/groups/#{group.slug}/huddlz/new")
+      |> assert_has("p.form-error", text: "is required for in-person huddlz")
+    end
+
     test "selecting a saved location preserves other form fields", %{
       conn: conn,
       owner: owner,


### PR DESCRIPTION
Validation errors don't show for locations because these have a custom location picker. This adds the `field_errors` component to these, and adds an `always_show `option to bypass the `used_input?` check for these.

### Screenshots
<img width="1059" height="254" alt="screenshot-2026-06-10_08-01-50" src="https://github.com/user-attachments/assets/b400ef0e-25e7-4fdd-bfc2-891d334eb20f" />
<img width="1225" height="374" alt="screenshot-2026-06-10_08-02-22" src="https://github.com/user-attachments/assets/4fbd00ec-babd-4255-b1ff-369dd1af0474" />
