### PR TITLE
Quality pass: shared LiveView helpers and domain-level huddl rules

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -185,6 +185,7 @@ defmodule Huddlz.Communities.Huddl do
       require_atomic? false
 
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
+      change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz
       change Huddlz.Geocoding.ApplyProvidedCoordinates
       change {Huddlz.Geocoding.GeocodeChange, field: :physical_location}

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -139,6 +139,7 @@ defmodule Huddlz.Communities.Huddl do
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.AddHuddlTemplate
+      change Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFields
       change Huddlz.Geocoding.ApplyProvidedCoordinates
       change {Huddlz.Geocoding.GeocodeChange, field: :physical_location}
       change Huddlz.Communities.Huddl.Changes.DefaultLocationFromGroup
@@ -186,6 +187,7 @@ defmodule Huddlz.Communities.Huddl do
 
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
+      change Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFields
       change Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz
       change Huddlz.Geocoding.ApplyProvidedCoordinates
       change {Huddlz.Geocoding.GeocodeChange, field: :physical_location}

--- a/lib/huddlz/communities/huddl/changes/clear_unused_location_fields.ex
+++ b/lib/huddlz/communities/huddl/changes/clear_unused_location_fields.ex
@@ -1,0 +1,31 @@
+defmodule Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFields do
+  @moduledoc """
+  Clears the location field that doesn't apply to the huddl's event type:
+  virtual huddlz carry no physical_location, in-person huddlz carry no
+  virtual_link. Hybrid huddlz keep both.
+
+  Only acts on create or when event_type is being set — an unrelated update
+  (e.g. a title edit) must not touch stored location data, re-trigger
+  geocoding, or notify attendees of a location change.
+
+  Runs before geocoding so a cleared physical_location is never geocoded.
+  """
+  use Ash.Resource.Change
+
+  def change(changeset, _opts, _context) do
+    if changeset.action_type == :create or
+         Ash.Changeset.changing_attribute?(changeset, :event_type) do
+      clear_unused_field(changeset)
+    else
+      changeset
+    end
+  end
+
+  defp clear_unused_field(changeset) do
+    case Ash.Changeset.get_attribute(changeset, :event_type) do
+      :virtual -> Ash.Changeset.force_change_attribute(changeset, :physical_location, nil)
+      :in_person -> Ash.Changeset.force_change_attribute(changeset, :virtual_link, nil)
+      _ -> changeset
+    end
+  end
+end

--- a/lib/huddlz/communities/huddl/changes/force_private_for_private_groups.ex
+++ b/lib/huddlz/communities/huddl/changes/force_private_for_private_groups.ex
@@ -1,12 +1,25 @@
 defmodule Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups do
   @moduledoc """
   Forces is_private to true if the group is private.
+
+  On update, only runs when is_private is being changed — the group lookup
+  isn't worth a query on every unrelated edit (and would run once per
+  occurrence when editing a whole recurring series).
   """
   use Ash.Resource.Change
 
   alias Huddlz.Communities.Group
 
   def change(changeset, _opts, _context) do
+    if changeset.action_type == :update and
+         not Ash.Changeset.changing_attribute?(changeset, :is_private) do
+      changeset
+    else
+      force_private_if_group_private(changeset)
+    end
+  end
+
+  defp force_private_if_group_private(changeset) do
     with group_id when not is_nil(group_id) <- Ash.Changeset.get_attribute(changeset, :group_id),
          {:ok, group} <- Ash.get(Group, group_id, authorize?: false) do
       changeset = Ash.Changeset.set_context(changeset, %{group: group})

--- a/lib/huddlz_web/components/avatar.ex
+++ b/lib/huddlz_web/components/avatar.ex
@@ -4,7 +4,6 @@ defmodule HuddlzWeb.Components.Avatar do
   """
   use Phoenix.Component
 
-  alias Huddlz.Storage.ProfilePictures
   alias HuddlzWeb.Components.Icon
 
   attr :user, :map,
@@ -35,8 +34,8 @@ defmodule HuddlzWeb.Components.Avatar do
       assigns
       |> assign(:size_class, size_classes[assigns.size])
       |> assign(:icon_size, icon_sizes[assigns.size])
-      |> assign(:initials, get_initials(assigns.user))
-      |> assign(:avatar_url, get_avatar_url(assigns.user))
+      |> assign(:initials, HuddlzWeb.Avatar.initials(assigns.user))
+      |> assign(:avatar_url, HuddlzWeb.Avatar.picture_url(assigns.user))
 
     ~H"""
     <div class={[
@@ -59,30 +58,6 @@ defmodule HuddlzWeb.Components.Avatar do
     </div>
     """
   end
-
-  defp get_initials(nil), do: nil
-  defp get_initials(%{display_name: nil}), do: nil
-  defp get_initials(%{display_name: ""}), do: nil
-
-  defp get_initials(%{display_name: name}) do
-    name
-    |> String.trim()
-    |> String.split(~r/\s+/)
-    |> Enum.take(2)
-    |> Enum.map_join(&String.first/1)
-    |> String.upcase()
-  end
-
-  defp get_initials(_), do: nil
-
-  defp get_avatar_url(nil), do: nil
-
-  defp get_avatar_url(%{current_profile_picture_url: url})
-       when is_binary(url) and url != "" do
-    ProfilePictures.url(url)
-  end
-
-  defp get_avatar_url(_), do: nil
 
   defp get_display_name(nil), do: "User"
   defp get_display_name(%{display_name: name}) when is_binary(name) and name != "", do: name

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -66,13 +66,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
     |> assign(:pending_preview_url, nil)
     |> assign(:selected_location_data, build_initial_location_data(group))
     |> assign(:upload_processing, false)
-    |> allow_upload(:group_image,
-      accept: ~w(.jpg .jpeg .png .webp),
-      max_entries: 1,
-      max_file_size: 5_000_000,
-      auto_upload: true,
-      progress: &handle_upload_progress/3
-    )
+    |> allow_image_upload(:group_image, &handle_upload_progress/3)
   end
 
   defp handle_upload_progress(:group_image, entry, socket) do

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -41,13 +41,7 @@ defmodule HuddlzWeb.GroupLive.New do
        |> assign(:pending_preview_url, nil)
        |> assign(:selected_location_data, nil)
        |> assign(:upload_processing, false)
-       |> allow_upload(:group_image,
-         accept: ~w(.jpg .jpeg .png .webp),
-         max_entries: 1,
-         max_file_size: 5_000_000,
-         auto_upload: true,
-         progress: &handle_upload_progress/3
-       )}
+       |> allow_image_upload(:group_image, &handle_upload_progress/3)}
     else
       {:ok,
        socket

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -4,6 +4,8 @@ defmodule HuddlzWeb.GroupLive.Show do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Live.Helpers.HuddlCardHelpers
+
   alias Huddlz.Communities
   alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl}
   alias Huddlz.Storage.GroupImages
@@ -595,31 +597,8 @@ defmodule HuddlzWeb.GroupLive.Show do
     |> Enum.reject(&(&1 == ""))
   end
 
-  defp tag_variant(:in_person), do: :in_person
-  defp tag_variant(:virtual), do: :online
-  defp tag_variant(:hybrid), do: :hybrid
+  defp huddl_kind_label(%{event_type: type}) when type in [:in_person, :virtual, :hybrid],
+    do: tag_label(type)
 
-  defp tag_label(:in_person), do: "In person"
-  defp tag_label(:virtual), do: "Online"
-  defp tag_label(:hybrid), do: "Hybrid"
-
-  defp huddl_kind_label(%{event_type: :in_person}), do: "In person"
-  defp huddl_kind_label(%{event_type: :virtual}), do: "Online"
-  defp huddl_kind_label(%{event_type: :hybrid}), do: "Hybrid"
   defp huddl_kind_label(_), do: "Huddl"
-
-  defp huddl_month(%{starts_at: %DateTime{} = dt}),
-    do: Calendar.strftime(dt, "%b") |> String.upcase()
-
-  defp huddl_day(%{starts_at: %DateTime{} = dt}), do: Calendar.strftime(dt, "%-d")
-
-  defp format_meta_when(%DateTime{} = dt) do
-    "#{Calendar.strftime(dt, "%a")} · #{Calendar.strftime(dt, "%-I:%M %p")}"
-  end
-
-  defp rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
-    do: "#{count} / #{max} RSVPs"
-
-  defp rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
-  defp rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
 end

--- a/lib/huddlz_web/live/helpers/huddl_card_helpers.ex
+++ b/lib/huddlz_web/live/helpers/huddl_card_helpers.ex
@@ -1,0 +1,29 @@
+defmodule HuddlzWeb.Live.Helpers.HuddlCardHelpers do
+  @moduledoc """
+  Shared formatting helpers for huddl card listings (discover, my huddlz,
+  group show): date block, `event_type` tag, and RSVP count labels.
+  """
+
+  def tag_variant(:in_person), do: :in_person
+  def tag_variant(:virtual), do: :online
+  def tag_variant(:hybrid), do: :hybrid
+
+  def tag_label(:in_person), do: "In person"
+  def tag_label(:virtual), do: "Online"
+  def tag_label(:hybrid), do: "Hybrid"
+
+  def huddl_month(%{starts_at: %DateTime{} = dt}),
+    do: Calendar.strftime(dt, "%b") |> String.upcase()
+
+  def huddl_day(%{starts_at: %DateTime{} = dt}), do: Calendar.strftime(dt, "%-d")
+
+  def format_meta_when(%DateTime{} = dt) do
+    "#{Calendar.strftime(dt, "%a")} · #{Calendar.strftime(dt, "%-I:%M %p")}"
+  end
+
+  def rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
+    do: "#{count} / #{max} RSVPs"
+
+  def rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
+  def rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
+end

--- a/lib/huddlz_web/live/helpers/param_helpers.ex
+++ b/lib/huddlz_web/live/helpers/param_helpers.ex
@@ -1,0 +1,19 @@
+defmodule HuddlzWeb.Live.Helpers.ParamHelpers do
+  @moduledoc """
+  Shared URL-param parsing for LiveViews.
+  """
+
+  @doc """
+  Parses a `?page=` param, falling back to 1 for anything that isn't a
+  positive integer.
+  """
+  def parse_page(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} when n >= 1 -> n
+      _ -> 1
+    end
+  end
+
+  def parse_page(val) when is_integer(val) and val >= 1, do: val
+  def parse_page(_), do: 1
+end

--- a/lib/huddlz_web/live/helpers/upload_helpers.ex
+++ b/lib/huddlz_web/live/helpers/upload_helpers.ex
@@ -4,6 +4,19 @@ defmodule HuddlzWeb.Live.Helpers.UploadHelpers do
   """
 
   @doc """
+  Standard single-image upload config (JPG/PNG/WebP, 5MB max, auto-upload).
+  """
+  def allow_image_upload(socket, name, progress_handler) do
+    Phoenix.LiveView.allow_upload(socket, name,
+      accept: ~w(.jpg .jpeg .png .webp),
+      max_entries: 1,
+      max_file_size: 5_000_000,
+      auto_upload: true,
+      progress: progress_handler
+    )
+  end
+
+  @doc """
   Converts a LiveView upload error atom to a user-friendly string.
   """
   def upload_error_to_string(:too_large), do: "File is too large (max 5MB)"

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -10,6 +10,8 @@ defmodule HuddlzWeb.HuddlLive do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Live.Helpers.HuddlCardHelpers
+
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
   alias Huddlz.Storage.HuddlImages
@@ -819,35 +821,12 @@ defmodule HuddlzWeb.HuddlLive do
   defp result_count_label(count, :groups),
     do: "#{count} #{if count == 1, do: "group", else: "groups"}"
 
-  defp tag_variant(:in_person), do: :in_person
-  defp tag_variant(:virtual), do: :online
-  defp tag_variant(:hybrid), do: :hybrid
-
-  defp tag_label(:in_person), do: "In person"
-  defp tag_label(:virtual), do: "Online"
-  defp tag_label(:hybrid), do: "Hybrid"
-
-  defp huddl_month(%{starts_at: %DateTime{} = dt}),
-    do: Calendar.strftime(dt, "%b") |> String.upcase()
-
-  defp huddl_day(%{starts_at: %DateTime{} = dt}), do: Calendar.strftime(dt, "%-d")
-
-  defp format_meta_when(%DateTime{} = dt) do
-    "#{Calendar.strftime(dt, "%a")} · #{Calendar.strftime(dt, "%-I:%M %p")}"
-  end
-
   defp format_distance(miles) when is_number(miles) and miles < 1, do: "< 1 mi"
 
   defp format_distance(miles) when is_number(miles) do
     rounded = Float.round(miles * 1.0, 1)
     if rounded == trunc(rounded), do: "#{trunc(rounded)} mi", else: "#{rounded} mi"
   end
-
-  defp rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
-    do: "#{count} / #{max} RSVPs"
-
-  defp rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
-  defp rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
 
   defp member_count_label(group) do
     case Map.get(group, :member_count) do

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -11,6 +11,7 @@ defmodule HuddlzWeb.HuddlLive do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Live.Helpers.HuddlCardHelpers
+  import HuddlzWeb.Live.Helpers.ParamHelpers
 
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
@@ -113,7 +114,6 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   defp parse_sort("newest"), do: :newest
-  defp parse_sort(:newest), do: :newest
   defp parse_sort(_), do: :soonest
 
   defp parse_location_params(params, socket) do
@@ -165,9 +165,6 @@ defmodule HuddlzWeb.HuddlLive do
 
   defp normalize_date_filter(_), do: "upcoming"
 
-  defp parse_distance(nil), do: 25
-  defp parse_distance(""), do: 25
-
   defp parse_distance(val) when is_binary(val) do
     case Integer.parse(val) do
       {n, _} when n in 5..100 -> n
@@ -177,19 +174,6 @@ defmodule HuddlzWeb.HuddlLive do
 
   defp parse_distance(val) when is_integer(val) and val in 5..100, do: val
   defp parse_distance(_), do: 25
-
-  defp parse_page(nil), do: 1
-  defp parse_page(""), do: 1
-
-  defp parse_page(val) when is_binary(val) do
-    case Integer.parse(val) do
-      {n, _} when n >= 1 -> n
-      _ -> 1
-    end
-  end
-
-  defp parse_page(val) when is_integer(val) and val >= 1, do: val
-  defp parse_page(_), do: 1
 
   defp page_title(:groups, _), do: "groups"
   defp page_title(:huddlz, :hosting), do: "huddlz you're hosting"

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -634,13 +634,6 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
   @impl true
   def handle_event("save", %{"form" => params}, socket) do
-    params =
-      case params["event_type"] do
-        "virtual" -> Map.put(params, "physical_location", nil)
-        "in_person" -> Map.put(params, "virtual_link", nil)
-        _ -> params
-      end
-
     params = inject_saved_location_params(params, socket.assigns[:selected_location])
 
     case AshPhoenix.Form.submit(socket.assigns.form,

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -635,13 +635,6 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   @impl true
   def handle_event("save", %{"form" => params}, socket) do
     params =
-      if socket.assigns.huddl.group.is_public do
-        params
-      else
-        Map.put(params, "is_private", "true")
-      end
-
-    params =
       case params["event_type"] do
         "virtual" -> Map.put(params, "physical_location", nil)
         "in_person" -> Map.put(params, "virtual_link", nil)

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -49,13 +49,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
         |> assign(:pending_image_id, nil)
         |> assign(:pending_preview_url, nil)
         |> assign(:upload_processing, false)
-        |> allow_upload(:huddl_image,
-          accept: ~w(.jpg .jpeg .png .webp),
-          max_entries: 1,
-          max_file_size: 5_000_000,
-          auto_upload: true,
-          progress: &handle_upload_progress/3
-        )
+        |> allow_image_upload(:huddl_image, &handle_upload_progress/3)
 
       {:noreply, socket}
     else

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -503,13 +503,6 @@ defmodule HuddlzWeb.HuddlLive.New do
   @impl true
   def handle_event("save", %{"form" => params}, socket) do
     params =
-      if socket.assigns.group.is_public do
-        params
-      else
-        Map.put(params, "is_private", "true")
-      end
-
-    params =
       params
       |> Map.put("group_id", socket.assigns.group.id)
       |> inject_saved_location_params(socket.assigns[:selected_location])

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -58,13 +58,7 @@ defmodule HuddlzWeb.HuddlLive.New do
   defp maybe_allow_image_upload(%{assigns: %{uploads: %{huddl_image: _}}} = socket), do: socket
 
   defp maybe_allow_image_upload(socket) do
-    allow_upload(socket, :huddl_image,
-      accept: ~w(.jpg .jpeg .png .webp),
-      max_entries: 1,
-      max_file_size: 5_000_000,
-      auto_upload: true,
-      progress: &handle_upload_progress/3
-    )
+    allow_image_upload(socket, :huddl_image, &handle_upload_progress/3)
   end
 
   defp assign_create_form(socket, group, user) do

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -12,6 +12,17 @@ defmodule HuddlzWeb.HuddlLive.Show do
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
 
+  @huddl_loads [
+    :status,
+    :rsvp_count,
+    :waitlist_count,
+    :at_capacity,
+    :visible_virtual_link,
+    :display_image_url,
+    :group,
+    creator: [:current_profile_picture_url]
+  ]
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok, socket}
@@ -22,7 +33,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
     case get_huddl(id, group_slug, socket.assigns.current_user) do
       {:ok, huddl} ->
         user = socket.assigns.current_user
-        attendance = check_attendance(huddl, user)
+        {attendance, waitlist_position} = attendance_info(huddl, user)
 
         {:noreply,
          socket
@@ -30,8 +41,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
          |> assign(:meta, huddl_meta(huddl))
          |> assign(:huddl, huddl)
          |> assign(:attendance, attendance)
-         |> assign(:has_rsvped, attendance == :attending)
-         |> assign(:waitlist_position, waitlist_position(huddl, user))
+         |> assign(:waitlist_position, waitlist_position)
          |> assign(:can_edit_huddl, Ash.can?({huddl, :update}, user))
          |> assign(:can_delete_huddl, Ash.can?({huddl, :destroy}, user))}
 
@@ -347,7 +357,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
   end
 
   defp render_rsvp_state(assigns) do
-    if event_full?(assigns.huddl) do
+    if assigns.huddl.at_capacity do
       ~H"""
       <div class="rsvp-banner warn">
         <svg
@@ -479,18 +489,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
   end
 
   defp get_huddl(id, group_slug, user) do
-    case Communities.get_huddl(id,
-           load: [
-             :status,
-             :rsvp_count,
-             :waitlist_count,
-             :visible_virtual_link,
-             :display_image_url,
-             :group,
-             creator: [:current_profile_picture_url]
-           ],
-           actor: user
-         ) do
+    case Communities.get_huddl(id, load: @huddl_loads, actor: user) do
       {:ok, huddl} ->
         if huddl.group.slug == group_slug do
           {:ok, huddl}
@@ -507,29 +506,24 @@ defmodule HuddlzWeb.HuddlLive.Show do
   end
 
   defp reload_huddl(huddl, user) do
-    Communities.get_huddl(huddl.id,
-      load: [
-        :status,
-        :rsvp_count,
-        :waitlist_count,
-        :visible_virtual_link,
-        :display_image_url,
-        :group,
-        creator: [:current_profile_picture_url]
-      ],
-      actor: user
-    )
+    Communities.get_huddl(huddl.id, load: @huddl_loads, actor: user)
   end
 
   defp refresh_attendance(socket, huddl, user) do
-    {:ok, reloaded} = reload_huddl(huddl, user)
-    attendance = check_attendance(reloaded, user)
+    case reload_huddl(huddl, user) do
+      {:ok, reloaded} ->
+        {attendance, waitlist_position} = attendance_info(reloaded, user)
 
-    socket
-    |> assign(:huddl, reloaded)
-    |> assign(:attendance, attendance)
-    |> assign(:has_rsvped, attendance == :attending)
-    |> assign(:waitlist_position, waitlist_position(reloaded, user))
+        socket
+        |> assign(:huddl, reloaded)
+        |> assign(:attendance, attendance)
+        |> assign(:waitlist_position, waitlist_position)
+
+      {:error, _} ->
+        socket
+        |> put_flash(:error, "This huddl is no longer available.")
+        |> push_navigate(to: ~p"/groups/#{huddl.group.slug}")
+    end
   end
 
   defp huddl_meta(huddl) do
@@ -542,33 +536,29 @@ defmodule HuddlzWeb.HuddlLive.Show do
     }
   end
 
-  defp check_attendance(_huddl, nil), do: :none
+  defp attendance_info(_huddl, nil), do: {:none, nil}
 
-  defp check_attendance(huddl, user) do
+  defp attendance_info(huddl, user) do
     case Communities.check_user_rsvp(huddl.id, actor: user) do
-      {:ok, []} -> :none
-      {:ok, [%{waitlisted_at: nil} | _]} -> :attending
-      {:ok, [%{waitlisted_at: _} | _]} -> :waitlisted
-      {:error, _} -> :none
+      {:ok, [%{waitlisted_at: nil} | _]} ->
+        {:attending, nil}
+
+      {:ok, [%{waitlisted_at: %DateTime{} = my_at} | _]} ->
+        {:waitlisted, waitlist_position(huddl, my_at)}
+
+      _ ->
+        {:none, nil}
     end
   end
 
-  defp waitlist_position(_huddl, nil), do: nil
-
-  defp waitlist_position(huddl, user) do
+  defp waitlist_position(huddl, %DateTime{} = my_at) do
     require Ash.Query
 
-    case Communities.check_user_rsvp(huddl.id, actor: user) do
-      {:ok, [%{waitlisted_at: %DateTime{} = my_at} | _]} ->
-        Huddlz.Communities.HuddlAttendee
-        |> Ash.Query.filter(
-          huddl_id == ^huddl.id and not is_nil(waitlisted_at) and waitlisted_at <= ^my_at
-        )
-        |> Ash.count!(authorize?: false)
-
-      _ ->
-        nil
-    end
+    Huddlz.Communities.HuddlAttendee
+    |> Ash.Query.filter(
+      huddl_id == ^huddl.id and not is_nil(waitlisted_at) and waitlisted_at <= ^my_at
+    )
+    |> Ash.count!(authorize?: false)
   end
 
   defp hero_eyebrow(huddl) do
@@ -684,15 +674,8 @@ defmodule HuddlzWeb.HuddlLive.Show do
   defp person_label(_), do: "people"
 
   defp capacity_bar_class(huddl) do
-    cond do
-      event_full?(huddl) -> "warn"
-      capacity_percent(huddl) >= 80 -> "warn"
-      true -> nil
-    end
+    if capacity_percent(huddl) >= 80, do: "warn"
   end
-
-  defp event_full?(%{max_attendees: nil}), do: false
-  defp event_full?(huddl), do: huddl.rsvp_count >= huddl.max_attendees
 
   defp capacity_percent(%{max_attendees: nil}), do: 0
 
@@ -702,7 +685,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
 
   defp capacity_status(huddl) do
     cond do
-      event_full?(huddl) -> "Huddl Full"
+      huddl.at_capacity -> "Huddl Full"
       capacity_percent(huddl) >= 80 -> "Almost full"
       capacity_percent(huddl) >= 50 -> "Filling up"
       true -> "Plenty of space"

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -10,6 +10,8 @@ defmodule HuddlzWeb.MyGroupsLive do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Live.Helpers.ParamHelpers
+
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
   alias HuddlzWeb.Layouts
@@ -61,19 +63,6 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
   defp parse_filter(_), do: :all
-
-  defp parse_page(nil), do: 1
-  defp parse_page(""), do: 1
-
-  defp parse_page(val) when is_binary(val) do
-    case Integer.parse(val) do
-      {n, _} when n >= 1 -> n
-      _ -> 1
-    end
-  end
-
-  defp parse_page(val) when is_integer(val) and val >= 1, do: val
-  defp parse_page(_), do: 1
 
   defp load_counts(user) do
     %{

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -10,6 +10,8 @@ defmodule HuddlzWeb.MyHuddlzLive do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Live.Helpers.HuddlCardHelpers
+
   alias Huddlz.Communities
   alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Layouts
@@ -268,29 +270,6 @@ defmodule HuddlzWeb.MyHuddlzLive do
   defp pill_label(:upcoming), do: "Going"
   defp pill_label(:waitlisted), do: "Waitlist"
   defp pill_label(:past), do: "Attended"
-
-  defp tag_variant(:in_person), do: :in_person
-  defp tag_variant(:virtual), do: :online
-  defp tag_variant(:hybrid), do: :hybrid
-
-  defp tag_label(:in_person), do: "In person"
-  defp tag_label(:virtual), do: "Online"
-  defp tag_label(:hybrid), do: "Hybrid"
-
-  defp huddl_month(%{starts_at: %DateTime{} = dt}),
-    do: Calendar.strftime(dt, "%b") |> String.upcase()
-
-  defp huddl_day(%{starts_at: %DateTime{} = dt}), do: Calendar.strftime(dt, "%-d")
-
-  defp format_meta_when(%DateTime{} = dt) do
-    "#{Calendar.strftime(dt, "%a")} · #{Calendar.strftime(dt, "%-I:%M %p")}"
-  end
-
-  defp rsvp_label(%{rsvp_count: count, max_attendees: max}) when is_integer(max) and max > 0,
-    do: "#{count} / #{max} RSVPs"
-
-  defp rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
-  defp rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
 
   defp relative_time(%DateTime{} = dt) do
     diff_seconds = DateTime.diff(dt, DateTime.utc_now(), :second)

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -11,6 +11,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Live.Helpers.HuddlCardHelpers
+  import HuddlzWeb.Live.Helpers.ParamHelpers
 
   alias Huddlz.Communities
   alias Huddlz.Storage.HuddlImages
@@ -69,19 +70,6 @@ defmodule HuddlzWeb.MyHuddlzLive do
 
   defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
   defp parse_filter(_), do: :upcoming
-
-  defp parse_page(nil), do: 1
-  defp parse_page(""), do: 1
-
-  defp parse_page(val) when is_binary(val) do
-    case Integer.parse(val) do
-      {n, _} when n >= 1 -> n
-      _ -> 1
-    end
-  end
-
-  defp parse_page(val) when is_integer(val) and val >= 1, do: val
-  defp parse_page(_), do: 1
 
   defp load_counts(user) do
     %{

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -11,6 +11,8 @@ defmodule HuddlzWeb.NotificationsLive do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Live.Helpers.ParamHelpers
+
   alias Huddlz.Notifications
   alias Huddlz.Notifications.Notification
   alias HuddlzWeb.Layouts
@@ -94,19 +96,6 @@ defmodule HuddlzWeb.NotificationsLive do
 
   defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
   defp parse_filter(_), do: :inbox
-
-  defp parse_page(nil), do: 1
-  defp parse_page(""), do: 1
-
-  defp parse_page(val) when is_binary(val) do
-    case Integer.parse(val) do
-      {n, _} when n >= 1 -> n
-      _ -> 1
-    end
-  end
-
-  defp parse_page(val) when is_integer(val) and val >= 1, do: val
-  defp parse_page(_), do: 1
 
   defp load_counts(user) do
     %{

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -35,7 +35,6 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_list, [])
      |> assign(:huddlz_filter, :live)
      |> assign(:upcoming_huddlz, [])
-     |> assign(:upcoming_count, 0)
      |> assign(:open_rsvps, 0)
      |> assign(:members, [])}
   end
@@ -82,7 +81,6 @@ defmodule HuddlzWeb.OrganizeLive do
 
     socket
     |> assign(:upcoming_huddlz, upcoming)
-    |> assign(:upcoming_count, length(upcoming))
     |> assign(:open_rsvps, open_rsvps)
   end
 
@@ -154,7 +152,6 @@ defmodule HuddlzWeb.OrganizeLive do
           <.overview_view
             group={@group}
             upcoming_huddlz={@upcoming_huddlz}
-            upcoming_count={@upcoming_count}
             open_rsvps={@open_rsvps}
           />
         <% :huddlz -> %>
@@ -228,11 +225,13 @@ defmodule HuddlzWeb.OrganizeLive do
   # ─────────────────────────────────────────  OVERVIEW  ───
   attr :group, :map, required: true
   attr :upcoming_huddlz, :list, required: true
-  attr :upcoming_count, :integer, required: true
   attr :open_rsvps, :integer, required: true
 
   defp overview_view(assigns) do
-    assigns = assign(assigns, :preview_limit, @upcoming_preview_limit)
+    assigns =
+      assigns
+      |> assign(:preview_limit, @upcoming_preview_limit)
+      |> assign(:upcoming_count, length(assigns.upcoming_huddlz))
 
     ~H"""
     <div class="page-head">
@@ -413,9 +412,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :members, :list, required: true
 
   defp members_view(assigns) do
-    grouped =
-      @member_role_order
-      |> Enum.map(fn role -> {role, Enum.filter(assigns.members, &(&1.role == role))} end)
+    by_role = Enum.group_by(assigns.members, & &1.role)
+    grouped = Enum.map(@member_role_order, fn role -> {role, Map.get(by_role, role, [])} end)
 
     assigns = assign(assigns, :grouped, grouped)
 

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -7,6 +7,7 @@ defmodule HuddlzWeb.ProfileLive do
   alias Huddlz.Storage.ProfilePictures
   alias HuddlzWeb.Avatar
   alias HuddlzWeb.Layouts
+  alias HuddlzWeb.Live.Helpers.UploadHelpers
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -52,13 +53,7 @@ defmodule HuddlzWeb.ProfileLive do
      |> assign(:current_user, user_with_avatar)
      |> assign(:avatar_error, nil)
      |> assign(:location_error, nil)
-     |> allow_upload(:avatar,
-       accept: ~w(.jpg .jpeg .png .webp),
-       max_entries: 1,
-       max_file_size: 5_000_000,
-       auto_upload: true,
-       progress: &handle_upload_progress/3
-     )}
+     |> UploadHelpers.allow_image_upload(:avatar, &handle_upload_progress/3)}
   end
 
   @impl true

--- a/test/huddlz/communities/huddl/changes/clear_unused_location_fields_test.exs
+++ b/test/huddlz/communities/huddl/changes/clear_unused_location_fields_test.exs
@@ -1,0 +1,101 @@
+defmodule Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFieldsTest do
+  use Huddlz.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Huddlz.Communities.Huddl
+
+  setup do
+    owner = generate(user(role: :user))
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+
+    {:ok, %{owner: owner, group: group}}
+  end
+
+  describe "on create" do
+    test "clears physical_location on virtual huddlz", %{owner: owner, group: group} do
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            actor: owner,
+            event_type: :virtual,
+            virtual_link: "https://example.com/meet",
+            physical_location: "123 Main St"
+          )
+        )
+
+      assert is_nil(huddl.physical_location)
+    end
+
+    test "clears virtual_link on in-person huddlz", %{owner: owner, group: group} do
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            actor: owner,
+            event_type: :in_person,
+            physical_location: "123 Main St",
+            virtual_link: "https://example.com/meet"
+          )
+        )
+
+      assert is_nil(huddl.virtual_link)
+    end
+  end
+
+  describe "on update" do
+    test "a title-only edit preserves a stored physical_location on a virtual huddl",
+         %{owner: owner, group: group} do
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            actor: owner,
+            event_type: :virtual,
+            virtual_link: "https://example.com/meet"
+          )
+        )
+
+      # Legacy row from before creates cleared unused location fields.
+      Repo.update_all(
+        from(h in Huddl, where: h.id == ^huddl.id),
+        set: [physical_location: "Legacy address"]
+      )
+
+      assert {:ok, updated} =
+               Huddl
+               |> Ash.get!(huddl.id, authorize?: false)
+               |> Ash.Changeset.for_update(:update, %{title: "New title"}, actor: owner)
+               |> Ash.update()
+
+      assert updated.title == "New title"
+      assert updated.physical_location == "Legacy address"
+    end
+
+    test "switching event_type to virtual clears physical_location",
+         %{owner: owner, group: group} do
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            actor: owner,
+            event_type: :in_person,
+            physical_location: "123 Main St"
+          )
+        )
+
+      assert {:ok, updated} =
+               huddl
+               |> Ash.Changeset.for_update(
+                 :update,
+                 %{event_type: :virtual, virtual_link: "https://example.com/meet"},
+                 actor: owner
+               )
+               |> Ash.update()
+
+      assert is_nil(updated.physical_location)
+      assert updated.virtual_link == "https://example.com/meet"
+    end
+  end
+end

--- a/test/huddlz/communities/huddl/changes/force_private_for_private_groups_test.exs
+++ b/test/huddlz/communities/huddl/changes/force_private_for_private_groups_test.exs
@@ -1,0 +1,27 @@
+defmodule Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroupsTest do
+  use Huddlz.DataCase, async: true
+
+  setup do
+    owner = generate(user(role: :user))
+    group = generate(group(owner_id: owner.id, is_public: false, actor: owner))
+
+    {:ok, %{owner: owner, group: group}}
+  end
+
+  test "create forces is_private for huddlz in private groups", %{owner: owner, group: group} do
+    huddl = generate(huddl(group_id: group.id, actor: owner, is_private: false))
+
+    assert huddl.is_private
+  end
+
+  test "update cannot flip a private-group huddl public", %{owner: owner, group: group} do
+    huddl = generate(huddl(group_id: group.id, actor: owner))
+
+    assert {:ok, updated} =
+             huddl
+             |> Ash.Changeset.for_update(:update, %{is_private: false}, actor: owner)
+             |> Ash.update()
+
+    assert updated.is_private
+  end
+end


### PR DESCRIPTION
Codebase-wide quality pass: a four-angle review (reuse, simplification, efficiency, altitude) followed by a verification review of the resulting diff. Eight commits, each precommit-clean; net −190 lines in `lib/`.

## Reuse — duplicated code moved to shared homes

- The avatar component re-implemented `HuddlzWeb.Avatar.initials/1` and `picture_url/1` verbatim; it now delegates.
- The identical five-option `allow_upload` image config from five LiveViews became `UploadHelpers.allow_image_upload/3`.
- The huddl-card formatters (`tag_variant`, `tag_label`, `huddl_month`, `huddl_day`, `format_meta_when`, `rsvp_label`), copied verbatim across discover, my huddlz, and group show, moved into a new `HuddlCardHelpers`; group show's `huddl_kind_label` now delegates to `tag_label`.
- `parse_page/1`, identical in four LiveViews, moved into a new `ParamHelpers` — dropping `nil`/empty-string clauses whose results the remaining clauses already produce, plus an unreachable `parse_sort(:newest)` clause.

## Simplification & efficiency

- Huddl show fetched the actor's RSVP twice (status + waitlist position) per page load and per RSVP action; one `attendance_info/2` query now derives both. The two identical 7-item load lists became one `@huddl_loads` attribute, and a failed reload now flashes and redirects instead of crashing the LiveView on a bare match.
- Huddl show loads the `at_capacity` calculation instead of reimplementing it, and a capacity `cond` branch subsumed by the ≥ 80% check is gone, as is the never-read `has_rsvped` assign.
- The organizer workspace tracked `upcoming_count` as separate state mirroring `length(upcoming_huddlz)` (now derived in the component) and filtered the full member list once per role (now a single `group_by` pass).

## Altitude — two rules moved from LiveViews into the domain

These are the behavior-relevant commits; both matter for the API-first direction since LiveView-only enforcement is bypassable via JSON:API/GraphQL.

- **Group privacy on update** — `ForcePrivateForPrivateGroups` only ran on `:create`, so an API update could flip a private group's huddl public. It now runs on `:update` too, skipping the group lookup unless `is_private` is actually changing (no extra query on unrelated edits or per-occurrence series edits). The LiveView-side forcing is deleted.
- **Location fields by event type** — clearing `physical_location`/`virtual_link` based on `event_type` lived only in the edit LiveView (creates and API writes bypassed it). A new `ClearUnusedLocationFields` change runs on both actions, ordered before geocoding. It only acts on create or when `event_type` is changing, so a title-only edit of a huddl with legacy inconsistent data leaves the stored address untouched, doesn't re-geocode, and doesn't email attendees about a location change.

One open question deferred from review: an API PATCH that supplies `physical_location` on a virtual huddl *without* changing `event_type` is now stored as-is rather than silently discarded. If that should instead be a validation error, it's a small follow-up.

## Tests

Six new tests (suite: 1349):

- update cannot flip a private-group huddl public; create still forces `is_private`
- create clears the irrelevant location field for virtual and in-person huddlz
- a title-only update preserves a legacy stored `physical_location` on a virtual huddl (seeded via `Repo.update_all`, since the create action can no longer produce that state)
- switching `event_type` to virtual still clears `physical_location`
