### PR TITLE
Derive location error display from field state

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -494,9 +494,17 @@ defmodule Huddlz.Communities.Huddl do
       message "is required for virtual huddlz"
     end
 
-    validate present([:physical_location, :virtual_link]) do
+    # Split per field so each error attaches only to the attribute that is
+    # actually missing; a combined present/2 fans its error out to both
+    # fields, flagging the one the user already filled in.
+    validate present([:physical_location]) do
       where attribute_equals(:event_type, :hybrid)
-      message "both physical location and virtual link are required for hybrid huddlz"
+      message "is required for hybrid huddlz"
+    end
+
+    validate present([:virtual_link]) do
+      where attribute_equals(:event_type, :hybrid)
+      message "is required for hybrid huddlz"
     end
   end
 

--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -133,16 +133,22 @@ defmodule HuddlzWeb.Components.Input do
   end
 
   attr :field, FormField, required: true, doc: "form field whose errors to render"
-  attr :always_show, :boolean, default: false
 
   @doc """
   Renders `<p class="form-error">` lines for a form field whose markup isn't
   produced by `input/textarea/select` (e.g. an inline raw input or a
-  radio-card group). Hidden until the field has been touched (`used_input?/1`) or always_show is set.
+  radio-card group). Hidden until the field has been touched (`used_input?/1`).
+
+  For fields with no client-side input at all (custom pickers), ensure the
+  param key is present once errors should show — see
+  `HuddlzWeb.HuddlLive.FormHelpers.mark_location_used/2`. LiveView's form
+  change tracking only re-renders this component when the field's value,
+  errors, or used state change, so visibility must be derived from field
+  state, not external flags.
   """
   def field_errors(%{field: %FormField{} = field} = assigns) do
     errors =
-      if assigns.always_show || Phoenix.Component.used_input?(field) do
+      if Phoenix.Component.used_input?(field) do
         Enum.map(field.errors, &translate_error/1)
       else
         []

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -295,7 +295,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
                 fetch_coordinates={true}
                 show_clear={true}
               />
-              <.field_errors field={@form[:location]} always_show={true} />
+              <.field_errors field={@form[:location]} />
               <p class="form-help">
                 Optional. Helps people find your group when they search nearby.
               </p>

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -237,7 +237,7 @@ defmodule HuddlzWeb.GroupLive.New do
                 fetch_coordinates={true}
                 show_clear={true}
               />
-              <.field_errors field={@form[:location]} always_show={true} />
+              <.field_errors field={@form[:location]} />
               <p class="form-help">
                 Optional. Helps people find your group when they search nearby.
               </p>

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -388,7 +388,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
                     ~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit/locations/new"
                   }
                 />
-                <.field_errors field={@form[:physical_location]} always_show={true} />
+                <.field_errors field={@form[:physical_location]} />
               </div>
             <% end %>
 
@@ -622,7 +622,10 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
   @impl true
   def handle_event("validate", %{"form" => params}, socket) do
-    params = inject_saved_location_params(params, socket.assigns[:selected_location])
+    params =
+      params
+      |> inject_saved_location_params(socket.assigns[:selected_location])
+      |> mark_location_used_after_submit(socket.assigns.form)
 
     socket =
       socket
@@ -635,7 +638,10 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
   @impl true
   def handle_event("save", %{"form" => params}, socket) do
-    params = inject_saved_location_params(params, socket.assigns[:selected_location])
+    params =
+      params
+      |> inject_saved_location_params(socket.assigns[:selected_location])
+      |> mark_location_used(socket.assigns.form)
 
     case AshPhoenix.Form.submit(socket.assigns.form,
            params: params,

--- a/lib/huddlz_web/live/huddl_live/form_helpers.ex
+++ b/lib/huddlz_web/live/huddl_live/form_helpers.ex
@@ -71,6 +71,37 @@ defmodule HuddlzWeb.HuddlLive.FormHelpers do
   end
 
   @doc """
+  Ensures the "physical_location" key is present in the params so
+  `Phoenix.Component.used_input?/1` treats the picker-backed field as used
+  and its validation errors display. The saved-location picker renders no
+  client-side input, so the browser never sends this key on its own. Falls
+  back to the form's current value to avoid clearing an existing location
+  on update.
+
+  Call on every submit. On validate, use `mark_location_used_after_submit/2`
+  so errors stay hidden while the user is still filling in the form but
+  remain visible while fixing a failed submit.
+  """
+  def mark_location_used(params, form) do
+    Map.put_new(params, "physical_location", current_location_value(form))
+  end
+
+  def mark_location_used_after_submit(params, form) do
+    if form.source.submitted_once? do
+      mark_location_used(params, form)
+    else
+      params
+    end
+  end
+
+  defp current_location_value(form) do
+    case Phoenix.HTML.Form.input_value(form, :physical_location) do
+      nil -> ""
+      value -> to_string(value)
+    end
+  end
+
+  @doc """
   Returns a `before_submit` function that applies pre-existing coordinates
   directly to the changeset. Used with `AshPhoenix.Form.submit/2`'s
   `:before_submit` option, which runs after `for_create`/`for_update`

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -273,7 +273,7 @@ defmodule HuddlzWeb.HuddlLive.New do
                   selected_location={@selected_location}
                   new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
                 />
-                <.field_errors field={@form[:physical_location]} always_show={true} />
+                <.field_errors field={@form[:physical_location]} />
               </div>
             <% end %>
 
@@ -490,7 +490,10 @@ defmodule HuddlzWeb.HuddlLive.New do
 
   @impl true
   def handle_event("validate", %{"form" => params}, socket) do
-    params = inject_saved_location_params(params, socket.assigns[:selected_location])
+    params =
+      params
+      |> inject_saved_location_params(socket.assigns[:selected_location])
+      |> mark_location_used_after_submit(socket.assigns.form)
 
     socket =
       socket
@@ -507,6 +510,7 @@ defmodule HuddlzWeb.HuddlLive.New do
       params
       |> Map.put("group_id", socket.assigns.group.id)
       |> inject_saved_location_params(socket.assigns[:selected_location])
+      |> mark_location_used(socket.assigns.form)
 
     case AshPhoenix.Form.submit(socket.assigns.form,
            params: params,

--- a/test/features/step_definitions/create_huddl_steps.exs
+++ b/test/features/step_definitions/create_huddl_steps.exs
@@ -1,8 +1,8 @@
 defmodule CreateHuddlSteps do
   use Cucumber.StepDefinition
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection, only: [select_saved_location: 2]
   import PhoenixTest
-  import Phoenix.LiveViewTest
   import ExUnit.Assertions
   alias Huddlz.Communities.Huddl
   require Ash.Query
@@ -302,10 +302,7 @@ defmodule CreateHuddlSteps do
               |> Ash.create(actor: current_user)
 
             # Simulate the SavedLocationPicker selecting this location
-            view = session.view
-            send(view.pid, {:saved_location_selected, "saved-location-picker", location})
-            render(view)
-            session
+            select_saved_location(session, location)
 
           "virtual_link" ->
             fill_in(session, "Online link", with: value, exact: false)

--- a/test/features/step_definitions/edit_huddl_steps.exs
+++ b/test/features/step_definitions/edit_huddl_steps.exs
@@ -6,6 +6,7 @@ defmodule EditHuddlSteps do
   use Cucumber.StepDefinition
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
   import PhoenixTest
 
   alias Huddlz.Communities.Group
@@ -68,8 +69,7 @@ defmodule EditHuddlSteps do
     session = context[:session] || context[:conn]
     location = lookup_saved_location(context, name)
 
-    send(session.view.pid, {:saved_location_selected, "saved-location-picker", location})
-    Phoenix.LiveViewTest.render(session.view)
+    select_saved_location(session, location)
 
     Map.merge(context, %{session: session, conn: session})
   end
@@ -83,19 +83,14 @@ defmodule EditHuddlSteps do
 
     # Simulate the LocationAutocomplete component selecting a place. The parent
     # huddl-edit LiveView captures the coords on its socket, ready for save.
-    send(
-      session.view.pid,
-      {:location_selected, "modal-address-autocomplete",
-       %{
-         place_id: "p_test_#{System.unique_integer([:positive])}",
-         display_text: address,
-         main_text: address,
-         latitude: lat,
-         longitude: lng
-       }}
+    select_location(session,
+      id: "modal-address-autocomplete",
+      place_id: "p_test_#{System.unique_integer([:positive])}",
+      display_text: address,
+      main_text: address,
+      latitude: lat,
+      longitude: lng
     )
-
-    Phoenix.LiveViewTest.render(session.view)
 
     session = click_button(session, "Save address")
 

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -1,9 +1,9 @@
 defmodule GroupManagementSteps do
   use Cucumber.StepDefinition
   import PhoenixTest
-  import Phoenix.LiveViewTest, only: [render: 1]
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection, only: [select_location: 2]
 
   alias Huddlz.Accounts.User
 
@@ -59,23 +59,12 @@ defmodule GroupManagementSteps do
       |> Enum.reduce(session, fn [field, value], session ->
         case field do
           "Location" ->
-            view = session.view
-
-            send(
-              view.pid,
-              {:location_selected, "group-location",
-               %{
-                 place_id: "test_place_id",
-                 display_text: value,
-                 main_text: value,
-                 latitude: 37.77,
-                 longitude: -122.42
-               }}
+            select_location(session,
+              display_text: value,
+              main_text: value,
+              latitude: 37.77,
+              longitude: -122.42
             )
-
-            render(view)
-
-            session
 
           _ ->
             fill_in(session, field, with: value)

--- a/test/huddlz/communities/huddl_permissions_edge_cases_test.exs
+++ b/test/huddlz/communities/huddl_permissions_edge_cases_test.exs
@@ -301,11 +301,9 @@ defmodule Huddlz.Communities.HuddlPermissionsEdgeCasesTest do
                )
                |> Ash.create()
 
-      # Check that there's an error related to virtual_link
-      error_messages = Enum.map_join(errors, " ", & &1.message)
-
-      assert String.contains?(error_messages, "virtual_link") or
-               String.contains?(error_messages, "virtual link")
+      # The error must attach to the missing field only
+      assert Enum.any?(errors, &(&1.field == :virtual_link))
+      refute Enum.any?(errors, &(&1.field == :physical_location))
     end
   end
 end

--- a/test/huddlz_web/live/group_live/edit_test.exs
+++ b/test/huddlz_web/live/group_live/edit_test.exs
@@ -2,6 +2,7 @@ defmodule HuddlzWeb.GroupLive.EditTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
   import Phoenix.LiveViewTest
 
   describe "Edit Group" do
@@ -63,23 +64,13 @@ defmodule HuddlzWeb.GroupLive.EditTest do
         |> fill_in("Group Name", with: "Updated Group Name")
         |> fill_in("Description", with: "Updated description", exact: false)
 
-      view = session.view
-
-      send(
-        view.pid,
-        {:location_selected, "group-location",
-         %{
-           place_id: "test_place_id",
-           display_text: "Updated location",
-           main_text: "Updated location",
-           latitude: 40.71,
-           longitude: -74.01
-         }}
-      )
-
-      Phoenix.LiveViewTest.render(view)
-
       session
+      |> select_location(
+        display_text: "Updated location",
+        main_text: "Updated location",
+        latitude: 40.71,
+        longitude: -74.01
+      )
       |> click_button("Save Changes")
       |> assert_has("div[role='alert']", text: "Group updated successfully")
       |> assert_has("h1", text: "Updated Group Name")
@@ -119,21 +110,8 @@ defmodule HuddlzWeb.GroupLive.EditTest do
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/edit")
 
-      send(
-        session.view.pid,
-        {:location_selected, "group-location",
-         %{
-           place_id: "test_place_id",
-           display_text: String.duplicate("x", 501),
-           main_text: "Too Long",
-           latitude: 30.27,
-           longitude: -97.74
-         }}
-      )
-
-      Phoenix.LiveViewTest.render(session.view)
-
       session
+      |> select_location(display_text: String.duplicate("x", 501), main_text: "Too Long")
       |> click_button("Save Changes")
       |> assert_path(~p"/groups/#{group.slug}/edit")
       |> assert_has("p.form-error", text: "length must be less than or equal to 500")
@@ -188,23 +166,8 @@ defmodule HuddlzWeb.GroupLive.EditTest do
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/edit")
 
-      view = session.view
-
-      send(
-        view.pid,
-        {:location_selected, "group-location",
-         %{
-           place_id: "test_place_id",
-           display_text: "Austin, TX, USA",
-           main_text: "Austin",
-           latitude: 30.27,
-           longitude: -97.74
-         }}
-      )
-
-      Phoenix.LiveViewTest.render(view)
-
       session
+      |> select_location()
       |> click_button("Save Changes")
       |> assert_has("div[role='alert']", text: "Group updated successfully")
       |> assert_has(".hero .meta span", text: "Austin, TX, USA")

--- a/test/huddlz_web/live/group_live/locations_test.exs
+++ b/test/huddlz_web/live/group_live/locations_test.exs
@@ -2,6 +2,7 @@ defmodule HuddlzWeb.GroupLive.LocationsTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
   import Phoenix.LiveViewTest
 
   describe "locations management page" do
@@ -156,19 +157,11 @@ defmodule HuddlzWeb.GroupLive.LocationsTest do
         |> live(~p"/groups/#{group.slug}/locations/new")
 
       # Simulate LocationAutocomplete selecting a place
-      send(
-        view.pid,
-        {:location_selected, "modal-address-autocomplete",
-         %{
-           place_id: "ChIJ_test",
-           display_text: "123 Main St, Austin, TX",
-           main_text: "123 Main St",
-           latitude: 30.27,
-           longitude: -97.74
-         }}
+      select_location(view,
+        id: "modal-address-autocomplete",
+        display_text: "123 Main St, Austin, TX",
+        main_text: "123 Main St"
       )
-
-      render(view)
 
       # Save button should now be enabled and name pre-populated
       assert has_element?(view, "input#location-name-input[value='123 Main St']")

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -2,6 +2,7 @@ defmodule HuddlzWeb.GroupLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
 
   alias Huddlz.Communities.Group
 
@@ -47,23 +48,8 @@ defmodule HuddlzWeb.GroupLiveTest do
         |> fill_in("Description", with: "A test group")
         |> check("Public group")
 
-      view = session.view
-
-      send(
-        view.pid,
-        {:location_selected, "group-location",
-         %{
-           place_id: "test_place_id",
-           display_text: "Test City, TX, USA",
-           main_text: "Test City",
-           latitude: 30.27,
-           longitude: -97.74
-         }}
-      )
-
-      Phoenix.LiveViewTest.render(view)
-
       session
+      |> select_location(display_text: "Test City, TX, USA", main_text: "Test City")
       |> click_button("Create group")
 
       group =
@@ -105,21 +91,8 @@ defmodule HuddlzWeb.GroupLiveTest do
         |> fill_in("Group name", with: "Test Group")
         |> fill_in("Description", with: "A test group description")
 
-      send(
-        session.view.pid,
-        {:location_selected, "group-location",
-         %{
-           place_id: "test_place_id",
-           display_text: String.duplicate("x", 501),
-           main_text: "Too Long",
-           latitude: 30.27,
-           longitude: -97.74
-         }}
-      )
-
-      Phoenix.LiveViewTest.render(session.view)
-
       session
+      |> select_location(display_text: String.duplicate("x", 501), main_text: "Too Long")
       |> click_button("Create group")
       |> assert_path(~p"/groups/new")
       |> assert_has("p.form-error", text: "length must be less than or equal to 500")

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -3,6 +3,7 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
 
   import Huddlz.Generator
   import Huddlz.Test.Helpers.Authentication, only: [login: 2]
+  import Huddlz.Test.Helpers.LocationSelection
   import Phoenix.LiveViewTest
 
   alias Huddlz.Communities.Huddl
@@ -518,8 +519,7 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       |> form("#huddl-form", %{"form" => %{"title" => "My Updated Title"}})
       |> render_change()
 
-      send(view.pid, {:saved_location_selected, "saved-location-picker", location})
-      render(view)
+      select_saved_location(view, location)
 
       # Location should be in selected state
       assert has_element?(view, "[data-testid='saved-location-selected']")

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -461,6 +461,34 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       assert_has(session, "#saved-location-picker")
     end
 
+    test "switching to in-person shows location error only after a failed save", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      huddl =
+        generate(
+          huddl(
+            title: "Virtual Huddl",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            event_type: :virtual,
+            virtual_link: "https://example.com/meet"
+          )
+        )
+
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit")
+      |> choose("In person")
+      # Revealing the picker must not immediately flag the missing location
+      |> refute_has("p.form-error", text: "is required for in-person huddlz")
+      |> click_button("Save changes")
+      |> assert_path(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit")
+      |> assert_has("p.form-error", text: "is required for in-person huddlz")
+    end
+
     test "selecting a saved location preserves other form fields", %{
       conn: conn,
       owner: owner,

--- a/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
   import Phoenix.LiveViewTest
 
   alias Huddlz.Communities.Huddl
@@ -194,7 +195,6 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
       longitude: -97.74
     }
 
-    send(view.pid, {:saved_location_selected, "saved-location-picker", location})
-    render(view)
+    select_saved_location(view, location)
   end
 end

--- a/test/huddlz_web/live/huddl_live/new_location_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_location_test.exs
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive.NewLocationTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
   import Phoenix.LiveViewTest
 
   describe "add new address modal from huddl form" do
@@ -65,16 +66,10 @@ defmodule HuddlzWeb.HuddlLive.NewLocationTest do
         |> live(~p"/groups/#{group.slug}/huddlz/new/locations/new")
 
       # Simulate LocationAutocomplete selecting a place
-      send(
-        view.pid,
-        {:location_selected, "modal-address-autocomplete",
-         %{
-           place_id: "ChIJ_test",
-           display_text: "500 E Cesar Chavez St, Austin, TX",
-           main_text: "Austin Convention Center",
-           latitude: 30.263,
-           longitude: -97.739
-         }}
+      select_location(view,
+        id: "modal-address-autocomplete",
+        display_text: "500 E Cesar Chavez St, Austin, TX",
+        main_text: "Austin Convention Center"
       )
 
       html = render(view)
@@ -97,19 +92,11 @@ defmodule HuddlzWeb.HuddlLive.NewLocationTest do
         |> live(~p"/groups/#{group.slug}/huddlz/new/locations/new")
 
       # Simulate selecting an address
-      send(
-        view.pid,
-        {:location_selected, "modal-address-autocomplete",
-         %{
-           place_id: "ChIJ_test",
-           display_text: "500 E Cesar Chavez St, Austin, TX",
-           main_text: "Convention Center",
-           latitude: 30.263,
-           longitude: -97.739
-         }}
+      select_location(view,
+        id: "modal-address-autocomplete",
+        display_text: "500 E Cesar Chavez St, Austin, TX",
+        main_text: "Convention Center"
       )
-
-      render(view)
 
       # Submit the form
       view

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -381,9 +381,14 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       |> fill_in("Date", with: tomorrow)
       |> fill_in("Start time", with: "14:00")
       |> select("Duration", option: "1 hour")
+      # Editing other fields must not surface the untouched location's error
+      |> refute_has("p.form-error", text: "is required for in-person huddlz")
       # Leave event type as in-person (default), no location selected
       |> click_button("Schedule huddl")
       |> assert_path(~p"/groups/#{group.slug}/huddlz/new")
+      |> assert_has("p.form-error", text: "is required for in-person huddlz")
+      # The error persists through later edits once the submit has failed
+      |> fill_in("Title", with: "Test Huddl Again")
       |> assert_has("p.form-error", text: "is required for in-person huddlz")
     end
 

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -2,6 +2,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
   use HuddlzWeb.ConnCase, async: true
 
   import Huddlz.Generator
+  import Huddlz.Test.Helpers.LocationSelection
   import Mox
   import Phoenix.LiveViewTest
 
@@ -421,9 +422,8 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> select("Duration", option: "1 hour")
         |> choose("Hybrid")
 
-      send(session.view.pid, {:saved_location_selected, "saved-location-picker", location})
-
       session
+      |> select_saved_location(location)
       |> click_button("Schedule huddl")
       |> assert_path(~p"/groups/#{group.slug}/huddlz/new")
       # Only the missing virtual link is flagged, right under its own input
@@ -464,8 +464,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       view = session.view
 
       # Simulate selecting a saved location
-      send(view.pid, {:saved_location_selected, "saved-location-picker", location})
-      render(view)
+      select_saved_location(view, location)
 
       # Location should be in selected state
       assert has_element?(
@@ -708,7 +707,6 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       longitude: -97.74
     }
 
-    send(view.pid, {:saved_location_selected, "saved-location-picker", location})
-    render(view)
+    select_saved_location(view, location)
   end
 end

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -392,6 +392,47 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       |> assert_has("p.form-error", text: "is required for in-person huddlz")
     end
 
+    test "hybrid huddl error shows under the missing virtual link, not the chosen location", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      location =
+        generate(
+          group_location(
+            group_id: group.id,
+            name: "Austin Coffee",
+            address: "Austin Coffee, Austin, TX, USA",
+            latitude: 30.27,
+            longitude: -97.74,
+            actor: owner
+          )
+        )
+
+      tomorrow = Date.utc_today() |> Date.add(1) |> Date.to_iso8601()
+
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/huddlz/new")
+        |> fill_in("Title", with: "Hybrid Huddl")
+        |> fill_in("Date", with: tomorrow)
+        |> fill_in("Start time", with: "15:00")
+        |> select("Duration", option: "1 hour")
+        |> choose("Hybrid")
+
+      send(session.view.pid, {:saved_location_selected, "saved-location-picker", location})
+
+      session
+      |> click_button("Schedule huddl")
+      |> assert_path(~p"/groups/#{group.slug}/huddlz/new")
+      # Only the missing virtual link is flagged, right under its own input
+      |> assert_has("input#form_virtual_link ~ p.form-error",
+        text: "is required for hybrid huddlz"
+      )
+      |> assert_has("p.form-error", text: "is required for hybrid huddlz", count: 1)
+    end
+
     test "selecting a saved location preserves other form fields", %{
       conn: conn,
       owner: owner,

--- a/test/support/helpers/location_selection.ex
+++ b/test/support/helpers/location_selection.ex
@@ -1,0 +1,49 @@
+defmodule Huddlz.Test.Helpers.LocationSelection do
+  @moduledoc """
+  Simulates the location picker components notifying their parent LiveView.
+
+  `select_location/2` mimics `HuddlzWeb.Live.LocationAutocomplete` sending
+  `{:location_selected, id, payload}`; `select_saved_location/3` mimics
+  `HuddlzWeb.Live.SavedLocationPicker` sending
+  `{:saved_location_selected, id, location}`. Both accept a PhoenixTest
+  session or a `Phoenix.LiveViewTest` view, wait for the message to be
+  processed, and return the session/view for piping.
+  """
+
+  @default_payload %{
+    place_id: "test_place_id",
+    display_text: "Austin, TX, USA",
+    main_text: "Austin",
+    latitude: 30.27,
+    longitude: -97.74
+  }
+
+  @doc """
+  Selects an autocomplete location. Options other than `:id` override the
+  default payload, e.g. `select_location(session, display_text: "Berlin")`.
+  """
+  def select_location(session_or_view, opts \\ []) do
+    {id, payload_overrides} = Keyword.pop(opts, :id, "group-location")
+    payload = Map.merge(@default_payload, Map.new(payload_overrides))
+    notify(session_or_view, {:location_selected, id, payload})
+  end
+
+  @doc """
+  Selects a saved `GroupLocation` in the saved-location picker.
+  """
+  def select_saved_location(session_or_view, location, opts \\ []) do
+    id = Keyword.get(opts, :id, "saved-location-picker")
+    notify(session_or_view, {:saved_location_selected, id, location})
+  end
+
+  defp notify(%{view: view} = session, message) do
+    notify(view, message)
+    session
+  end
+
+  defp notify(view, message) do
+    send(view.pid, message)
+    Phoenix.LiveViewTest.render(view)
+    view
+  end
+end


### PR DESCRIPTION
Follow-up to #249, addressing the review findings on the `always_show` approach.

## Problem

`always_show={true}` on `field_errors` surfaced errors on every `phx-change`, not just after submit:

- On huddl creation, typing one character into Title rendered "is required for in-person huddlz" under an untouched location picker (event type defaults to in-person and `phx-change="validate"` populates errors).
- On huddl edit, switching a virtual huddl to in-person flagged the missing location in the same render that revealed the picker.
- On the two group forms the flag was a no-op: LocationAutocomplete renders a hidden `form[location]` input, and LiveView never marks hidden inputs unused, so `used_input?/1` was already true.
- For hybrid huddlz, the combined `present([:physical_location, :virtual_link])` validation fanned its error out to both fields, so a chosen location was flagged with "both physical location and virtual link are required" while the actually-missing virtual link stayed silent.

## Approach

An in-component "show after submit" flag turns out to be impossible: LiveView's form-aware change tracking (`engine.ex` / `Form.input_changed?`) only re-renders a component receiving `@form[:field]` when the field's value, errors, or `used_input?` state change — so error visibility has to be derived from field state.

- `field_errors` goes back to plain `used_input?/1` gating.
- The huddl save handlers now inject the `physical_location` param (`mark_location_used/2`, falling back to the form's current value so updates don't clear an existing location). The saved-location picker renders no client-side input, so the browser never sends the key on its own; injecting it on submit flips `used_input?` and errors display exactly from the failed save onward. Validate handlers re-inject once the form has been submitted so the error persists while the user fixes it.
- The hybrid validation is split per field so each error attaches only to the attribute that is actually missing.
- The ten copies of the raw `{:location_selected, ...}` / `{:saved_location_selected, ...}` send blocks in tests are collapsed into a shared `Huddlz.Test.Helpers.LocationSelection` helper.

## Tests

- huddl new: no location error while filling in other fields; error appears after failed submit and persists through subsequent edits
- huddl edit (previously untested flow): switching virtual → in-person shows the error only after a failed save
- hybrid: error renders under the missing virtual link only, with exactly one error on the page
- resource-level: hybrid error attaches to `:virtual_link` and not `:physical_location`