### PR TITLE
Add dev stub for places adapter

### DIFF
--- a/.dev.env.example
+++ b/.dev.env.example
@@ -46,8 +46,10 @@ MAILER_ADAPTER=Swoosh.Adapters.Local
 # AWS_SECRET_ACCESS_KEY=your-secret-key
 
 # -----------------------------------------------------------------------------
-# Google Maps (geocoding for location search)
+# Google Maps (geocoding and location search)
 # -----------------------------------------------------------------------------
+# Optional in development. When omitted, location autocomplete uses a fixed set
+# of preset locations without making requests to Google.
 GOOGLE_MAPS_API_KEY=your-google-maps-api-key
 
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -57,10 +57,22 @@ This installs Elixir 1.19.5 (OTP 28) and Erlang 28.4 as specified in `.mise.toml
 
 To start your Phoenix server:
 
+* Copy `.dev.env.example` to `.dev.env` and customize the local settings
 * Run `mix setup` to install and setup dependencies
 * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+
+### Google Maps in development
+
+Location search uses Google Places when `GOOGLE_MAPS_API_KEY` is set in
+`.dev.env`. Create a key in Google Cloud with the Places API (New) enabled,
+restrict it to the APIs used by huddlz, and set conservative usage quotas and
+billing alerts. The `.dev.env` file is ignored by Git and must not be committed.
+
+If the key is omitted, development automatically uses a fixed set of preset
+locations. This keyless mode avoids Google API usage and is useful for routine
+local development.
 
 ## Development
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -46,6 +46,7 @@ config :huddlz, Huddlz.Repo,
 
 # Adapters (compile-time - modules must exist at compile)
 config :huddlz, :storage, adapter: Huddlz.Storage.Local
+config :huddlz, :places, adapter: Huddlz.Places.Development
 
 # CORS — allow all origins in development
 config :huddlz, :cors_origins, :all

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,10 +89,19 @@ config :huddlz, Huddlz.Mailer, mailer_opts
 # =============================================================================
 
 # =============================================================================
-# Google Maps Configuration (geocoding)
+# Google Maps Configuration (geocoding + places)
 # =============================================================================
 
-config :huddlz, :google_maps, api_key: required!("GOOGLE_MAPS_API_KEY")
+if config_env() != :test do
+  case optional("GOOGLE_MAPS_API_KEY") do
+    nil ->
+      config :huddlz, :places, adapter: Huddlz.Places.DevStub
+
+    api_key ->
+      config :huddlz, :google_maps, api_key: api_key
+      config :huddlz, :places, adapter: Huddlz.Places.Google
+  end
+end
 
 if config_env() == :prod do
   required!("AWS_ACCESS_KEY_ID")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -92,16 +92,12 @@ config :huddlz, Huddlz.Mailer, mailer_opts
 # Google Maps Configuration (geocoding + places)
 # =============================================================================
 
-if config_env() != :test do
-  case optional("GOOGLE_MAPS_API_KEY") do
-    nil ->
-      config :huddlz, :places, adapter: Huddlz.Places.DevStub
+google_maps_api_key =
+  if config_env() == :prod,
+    do: required!("GOOGLE_MAPS_API_KEY"),
+    else: optional("GOOGLE_MAPS_API_KEY")
 
-    api_key ->
-      config :huddlz, :google_maps, api_key: api_key
-      config :huddlz, :places, adapter: Huddlz.Places.Google
-  end
-end
+config :huddlz, :google_maps, api_key: google_maps_api_key
 
 if config_env() == :prod do
   required!("AWS_ACCESS_KEY_ID")

--- a/lib/huddlz/places.ex
+++ b/lib/huddlz/places.ex
@@ -21,12 +21,16 @@ defmodule Huddlz.Places do
   @callback place_details(place_id :: String.t(), session_token :: String.t()) ::
               {:ok, coordinates()} | {:error, term()}
 
-  @adapter Application.compile_env(:huddlz, [:places, :adapter], Huddlz.Places.Google)
-
   def autocomplete(query, session_token, opts \\ []),
-    do: @adapter.autocomplete(query, session_token, opts)
+    do: adapter().autocomplete(query, session_token, opts)
 
-  def place_details(place_id, session_token), do: @adapter.place_details(place_id, session_token)
+  def place_details(place_id, session_token), do: adapter().place_details(place_id, session_token)
+
+  defp adapter do
+    :huddlz
+    |> Application.get_env(:places, [])
+    |> Keyword.fetch!(:adapter)
+  end
 
   @spec error_message(atom()) :: String.t()
   def error_message(:not_found), do: "Could not find that location."

--- a/lib/huddlz/places.ex
+++ b/lib/huddlz/places.ex
@@ -1,7 +1,7 @@
 defmodule Huddlz.Places do
   @moduledoc """
   Places autocomplete behaviour and facade.
-  Delegates to the configured adapter (Google Places in production, Mox in test).
+  Delegates to the adapter configured for the current environment.
   """
 
   @type suggestion :: %{
@@ -21,16 +21,12 @@ defmodule Huddlz.Places do
   @callback place_details(place_id :: String.t(), session_token :: String.t()) ::
               {:ok, coordinates()} | {:error, term()}
 
+  @adapter Application.compile_env(:huddlz, [:places, :adapter], Huddlz.Places.Google)
+
   def autocomplete(query, session_token, opts \\ []),
-    do: adapter().autocomplete(query, session_token, opts)
+    do: @adapter.autocomplete(query, session_token, opts)
 
-  def place_details(place_id, session_token), do: adapter().place_details(place_id, session_token)
-
-  defp adapter do
-    :huddlz
-    |> Application.get_env(:places, [])
-    |> Keyword.fetch!(:adapter)
-  end
+  def place_details(place_id, session_token), do: @adapter.place_details(place_id, session_token)
 
   @spec error_message(atom()) :: String.t()
   def error_message(:not_found), do: "Could not find that location."

--- a/lib/huddlz/places/dev_stub.ex
+++ b/lib/huddlz/places/dev_stub.ex
@@ -4,10 +4,6 @@ defmodule Huddlz.Places.DevStub do
 
   Returns a fixed preset of locations regardless of the search query so the
   LocationAutocomplete component is fully usable without a Google API key.
-
-  To enable, add to config/dev.exs:
-
-      config :huddlz, :places, adapter: Huddlz.Places.DevStub
   """
 
   @behaviour Huddlz.Places
@@ -85,7 +81,7 @@ defmodule Huddlz.Places.DevStub do
   def place_details(place_id, _session_token) do
     case Map.fetch(@coordinates, place_id) do
       {:ok, coords} -> {:ok, coords}
-      :error -> {:ok, %{latitude: 37.7749, longitude: -122.4194}}
+      :error -> {:error, :not_found}
     end
   end
 end

--- a/lib/huddlz/places/dev_stub.ex
+++ b/lib/huddlz/places/dev_stub.ex
@@ -1,0 +1,91 @@
+defmodule Huddlz.Places.DevStub do
+  @moduledoc """
+  Development stub for Places autocomplete.
+
+  Returns a fixed preset of locations regardless of the search query so the
+  LocationAutocomplete component is fully usable without a Google API key.
+
+  To enable, add to config/dev.exs:
+
+      config :huddlz, :places, adapter: Huddlz.Places.DevStub
+  """
+
+  @behaviour Huddlz.Places
+
+  @places [
+    %{
+      place_id: "dev_stub_sf",
+      display_text: "San Francisco, CA, USA",
+      main_text: "San Francisco",
+      secondary_text: "CA, USA",
+      latitude: 37.7749,
+      longitude: -122.4194
+    },
+    %{
+      place_id: "dev_stub_brooklyn",
+      display_text: "Brooklyn, New York, NY, USA",
+      main_text: "Brooklyn",
+      secondary_text: "New York, NY, USA",
+      latitude: 40.6782,
+      longitude: -74.0060
+    },
+    %{
+      place_id: "dev_stub_austin",
+      display_text: "Austin, TX, USA",
+      main_text: "Austin",
+      secondary_text: "TX, USA",
+      latitude: 30.2672,
+      longitude: -97.7431
+    },
+    %{
+      place_id: "dev_stub_chicago",
+      display_text: "Chicago, IL, USA",
+      main_text: "Chicago",
+      secondary_text: "IL, USA",
+      latitude: 41.8781,
+      longitude: -87.6298
+    },
+    %{
+      place_id: "dev_stub_portland",
+      display_text: "Portland, OR, USA",
+      main_text: "Portland",
+      secondary_text: "OR, USA",
+      latitude: 45.5051,
+      longitude: -122.6750
+    },
+    %{
+      place_id: "dev_stub_denver",
+      display_text: "Denver, CO, USA",
+      main_text: "Denver",
+      secondary_text: "CO, USA",
+      latitude: 39.7392,
+      longitude: -104.9903
+    },
+    %{
+      place_id: "dev_stub_nashville",
+      display_text: "Nashville, TN, USA",
+      main_text: "Nashville",
+      secondary_text: "TN, USA",
+      latitude: 36.1627,
+      longitude: -86.7816
+    }
+  ]
+
+  @suggestions Enum.map(
+                 @places,
+                 &Map.take(&1, [:place_id, :display_text, :main_text, :secondary_text])
+               )
+
+  @coordinates Map.new(@places, &{&1.place_id, %{latitude: &1.latitude, longitude: &1.longitude}})
+
+  @impl true
+  def autocomplete(_query, _session_token, _opts), do: {:ok, @suggestions}
+
+  @impl true
+  def place_details(place_id, _session_token) do
+    case Map.fetch(@coordinates, place_id) do
+      {:ok, coords} -> {:ok, coords}
+      :error -> {:ok, %{latitude: 37.7749, longitude: -122.4194}}
+    end
+  end
+end

--- a/lib/huddlz/places/development.ex
+++ b/lib/huddlz/places/development.ex
@@ -1,0 +1,25 @@
+defmodule Huddlz.Places.Development do
+  @moduledoc """
+  Development adapter that uses Google Places when an API key is configured
+  and falls back to preset locations otherwise.
+  """
+
+  @behaviour Huddlz.Places
+
+  @impl true
+  def autocomplete(query, session_token, opts) do
+    adapter().autocomplete(query, session_token, opts)
+  end
+
+  @impl true
+  def place_details(place_id, session_token) do
+    adapter().place_details(place_id, session_token)
+  end
+
+  defp adapter do
+    case Application.get_env(:huddlz, :google_maps, [])[:api_key] do
+      api_key when is_binary(api_key) and api_key != "" -> Huddlz.Places.Google
+      _ -> Huddlz.Places.DevStub
+    end
+  end
+end

--- a/test/huddlz/places/dev_stub_test.exs
+++ b/test/huddlz/places/dev_stub_test.exs
@@ -1,0 +1,20 @@
+defmodule Huddlz.Places.DevStubTest do
+  use ExUnit.Case, async: true
+
+  alias Huddlz.Places.DevStub
+
+  test "autocomplete returns all preset locations for any query" do
+    assert {:ok, suggestions} = DevStub.autocomplete("anything", "token", [])
+    assert length(suggestions) == 7
+    assert Enum.any?(suggestions, &(&1.main_text == "San Francisco"))
+  end
+
+  test "place_details returns coordinates for a preset location" do
+    assert {:ok, %{latitude: 30.2672, longitude: -97.7431}} =
+             DevStub.place_details("dev_stub_austin", "token")
+  end
+
+  test "place_details rejects an unknown location" do
+    assert {:error, :not_found} = DevStub.place_details("unknown", "token")
+  end
+end

--- a/test/huddlz/places/development_test.exs
+++ b/test/huddlz/places/development_test.exs
@@ -1,0 +1,34 @@
+defmodule Huddlz.Places.DevelopmentTest do
+  use ExUnit.Case, async: false
+
+  alias Huddlz.Places.Development
+  alias Huddlz.Places.Google
+
+  setup do
+    google_maps_config = Application.get_env(:huddlz, :google_maps)
+
+    on_exit(fn ->
+      Application.put_env(:huddlz, :google_maps, google_maps_config)
+    end)
+
+    :ok
+  end
+
+  test "uses preset locations when the Google Maps API key is absent" do
+    Application.put_env(:huddlz, :google_maps, api_key: nil)
+
+    assert {:ok, suggestions} = Development.autocomplete("anything", "token", [])
+    assert length(suggestions) == 7
+  end
+
+  test "uses Google Places when the Google Maps API key is configured" do
+    Application.put_env(:huddlz, :google_maps, api_key: "configured-key")
+
+    Req.Test.stub(Google, fn conn ->
+      assert Plug.Conn.get_req_header(conn, "x-goog-api-key") == ["configured-key"]
+      Req.Test.json(conn, %{"suggestions" => []})
+    end)
+
+    assert {:ok, []} = Development.autocomplete("Austin", "token", [])
+  end
+end


### PR DESCRIPTION
Removes the hard requirement on `GOOGLE_MAPS_API_KEY` during local development. When the env var is absent, the app now falls back to a `DevStub` adapter that returns a fixed set of preset locations, making the `LocationAutocomplete` component fully usable without a real API key.

There are 7 preset locations provided. Any search for locations on group or huddl pages will return all of these locations regardless of what is being searched. The goal here is to save on Google Maps API usage for basic dev testing.