### PR TITLE
feat(deploy): add readiness health check

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,8 +21,18 @@ kill_signal = 'SIGTERM'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
+
+  [[http_service.checks]]
+    grace_period = '10s'
+    interval = '15s'
+    method = 'GET'
+    path = '/healthz'
+    timeout = '5s'
+
+    [http_service.checks.headers]
+      X-Forwarded-Proto = 'https'
 
   [http_service.concurrency]
     type = 'connections'

--- a/lib/huddlz/health.ex
+++ b/lib/huddlz/health.ex
@@ -1,0 +1,41 @@
+defmodule Huddlz.Health do
+  @moduledoc """
+  Readiness checks for dependencies required to serve huddlz traffic.
+  """
+
+  alias Ecto.Adapters.SQL
+
+  require Logger
+
+  @spec check() :: :ok | :error
+  def check do
+    with :ok <- check_database(), do: check_oban()
+  end
+
+  defp check_database do
+    case SQL.query(Huddlz.Repo, "SELECT 1", [], timeout: 2_000) do
+      {:ok, _result} ->
+        :ok
+
+      {:error, reason} ->
+        log_failure("database", reason)
+    end
+  catch
+    :exit, reason -> log_failure("database", reason)
+  end
+
+  defp check_oban do
+    case Oban.whereis(Oban) do
+      pid when is_pid(pid) ->
+        :ok
+
+      nil ->
+        log_failure("Oban", "process is not running")
+    end
+  end
+
+  defp log_failure(dependency, reason) do
+    Logger.warning("Readiness #{dependency} check failed: #{inspect(reason)}")
+    :error
+  end
+end

--- a/lib/huddlz_web/controllers/health_controller.ex
+++ b/lib/huddlz_web/controllers/health_controller.ex
@@ -1,0 +1,20 @@
+defmodule HuddlzWeb.HealthController do
+  @moduledoc """
+  Reports whether this Machine is ready to receive traffic.
+  """
+
+  use HuddlzWeb, :controller
+
+  def show(conn, _params) do
+    case Huddlz.Health.check() do
+      :ok -> send_health(conn, 200, "ok")
+      :error -> send_health(conn, 503, "unavailable")
+    end
+  end
+
+  defp send_health(conn, status, body) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(status, body)
+  end
+end

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -37,6 +37,10 @@ defmodule HuddlzWeb.Router do
     plug HuddlzWeb.ApiAuth, resource: Huddlz.Accounts.User, required?: false
   end
 
+  scope "/", HuddlzWeb do
+    get "/healthz", HealthController, :show
+  end
+
   scope "/gql" do
     pipe_through [:graphql]
 

--- a/test/huddlz_web/controllers/health_controller_test.exs
+++ b/test/huddlz_web/controllers/health_controller_test.exs
@@ -1,0 +1,10 @@
+defmodule HuddlzWeb.HealthControllerTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  test "GET /healthz reports that Phoenix, Postgres, and Oban are ready", %{conn: conn} do
+    conn = get(conn, ~p"/healthz")
+
+    assert response(conn, 200) == "ok"
+    assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+  end
+end


### PR DESCRIPTION
## Summary

- keep one Fly Machine running so Oban schedules continue without web traffic
- add an unauthenticated `/healthz` readiness endpoint
- verify Postgres connectivity and the Oban supervisor before returning success
- configure Fly service health checks for deployment routing

## Verification

- `fly config validate --config fly.toml`
- `mix test test/huddlz_web/controllers/health_controller_test.exs`
- `mix precommit` (1,355 tests passed; no Credo issues)
