### PR TITLE
fix(deploy): configure Fly Managed Postgres

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,7 @@ config :ash_oban, pro?: false
 
 config :huddlz, Oban,
   engine: Oban.Engines.Basic,
-  notifier: Oban.Notifiers.Postgres,
+  notifier: Oban.Notifiers.PG,
   queues: [
     default: 10,
     notifications: 10,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -19,12 +19,13 @@ end
 # =============================================================================
 
 database_url = required!("DATABASE_URL")
-pool_size = optional("POOL_SIZE", "10") |> integer!()
+pool_size = optional("POOL_SIZE", "8") |> integer!()
 ecto_ipv6 = optional("ECTO_IPV6", "false") |> boolean!()
 
 config :huddlz, Huddlz.Repo,
   url: database_url,
   pool_size: pool_size,
+  prepare: :unnamed,
   socket_options: if(ecto_ipv6, do: [:inet6], else: [])
 
 # =============================================================================

--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,7 @@ kill_signal = 'SIGTERM'
 [build]
 
 [deploy]
-  release_command = '/app/bin/migrate'
+  release_command = "/bin/sh -lc 'DATABASE_URL=$DIRECT_DATABASE_URL POOL_SIZE=2 /app/bin/migrate'"
 
 [env]
   PHX_HOST = 'huddlz.fly.dev'

--- a/test/huddlz/fly_mpg_configuration_test.exs
+++ b/test/huddlz/fly_mpg_configuration_test.exs
@@ -1,0 +1,15 @@
+defmodule Huddlz.FlyMpgConfigurationTest do
+  use ExUnit.Case, async: true
+
+  test "uses transaction-pool-compatible Repo settings" do
+    repo_config = Application.fetch_env!(:huddlz, Huddlz.Repo)
+
+    assert repo_config[:prepare] == :unnamed
+  end
+
+  test "uses a notifier that does not require Postgres LISTEN/NOTIFY" do
+    oban_config = Application.fetch_env!(:huddlz, Oban)
+
+    assert oban_config[:notifier] == Oban.Notifiers.PG
+  end
+end


### PR DESCRIPTION
## Summary

- run release migrations through `DIRECT_DATABASE_URL` with a two-connection pool
- configure Ecto to use unnamed prepared statements for PgBouncer Transaction mode
- replace Oban's Postgres `LISTEN/NOTIFY` notifier with the Distributed Erlang PG notifier
- reduce the default per-Machine Ecto pool from 10 to 8
- test the transaction-pool-safe Repo and Oban settings

## Required rollout order

Do not merge until `DIRECT_DATABASE_URL` is configured on the `huddlz` Fly app.

1. Copy the direct connection URL from Managed Postgres **Connect**.
2. Set it as `DIRECT_DATABASE_URL` on the `huddlz` app.
3. Merge this PR while the MPG pooler remains in **Session** mode.
4. Wait for the deployment to succeed.
5. Change **Connect → Pooler settings → Pool mode** to **Transaction**.

## Verification

- `fly config validate --config fly.toml`
- `mix test test/huddlz/fly_mpg_configuration_test.exs`
- `mix precommit` (1,357 tests passed; no Credo issues)

## Documentation

- [Fly Phoenix with Managed Postgres guide](https://fly.io/docs/mpg/guides-examples/phoenix-guide/)
