### PR TITLE
fix(landing): refine homepage clarity

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1940,44 +1940,74 @@ body.is-landing {
 body .land-topbar {
   display: flex;
   align-items: center;
-  height: 80px;
-  padding: 0 64px;
+  height: 72px;
+  padding: 0 clamp(24px, 4vw, 64px);
   border-bottom: 1px solid var(--line);
 }
 
 body .land-topbar .nav { margin-left: auto; display: flex; align-items: center; gap: 16px; }
 
-body .land-topbar .nav a {
+body .land-topbar .nav .btn-secondary {
   color: var(--soft);
   font-size: 14px;
-  font-weight: 580;
+  font-weight: 600;
 }
 
-body .land-topbar .nav a:hover { color: var(--text); }
+body .land-topbar .nav .btn-secondary:hover { color: var(--text); }
+
+body .land-topbar .nav .btn-primary {
+  color: #001011;
+  font-size: 14px;
+  box-shadow: 0 0 22px rgba(24, 203, 212, 0.16);
+}
+
+body.is-landing .btn-primary,
+body.is-landing .btn-secondary {
+  transition: color 140ms ease, background-color 140ms ease, border-color 140ms ease,
+    box-shadow 140ms ease, transform 140ms ease;
+}
+
+body.is-landing .btn-primary:hover {
+  background: #5fe1e7;
+  color: #001011;
+  box-shadow: 0 8px 28px rgba(24, 203, 212, 0.2);
+  transform: translateY(-1px);
+}
+
+body.is-landing .btn-primary:focus-visible,
+body.is-landing .btn-secondary:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 3px;
+}
 
 body .land-hero {
   max-width: 1080px;
   margin: 0 auto;
-  padding: 96px 32px 80px;
+  padding: 68px 32px 56px;
   text-align: center;
 }
 
 body .land-hero h1 {
-  margin: 16px auto 24px;
+  margin: 14px auto 20px;
   font-family: var(--mono);
-  font-size: clamp(44px, 6.4vw, 88px);
-  line-height: 0.98;
-  letter-spacing: -0.01em;
-  max-width: 12ch;
+  font-size: clamp(44px, 5.2vw, 74px);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
   text-shadow: 0 0 40px rgba(24, 203, 212, 0.24);
 }
 
+body .land-hero h1 span { display: block; }
+
+@media (min-width: 560px) {
+  body .land-hero h1 span { white-space: nowrap; }
+}
+
 body .land-hero p {
-  max-width: 620px;
-  margin: 0 auto 32px;
-  color: var(--soft);
-  font-size: 19px;
-  line-height: 1.5;
+  max-width: 700px;
+  margin: 0 auto 28px;
+  color: #c3ced0;
+  font-size: 17px;
+  line-height: 1.55;
 }
 
 body .land-cta { display: flex; justify-content: center; gap: 12px; }
@@ -1986,8 +2016,8 @@ body .land-cta .btn-primary, body .land-cta .btn-secondary { height: 48px; paddi
 
 body .land-features {
   max-width: 1180px;
-  margin: 56px auto 0;
-  padding: 0 32px 96px;
+  margin: 0 auto;
+  padding: 0 32px 72px;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 18px;
@@ -2000,8 +2030,15 @@ body .land-features {
 body .feat {
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--panel);
+  background: rgba(5, 8, 8, 0.88);
   padding: 28px 26px;
+  transition: border-color 160ms ease, background-color 160ms ease, transform 160ms ease;
+}
+
+body .feat:hover {
+  border-color: var(--line-strong);
+  background: var(--panel-2);
+  transform: translateY(-2px);
 }
 
 body .feat .feat-mark {
@@ -2017,7 +2054,16 @@ body .feat .feat-mark {
 }
 
 body .feat h3 { margin: 0 0 8px; font-size: 17px; font-weight: 700; color: var(--text); }
-body .feat p { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.55; }
+body .feat p { margin: 0; color: var(--soft); font-size: 14px; line-height: 1.6; }
+
+@media (prefers-reduced-motion: reduce) {
+  body.is-landing .btn-primary,
+  body.is-landing .btn-secondary,
+  body .feat { transition: none; }
+
+  body.is-landing .btn-primary:hover,
+  body .feat:hover { transform: none; }
+}
 
 body .land-foot {
   border-top: 1px solid var(--line);
@@ -2865,10 +2911,11 @@ body .page-nav:disabled {
   body .row.members-row { grid-template-columns: 48px 1fr; }
   /* Land marketing */
   body .land-topbar { height: 64px; padding: 0 16px; }
-  body .land-hero { padding: 56px 16px 48px; }
+  body .land-hero { padding: 48px 16px 40px; }
+  body .land-hero h1 { font-size: clamp(34px, 10.5vw, 48px); }
+  body .land-hero p { font-size: 16px; }
   body .land-features { padding: 0 16px 64px; }
   body .profile-head { flex-direction: column; align-items: flex-start; gap: 14px; }
   body .pagination { justify-content: center; flex-wrap: wrap; }
   body .pagination .page-numbers { order: -1; flex-basis: 100%; justify-content: center; flex-wrap: wrap; }
 }
-

--- a/lib/huddlz_web/controllers/dev_design_html/clickthrough_landing.html.heex
+++ b/lib/huddlz_web/controllers/dev_design_html/clickthrough_landing.html.heex
@@ -12,10 +12,10 @@
 
   <section class="land-hero">
     <span class="eyebrow">In-person and online · everywhere</span>
-    <h1>Find your people.<br />Run the meetup.</h1>
+    <h1>Find your people.<br />Run the huddl.</h1>
     <p>
-      huddlz is the calmer, AI-native home for community events — discover huddlz worth
-      showing up to, organize the ones you run, and skip the noise.
+      huddlz is a calmer home for communities and the huddlz that bring them together.
+      Discover what fits, keep RSVPs organized, and give your group one place to gather.
     </p>
     <div class="land-cta">
       <a href="/dev/design/clickthrough/explore?signed_in=0" class="btn-primary">Browse huddlz</a>
@@ -40,7 +40,7 @@
       </span>
       <h3>Discovery that learns you</h3>
       <p>
-        Conversational search, semantic recommendations, and saved queries that update as new huddlz drop. No more sifting feeds.
+        Search by interest, place, time, or a plain-language idea. Save the search and hear when a matching huddl appears.
       </p>
     </div>
     <div class="feat">
@@ -60,7 +60,7 @@
       </span>
       <h3>Organize without the spreadsheet</h3>
       <p>
-        RSVPs, invites, capacity, waitlists, and recurring huddlz — all from one rail. Members and insights one tap away.
+        Publish one-off or recurring huddlz, manage capacity and waitlists, invite members, and keep every RSVP together.
       </p>
     </div>
     <div class="feat">
@@ -80,7 +80,7 @@
       </span>
       <h3>Bring your agent</h3>
       <p>
-        Browse, RSVP, and schedule huddlz from the LLM you already use. MCP tools, an agent-friendly API, and human-clear copy.
+        Ask your LLM to find a huddl, check the details, RSVP, or add it to your schedule through MCP and API tools.
       </p>
     </div>
   </section>

--- a/lib/huddlz_web/live/landing_live.ex
+++ b/lib/huddlz_web/live/landing_live.ex
@@ -33,9 +33,12 @@ defmodule HuddlzWeb.LandingLive do
 
     <section class="land-hero">
       <span class="eyebrow">In-person and online · everywhere</span>
-      <h1>Find your people.<br />Run the meetup.</h1>
+      <h1>
+        <span>Find your people.</span>
+        <span>Run the huddl.</span>
+      </h1>
       <p>
-        huddlz is the calmer, AI-native home for community events — discover huddlz worth showing up to, organize the ones you run, and skip the noise.
+        huddlz is a calmer home for communities and the huddlz that bring them together. Discover what fits, keep RSVPs organized, and give your group one place to gather.
       </p>
       <div class="land-cta">
         <.link navigate={~p"/discover"} class="btn-primary">Browse huddlz</.link>
@@ -60,7 +63,7 @@ defmodule HuddlzWeb.LandingLive do
         </span>
         <h3>Discovery that learns you</h3>
         <p>
-          Conversational search, semantic recommendations, and saved queries that update as new huddlz drop. No more sifting feeds.
+          Search by interest, place, time, or a plain-language idea. Save the search and hear when a matching huddl appears.
         </p>
       </div>
       <div class="feat">
@@ -80,7 +83,7 @@ defmodule HuddlzWeb.LandingLive do
         </span>
         <h3>Organize without the spreadsheet</h3>
         <p>
-          RSVPs, invites, capacity, waitlists, and recurring huddlz — all from one rail. Members and insights one tap away.
+          Publish one-off or recurring huddlz, manage capacity and waitlists, invite members, and keep every RSVP together.
         </p>
       </div>
       <div class="feat">
@@ -100,7 +103,7 @@ defmodule HuddlzWeb.LandingLive do
         </span>
         <h3>Bring your agent</h3>
         <p>
-          Browse, RSVP, and schedule huddlz from the LLM you already use. MCP tools, an agent-friendly API, and human-clear copy.
+          Ask your LLM to find a huddl, check the details, RSVP, or add it to your schedule through MCP and API tools.
         </p>
       </div>
     </section>

--- a/test/features/landing_surface.feature
+++ b/test/features/landing_surface.feature
@@ -12,7 +12,7 @@ Feature: Landing surface
   Scenario: Anonymous visitor sees the landing hero and CTAs
     When I visit "/"
     Then I should see "Find your people."
-    And I should see "Run the meetup."
+    And I should see "Run the huddl."
     And I should see "In-person and online · everywhere"
     And I should see "Browse huddlz"
     And I should see "Start a group"


### PR DESCRIPTION
## Summary

- replace generic event language with the huddl and huddlz vocabulary
- keep the desktop hero headline on two deliberate lines
- improve topbar CTA and feature-card contrast
- tighten the hero so all three product capabilities appear in the first desktop viewport
- make feature copy concrete about search, organizing, RSVPs, MCP, and API support

## Testing

- mix precommit
- 1,362 tests passed
- Credo found no issues
- reviewed at desktop and mobile widths on localhost:4000