### PR TITLE
Replace native huddl delete confirmation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1448,6 +1448,83 @@ body .facts .value .muted { color: var(--muted); font-weight: 500; font-size: 12
 body .btn-secondary.destructive-btn { color: var(--magenta); border-color: rgba(232, 79, 180, 0.4); }
 body .btn-secondary.destructive-btn:hover { color: var(--magenta); border-color: var(--magenta); }
 
+/* Huddl deletion confirmation — one focused warning moment, not a browser alert. */
+body .delete-confirm {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 16px;
+  padding: 2px 0 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+body .delete-confirm-icon {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border: 1px solid rgba(232, 79, 180, 0.42);
+  border-radius: var(--radius-sm);
+  color: var(--magenta);
+  background:
+    linear-gradient(135deg, rgba(232, 79, 180, 0.16), rgba(232, 79, 180, 0.04));
+  box-shadow: inset 3px 0 0 rgba(232, 79, 180, 0.72);
+}
+
+body .delete-confirm-copy h2 {
+  margin: 5px 0 9px;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: clamp(21px, 3vw, 27px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+body .delete-confirm-copy p {
+  color: var(--soft);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+body .delete-confirm-copy strong { color: var(--text); }
+
+body .delete-confirm-series-note {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-left: 2px solid var(--warn);
+  background: rgba(246, 193, 119, 0.06);
+  color: var(--warn) !important;
+  font-size: 12px !important;
+}
+
+body .delete-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 18px;
+}
+
+body .delete-confirm-submit {
+  color: #fff !important;
+  border-color: var(--magenta) !important;
+  background: rgba(232, 79, 180, 0.86) !important;
+}
+
+body .delete-confirm-submit:hover {
+  background: var(--magenta) !important;
+  box-shadow: 0 0 22px rgba(232, 79, 180, 0.18);
+}
+
+@media (max-width: 520px) {
+  body .delete-confirm {
+    grid-template-columns: 40px minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  body .delete-confirm-icon { width: 40px; height: 40px; }
+  body .delete-confirm-actions { flex-direction: column; }
+  body .delete-confirm-actions .btn-secondary { width: 100%; justify-content: center; }
+}
+
 /* "Organized by" row in huddl-side */
 body .creator-row { display: flex; align-items: center; gap: 10px; font-size: 13px; }
 

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -25,7 +25,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :confirming_delete?, false)}
   end
 
   @impl true
@@ -221,8 +221,8 @@ defmodule HuddlzWeb.HuddlLive.Show do
               <.button
                 :if={@can_delete_huddl}
                 variant={:destructive}
-                phx-click="delete_huddl"
-                data-confirm="Are you sure you want to delete this huddl?"
+                id="open-delete-huddl-modal"
+                phx-click={JS.push_focus() |> JS.push("confirm_delete_huddl")}
               >
                 Delete huddl
               </.button>
@@ -238,6 +238,51 @@ defmodule HuddlzWeb.HuddlLive.Show do
           </div>
         </aside>
       </div>
+
+      <.modal
+        :if={@confirming_delete?}
+        id="delete-huddl-modal"
+        show
+        on_cancel={JS.push("cancel_delete_huddl")}
+      >
+        <div class="delete-confirm">
+          <div class="delete-confirm-icon" aria-hidden="true">
+            <.icon name="hero-exclamation-triangle" class="h-6 w-6" />
+          </div>
+
+          <div class="delete-confirm-copy">
+            <span class="eyebrow eyebrow-magenta">Permanent action</span>
+            <h2 id="delete-huddl-modal-title">Delete this huddl?</h2>
+            <p>
+              <strong>{@huddl.title}</strong> will be permanently deleted. All RSVPs will be
+              canceled, and everyone who RSVP'd will be notified.
+            </p>
+            <p :if={@huddl.huddl_template_id} class="delete-confirm-series-note">
+              This deletes only the selected occurrence. Other occurrences in the recurring
+              series will remain.
+            </p>
+          </div>
+        </div>
+
+        <div class="delete-confirm-actions">
+          <.button
+            variant={:muted}
+            id="cancel-delete-huddl"
+            phx-click="cancel_delete_huddl"
+          >
+            Keep huddl
+          </.button>
+          <.button
+            variant={:destructive}
+            class="delete-confirm-submit"
+            id="confirm-delete-huddl"
+            phx-click="delete_huddl"
+            phx-disable-with="Deleting…"
+          >
+            Delete huddl
+          </.button>
+        </div>
+      </.modal>
     </Layouts.app>
     """
   end
@@ -472,6 +517,14 @@ defmodule HuddlzWeb.HuddlLive.Show do
     end
   end
 
+  def handle_event("confirm_delete_huddl", _, socket) do
+    {:noreply, assign(socket, :confirming_delete?, true)}
+  end
+
+  def handle_event("cancel_delete_huddl", _, socket) do
+    {:noreply, assign(socket, :confirming_delete?, false)}
+  end
+
   def handle_event("delete_huddl", _, socket) do
     huddl = socket.assigns.huddl
     user = socket.assigns.current_user
@@ -484,7 +537,10 @@ defmodule HuddlzWeb.HuddlLive.Show do
          |> redirect(to: ~p"/groups/#{huddl.group.slug}")}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to delete huddl.")}
+        {:noreply,
+         socket
+         |> assign(:confirming_delete?, false)
+         |> put_flash(:error, "Failed to delete huddl.")}
     end
   end
 

--- a/test/features/delete_huddl.feature
+++ b/test/features/delete_huddl.feature
@@ -18,6 +18,8 @@ Feature: Delete Huddl
     When I visit the "Future Workshop" huddl page
     Then I should see "Delete huddl"
     When I click "Delete huddl"
+    Then I should see "Delete this huddl?"
+    When I confirm deleting the huddl
     Then I should be redirected to the "Tech Meetup" group page
     And I should see "Huddl deleted successfully!"
 

--- a/test/features/step_definitions/delete_huddl_steps.exs
+++ b/test/features/step_definitions/delete_huddl_steps.exs
@@ -1,0 +1,16 @@
+defmodule DeleteHuddlSteps do
+  use Cucumber.StepDefinition
+
+  import PhoenixTest
+
+  step "I confirm deleting the huddl", context do
+    session = context[:session] || context[:conn]
+
+    session =
+      within(session, "#delete-huddl-modal", fn scoped ->
+        click_button(scoped, "Delete huddl")
+      end)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -9,6 +9,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.HuddlImage
+  alias Huddlz.Communities.HuddlTemplate
 
   describe "Show huddl details" do
     setup do
@@ -652,6 +653,114 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has("a", text: "Edit huddl")
       |> assert_has("button", text: "Delete huddl")
     end
+
+    test "opens and cancels the styled delete confirmation", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> refute_has("#delete-huddl-modal")
+      |> click_button("Delete huddl")
+      |> assert_has("#delete-huddl-modal [role='dialog']")
+      |> assert_has("#delete-huddl-modal-title", text: "Delete this huddl?")
+      |> assert_has("#delete-huddl-modal", text: huddl.title)
+      |> assert_has("#delete-huddl-modal", text: "All RSVPs will be canceled")
+      |> assert_has("#delete-huddl-modal", text: "everyone who RSVP'd will be notified")
+      |> assert_has("#delete-huddl-modal [role='dialog'][aria-modal='true'][tabindex='0']")
+      |> assert_has(
+        "#delete-huddl-modal-container[phx-key='escape'][phx-window-keydown][phx-click-away]"
+      )
+      |> refute_has("#open-delete-huddl-modal[data-confirm]")
+      |> assert_has("#open-delete-huddl-modal[phx-click*='push_focus']")
+      |> within("#delete-huddl-modal", fn session ->
+        click_button(session, "Keep huddl")
+      end)
+      |> refute_has("#delete-huddl-modal")
+      |> assert_path(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+
+      assert huddl_still_exists?(huddl.id)
+    end
+
+    test "explains that deleting a recurring huddl leaves the series intact", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      template =
+        HuddlTemplate
+        |> Ash.Changeset.for_create(:create, %{
+          frequency: :weekly,
+          repeat_until: DateTime.add(DateTime.utc_now(), 30, :day)
+        })
+        |> Ash.create!(authorize?: false)
+
+      recurring_huddl =
+        Huddl
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            title: "Weekly Workshop",
+            description: "A recurring workshop",
+            date: Date.add(Date.utc_today(), 2),
+            start_time: ~T[14:00:00],
+            duration_minutes: 60,
+            event_type: :virtual,
+            virtual_link: "https://example.com/weekly-workshop",
+            is_private: false,
+            group_id: group.id,
+            huddl_template_id: template.id
+          },
+          actor: owner
+        )
+        |> Ash.create!()
+
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{recurring_huddl.id}")
+      |> click_button("Delete huddl")
+      |> assert_has(
+        "#delete-huddl-modal .delete-confirm-series-note",
+        text: "This deletes only the selected occurrence"
+      )
+      |> assert_has(
+        "#delete-huddl-modal .delete-confirm-series-note",
+        text: "Other occurrences in the recurring series will remain"
+      )
+    end
+
+    test "deletes the huddl only after modal confirmation", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> click_button("Delete huddl")
+      |> within("#delete-huddl-modal", fn session ->
+        click_button(session, "Delete huddl")
+      end)
+      |> assert_path(~p"/groups/#{group.slug}")
+
+      deleted =
+        Huddl
+        |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl.id})
+        |> Ash.read_one!(authorize?: false)
+
+      assert is_nil(deleted)
+    end
+  end
+
+  defp huddl_still_exists?(id) do
+    Huddl
+    |> Ash.Query.for_read(:get_for_recurrence, %{id: id})
+    |> Ash.read_one!(authorize?: false)
+    |> is_struct(Huddl)
   end
 
   defp create_verified_user do


### PR DESCRIPTION
## Summary

- replace the native browser confirmation with a styled, non-blocking LiveView dialog
- explain permanent deletion, RSVP cancellation, notifications, and recurring-occurrence behavior
- restore focus to the delete trigger after Escape or dismissal
- cover cancellation, recurring copy, confirmation, redirect, and deletion in LiveView and feature tests

## Verification

- `mix test test/huddlz_web/live/huddl_live/show_test.exs` — 170 passed
- `mix test --only feature_delete_huddl` — 2 passed
- `mix precommit` — 1,365 tests passed; Credo clean
- browser verification at 1440×900 and 390×844
- verified Escape dismisses without deletion and returns focus to **Delete huddl**

## Visual verification

The native confirmation is reproducible on the `main` baseline, but it blocks browser automation and could not be captured directly. The closest baseline is the same huddl detail page immediately before selecting **Delete huddl**. Final desktop and mobile dialog captures were taken from this branch.

Closes #264