### PR TITLE
Replace the Leave Group browser alert

### DIFF
--- a/lib/huddlz_web/components/modal.ex
+++ b/lib/huddlz_web/components/modal.ex
@@ -49,6 +49,7 @@ defmodule HuddlzWeb.Components.Modal do
               phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
               class="relative border border-base-300 bg-base-200 rounded-hz-modal shadow-pop p-6"
             >
+              {render_slot(@inner_block)}
               <button
                 phx-click={JS.exec("data-cancel", to: "##{@id}")}
                 type="button"
@@ -57,7 +58,6 @@ defmodule HuddlzWeb.Components.Modal do
               >
                 <Icon.icon name="hero-x-mark" class="h-5 w-5" />
               </button>
-              {render_slot(@inner_block)}
             </.focus_wrap>
           </div>
         </div>

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -13,6 +13,7 @@ defmodule HuddlzWeb.GroupLive.Show do
   alias HuddlzWeb.Avatar
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.MetaHelpers
+  alias Phoenix.LiveView.JS
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_optional}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -21,7 +22,7 @@ defmodule HuddlzWeb.GroupLive.Show do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :leave_dialog_open, false)}
   end
 
   @impl true
@@ -232,9 +233,7 @@ defmodule HuddlzWeb.GroupLive.Show do
               <.button
                 :if={@can_leave_group}
                 variant={:muted}
-                phx-click="leave_group"
-                phx-disable-with="Leaving..."
-                data-confirm="Are you sure you want to leave this group?"
+                phx-click="open_leave_dialog"
               >
                 Leave Group
               </.button>
@@ -315,6 +314,59 @@ defmodule HuddlzWeb.GroupLive.Show do
           <% end %>
         </div>
       </div>
+
+      <.modal
+        :if={@leave_dialog_open}
+        id="leave-group-dialog"
+        show
+        on_cancel={JS.push("cancel_leave_group")}
+      >
+        <div class="flex gap-4 pr-8">
+          <div class="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-warning/30 bg-warning/10 text-warning">
+            <.icon name="hero-arrow-right-start-on-rectangle" class="h-5 w-5" />
+          </div>
+          <div>
+            <h2 id="leave-group-dialog-title" class="text-xl font-bold text-base-content">
+              Leave {@group.name}?
+            </h2>
+            <p class="mt-2 text-sm leading-6 text-base-content/70">
+              Leaving this group will:
+            </p>
+          </div>
+        </div>
+
+        <ul class="mt-5 space-y-3 rounded-hz-card border border-base-300 bg-base-100/50 p-4 text-sm text-base-content/80">
+          <li class="flex gap-3">
+            <.icon name="hero-user-group" class="mt-0.5 h-4 w-4 shrink-0 text-base-content/50" />
+            <span>Remove you from the <strong class="text-base-content">member roster</strong></span>
+          </li>
+          <li class="flex gap-3">
+            <.icon name="hero-rectangle-stack" class="mt-0.5 h-4 w-4 shrink-0 text-base-content/50" />
+            <span>Remove this group from <strong class="text-base-content">My groups</strong></span>
+          </li>
+          <li class="flex gap-3">
+            <.icon name="hero-bell-slash" class="mt-0.5 h-4 w-4 shrink-0 text-base-content/50" />
+            <span>Stop <strong class="text-base-content">notifications</strong> from this group</span>
+          </li>
+        </ul>
+
+        <p class="mt-4 text-sm text-base-content/60">
+          You can rejoin later if the group is public or you receive another invitation.
+        </p>
+
+        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <.button id="leave-group-dialog-cancel" phx-click="cancel_leave_group">
+            Cancel
+          </.button>
+          <.button
+            variant={:destructive}
+            phx-click="leave_group"
+            phx-disable-with="Leaving..."
+          >
+            Yes, leave group
+          </.button>
+        </div>
+      </.modal>
     </Layouts.app>
     """
   end
@@ -437,16 +489,27 @@ defmodule HuddlzWeb.GroupLive.Show do
     end
   end
 
-  def handle_event("leave_group", _, socket) do
+  def handle_event("open_leave_dialog", _, %{assigns: %{can_leave_group: true}} = socket) do
+    {:noreply, assign(socket, :leave_dialog_open, true)}
+  end
+
+  def handle_event("open_leave_dialog", _, socket), do: {:noreply, socket}
+
+  def handle_event("cancel_leave_group", _, socket) do
+    {:noreply, assign(socket, :leave_dialog_open, false)}
+  end
+
+  def handle_event("leave_group", _, %{assigns: %{leave_dialog_open: true}} = socket) do
     user = socket.assigns.current_user
 
     case leave_group(socket.assigns.group, user) do
-      {:ok, _} ->
+      :ok ->
         group = reload_group(socket.assigns.group, user)
 
         {:noreply,
          socket
          |> put_flash(:info, "Successfully left the group")
+         |> assign(:leave_dialog_open, false)
          |> assign(:group, group)
          |> assign(:is_member, false)
          |> assign(:members, nil)
@@ -457,6 +520,8 @@ defmodule HuddlzWeb.GroupLive.Show do
         {:noreply, put_flash(socket, :error, "Failed to leave group")}
     end
   end
+
+  def handle_event("leave_group", _, socket), do: {:noreply, socket}
 
   @group_loads [:current_image_url, :member_count, owner: [:current_profile_picture_url]]
 

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -74,6 +74,22 @@ Feature: Group Management
     When I visit the edit page for "Book Club"
     Then I should see "You don't have permission to edit this group"
 
+  Scenario: Member confirms before leaving a group
+    Given a public group "Book Club" exists with owner "verified@example.com"
+    And "regular@example.com" is a member of "Book Club"
+    And I am signed in as "regular@example.com"
+    When I visit the group page for "Book Club"
+    And I click "Leave Group"
+    Then I should see the leave dialog for "Book Club"
+    When I click "Cancel"
+    Then the "Leave Group" button should be visible
+    When I click "Leave Group"
+    And I click "Yes, leave group"
+    Then the "Leave Group" button should not be visible
+    And the "Join Group" button should be visible
+    When I visit "/my-groups"
+    Then I should not see "Book Club"
+
   Scenario: Group name is required
     Given I am signed in as "verified@example.com"
     When I visit "/groups/new"

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -119,4 +119,17 @@ defmodule GroupManagementSteps do
     assert_has(session, "*", text: "is required")
     context
   end
+
+  step "I should see the leave dialog for {string}", %{args: [group_name]} = context do
+    session = context[:session] || context[:conn]
+
+    session
+    |> assert_has("#leave-group-dialog [role='dialog']")
+    |> assert_has("#leave-group-dialog-title", text: "Leave #{group_name}?")
+    |> assert_has("#leave-group-dialog", text: "member roster")
+    |> assert_has("#leave-group-dialog", text: "My groups")
+    |> assert_has("#leave-group-dialog", text: "notifications")
+
+    context
+  end
 end

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -29,7 +29,47 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> assert_has("button[phx-disable-with='Joining...']", text: "Join Group")
     end
 
-    test "leave button shows a pending state while submitting", %{
+    test "leave button opens an in-app confirmation without changing membership", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      member = generate(user(role: :user))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: member.id,
+          role: :member,
+          actor: owner
+        )
+      )
+
+      session =
+        conn
+        |> login(member)
+        |> visit(~p"/groups/#{group.slug}")
+        |> refute_has("button[data-confirm]", text: "Leave Group")
+        |> click_button("Leave Group")
+        |> assert_has("#leave-group-dialog [role='dialog']")
+        |> assert_has("#leave-group-dialog-title", text: "Leave Membership Test Group?")
+        |> assert_has("#leave-group-dialog", text: "member roster")
+        |> assert_has("#leave-group-dialog", text: "My groups")
+        |> assert_has("#leave-group-dialog", text: "notifications")
+        |> assert_has(
+          "#leave-group-dialog-container[phx-key='escape'][phx-window-keydown][phx-click-away]"
+        )
+        |> assert_has("#leave-group-dialog-cancel", text: "Cancel")
+
+      session
+      |> within("#leave-group-dialog", fn session ->
+        click_button(session, "Cancel")
+      end)
+      |> refute_has("#leave-group-dialog")
+      |> assert_has("button", text: "Leave Group")
+    end
+
+    test "confirming leave updates the group page and My groups", %{
       conn: conn,
       owner: owner,
       group: group
@@ -48,7 +88,23 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}")
-      |> assert_has("button[phx-disable-with='Leaving...']", text: "Leave Group")
+      |> click_button("Leave Group")
+      |> within("#leave-group-dialog", fn session ->
+        click_button(session, "Yes, leave group")
+      end)
+      |> assert_has("*", text: "Successfully left the group")
+      |> refute_has("button", text: "Leave Group")
+      |> assert_has("button", text: "Join Group")
+      |> visit(~p"/my-groups")
+      |> refute_has("*", text: "Membership Test Group")
+    end
+
+    test "owner cannot open the leave dialog", %{conn: conn, owner: owner, group: group} do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}")
+      |> refute_has("button", text: "Leave Group")
+      |> refute_has("#leave-group-dialog")
     end
   end
 end


### PR DESCRIPTION
## Summary

- replace the native leave-group confirmation with a styled in-app dialog
- explain the member roster, My groups, and notification impact before leaving
- focus the safe action and preserve membership on cancel, Escape, or dismissal
- update the group page and My groups after confirmation
- add LiveView and feature coverage for the complete flow

## Testing

- mix test test/huddlz_web/live/group_live/show_test.exs (149 passed)
- mix test (1365 passed)
- mix precommit (1365 passed; Credo found no issues)
- browser-verified initial Cancel focus, Escape cancellation, no native dialog, confirmation, and My groups refresh

Closes #265