### PR TITLE
fix(groups): show accurate member counts

### DIFF
--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -376,6 +376,7 @@ defmodule Huddlz.Communities.Group do
 
     count :member_count, :group_members do
       description "Total members in the group, including owner and organizers"
+      authorize? false
     end
   end
 

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -46,6 +46,7 @@ Feature: Group Management
     Given a public group "Book Club" exists with owner "verified@example.com"
     When I visit the group page for "Book Club"
     Then I should see "Book Club"
+    And the group member count should be 1
 
   Scenario: Cannot view private group as non-member
     Given a private group "VIP Club" exists with owner "admin@example.com"
@@ -79,7 +80,8 @@ Feature: Group Management
     And "regular@example.com" is a member of "Book Club"
     And I am signed in as "regular@example.com"
     When I visit the group page for "Book Club"
-    And I click "Leave Group"
+    Then the group member count should be 2
+    When I click "Leave Group"
     Then I should see the leave dialog for "Book Club"
     When I click "Cancel"
     Then the "Leave Group" button should be visible
@@ -87,6 +89,7 @@ Feature: Group Management
     And I click "Yes, leave group"
     Then the "Leave Group" button should not be visible
     And the "Join Group" button should be visible
+    And the group member count should be 1
     When I visit "/my-groups"
     Then I should not see "Book Club"
 

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -35,6 +35,16 @@ Feature: Organizer workspace
     And I should see "Public"
     And I should see "Private"
 
+  Scenario: Organizer views show the complete member count
+    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
+    And "attendee@example.com" is a member of "Cyberpunk Builders"
+    And "stranger@example.com" is a member of "Cyberpunk Builders"
+    And I am signed in as "host@example.com"
+    When I visit "/organize"
+    Then I should see "3 members"
+    When I visit "/organize/cyberpunk-builders"
+    Then the organizer member count should be 3
+
   Scenario: /organize picker does not list groups the actor does not own
     Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
     And I am signed in as "host@example.com"

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -132,4 +132,10 @@ defmodule GroupManagementSteps do
 
     context
   end
+
+  step "the group member count should be {int}", %{args: [count]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, ".facts li", text: "Members #{count}")
+    context
+  end
 end

--- a/test/features/step_definitions/organize_workspace_steps.exs
+++ b/test/features/step_definitions/organize_workspace_steps.exs
@@ -67,6 +67,12 @@ defmodule OrganizeWorkspaceSteps do
     context
   end
 
+  step "the organizer member count should be {int}", %{args: [count]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, ".kpi", text: "Members #{count}")
+    context
+  end
+
   defp lookup_group(name) do
     Huddlz.Communities.Group
     |> Ash.Query.filter(name: name)

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -88,15 +88,32 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       conn
       |> login(member)
       |> visit(~p"/groups/#{group.slug}")
+      |> assert_has(".facts li", text: "Members 2")
       |> click_button("Leave Group")
       |> within("#leave-group-dialog", fn session ->
         click_button(session, "Yes, leave group")
       end)
       |> assert_has("*", text: "Successfully left the group")
+      |> assert_has(".facts li", text: "Members 1")
       |> refute_has("button", text: "Leave Group")
       |> assert_has("button", text: "Join Group")
       |> visit(~p"/my-groups")
       |> refute_has("*", text: "Membership Test Group")
+    end
+
+    test "joining updates the member count without a refresh", %{
+      conn: conn,
+      group: group
+    } do
+      visitor = generate(user(role: :user))
+
+      conn
+      |> login(visitor)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has(".facts li", text: "Members 1")
+      |> click_button("Join Group")
+      |> assert_has("*", text: "Successfully joined the group!")
+      |> assert_has(".facts li", text: "Members 2")
     end
 
     test "owner cannot open the leave dialog", %{conn: conn, owner: owner, group: group} do

--- a/test/huddlz_web/live/group_live_permissions_test.exs
+++ b/test/huddlz_web/live/group_live_permissions_test.exs
@@ -208,6 +208,33 @@ defmodule HuddlzWeb.GroupLivePermissionsTest do
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("h1", text: "Browse groups")
     end
+
+    test "member count is consistent for visitors and every group role", %{
+      conn: conn,
+      owner: owner,
+      organizer: organizer,
+      verified_member: member,
+      verified_non_member: non_member,
+      public_group: group
+    } do
+      [
+        conn,
+        login(conn, non_member),
+        login(conn, member),
+        login(conn, organizer),
+        login(conn, owner)
+      ]
+      |> Enum.each(fn viewer_conn ->
+        viewer_conn
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has(".facts li", text: "Members 4")
+      end)
+
+      conn
+      |> login(member)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has(".member-grid .member-mark", count: 4)
+    end
   end
 
   defp member_initials(%{display_name: name}) when is_binary(name) and name != "" do

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -300,13 +300,20 @@ defmodule HuddlzWeb.HuddlLiveTest do
       %{host: host}
     end
 
-    test "lists public groups", %{conn: conn, host: host} do
-      generate(group(is_public: true, owner_id: host.id, actor: host, name: "Elixir Club"))
+    test "lists public groups with the complete member count", %{conn: conn, host: host} do
+      group =
+        generate(group(is_public: true, owner_id: host.id, actor: host, name: "Elixir Club"))
+
+      for _ <- 1..2 do
+        member = generate(user(role: :user))
+        generate(group_member(group_id: group.id, user_id: member.id, actor: host))
+      end
 
       conn
       |> visit("/discover?scope=groups")
       |> assert_has("h1", text: "Browse groups")
       |> assert_has("h2", text: "Elixir Club")
+      |> assert_has(".grid .card .card-meta", text: "3 members")
     end
 
     test "hides huddlz when scope=groups", %{conn: conn, host: host} do

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -179,14 +179,19 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
   end
 
   describe "card content" do
-    test "renders member count", %{conn: conn, member: member} do
-      _g =
+    test "renders the complete member count", %{conn: conn, member: member} do
+      group =
         generate(group(name: "Crowded Crew", is_public: true, owner_id: member.id, actor: member))
+
+      for _ <- 1..2 do
+        member_user = generate(user(role: :user))
+        generate(group_member(group_id: group.id, user_id: member_user.id, actor: member))
+      end
 
       conn
       |> login(member)
       |> visit("/my-groups")
-      |> assert_has(".grid .card .card-meta", text: "1 member")
+      |> assert_has(".grid .card .card-meta", text: "3 members")
     end
   end
 


### PR DESCRIPTION
## Summary

- make the public member-count aggregate independent of roster authorization filters
- keep roster visibility policies unchanged
- cover signed-out, nonmember, member, organizer, and owner views
- cover live join/leave transitions and all member-count display surfaces
- add Gherkin coverage for visitor, membership-transition, and organizer counts

## Verification

- focused LiveView role and transition tests
- focused Discover, My groups, and organizer feature coverage
- mix compile --warnings-as-errors
- mix precommit (1371 passed; Credo clean)

Closes #266