### PR TITLE
feat(huddlz): add creator attendance on huddl creation

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -136,6 +136,7 @@ defmodule Huddlz.Communities.Huddl do
 
       validate Huddlz.Communities.Huddl.Validations.FutureDateValidation
       change Huddlz.Communities.Huddl.Changes.SetCreatorToActor
+      change Huddlz.Communities.Huddl.Changes.AddCreatorAsAttendee
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.AddHuddlTemplate

--- a/lib/huddlz/communities/huddl/changes/add_creator_as_attendee.ex
+++ b/lib/huddlz/communities/huddl/changes/add_creator_as_attendee.ex
@@ -1,0 +1,28 @@
+defmodule Huddlz.Communities.Huddl.Changes.AddCreatorAsAttendee do
+  @moduledoc false
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities.HuddlAttendee
+
+  @impl true
+  def change(changeset, _opts, context) do
+    Ash.Changeset.after_action(changeset, fn _changeset, huddl ->
+      with {:ok, actor} <- creator_actor(context.actor, huddl.creator_id),
+           {:ok, _attendance} <-
+             HuddlAttendee
+             |> Ash.Changeset.for_create(
+               :rsvp,
+               %{huddl_id: huddl.id, user_id: huddl.creator_id},
+               actor: actor
+             )
+             |> Ash.create(authorize?: false) do
+        {:ok, huddl}
+      end
+    end)
+  end
+
+  defp creator_actor(%{id: _id} = actor, _creator_id), do: {:ok, actor}
+  defp creator_actor(_actor, creator_id), do: Ash.get(User, creator_id, authorize?: false)
+end

--- a/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
+++ b/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
@@ -113,8 +113,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
       :attending ->
         Ash.Query.filter(
           query,
-          exists(attendees, user_id == ^actor.id and is_nil(waitlisted_at)) and
-            creator_id != ^actor.id
+          exists(attendees, user_id == ^actor.id and is_nil(waitlisted_at))
         )
 
       :waitlisted ->

--- a/test/features/create_huddl.feature
+++ b/test/features/create_huddl.feature
@@ -57,6 +57,32 @@ Feature: Create Huddl
     Then I should be redirected to the "Tech Meetup" group page
     And I should see "Huddl created successfully!"
 
+  @creator_attendance
+  Scenario: Creator automatically attends and can later cancel their RSVP
+    Given I am signed in as "owner@example.com"
+    When I visit the new huddl page for "Tech Meetup"
+    And I fill in the huddl form with:
+      | Field             | Value                         |
+      | Title             | Creator Attendance            |
+      | Description       | The creator initially hosts   |
+      | Start Date & Time | tomorrow at 6:00 PM          |
+      | End Date & Time   | tomorrow at 8:00 PM          |
+      | Huddl Type        | Virtual                      |
+      | Virtual Link      | https://example.com/creator  |
+    And I submit the form
+    And I visit "/my-huddlz"
+    Then I should see "Creator Attendance"
+
+    When I visit the "Creator Attendance" huddl page
+    Then I should see "You're attending"
+    And I should see "Cancel RSVP"
+    And I should see "1 person attending"
+
+    When I click "Cancel RSVP"
+    Then I should see "RSVP cancelled successfully"
+    When I visit "/my-huddlz"
+    Then I should not see "Creator Attendance"
+
   Scenario: Owner creates a monthly recurring huddl
     Given I am signed in as "owner@example.com"
     When I visit the "Tech Meetup" group page

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -131,7 +131,7 @@ Feature: Organizer workspace
     And I am signed in as "host@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Open RSVPs"
-    And I should see "1 RSVP"
+    And I should see "2 RSVPs"
 
   Scenario: Overview does not show huddlz from groups the actor does not organize
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"

--- a/test/features/rsvp_cancellation.feature
+++ b/test/features/rsvp_cancellation.feature
@@ -31,13 +31,13 @@ Feature: RSVP Cancellation
     Then I should see "Successfully RSVPed to this huddl!"
     And I should see "You're attending"
     And I should see "Cancel RSVP"
-    And I should see "1 person attending"
+    And I should see "2 people attending"
     
     When I click "Cancel RSVP"
     Then I should see "RSVP cancelled successfully"
     And I should see "RSVP to this huddl"
     And I should not see "You're attending"
-    And I should see "Be the first to RSVP!"
+    And I should see "1 person attending"
 
   Scenario: User can RSVP again after cancelling
     Given I am logged in as "member@example.com"
@@ -49,7 +49,7 @@ Feature: RSVP Cancellation
     When I click "RSVP to this huddl"
     Then I should see "Successfully RSVPed to this huddl!"
     And I should see "You're attending"
-    And I should see "1 person attending"
+    And I should see "2 people attending"
 
   Scenario: Multiple users can manage their RSVPs independently
     Given I am logged in as "organizer@example.com"

--- a/test/features/step_definitions/rsvp_cancellation_steps.exs
+++ b/test/features/step_definitions/rsvp_cancellation_steps.exs
@@ -27,7 +27,8 @@ defmodule RsvpCancellationSteps do
           name: group_data["name"],
           description: group_data["description"],
           is_public: is_public,
-          owner: owner
+          owner_id: owner.id,
+          actor: owner
         )
       )
 

--- a/test/features/waitlist.feature
+++ b/test/features/waitlist.feature
@@ -17,7 +17,7 @@ Feature: Waitlist
     And "hopeful@example.com" is a member of "Tech Meetup"
     And the following capped huddl exists in "Tech Meetup":
       | title              | description       | event_type | starts_at    | virtual_link                | max_attendees |
-      | Capped Code Review | Limited seats     | virtual    | tomorrow 2pm | https://zoom.us/j/123456789 | 1             |
+      | Capped Code Review | Limited seats     | virtual    | tomorrow 2pm | https://zoom.us/j/123456789 | 2             |
     And "member@example.com" has RSVPed to "Capped Code Review"
 
   Scenario: User joins the waitlist when the huddl is full

--- a/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
+++ b/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
@@ -264,7 +264,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
       assert hosted.id in ids
     end
 
-    test ":attending excludes huddlz the actor created (even if they RSVPed)", %{
+    test ":attending includes huddlz the actor created when they RSVPed", %{
       owner: owner,
       hosted_by_owner: hosted
     } do
@@ -279,7 +279,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
         )
         |> Ash.read(actor: owner, page: [limit: 50, count: true])
 
-      refute hosted.id in Enum.map(results, & &1.id)
+      assert hosted.id in Enum.map(results, & &1.id)
     end
 
     test "anonymous actor with relationship filter returns []", %{} do

--- a/test/huddlz/communities/huddl_rsvp_edge_cases_test.exs
+++ b/test/huddlz/communities/huddl_rsvp_edge_cases_test.exs
@@ -132,7 +132,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
       |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: member)
       |> Ash.update!()
 
-      assert rsvp_count(huddl) == 0
+      assert rsvp_count(huddl) == 1
     end
 
     test "RSVP count is always consistent with attendee records", %{
@@ -158,12 +158,12 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
         )
         |> Ash.create!()
 
-      # Try to cancel without RSVPing first - count stays at 0
+      # Cancelling a non-existent member RSVP leaves the creator attending.
       huddl
       |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: member)
       |> Ash.update!()
 
-      assert rsvp_count(huddl) == 0
+      assert rsvp_count(huddl) == 1
 
       # RSVP then cancel - count is always consistent
       huddl
@@ -171,14 +171,14 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
       |> Ash.update!()
 
-      assert rsvp_count(huddl) == 1
+      assert rsvp_count(huddl) == 2
 
       huddl
       |> Ash.reload!()
       |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: member)
       |> Ash.update!()
 
-      assert rsvp_count(huddl) == 0
+      assert rsvp_count(huddl) == 1
     end
 
     test "admin can see RSVP cancellations work correctly", %{
@@ -218,7 +218,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
         |> Ash.Query.load(:rsvp_count)
         |> Ash.read_one!(actor: admin)
 
-      assert admin_view.rsvp_count == 1
+      assert admin_view.rsvp_count == 2
 
       # Member cancels
       huddl
@@ -233,7 +233,7 @@ defmodule Huddlz.Communities.HuddlRsvpEdgeCasesTest do
         |> Ash.Query.load(:rsvp_count)
         |> Ash.read_one!(actor: admin)
 
-      assert admin_view_after.rsvp_count == 0
+      assert admin_view_after.rsvp_count == 1
     end
   end
 

--- a/test/huddlz/communities/huddl_rsvp_test.exs
+++ b/test/huddlz/communities/huddl_rsvp_test.exs
@@ -8,6 +8,39 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
 
   require Ash.Query
 
+  describe "creator attendance" do
+    test "creating a huddl confirms the creator's attendance and allows cancellation" do
+      owner = generate(user(role: :user))
+      group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            max_attendees: 1
+          )
+        )
+
+      assert rsvp_count(huddl) == 1
+
+      assert [%{user_id: user_id}] =
+               HuddlAttendee
+               |> Ash.Query.for_read(:by_huddl, %{huddl_id: huddl.id})
+               |> Ash.read!(authorize?: false)
+
+      assert user_id == owner.id
+
+      huddl
+      |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: owner)
+      |> Ash.update!()
+
+      assert rsvp_count(huddl) == 0
+      assert Ash.reload!(huddl).creator_id == owner.id
+    end
+  end
+
   describe "RSVP functionality" do
     setup do
       owner = generate(user(role: :user))
@@ -59,6 +92,10 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
           actor: owner
         )
         |> Ash.create!()
+
+      huddl
+      |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: owner)
+      |> Ash.update!()
 
       %{
         owner: owner,
@@ -214,7 +251,6 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
     test "max_attendees can be set on :create and is enforced", %{
       owner: owner,
       member: member,
-      non_member: non_member,
       group: group
     } do
       limited_huddl =
@@ -236,14 +272,10 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
         )
         |> Ash.create!()
 
-      limited_huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
-      |> Ash.update!()
-
       assert_raise Ash.Error.Invalid, ~r/This huddl is full/, fn ->
         limited_huddl
         |> Ash.reload!()
-        |> Ash.Changeset.for_update(:rsvp, %{}, actor: non_member)
+        |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
         |> Ash.update!()
       end
 
@@ -472,6 +504,10 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
         )
         |> Ash.create!()
 
+      huddl
+      |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: owner)
+      |> Ash.update!()
+
       %{
         owner: owner,
         member: member,
@@ -698,8 +734,8 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
         |> Ash.read(actor: attendee)
 
       assert {:ok, attendees} = result
-      assert length(attendees) == 1
-      assert hd(attendees).user_id == attendee.id
+      assert length(attendees) == 2
+      assert Enum.any?(attendees, &(&1.user_id == attendee.id))
     end
 
     test "group owner can see attendee list", %{owner: owner, huddl: huddl, attendee: attendee} do
@@ -710,8 +746,8 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
         |> Ash.read(actor: owner)
 
       assert {:ok, attendees} = result
-      assert length(attendees) == 1
-      assert hd(attendees).user_id == attendee.id
+      assert length(attendees) == 2
+      assert Enum.any?(attendees, &(&1.user_id == attendee.id))
     end
 
     test "group organizer can see attendee list", %{
@@ -726,8 +762,8 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
         |> Ash.read(actor: organizer)
 
       assert {:ok, attendees} = result
-      assert length(attendees) == 1
-      assert hd(attendees).user_id == attendee.id
+      assert length(attendees) == 2
+      assert Enum.any?(attendees, &(&1.user_id == attendee.id))
     end
 
     test "group member who is not attending cannot see attendee list", %{
@@ -773,8 +809,8 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
         |> Ash.read(actor: admin)
 
       assert {:ok, attendees} = result
-      assert length(attendees) == 1
-      assert hd(attendees).user_id == attendee.id
+      assert length(attendees) == 2
+      assert Enum.any?(attendees, &(&1.user_id == attendee.id))
     end
   end
 

--- a/test/huddlz/communities/huddl_waitlist_test.exs
+++ b/test/huddlz/communities/huddl_waitlist_test.exs
@@ -347,14 +347,9 @@ defmodule Huddlz.Communities.HuddlWaitlistTest do
 
     test "is true once rsvp_count reaches max_attendees", %{
       owner: owner,
-      member: member,
       group: group
     } do
       huddl = capped_huddl(owner, group, 1)
-
-      huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
-      |> Ash.update!()
 
       assert load_at_capacity(huddl) == true
     end
@@ -441,6 +436,10 @@ defmodule Huddlz.Communities.HuddlWaitlistTest do
         actor: owner
       )
       |> Ash.create!()
+
+    huddl
+    |> Ash.Changeset.for_update(:cancel_rsvp, %{}, actor: owner)
+    |> Ash.update!()
 
     %{
       owner: owner,

--- a/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
+++ b/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
@@ -611,10 +611,10 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
 
       assert %DateTime{} = stamped_huddl.reminder_24h_sent_at
 
-      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+      assert %{success: 3} = Oban.drain_queue(queue: :notifications)
       emails = drain_mailbox()
 
-      for recipient <- [attendee_a, attendee_b] do
+      for recipient <- [owner, attendee_a, attendee_b] do
         assert Enum.any?(emails, fn email ->
                  email.subject == "Tomorrow: Saturday Soccer" and
                    email.to == [{"", to_string(recipient.email)}] and
@@ -701,7 +701,7 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       # action invocation only happens by manual call. Even then the
       # caller still gets one delivery; we just confirm nothing about
       # idempotency at the action level — see the filter test above.
-      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
 
       candidates =
         Huddl
@@ -747,12 +747,13 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
 
       assert %DateTime{} = stamped.reminder_1h_sent_at
 
-      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      assert %{success: 2} = Oban.drain_queue(queue: :notifications)
+      emails = drain_mailbox()
 
-      assert_email_sent(fn email ->
-        email.subject == "Starting soon: Morning Standup" and
-          email.to == [{"", to_string(attendee.email)}]
-      end)
+      assert Enum.any?(emails, fn email ->
+               email.subject == "Starting soon: Morning Standup" and
+                 email.to == [{"", to_string(attendee.email)}]
+             end)
     end
   end
 

--- a/test/huddlz/notifications/rsvp_notifications_test.exs
+++ b/test/huddlz/notifications/rsvp_notifications_test.exs
@@ -15,11 +15,8 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
 
   describe "E3: rsvp_confirmation" do
     test "emails the rsvper themselves with an .ics attachment" do
-      # Setup: actor IS the sole owner of the group, so E1's recipient
-      # set (owner+organizers minus actor) is empty and only E3 fires.
-      # This keeps the test focused on E3's distinguishing properties
-      # (subject + .ics attachment).
       owner = generate(user(role: :user, display_name: "Owner"))
+      attendee = generate(user(role: :user, display_name: "Attendee"))
 
       group =
         generate(
@@ -46,16 +43,17 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       flush_mailbox()
 
       huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: owner)
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
       |> Ash.update!()
 
       assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
+      emails = drain_mailbox()
 
-      assert_email_sent(fn email ->
-        email.subject == "You're going to Saturday Soccer" and
-          email.to == [{"", to_string(owner.email)}] and
-          Enum.any?(email.attachments, &(&1.content_type == "text/calendar"))
-      end)
+      assert Enum.any?(emails, fn email ->
+               email.subject == "You're going to Saturday Soccer" and
+                 email.to == [{"", to_string(attendee.email)}] and
+                 Enum.any?(email.attachments, &(&1.content_type == "text/calendar"))
+             end)
     end
 
     test "does not fire on duplicate RSVP" do
@@ -96,7 +94,7 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
             group_id: group.id,
             creator_id: owner.id,
             actor: owner,
-            max_attendees: 1
+            max_attendees: 2
           )
         )
 
@@ -211,29 +209,18 @@ defmodule Huddlz.Notifications.RsvpNotificationsTest do
       end)
     end
 
-    test "does not fire when the actor is the only owner/organizer (recipient set is empty)" do
+    test "automatic creator attendance does not fire RSVP notifications" do
       owner = generate(user(role: :user))
 
       group =
         generate(group(name: "Solo Group", is_public: true, owner_id: owner.id, actor: owner))
 
-      huddl =
-        generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
-
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
 
-      huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: owner)
-      |> Ash.update!()
+      generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
 
-      # Only E3 to the owner. No E1 since owner is the actor.
-      assert %{failure: 0} = Oban.drain_queue(queue: :notifications)
-
-      assert_email_sent(fn email ->
-        email.subject == "You're going to #{huddl.title}" and
-          email.to == [{"", to_string(owner.email)}]
-      end)
+      refute_enqueued(worker: DeliverWorker)
     end
   end
 

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -124,9 +124,6 @@ defmodule HuddlzWeb.CalendarLiveTest do
           date: tomorrow()
         )
 
-      filler = generate(user(role: :user))
-      rsvp!(huddl, filler, :rsvp)
-
       huddl = Ash.reload!(huddl)
       rsvp!(huddl, attendee, :join_waitlist)
 

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -164,6 +164,27 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> assert_has(".cal-pill", text: "I Am Hosting")
     end
 
+    test "creator RSVP does not duplicate the huddl or month count", %{
+      conn: conn,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Hosted and Going", date: tomorrow())
+      rsvp!(huddl, host, :rsvp)
+
+      session =
+        conn
+        |> login(host)
+        |> visit(calendar_path_for(tomorrow()))
+        |> assert_has(".cal-month-count", text: "1 huddl")
+
+      assert session.view
+             |> Phoenix.LiveViewTest.render()
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query(".cal-pill")
+             |> Enum.count() == 1
+    end
+
     test "does not leak another user's RSVP'd huddl", %{
       conn: conn,
       attendee: attendee,

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -316,7 +316,7 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       conn
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
-      |> assert_has("*", text: "0/5 spots filled")
+      |> assert_has("*", text: "1/5 spots filled")
     end
 
     test "creates private huddl for private group", %{conn: conn, owner: owner} do

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -91,7 +91,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has(".facts .label", text: "When")
       |> assert_has(".facts .label", text: "Virtual access")
       |> assert_has(".facts .label", text: "Capacity")
-      |> assert_has(".facts .value", text: "Be the first to RSVP!")
+      |> assert_has(".facts .value", text: "1 person attending")
     end
 
     test "renders rich link preview metadata", %{conn: conn, group: group, huddl: huddl} do
@@ -183,8 +183,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       # Check UI updates after RSVP
       |> assert_has(".rsvp-banner.cyan", text: "You're attending")
       |> refute_has("button", text: "RSVP to this huddl")
-      # Should show 1 person attending
-      |> assert_has(".facts .value", text: "1 person attending")
+      # The creator and member are both attending.
+      |> assert_has(".facts .value", text: "2 people attending")
     end
 
     test "shows virtual link after RSVP", %{
@@ -218,7 +218,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       # Should already show as attending
       |> assert_has(".rsvp-banner.cyan", text: "You're attending")
       |> refute_has("button", text: "RSVP to this huddl")
-      |> assert_has(".facts .value", text: "1 person attending")
+      |> assert_has(".facts .value", text: "2 people attending")
     end
 
     test "shows correct attendee count with multiple RSVPs", %{
@@ -330,7 +330,12 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has("a", text: "Sign in to RSVP")
     end
 
-    test "handles different event types correctly", %{conn: conn, owner: owner, group: group} do
+    test "handles different huddl types correctly", %{
+      conn: conn,
+      owner: owner,
+      non_member: non_member,
+      group: group
+    } do
       # Create in-person huddl
       in_person_huddl =
         Huddl
@@ -352,7 +357,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
         |> Ash.create!()
 
       conn
-      |> login(owner)
+      |> login(non_member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{in_person_huddl.id}")
       |> assert_has(".facts .value", text: "123 Main St, City")
       |> refute_has(".facts .label", text: "Virtual access")
@@ -379,7 +384,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
         |> Ash.create!()
 
       conn
-      |> login(owner)
+      |> login(non_member)
       |> visit(~p"/groups/#{group.slug}/huddlz/#{hybrid_huddl.id}")
       |> assert_has(".facts .value", text: "Conference Room A")
       |> assert_has(".facts .label", text: "Virtual access")
@@ -516,8 +521,8 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has("button", text: "RSVP to this huddl")
       |> refute_has(".rsvp-banner.cyan", text: "You're attending")
       |> refute_has("button", text: "Cancel RSVP")
-      # Should show 0 people attending
-      |> assert_has(".facts .value", text: "Be the first to RSVP!")
+      # The creator remains attending.
+      |> assert_has(".facts .value", text: "1 person attending")
     end
 
     test "cancel_rsvp updates attendee count correctly", %{
@@ -567,7 +572,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> click_button("RSVP to this huddl")
       # Check UI updates after second RSVP
       |> assert_has(".rsvp-banner.cyan", text: "You're attending")
-      |> assert_has(".facts .value", text: "1 person attending")
+      |> assert_has(".facts .value", text: "2 people attending")
     end
 
     test "rendering type and status correctly", %{conn: conn, owner: owner, group: group} do

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -112,7 +112,7 @@ defmodule HuddlzWeb.HuddlSearchTest do
       conn
       |> visit("/discover")
       |> assert_has("h3", text: "Capped Huddl")
-      |> assert_has(".card-meta span", text: "0 / 5 RSVPs")
+      |> assert_has(".card-meta span", text: "1 / 5 RSVPs")
     end
 
     test "renders RSVP-out-of-capacity meta for limited huddlz with at least one RSVP", %{

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -123,6 +123,36 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> visit("/my-huddlz")
       |> assert_has(".filters .chip", text: "Upcoming · 1")
     end
+
+    test "shows a creator's huddl only after they RSVP and removes it after cancellation", %{
+      conn: conn,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Creator RSVP")
+
+      conn
+      |> login(host)
+      |> visit("/my-huddlz")
+      |> refute_has("h3.card-title", text: "Creator RSVP")
+      |> assert_has(".filters .chip", text: "Upcoming · 0")
+
+      rsvp!(huddl, host, :rsvp)
+
+      conn
+      |> login(host)
+      |> visit("/my-huddlz")
+      |> assert_has("h3.card-title", text: "Creator RSVP")
+      |> assert_has(".filters .chip", text: "Upcoming · 1")
+
+      rsvp!(Ash.reload!(huddl), host, :cancel_rsvp)
+
+      conn
+      |> login(host)
+      |> visit("/my-huddlz")
+      |> refute_has("h3.card-title", text: "Creator RSVP")
+      |> assert_has(".filters .chip", text: "Upcoming · 0")
+    end
   end
 
   describe "Waitlisted filter" do
@@ -189,6 +219,22 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(attendee)
       |> visit("/my-huddlz?filter=past")
       |> assert_has("p", text: "No past attendance yet.")
+    end
+
+    test "places a creator's RSVP in Past after the huddl ends", %{
+      conn: conn,
+      host: host,
+      public_group: public_group
+    } do
+      past = create_past_huddl(host, public_group, title: "Creator Attended")
+      rsvp!(past, host, :rsvp)
+
+      conn
+      |> login(host)
+      |> visit("/my-huddlz?filter=past")
+      |> assert_has("h3.card-title", text: "Creator Attended")
+      |> assert_has(".filters .chip", text: "Past · 1")
+      |> assert_has(".pill", text: "Attended")
     end
   end
 

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -124,20 +124,12 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> assert_has(".filters .chip", text: "Upcoming · 1")
     end
 
-    test "shows a creator's huddl only after they RSVP and removes it after cancellation", %{
+    test "shows a creator's huddl automatically and removes it after cancellation", %{
       conn: conn,
       host: host,
       public_group: public_group
     } do
       huddl = create_huddl(host, public_group, title: "Creator RSVP")
-
-      conn
-      |> login(host)
-      |> visit("/my-huddlz")
-      |> refute_has("h3.card-title", text: "Creator RSVP")
-      |> assert_has(".filters .chip", text: "Upcoming · 0")
-
-      rsvp!(huddl, host, :rsvp)
 
       conn
       |> login(host)
@@ -160,7 +152,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       huddl =
         create_huddl(ctx.host, ctx.public_group,
           title: "Sold Out Show",
-          max_attendees: 1
+          max_attendees: 2
         )
 
       # First attendee fills the seat


### PR DESCRIPTION
## Summary

- automatically add each huddl creator as a confirmed attendee
- count the creator toward capacity while allowing them to cancel attendance without changing ownership
- keep creator attendance visible once in My huddlz and the calendar
- avoid RSVP-received and RSVP-confirmation notifications for automatic attendance
- add a tagged Cucumber scenario for creation, My huddlz placement, and cancellation

## Verification

- `mix test --only creator_attendance` (1 passed)
- focused resource, My huddlz, calendar, and notification tests (223 passed)
- `mix compile --warnings-as-errors`
- `mix test` (1,376 passed: 1 doctest, 1,375 tests)
- `mix precommit` (1,376 passed; Credo found no issues)
- Standards review: one terminology finding fixed
- Spec review: no actionable findings

Closes #267