### PR TITLE
fix(huddl): complete recurring occurrence generation

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -133,12 +133,14 @@ defmodule Huddlz.Communities.Huddl do
 
       argument :provided_latitude, :float, allow_nil?: true, public?: false
       argument :provided_longitude, :float, allow_nil?: true, public?: false
+      argument :pending_image_id, :uuid, allow_nil?: true, public?: false
 
       validate Huddlz.Communities.Huddl.Validations.FutureDateValidation
       change Huddlz.Communities.Huddl.Changes.SetCreatorToActor
       change Huddlz.Communities.Huddl.Changes.AddCreatorAsAttendee
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
+      change Huddlz.Communities.Huddl.Changes.AssignPendingImage
       change Huddlz.Communities.Huddl.Changes.AddHuddlTemplate
       change Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFields
       change Huddlz.Geocoding.ApplyProvidedCoordinates

--- a/lib/huddlz/communities/huddl/changes/assign_pending_image.ex
+++ b/lib/huddlz/communities/huddl/changes/assign_pending_image.ex
@@ -1,0 +1,43 @@
+defmodule Huddlz.Communities.Huddl.Changes.AssignPendingImage do
+  @moduledoc """
+  Assigns an eagerly uploaded pending image inside the huddl create transaction.
+
+  Recurring-series generation is enqueued by a later after-action hook, so this
+  guarantees the worker can observe and copy the source huddl's cover image.
+  """
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Communities
+  alias Huddlz.Communities.HuddlImage
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, &assign_pending_image/2)
+  end
+
+  defp assign_pending_image(changeset, huddl) do
+    case Ash.Changeset.get_argument(changeset, :pending_image_id) do
+      nil ->
+        {:ok, huddl}
+
+      image_id ->
+        with {:ok, %HuddlImage{} = image} <-
+               Communities.get_huddl_image_by_id(image_id, authorize?: false),
+             {:ok, _image} <-
+               Communities.assign_huddl_image_to_huddl(
+                 image,
+                 huddl.id,
+                 authorize?: false
+               ) do
+          {:ok, huddl}
+        else
+          {:ok, nil} ->
+            {:error, ArgumentError.exception("pending huddl image not found")}
+
+          {:error, error} ->
+            {:error, error}
+        end
+    end
+  end
+end

--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -13,7 +13,10 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
       destroys dates that fall off the schedule.
   """
 
+  alias Huddlz.Communities
   alias Huddlz.Communities.Huddl
+  alias Huddlz.Communities.HuddlImage
+  alias Huddlz.Storage.HuddlImages
 
   @max_instances 104
 
@@ -23,8 +26,10 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     :title,
     :description,
     :physical_location,
+    :virtual_link,
     :is_private,
-    :thumbnail_url
+    :thumbnail_url,
+    :max_attendees
   ]
 
   @doc """
@@ -34,7 +39,7 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
   cascade-deletes RSVPs. "Edit all" uses `reconcile_future_instances/3` instead.
   """
   def regenerate_series(source, template) do
-    source |> future_instances() |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+    source |> future_instances() |> Enum.each(&destroy_instance!(&1))
     generate_huddlz_from_template(template, source)
     :ok
   end
@@ -74,7 +79,7 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     # Cancel dates the series lost.
     existing
     |> Enum.drop(length(desired))
-    |> Enum.each(&Ash.destroy!(&1, actor: actor, authorize?: false))
+    |> Enum.each(&destroy_instance!(&1, actor))
 
     :ok
   end
@@ -136,19 +141,70 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
   end
 
   defp create_instance!(source, template, starts_at, ends_at) do
-    Huddl
-    |> Ash.Changeset.new()
-    # Reuse the source's already-resolved coordinates so the instance skips
-    # geocoding (ApplyProvidedCoordinates short-circuits GeocodeChange). Private
-    # args, so set before for_create; nil is ignored, so virtual huddlz work.
-    |> Ash.Changeset.set_argument(:provided_latitude, source.latitude)
-    |> Ash.Changeset.set_argument(:provided_longitude, source.longitude)
-    |> Ash.Changeset.for_create(:create, instance_attrs(source, starts_at, ends_at, template))
-    # creator_id is not an accepted input — the :create action derives it from
-    # the actor. This actorless generation sets it directly so each instance
-    # inherits the source's creator (SetCreatorToActor no-ops without an actor).
-    |> Ash.Changeset.force_change_attribute(:creator_id, source.creator_id)
-    |> Ash.create!(authorize?: false)
+    instance =
+      Huddl
+      |> Ash.Changeset.new()
+      # Reuse the source's already-resolved coordinates so the instance skips
+      # geocoding (ApplyProvidedCoordinates short-circuits GeocodeChange). Private
+      # args, so set before for_create; nil is ignored, so virtual huddlz work.
+      |> Ash.Changeset.set_argument(:provided_latitude, source.latitude)
+      |> Ash.Changeset.set_argument(:provided_longitude, source.longitude)
+      |> Ash.Changeset.for_create(:create, instance_attrs(source, starts_at, ends_at, template))
+      # creator_id is not an accepted input — the :create action derives it from
+      # the actor. This actorless generation sets it directly so each instance
+      # inherits the source's creator (SetCreatorToActor no-ops without an actor).
+      |> Ash.Changeset.force_change_attribute(:creator_id, source.creator_id)
+      |> Ash.create!(authorize?: false)
+
+    copy_current_image!(source, instance)
+    instance
+  end
+
+  defp copy_current_image!(source, instance) do
+    case Communities.list_huddl_images(source.id, authorize?: false) do
+      {:ok, []} ->
+        :ok
+
+      {:ok, [image | _]} ->
+        attrs = duplicate_image!(image, instance.id)
+
+        HuddlImage
+        |> Ash.Changeset.for_create(:create, Map.put(attrs, :huddl_id, instance.id))
+        |> Ash.create(authorize?: false)
+        |> case do
+          {:ok, _image} ->
+            :ok
+
+          {:error, error} ->
+            HuddlImages.delete(attrs.storage_path)
+            HuddlImages.delete(attrs.thumbnail_path)
+            raise error
+        end
+
+      {:error, error} ->
+        raise error
+    end
+  end
+
+  defp duplicate_image!(image, instance_id) do
+    case HuddlImages.duplicate(image, instance_id) do
+      {:ok, attrs} -> attrs
+      {:error, reason} -> raise "failed to copy recurring huddl image: #{inspect(reason)}"
+    end
+  end
+
+  defp destroy_instance!(instance, actor \\ nil) do
+    instance.id
+    |> Communities.list_huddl_images(authorize?: false)
+    |> then(fn
+      {:ok, images} ->
+        Enum.each(images, &Ash.destroy!(&1, action: :hard_delete, authorize?: false))
+
+      {:error, error} ->
+        raise error
+    end)
+
+    Ash.destroy!(instance, actor: actor, authorize?: false)
   end
 
   # Updates a kept instance in place via the :update action with

--- a/lib/huddlz/communities/workers/regenerate_recurring_series.ex
+++ b/lib/huddlz/communities/workers/regenerate_recurring_series.ex
@@ -10,9 +10,12 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeries do
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.Huddl.RecurrenceHelper
   alias Huddlz.Communities.HuddlTemplate
+  alias Huddlz.Notifications
+
+  require Logger
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"huddl_id" => huddl_id}}) do
+  def perform(%Oban.Job{args: %{"huddl_id" => huddl_id}} = job) do
     huddl =
       Huddl
       |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
@@ -30,5 +33,55 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeries do
     end
 
     :ok
+  rescue
+    exception ->
+      notify_organizer_after_final_failure(job, huddl_id)
+      reraise exception, __STACKTRACE__
+  end
+
+  defp notify_organizer_after_final_failure(
+         %Oban.Job{attempt: attempt, max_attempts: max_attempts},
+         huddl_id
+       )
+       when attempt >= max_attempts do
+    with {:ok, %Huddl{} = huddl} <- get_huddl_for_failure_notification(huddl_id),
+         {:ok, _job} <-
+           Notifications.deliver(
+             huddl.creator,
+             :recurring_huddl_generation_failed,
+             failure_payload(huddl)
+           ) do
+      :ok
+    else
+      reason ->
+        Logger.error(
+          "Failed to notify organizer about recurring huddl generation failure for " <>
+            "#{huddl_id}: #{inspect(reason)}"
+        )
+    end
+  rescue
+    notification_exception ->
+      Logger.error(
+        "Failed to notify organizer about recurring huddl generation failure for " <>
+          "#{huddl_id}: #{Exception.message(notification_exception)}"
+      )
+  end
+
+  defp notify_organizer_after_final_failure(_job, _huddl_id), do: :ok
+
+  defp get_huddl_for_failure_notification(huddl_id) do
+    Huddl
+    |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
+    |> Ash.Query.load([:creator, :group])
+    |> Ash.read_one(authorize?: false)
+  end
+
+  defp failure_payload(huddl) do
+    %{
+      "huddl_id" => huddl.id,
+      "huddl_title" => huddl.title,
+      "group_name" => huddl.group.name,
+      "group_slug" => huddl.group.slug
+    }
   end
 end

--- a/lib/huddlz/notifications/senders/recurring_huddl_generation_failed.ex
+++ b/lib/huddlz/notifications/senders/recurring_huddl_generation_failed.ex
@@ -1,0 +1,54 @@
+defmodule Huddlz.Notifications.Senders.RecurringHuddlGenerationFailed do
+  @moduledoc """
+  Tells an organizer when all attempts to generate a recurring huddl series fail.
+
+  This notification is transactional because the organizer must know that the
+  future dates they requested were not created.
+  """
+
+  @behaviour Huddlz.Notifications.Sender
+
+  import Swoosh.Email
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.Senders.HeaderSafe
+  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Senders.Urls
+
+  @impl true
+  def build(user, payload) do
+    safe_name = HtmlEscape.escape(user.display_name)
+    safe_title = HtmlEscape.escape(huddl_title(payload))
+    safe_group = HtmlEscape.escape(group_name(payload))
+    huddl_url = Urls.huddl_url(payload)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(user.email))
+    |> subject(HeaderSafe.safe("Recurring dates need attention: #{huddl_title(payload)}"))
+    |> html_body("""
+    <p>Hi #{safe_name},</p>
+
+    <p>We couldn't generate all recurring dates for
+    <strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>.</p>
+
+    <p>The original huddl is still available. Review it at
+    <a href="#{huddl_url}">#{huddl_url}</a>, then save the series again to retry.</p>
+    """)
+    |> text_body("""
+    Hi #{user.display_name},
+
+    We couldn't generate all recurring dates for "#{huddl_title(payload)}" in
+    "#{group_name(payload)}".
+
+    The original huddl is still available. Review it at #{huddl_url}, then save
+    the series again to retry.
+    """)
+  end
+
+  defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title
+  defp huddl_title(_), do: "your recurring huddl"
+
+  defp group_name(%{"group_name" => name}) when is_binary(name), do: name
+  defp group_name(_), do: "your group"
+end

--- a/lib/huddlz/notifications/summary.ex
+++ b/lib/huddlz/notifications/summary.ex
@@ -62,6 +62,9 @@ defmodule Huddlz.Notifications.Summary do
   defp title(:huddl_series_updated, %{"huddl_title" => huddl}),
     do: "Series updated: #{huddl}"
 
+  defp title(:recurring_huddl_generation_failed, %{"huddl_title" => huddl}),
+    do: "Recurring dates need attention: #{huddl}"
+
   # Reminders
   defp title(:huddl_reminder_24h, %{"huddl_title" => huddl}),
     do: "Reminder: #{huddl} (24h)"

--- a/lib/huddlz/notifications/triggers.ex
+++ b/lib/huddlz/notifications/triggers.ex
@@ -102,6 +102,12 @@ defmodule Huddlz.Notifications.Triggers do
       default: true,
       label: "A recurring huddl series I'm in was updated"
     },
+    recurring_huddl_generation_failed: %{
+      category: :transactional,
+      sender: Senders.RecurringHuddlGenerationFailed,
+      default: true,
+      label: "Recurring huddl dates need attention"
+    },
 
     # D — Huddl reminders
     huddl_reminder_24h: %{

--- a/lib/huddlz/storage.ex
+++ b/lib/huddlz/storage.ex
@@ -13,6 +13,9 @@ defmodule Huddlz.Storage do
   @doc "Store a file from source_path to storage_path and return the storage path"
   @callback put(source_path, storage_path, content_type) :: {:ok, storage_path} | {:error, term()}
 
+  @doc "Copy a stored file to a new storage path"
+  @callback copy(path, path, content_type) :: {:ok, path} | {:error, term()}
+
   @doc "Delete a file by its storage path"
   @callback delete(path) :: :ok | {:error, term()}
 
@@ -29,6 +32,13 @@ defmodule Huddlz.Storage do
   """
   def put(source_path, storage_path, content_type) do
     @adapter.put(source_path, storage_path, content_type)
+  end
+
+  @doc """
+  Copy an existing stored file to a new storage path.
+  """
+  def copy(source_path, destination_path, content_type) do
+    @adapter.copy(source_path, destination_path, content_type)
   end
 
   @doc """

--- a/lib/huddlz/storage/huddl_images.ex
+++ b/lib/huddlz/storage/huddl_images.ex
@@ -75,6 +75,34 @@ defmodule Huddlz.Storage.HuddlImages do
     end
   end
 
+  @doc """
+  Copy a stored huddl image and its thumbnail to paths owned by another huddl.
+
+  Returns metadata suitable for creating a `HuddlImage` record. If either copy
+  fails, any destination file already written is removed.
+  """
+  def duplicate(image, huddl_id) do
+    storage_path = generate_path(huddl_id, image.filename)
+    thumbnail_path = duplicate_thumbnail_path(image, storage_path)
+
+    with {:ok, _path} <- Storage.copy(image.storage_path, storage_path, image.content_type),
+         :ok <- duplicate_thumbnail(image.thumbnail_path, thumbnail_path) do
+      {:ok,
+       %{
+         filename: image.filename,
+         content_type: image.content_type,
+         size_bytes: image.size_bytes,
+         storage_path: storage_path,
+         thumbnail_path: thumbnail_path
+       }}
+    else
+      {:error, reason} ->
+        delete(storage_path)
+        delete(thumbnail_path)
+        {:error, reason}
+    end
+  end
+
   defp store_thumbnail(binary, path) do
     # Write thumbnail to a temp file, then store it
     temp_path = Path.join(System.tmp_dir!(), "thumb_#{:erlang.unique_integer([:positive])}.jpg")
@@ -132,6 +160,19 @@ defmodule Huddlz.Storage.HuddlImages do
   """
   def generate_thumbnail_path(original_path) do
     String.replace(original_path, ~r/\.\w+$/, "_thumb.jpg")
+  end
+
+  defp duplicate_thumbnail_path(thumbnail_path, storage_path) do
+    if thumbnail_path, do: generate_thumbnail_path(storage_path)
+  end
+
+  defp duplicate_thumbnail(nil, nil), do: :ok
+
+  defp duplicate_thumbnail(source_path, destination_path) do
+    case Storage.copy(source_path, destination_path, "image/jpeg") do
+      {:ok, _path} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """

--- a/lib/huddlz/storage/local.ex
+++ b/lib/huddlz/storage/local.ex
@@ -22,6 +22,19 @@ defmodule Huddlz.Storage.Local do
   end
 
   @impl true
+  def copy(source_path, destination_path, _content_type) do
+    source_full_path = full_path(source_path)
+    destination_full_path = full_path(destination_path)
+
+    destination_full_path |> Path.dirname() |> File.mkdir_p!()
+
+    case File.cp(source_full_path, destination_full_path) do
+      :ok -> {:ok, destination_path}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
   def delete(storage_path) do
     full_path = full_path(storage_path)
 

--- a/lib/huddlz/storage/s3.ex
+++ b/lib/huddlz/storage/s3.ex
@@ -34,6 +34,41 @@ defmodule Huddlz.Storage.S3 do
   end
 
   @impl true
+  def copy(source_path, destination_path, content_type) do
+    bucket = bucket_name()
+    source_key = normalize_key(source_path)
+    destination_key = normalize_key(destination_path)
+    req = Req.new() |> ReqS3.attach()
+
+    with {:ok, %{status: get_status, body: content}} when get_status in 200..299 <-
+           Req.get(req, url: "s3://#{bucket}/#{source_key}"),
+         {:ok, %{status: put_status}} when put_status in 200..299 <-
+           Req.put(req,
+             url: "s3://#{bucket}/#{destination_key}",
+             body: content,
+             headers: [{"content-type", content_type}]
+           ) do
+      {:ok, destination_path}
+    else
+      {:ok, %{status: status, body: body}} ->
+        Logger.error(
+          "S3 copy failed: status=#{status} source=#{source_key} " <>
+            "destination=#{destination_key} body=#{inspect(body)}"
+        )
+
+        {:error, "Storage copy failed"}
+
+      {:error, reason} ->
+        Logger.error(
+          "S3 copy error: source=#{source_key} destination=#{destination_key} " <>
+            "reason=#{inspect(reason)}"
+        )
+
+        {:error, "Storage copy failed"}
+    end
+  end
+
+  @impl true
   def delete(path) do
     bucket = bucket_name()
     key = normalize_key(path)

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -515,11 +515,13 @@ defmodule HuddlzWeb.HuddlLive.New do
     case AshPhoenix.Form.submit(socket.assigns.form,
            params: params,
            actor: socket.assigns.current_user,
-           before_submit: prepare_source_with_coordinates(socket.assigns[:selected_location])
+           before_submit:
+             prepare_source_for_submit(
+               socket.assigns[:selected_location],
+               socket.assigns[:pending_image_id]
+             )
          ) do
       {:ok, huddl} ->
-        assign_pending_image_to_huddl(socket, huddl)
-
         {:noreply,
          socket
          |> put_flash(:info, "Huddl created successfully!")
@@ -589,19 +591,20 @@ defmodule HuddlzWeb.HuddlLive.New do
     {:noreply, ModalLocationHelpers.clear(socket)}
   end
 
-  defp assign_pending_image_to_huddl(socket, huddl) do
-    case socket.assigns[:pending_image_id] do
-      nil ->
-        :ok
+  defp prepare_source_for_submit(location, pending_image_id) do
+    coordinate_preparer = prepare_source_with_coordinates(location)
 
-      image_id ->
-        with {:ok, image} <- Communities.get_huddl_image_by_id(image_id) do
-          Communities.assign_huddl_image_to_huddl(image, huddl.id,
-            actor: socket.assigns.current_user
-          )
-        end
+    fn changeset ->
+      changeset
+      |> coordinate_preparer.()
+      |> maybe_set_pending_image(pending_image_id)
     end
   end
+
+  defp maybe_set_pending_image(changeset, nil), do: changeset
+
+  defp maybe_set_pending_image(changeset, pending_image_id),
+    do: Ash.Changeset.set_argument(changeset, :pending_image_id, pending_image_id)
 
   defp get_group_by_slug(slug, actor) do
     case Huddlz.Communities.get_by_slug(slug, actor: actor, load: [:owner]) do

--- a/test/features/recurring_huddl_generation.feature
+++ b/test/features/recurring_huddl_generation.feature
@@ -1,0 +1,32 @@
+@async @database
+Feature: Reliable recurring huddl generation
+  As a group organizer
+  I want every recurring occurrence to retain the series details
+  So that attendees can rely on every scheduled date
+
+  Scenario: Weekly virtual huddlz retain the full recurrence contract
+    Given a weekly recurring virtual huddl with a cover image
+    When its recurring occurrences are generated
+    Then two future occurrences should exist
+    And every occurrence should retain the virtual huddl details and cover image
+
+  Scenario: Weekly hybrid huddlz retain both locations
+    Given a weekly recurring hybrid huddl
+    When its recurring occurrences are generated
+    Then two future occurrences should exist
+    And every occurrence should retain both hybrid locations
+
+  Scenario: Capacity limits apply to every recurring occurrence
+    Given a weekly recurring huddl with a capacity of 3
+    When its recurring occurrences are generated
+    Then every occurrence should have a capacity of 3
+
+  Scenario: Retrying recurring generation does not duplicate occurrences
+    Given a weekly recurring huddl
+    When its recurring occurrences are generated twice
+    Then two future occurrences should exist
+
+  Scenario: The organizer learns when generation ultimately fails
+    Given a weekly recurring virtual huddl that cannot generate future occurrences
+    When its final recurring generation attempt runs
+    Then the organizer should receive a recurring generation failure notification

--- a/test/features/step_definitions/recurring_huddl_generation_steps.exs
+++ b/test/features/step_definitions/recurring_huddl_generation_steps.exs
@@ -1,0 +1,202 @@
+defmodule RecurringHuddlGenerationSteps do
+  use Cucumber.StepDefinition
+
+  import Ecto.Query
+  import ExUnit.Assertions
+  import Huddlz.Generator
+
+  alias Huddlz.Communities
+  alias Huddlz.Communities.Huddl
+  alias Huddlz.Communities.HuddlImage
+  alias Huddlz.Communities.Workers.RegenerateRecurringSeries
+  alias Huddlz.Notifications
+  alias Huddlz.Storage
+
+  step "a weekly recurring virtual huddl with a cover image", context do
+    context
+    |> create_recurring_huddl(
+      event_type: :virtual,
+      physical_location: nil,
+      virtual_link: "https://meet.example.com/weekly",
+      is_private: true,
+      max_attendees: 24
+    )
+    |> attach_cover_image()
+  end
+
+  step "a weekly recurring hybrid huddl", context do
+    create_recurring_huddl(context,
+      event_type: :hybrid,
+      physical_location: "456 Congress Ave",
+      virtual_link: "https://meet.example.com/hybrid"
+    )
+  end
+
+  step "a weekly recurring huddl with a capacity of {int}",
+       %{args: [capacity]} = context do
+    create_recurring_huddl(context, max_attendees: capacity)
+  end
+
+  step "a weekly recurring huddl", context do
+    create_recurring_huddl(context)
+  end
+
+  step "a weekly recurring virtual huddl that cannot generate future occurrences", context do
+    context =
+      create_recurring_huddl(context,
+        event_type: :virtual,
+        physical_location: nil,
+        virtual_link: "https://meet.example.com/failure"
+      )
+
+    Huddlz.Repo.update_all(
+      from(h in "huddlz", where: h.id == type(^context.huddl.id, Ecto.UUID)),
+      set: [virtual_link: nil]
+    )
+
+    context
+  end
+
+  step "its recurring occurrences are generated", context do
+    assert :ok = perform_job(context.huddl)
+    context
+  end
+
+  step "its recurring occurrences are generated twice", context do
+    assert :ok = perform_job(context.huddl)
+    assert :ok = perform_job(context.huddl)
+    context
+  end
+
+  step "its final recurring generation attempt runs", context do
+    job = %Oban.Job{
+      args: %{"huddl_id" => context.huddl.id},
+      attempt: 3,
+      max_attempts: 3
+    }
+
+    assert_raise Ash.Error.Invalid, fn ->
+      RegenerateRecurringSeries.perform(job)
+    end
+
+    context
+  end
+
+  step "two future occurrences should exist", context do
+    assert length(future_occurrences(context.huddl)) == 2
+    context
+  end
+
+  step "every occurrence should retain the virtual huddl details and cover image", context do
+    for occurrence <- future_occurrences(context.huddl) do
+      assert occurrence.virtual_link == "https://meet.example.com/weekly"
+      assert occurrence.max_attendees == 24
+      assert occurrence.is_private
+      assert occurrence.creator_id == context.owner.id
+      assert occurrence.group_id == context.group.id
+
+      assert {:ok, image} =
+               Communities.get_current_huddl_image(occurrence.id, authorize?: false)
+
+      assert image.filename == "recurrence.jpg"
+      assert Storage.exists?(image.storage_path)
+      assert Storage.exists?(image.thumbnail_path)
+    end
+
+    context
+  end
+
+  step "every occurrence should retain both hybrid locations", context do
+    for occurrence <- future_occurrences(context.huddl) do
+      assert occurrence.physical_location == "456 Congress Ave"
+      assert occurrence.virtual_link == "https://meet.example.com/hybrid"
+    end
+
+    context
+  end
+
+  step "every occurrence should have a capacity of {int}",
+       %{args: [capacity]} = context do
+    assert Enum.all?(future_occurrences(context.huddl), &(&1.max_attendees == capacity))
+    context
+  end
+
+  step "the organizer should receive a recurring generation failure notification", context do
+    assert {:ok, %{results: notifications}} =
+             Notifications.list_for_user(actor: context.owner, page: [limit: 10])
+
+    assert Enum.any?(
+             notifications,
+             &(&1.trigger == "recurring_huddl_generation_failed")
+           )
+
+    context
+  end
+
+  defp create_recurring_huddl(context, opts \\ []) do
+    owner = generate(user(role: :user))
+    group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+    huddl =
+      generate(
+        huddl(
+          Keyword.merge(
+            [
+              title: "Recurring",
+              group_id: group.id,
+              creator_id: owner.id,
+              actor: owner,
+              physical_location: "123 Main St",
+              date: Date.add(Date.utc_today(), 1),
+              is_recurring: true,
+              frequency: "weekly",
+              repeat_until: Date.add(Date.utc_today(), 22)
+            ],
+            opts
+          )
+        )
+      )
+
+    Map.merge(context, %{owner: owner, group: group, huddl: huddl})
+  end
+
+  defp attach_cover_image(context) do
+    source_file = "test/fixtures/test_image.jpg"
+    storage_path = "/uploads/huddl_images/#{context.huddl.id}/recurrence.jpg"
+    thumbnail_path = "/uploads/huddl_images/#{context.huddl.id}/recurrence_thumb.jpg"
+
+    assert {:ok, ^storage_path} = Storage.put(source_file, storage_path, "image/jpeg")
+    assert {:ok, ^thumbnail_path} = Storage.put(source_file, thumbnail_path, "image/jpeg")
+
+    assert {:ok, _image} =
+             HuddlImage
+             |> Ash.Changeset.for_create(:create, %{
+               filename: "recurrence.jpg",
+               content_type: "image/jpeg",
+               size_bytes: File.stat!(source_file).size,
+               storage_path: storage_path,
+               thumbnail_path: thumbnail_path,
+               huddl_id: context.huddl.id
+             })
+             |> Ash.create(authorize?: false)
+
+    context
+  end
+
+  defp perform_job(huddl) do
+    RegenerateRecurringSeries.perform(%Oban.Job{
+      args: %{"huddl_id" => huddl.id},
+      attempt: 1,
+      max_attempts: 3
+    })
+  end
+
+  defp future_occurrences(huddl) do
+    Huddl
+    |> Ash.Query.for_read(:siblings_in_series, %{
+      huddl_template_id: huddl.huddl_template_id,
+      starting_after: huddl.starts_at
+    })
+    |> Ash.read!(authorize?: false)
+  end
+end

--- a/test/huddlz/communities/workers/regenerate_recurring_series_test.exs
+++ b/test/huddlz/communities/workers/regenerate_recurring_series_test.exs
@@ -2,8 +2,13 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
   use Huddlz.DataCase, async: true
   use Oban.Testing, repo: Huddlz.Repo
 
+  import Ecto.Query
+
+  alias Huddlz.Communities
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.Workers.RegenerateRecurringSeries
+  alias Huddlz.Notifications
+  alias Huddlz.Storage
 
   # Creates a recurring huddl through the :create action. Pins the start to
   # "tomorrow" so the weekly cadence is deterministic: with repeat_until 22 days
@@ -45,6 +50,29 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
     |> Ash.read!(authorize?: false)
   end
 
+  defp attach_cover_image(huddl, _owner) do
+    source_file = "test/fixtures/test_image.jpg"
+    storage_path = "/uploads/huddl_images/#{huddl.id}/recurrence.jpg"
+    thumbnail_path = "/uploads/huddl_images/#{huddl.id}/recurrence_thumb.jpg"
+
+    assert {:ok, ^storage_path} = Storage.put(source_file, storage_path, "image/jpeg")
+    assert {:ok, ^thumbnail_path} = Storage.put(source_file, thumbnail_path, "image/jpeg")
+
+    assert {:ok, image} =
+             Huddlz.Communities.HuddlImage
+             |> Ash.Changeset.for_create(:create, %{
+               filename: "recurrence.jpg",
+               content_type: "image/jpeg",
+               size_bytes: File.stat!(source_file).size,
+               storage_path: storage_path,
+               thumbnail_path: thumbnail_path,
+               huddl_id: huddl.id
+             })
+             |> Ash.create(authorize?: false)
+
+    image
+  end
+
   test "creating a recurring huddl links the template inline and enqueues generation" do
     %{huddl: huddl} = create_recurring()
 
@@ -56,6 +84,66 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
     assert_enqueued(worker: RegenerateRecurringSeries, args: %{huddl_id: huddl.id})
   end
 
+  test "the create transaction assigns a pending cover image before generation is enqueued" do
+    owner = generate(user(role: :user))
+    group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+    source_file = "test/fixtures/test_image.jpg"
+    storage_path = "/uploads/huddl_images/pending/#{Ecto.UUID.generate()}.jpg"
+    thumbnail_path = "/uploads/huddl_images/pending/#{Ecto.UUID.generate()}_thumb.jpg"
+
+    assert {:ok, ^storage_path} = Storage.put(source_file, storage_path, "image/jpeg")
+    assert {:ok, ^thumbnail_path} = Storage.put(source_file, thumbnail_path, "image/jpeg")
+
+    assert {:ok, pending_image} =
+             Communities.create_pending_huddl_image(
+               group.id,
+               %{
+                 filename: "pending.jpg",
+                 content_type: "image/jpeg",
+                 size_bytes: File.stat!(source_file).size,
+                 storage_path: storage_path,
+                 thumbnail_path: thumbnail_path
+               },
+               actor: owner
+             )
+
+    huddl =
+      Huddl
+      |> Ash.Changeset.new()
+      |> Ash.Changeset.set_argument(:pending_image_id, pending_image.id)
+      |> Ash.Changeset.for_create(
+        :create,
+        %{
+          title: "Recurring with image",
+          description: "Test",
+          date: Date.add(Date.utc_today(), 1),
+          start_time: ~T[14:00:00],
+          duration_minutes: 60,
+          event_type: :virtual,
+          virtual_link: "https://meet.example.com/ordered",
+          group_id: group.id,
+          is_recurring: true,
+          frequency: "weekly",
+          repeat_until: Date.add(Date.utc_today(), 22)
+        },
+        actor: owner
+      )
+      |> Ash.create!()
+
+    assert {:ok, source_image} =
+             Communities.get_current_huddl_image(huddl.id, authorize?: false)
+
+    assert source_image.id == pending_image.id
+    assert %{success: 1} = Oban.drain_queue(queue: :default)
+
+    for occurrence <- future_instances(huddl) do
+      assert {:ok, occurrence_image} =
+               Communities.get_current_huddl_image(occurrence.id, authorize?: false)
+
+      assert occurrence_image.filename == "pending.jpg"
+    end
+  end
+
   test "draining the queue generates the future instances" do
     %{huddl: huddl} = create_recurring()
 
@@ -63,14 +151,106 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
     assert length(future_instances(huddl)) == 2
   end
 
-  test "re-running the job regenerates without duplicating" do
-    %{huddl: huddl} = create_recurring()
+  test "weekly virtual huddlz generate every occurrence with the recurrence contract" do
+    %{owner: owner, group: group, huddl: huddl} =
+      create_recurring(
+        event_type: :virtual,
+        physical_location: nil,
+        virtual_link: "https://meet.example.com/weekly",
+        max_attendees: 24,
+        is_private: true,
+        thumbnail_url: "https://images.example.com/weekly.jpg"
+      )
+
+    source_image = attach_cover_image(huddl, owner)
 
     assert %{success: 1} = Oban.drain_queue(queue: :default)
-    assert length(future_instances(huddl)) == 2
+
+    assert [first, second] = future_instances(huddl) |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    assert DateTime.diff(first.starts_at, huddl.starts_at, :day) == 7
+    assert DateTime.diff(second.starts_at, huddl.starts_at, :day) == 14
+
+    for occurrence <- [first, second] do
+      assert occurrence.event_type == :virtual
+      assert occurrence.virtual_link == "https://meet.example.com/weekly"
+      assert occurrence.physical_location == nil
+      assert occurrence.max_attendees == 24
+      assert occurrence.is_private
+      assert occurrence.thumbnail_url == "https://images.example.com/weekly.jpg"
+      assert occurrence.creator_id == owner.id
+      assert occurrence.group_id == group.id
+
+      assert {:ok, occurrence_image} =
+               Communities.get_current_huddl_image(occurrence.id, authorize?: false)
+
+      assert occurrence_image.filename == source_image.filename
+      assert occurrence_image.content_type == source_image.content_type
+      assert occurrence_image.size_bytes == source_image.size_bytes
+      refute occurrence_image.storage_path == source_image.storage_path
+      refute occurrence_image.thumbnail_path == source_image.thumbnail_path
+      assert Storage.exists?(occurrence_image.storage_path)
+      assert Storage.exists?(occurrence_image.thumbnail_path)
+    end
+  end
+
+  test "weekly hybrid huddlz retain both locations for every occurrence" do
+    %{huddl: huddl} =
+      create_recurring(
+        event_type: :hybrid,
+        physical_location: "456 Congress Ave",
+        virtual_link: "https://meet.example.com/hybrid"
+      )
+
+    assert %{success: 1} = Oban.drain_queue(queue: :default)
+
+    assert [first, second] = future_instances(huddl) |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    for occurrence <- [first, second] do
+      assert occurrence.event_type == :hybrid
+      assert occurrence.physical_location == "456 Congress Ave"
+      assert occurrence.virtual_link == "https://meet.example.com/hybrid"
+    end
+  end
+
+  test "capacity-constrained recurring huddlz retain their attendance limit" do
+    %{huddl: huddl} = create_recurring(max_attendees: 3)
+
+    assert %{success: 1} = Oban.drain_queue(queue: :default)
+
+    assert future_instances(huddl)
+           |> Enum.all?(&(&1.max_attendees == 3))
+  end
+
+  test "re-running the job regenerates without duplicating" do
+    %{owner: owner, huddl: huddl} = create_recurring()
+    attach_cover_image(huddl, owner)
+
+    assert %{success: 1} = Oban.drain_queue(queue: :default)
+    first_generation = future_instances(huddl)
+    assert length(first_generation) == 2
+
+    old_image_paths =
+      Enum.map(first_generation, fn occurrence ->
+        assert {:ok, image} =
+                 Communities.get_current_huddl_image(occurrence.id, authorize?: false)
+
+        image.storage_path
+      end)
 
     assert :ok = perform_job(RegenerateRecurringSeries, %{huddl_id: huddl.id})
-    assert length(future_instances(huddl)) == 2
+
+    second_generation = future_instances(huddl)
+    assert length(second_generation) == 2
+
+    refute Enum.any?(old_image_paths, &Storage.exists?/1)
+
+    for occurrence <- second_generation do
+      assert {:ok, image} =
+               Communities.get_current_huddl_image(occurrence.id, authorize?: false)
+
+      assert Storage.exists?(image.storage_path)
+    end
   end
 
   test "generated instances inherit the parent's coordinates without re-geocoding" do
@@ -118,5 +298,37 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
     Ash.destroy!(huddl, authorize?: false)
 
     assert :ok = perform_job(RegenerateRecurringSeries, %{huddl_id: huddl.id})
+  end
+
+  test "surfaces a final generation failure to the organizer" do
+    %{owner: owner, huddl: huddl} =
+      create_recurring(
+        event_type: :virtual,
+        physical_location: nil,
+        virtual_link: "https://meet.example.com/failure"
+      )
+
+    Huddlz.Repo.update_all(
+      from(h in "huddlz", where: h.id == type(^huddl.id, Ecto.UUID)),
+      set: [virtual_link: nil]
+    )
+
+    job = %Oban.Job{
+      args: %{"huddl_id" => huddl.id},
+      attempt: 3,
+      max_attempts: 3
+    }
+
+    assert_raise Ash.Error.Invalid, fn ->
+      RegenerateRecurringSeries.perform(job)
+    end
+
+    assert {:ok, %{results: notifications}} =
+             Notifications.list_for_user(actor: owner, page: [limit: 10])
+
+    assert Enum.any?(notifications, fn notification ->
+             notification.trigger == "recurring_huddl_generation_failed" and
+               notification.source_url =~ huddl.id
+           end)
   end
 end

--- a/test/huddlz/notifications/senders/recurring_huddl_generation_failed_test.exs
+++ b/test/huddlz/notifications/senders/recurring_huddl_generation_failed_test.exs
@@ -1,0 +1,38 @@
+defmodule Huddlz.Notifications.Senders.RecurringHuddlGenerationFailedTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Notifications.Senders.RecurringHuddlGenerationFailed
+
+  test "tells the organizer which recurring huddl needs attention" do
+    user = generate(user(display_name: "Sam"))
+
+    email =
+      RecurringHuddlGenerationFailed.build(user, %{
+        "huddl_id" => "00000000-0000-0000-0000-000000000000",
+        "huddl_title" => "Weekly Workshop",
+        "group_name" => "Austin Elixir",
+        "group_slug" => "austin-elixir"
+      })
+
+    assert email.subject == "Recurring dates need attention: Weekly Workshop"
+    assert email.html_body =~ "Hi Sam"
+    assert email.html_body =~ "Weekly Workshop"
+    assert email.html_body =~ "Austin Elixir"
+    assert email.text_body =~ "/groups/austin-elixir/huddlz/00000000-0000-0000-0000-000000000000"
+  end
+
+  test "escapes organizer-controlled content" do
+    user = generate(user(display_name: "<script>x</script>"))
+
+    email =
+      RecurringHuddlGenerationFailed.build(user, %{
+        "huddl_title" => "<img src=x>",
+        "group_name" => "<strong>Group</strong>"
+      })
+
+    refute email.html_body =~ "<script>"
+    refute email.html_body =~ "<img src=x"
+    assert email.html_body =~ "&lt;script&gt;"
+    assert email.html_body =~ "&lt;img"
+  end
+end

--- a/test/huddlz/storage_test.exs
+++ b/test/huddlz/storage_test.exs
@@ -44,6 +44,20 @@ defmodule Huddlz.StorageTest do
       refute File.exists?(full_path)
     end
 
+    test "copy/3 duplicates a stored file at a new path", %{test_id: test_id} do
+      source_path = "/uploads/test_#{test_id}/source.txt"
+      destination_path = "/uploads/test_#{test_id}/destination.txt"
+      source_full_path = Path.join("priv/static", source_path)
+
+      File.mkdir_p!(Path.dirname(source_full_path))
+      File.write!(source_full_path, "copy me")
+
+      assert {:ok, ^destination_path} =
+               Local.copy(source_path, destination_path, "text/plain")
+
+      assert File.read!(Path.join("priv/static", destination_path)) == "copy me"
+    end
+
     test "delete/1 returns ok for non-existent file", %{test_id: test_id} do
       storage_path = "/uploads/test_#{test_id}/nonexistent.txt"
       assert :ok = Local.delete(storage_path)


### PR DESCRIPTION
## Summary

- generate complete weekly virtual, hybrid, and capacity-constrained occurrences
- retain privacy, location, uploaded cover images, creator, and group relationships
- assign pending images before enqueueing generation and copy image storage safely
- keep retries idempotent and notify organizers after terminal generation failures
- add Gherkin and focused ExUnit coverage for the full recurrence contract

## Testing

- Focused: recurrence, create-image ordering, LiveView upload, notification, and storage tests — 234 passed
- Full suite: `mix precommit` — 1,389 passed (1 doctest, 1,388 tests)
- `mix precommit`: warnings-as-errors compilation, formatting, unused dependency check, full tests, and strict Credo all passed

## Screenshots

Not applicable — non-visual domain fix.

Closes #268
