### PR TITLE
fix(huddl): preserve RSVP dates during reconciliation

### DIFF
--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -60,25 +60,23 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
   """
   def reconcile_future_instances(source, template, actor) do
     desired = desired_occurrences(source, template)
-    existing = source |> future_instances() |> Enum.sort_by(& &1.starts_at, DateTime)
+    existing_by_date = Map.new(future_instances(source), &{occurrence_date(&1.starts_at), &1})
 
-    # Update the overlapping positions in place.
-    desired
-    |> Enum.zip(existing)
-    |> Enum.each(fn {{starts_at, ends_at}, instance} ->
-      update_instance!(instance, source, starts_at, ends_at, actor)
-    end)
+    unmatched_existing =
+      Enum.reduce(desired, existing_by_date, fn {starts_at, ends_at}, remaining ->
+        case Map.pop(remaining, occurrence_date(starts_at)) do
+          {nil, remaining} ->
+            create_instance!(source, template, starts_at, ends_at)
+            remaining
 
-    # Create dates the series gained.
-    desired
-    |> Enum.drop(length(existing))
-    |> Enum.each(fn {starts_at, ends_at} ->
-      create_instance!(source, template, starts_at, ends_at)
-    end)
+          {instance, remaining} ->
+            update_instance!(instance, source, starts_at, ends_at, actor)
+            remaining
+        end
+      end)
 
-    # Cancel dates the series lost.
-    existing
-    |> Enum.drop(length(desired))
+    unmatched_existing
+    |> Map.values()
     |> Enum.each(&destroy_instance!(&1, actor))
 
     :ok
@@ -139,6 +137,8 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     end)
     |> Enum.reverse()
   end
+
+  defp occurrence_date(datetime), do: DateTime.to_date(datetime)
 
   defp create_instance!(source, template, starts_at, ends_at) do
     instance =

--- a/test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs
+++ b/test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs
@@ -3,6 +3,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
 
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.Huddl.RecurrenceHelper
+  alias Huddlz.Communities.HuddlAttendee
   alias Huddlz.Communities.HuddlTemplate
   alias Huddlz.Generator
 
@@ -10,7 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
   # its generated future instances. `is_public` controls whether the group (and
   # therefore every instance) is private — the bug only surfaces for private
   # series, where the old actor-less read could not see the instances.
-  defp build_series(is_public) do
+  defp build_series(is_public, opts \\ []) do
     owner = Generator.generate(Generator.user())
 
     group =
@@ -25,6 +26,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
           creator_id: owner.id,
           group_id: group.id,
           is_private: not is_public,
+          max_attendees: opts[:max_attendees],
           actor: owner
         )
       )
@@ -38,7 +40,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
       )
       |> Ash.update!()
 
-    repeat_until = Date.add(Date.utc_today(), 22)
+    repeat_until = opts[:repeat_until] || Date.add(Date.utc_today(), 22)
 
     template =
       HuddlTemplate
@@ -82,6 +84,22 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
     |> Ash.update!()
   end
 
+  defp attendee_entries(huddl) do
+    HuddlAttendee
+    |> Ash.Query.for_read(:by_huddl, %{huddl_id: huddl.id})
+    |> Ash.read!(authorize?: false)
+  end
+
+  defp waitlist_entries(huddl) do
+    HuddlAttendee
+    |> Ash.Query.for_read(:waitlist_for_huddl, %{huddl_id: huddl.id})
+    |> Ash.read!(authorize?: false)
+  end
+
+  defp instance_on(instances, date) do
+    Enum.find(instances, &(DateTime.to_date(&1.starts_at) == date))
+  end
+
   test "edit-all on a private series regenerates instances without duplicating them" do
     %{owner: owner, source: source, template: template, repeat_until: repeat_until} =
       build_series(false)
@@ -105,5 +123,82 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
     edit_all(source, owner, repeat_until)
 
     assert length(future_instances(template.id, source.starts_at)) == 2
+  end
+
+  test "reconciliation fills a beginning gap without moving a later RSVP" do
+    repeat_until = Date.add(Date.utc_today(), 36)
+
+    %{owner: owner, source: source, template: template} =
+      build_series(true, repeat_until: repeat_until)
+
+    [first, subscribed | _] =
+      future_instances(template.id, source.starts_at)
+      |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    attendee = Generator.generate(Generator.user())
+
+    subscribed
+    |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+    |> Ash.update!()
+
+    subscribed_date = DateTime.to_date(subscribed.starts_at)
+    Ash.destroy!(first, authorize?: false)
+
+    assert :ok = RecurrenceHelper.reconcile_future_instances(source, template, owner)
+
+    reconciled =
+      future_instances(template.id, source.starts_at)
+      |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    occurrence = instance_on(reconciled, subscribed_date)
+
+    assert occurrence.id == subscribed.id
+    assert Enum.any?(attendee_entries(occurrence), &(&1.user_id == attendee.id))
+  end
+
+  test "reconciliation fills a middle gap without moving RSVPs or waitlist entries" do
+    repeat_until = Date.add(Date.utc_today(), 36)
+
+    %{owner: owner, source: source, template: template} =
+      build_series(true, repeat_until: repeat_until, max_attendees: 2)
+
+    [_first, gap, subscribed | _] =
+      future_instances(template.id, source.starts_at)
+      |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    attendee = Generator.generate(Generator.user())
+    waitlister = Generator.generate(Generator.user())
+
+    subscribed
+    |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+    |> Ash.update!()
+
+    subscribed
+    |> Ash.reload!()
+    |> Ash.Changeset.for_update(:join_waitlist, %{}, actor: waitlister)
+    |> Ash.update!()
+
+    subscribed_date = DateTime.to_date(subscribed.starts_at)
+    Ash.destroy!(gap, authorize?: false)
+
+    assert :ok = RecurrenceHelper.reconcile_future_instances(source, template, owner)
+
+    reconciled =
+      future_instances(template.id, source.starts_at)
+      |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    occurrence = instance_on(reconciled, subscribed_date)
+
+    assert occurrence.id == subscribed.id
+
+    assert Enum.any?(
+             attendee_entries(occurrence),
+             &(&1.user_id == attendee.id and is_nil(&1.waitlisted_at))
+           )
+
+    assert Enum.any?(
+             waitlist_entries(occurrence),
+             &(&1.user_id == waitlister.id and not is_nil(&1.waitlisted_at))
+           )
   end
 end


### PR DESCRIPTION
## Summary

- Match existing recurring huddlz to desired occurrences by calendar date instead of list position.
- Create missing dates without shifting later huddl identities, RSVPs, or waitlist entries.
- Cancel only unmatched dates through the established destroy and notification path.
- Add regression coverage for gaps at the beginning and middle of a series.

## Validation

- Focused reconciliation tests: `mix test test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs` — passed (156 results including generated feature coverage).
- Focused lifecycle/notification tests: `mix test test/huddlz/notifications/huddl_lifecycle_notifications_test.exs` — passed (169 results including generated feature coverage).
- Typecheck: `mix compile --warnings-as-errors` — passed.
- Full suite (run once at the end through precommit): 1,391 passed (1 doctest, 1,390 tests).
- `mix precommit` — passed; Credo checked 379 files with no issues.

## Review

- Standards review found one overlong commit-body line; the commit message was rewrapped.
- Standards review found no source violations; one small repeated test-query shape was retained because separate domain-named helpers improve intent.
- Spec review found no missing requirements, incorrect behavior, or scope creep.

## Screenshots

Not applicable: this is non-visual reconciliation and subscription-preservation behavior.

Closes #269