### PR TITLE
fix(huddlz): preserve format during series edit

### DIFF
--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -96,7 +96,10 @@ defmodule HuddlzWeb.HuddlLive.Edit do
       "date" => Date.to_iso8601(date),
       "start_time" => Calendar.strftime(start_time, "%H:%M"),
       "duration_minutes" => to_string(duration_minutes),
-      "max_attendees" => if(huddl.max_attendees, do: to_string(huddl.max_attendees), else: "")
+      "max_attendees" => if(huddl.max_attendees, do: to_string(huddl.max_attendees), else: ""),
+      "event_type" => to_string(huddl.event_type),
+      "physical_location" => huddl.physical_location || "",
+      "virtual_link" => huddl.virtual_link || ""
     }
 
     initial_params = maybe_add_recurring_params(initial_params, huddl)

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -303,6 +303,120 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       refute_has(session, "select[name='form[frequency]']")
       refute_has(session, "input[name='form[repeat_until]']")
     end
+
+    test "whole-series editing preserves a virtual huddl's online controls", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      huddl =
+        huddl
+        |> Ash.Changeset.for_update(
+          :update,
+          %{
+            event_type: :virtual,
+            virtual_link: "https://meet.example.com/recurring"
+          },
+          actor: owner
+        )
+        |> Ash.update!()
+
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit")
+        |> click_button("Whole series")
+
+      assert_has(
+        session,
+        "input[name='form[virtual_link]'][value='https://meet.example.com/recurring']"
+      )
+
+      refute_has(session, "#saved-location-picker")
+
+      session
+      |> click_button("Save changes")
+      |> assert_has("*", text: "Huddl updated successfully!")
+
+      updated_huddl = read_huddl(huddl.id, owner)
+      assert updated_huddl.event_type == :virtual
+      assert updated_huddl.virtual_link == "https://meet.example.com/recurring"
+      assert is_nil(updated_huddl.physical_location)
+    end
+
+    test "whole-series editing preserves a hybrid huddl's location and online controls", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      huddl =
+        huddl
+        |> Ash.Changeset.for_update(
+          :update,
+          %{
+            event_type: :hybrid,
+            physical_location: "456 Oak Ave",
+            virtual_link: "https://meet.example.com/hybrid"
+          },
+          actor: owner
+        )
+        |> Ash.update!()
+
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit")
+        |> click_button("Whole series")
+
+      assert_has(session, "#saved-location-picker")
+
+      assert_has(
+        session,
+        "input[name='form[virtual_link]'][value='https://meet.example.com/hybrid']"
+      )
+
+      session
+      |> click_button("Save changes")
+      |> assert_has("*", text: "Huddl updated successfully!")
+
+      updated_huddl = read_huddl(huddl.id, owner)
+      assert updated_huddl.event_type == :hybrid
+      assert updated_huddl.physical_location == "456 Oak Ave"
+      assert updated_huddl.virtual_link == "https://meet.example.com/hybrid"
+    end
+
+    test "whole-series editing keeps an in-person huddl free of online controls", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit")
+        |> click_button("Whole series")
+
+      assert_has(session, "#saved-location-picker")
+      refute_has(session, "input[name='form[virtual_link]']")
+
+      session
+      |> click_button("Save changes")
+      |> assert_has("*", text: "Huddl updated successfully!")
+
+      updated_huddl = read_huddl(huddl.id, owner)
+      assert updated_huddl.event_type == :in_person
+      assert updated_huddl.physical_location == "456 Oak Ave"
+      assert is_nil(updated_huddl.virtual_link)
+    end
+  end
+
+  defp read_huddl(id, actor) do
+    Huddl
+    |> Ash.Query.filter(id == ^id)
+    |> Ash.read_one!(actor: actor)
   end
 
   describe "form submission" do


### PR DESCRIPTION
## Summary
- retain recurring huddl format, location, and online-link values when switching to whole-series editing
- cover virtual, hybrid, and in-person whole-series saves

## Verification
- Getting extensions in current project...
Running setup for AshPostgres.DataLayer...
Running ExUnit with seed: 93434, max_cases: 36

................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 8.4 seconds (7.0s async, 1.4s sync)

Result: 1392 passed (1 doctest, 1391 tests)
Checking 379 source files (this might take a while) ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.3 seconds (0.04s to load, 0.3s running 67 checks on 379 files)
2023 mods/funs, found no issues.

Use `mix credo explain` to explain issues, `mix credo --help` for options.

Closes #270