### PR TITLE
Fix inline form error associations

### DIFF
--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -37,7 +37,7 @@ defmodule HuddlzWeb.Components.Input do
   end
 
   def input(assigns) do
-    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+    assigns = prepare_accessibility(assigns)
 
     ~H"""
     <div class="form-row">
@@ -48,10 +48,14 @@ defmodule HuddlzWeb.Components.Input do
         name={@name}
         value={Form.normalize_value(@type, @value)}
         class={["form-input", @class]}
+        aria-invalid={@invalid? && "true"}
+        aria-describedby={@describedby}
         {@rest}
       />
-      <p :if={@help && @errors == []} class="form-help">{@help}</p>
-      <p :for={msg <- @errors} class="form-error">{msg}</p>
+      <p :if={@help} id={help_id(@id)} class="form-help">{@help}</p>
+      <p :for={{msg, index} <- Enum.with_index(@errors)} id={error_id(@id, index)} class="form-error">
+        {msg}
+      </p>
     </div>
     """
   end
@@ -80,14 +84,23 @@ defmodule HuddlzWeb.Components.Input do
   end
 
   def textarea(assigns) do
-    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+    assigns = prepare_accessibility(assigns)
 
     ~H"""
     <div class="form-row">
       <label :if={@label} for={@id} class="form-label">{@label}</label>
-      <textarea id={@id} name={@name} class={["form-textarea", @class]} {@rest}>{Form.normalize_value("textarea", @value)}</textarea>
-      <p :if={@help && @errors == []} class="form-help">{@help}</p>
-      <p :for={msg <- @errors} class="form-error">{msg}</p>
+      <textarea
+        id={@id}
+        name={@name}
+        class={["form-textarea", @class]}
+        aria-invalid={@invalid? && "true"}
+        aria-describedby={@describedby}
+        {@rest}
+      >{Form.normalize_value("textarea", @value)}</textarea>
+      <p :if={@help} id={help_id(@id)} class="form-help">{@help}</p>
+      <p :for={{msg, index} <- Enum.with_index(@errors)} id={error_id(@id, index)} class="form-error">
+        {msg}
+      </p>
     </div>
     """
   end
@@ -117,17 +130,26 @@ defmodule HuddlzWeb.Components.Input do
   end
 
   def select(assigns) do
-    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+    assigns = prepare_accessibility(assigns)
 
     ~H"""
     <div class="form-row">
       <label :if={@label} for={@id} class="form-label">{@label}</label>
-      <select id={@id} name={@name} class={["form-select", @class]} {@rest}>
+      <select
+        id={@id}
+        name={@name}
+        class={["form-select", @class]}
+        aria-invalid={@invalid? && "true"}
+        aria-describedby={@describedby}
+        {@rest}
+      >
         <option :if={@prompt} value="">{@prompt}</option>
         {Phoenix.HTML.Form.options_for_select(@options, @value)}
       </select>
-      <p :if={@help && @errors == []} class="form-help">{@help}</p>
-      <p :for={msg <- @errors} class="form-error">{msg}</p>
+      <p :if={@help} id={help_id(@id)} class="form-help">{@help}</p>
+      <p :for={{msg, index} <- Enum.with_index(@errors)} id={error_id(@id, index)} class="form-error">
+        {msg}
+      </p>
     </div>
     """
   end
@@ -166,4 +188,26 @@ defmodule HuddlzWeb.Components.Input do
       String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
     end)
   end
+
+  defp prepare_accessibility(assigns) do
+    assigns = assign_new(assigns, :id, fn -> assigns[:name] end)
+    id = assigns[:id]
+    errors = assigns[:errors]
+
+    assigns
+    |> assign(:invalid?, errors != [])
+    |> assign(:describedby, describedby_ids(id, assigns[:help], errors))
+  end
+
+  defp describedby_ids(id, help, errors) do
+    [
+      help && help_id(id)
+      | Enum.map(Enum.with_index(errors), fn {_error, index} -> error_id(id, index) end)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+  end
+
+  defp help_id(id), do: "#{id}-help"
+  defp error_id(id, index), do: "#{id}-error-#{index}"
 end

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -63,21 +63,48 @@ defmodule HuddlzWeb.GroupLiveTest do
     end
 
     test "shows errors with invalid data", %{conn: conn, verified: verified} do
-      conn
-      |> login(verified)
-      |> visit(~p"/groups/new")
-      |> fill_in("Group name", with: "")
-      |> fill_in("Description", with: "Missing name")
-      |> click_button("Create group")
-      |> assert_has("p", text: "is required")
+      session =
+        conn
+        |> login(verified)
+        |> visit(~p"/groups/new")
+        |> fill_in("Group name", with: "")
+        |> fill_in("Description", with: "Missing name")
+        |> click_button("Create group")
+
+      session
+      |> assert_has(
+        "input[name='form[name]'][aria-invalid='true'][aria-describedby='form_name-help form_name-error-0']"
+      )
+      |> assert_has("#form_name-help", text: "3–100 characters.")
+      |> assert_has("#form_name-error-0", text: "is required")
     end
 
     test "validates on change", %{conn: conn, verified: verified} do
-      conn
-      |> login(verified)
-      |> visit(~p"/groups/new")
-      |> fill_in("Group name", with: "ab")
-      |> assert_has("p", text: "length must be greater than or equal to")
+      session =
+        conn
+        |> login(verified)
+        |> visit(~p"/groups/new")
+        |> fill_in("Group name", with: "ab")
+
+      session
+      |> assert_has(
+        "input[name='form[name]'][aria-invalid='true'][aria-describedby='form_name-help form_name-error-0']"
+      )
+      |> assert_has("#form_name-error-0", text: "length must be greater than or equal to")
+    end
+
+    test "associates help text without marking valid fields invalid", %{
+      conn: conn,
+      verified: verified
+    } do
+      session =
+        conn
+        |> login(verified)
+        |> visit(~p"/groups/new")
+
+      session
+      |> assert_has("input[name='form[name]'][aria-describedby='form_name-help']")
+      |> refute_has("input[name='form[name]'][aria-invalid='true']")
     end
 
     test "shows location error when submitting with a location that is too long", %{


### PR DESCRIPTION
## Summary

- add stable help and error IDs to shared input, textarea, and select components
- expose invalid state and link controls to their validation guidance
- cover required, constraint, and valid-field relationships

## Verification

- Getting extensions in current project...
Running setup for AshPostgres.DataLayer...
Running ExUnit with seed: 753440, max_cases: 36

..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 8.2 seconds (6.7s async, 1.4s sync)

Result: 1390 passed (1 doctest, 1389 tests)
Checking 379 source files (this might take a while) ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.3 seconds (0.04s to load, 0.3s running 67 checks on 379 files)
2026 mods/funs, found no issues.

Use `mix credo explain` to explain issues, `mix credo --help` for options.

Closes #319