### PR TITLE
fix(auth): restore RSVP destination after authentication

### DIFF
--- a/lib/huddlz_web/auth_return_to.ex
+++ b/lib/huddlz_web/auth_return_to.ex
@@ -1,0 +1,23 @@
+defmodule HuddlzWeb.AuthReturnTo do
+  @moduledoc false
+
+  @doc """
+  Returns a local path that is safe to use after authentication, or `nil`.
+  """
+  @spec validate(term()) :: String.t() | nil
+  def validate(path) when is_binary(path) do
+    case URI.new(path) do
+      {:ok, uri} -> if local_path?(uri, path), do: path
+      _ -> nil
+    end
+  end
+
+  def validate(_path), do: nil
+
+  defp local_path?(%URI{scheme: nil, host: nil, path: "/" <> _}, path) do
+    not String.starts_with?(path, "//") and
+      not String.contains?(String.downcase(path), ["\\", "%2f", "%5c"])
+  end
+
+  defp local_path?(_uri, _path), do: false
+end

--- a/lib/huddlz_web/controllers/auth_controller.ex
+++ b/lib/huddlz_web/controllers/auth_controller.ex
@@ -2,8 +2,10 @@ defmodule HuddlzWeb.AuthController do
   use HuddlzWeb, :controller
   use AshAuthentication.Phoenix.Controller
 
+  alias HuddlzWeb.AuthReturnTo
+
   def success(conn, activity, user, _token) do
-    return_to = get_session(conn, :return_to) || ~p"/"
+    return_to = return_to(conn)
 
     message =
       case activity do
@@ -56,11 +58,17 @@ defmodule HuddlzWeb.AuthController do
   end
 
   def sign_out(conn, _params) do
-    return_to = get_session(conn, :return_to) || ~p"/"
+    return_to = return_to(conn)
 
     conn
     |> clear_session(:huddlz)
     |> put_flash(:info, "You are now signed out")
     |> redirect(to: return_to)
+  end
+
+  defp return_to(conn) do
+    [conn.params["return_to"], get_session(conn, :return_to)]
+    |> Enum.find_value(&AuthReturnTo.validate/1)
+    |> Kernel.||(~p"/")
   end
 end

--- a/lib/huddlz_web/live/auth_live/register.ex
+++ b/lib/huddlz_web/live/auth_live/register.ex
@@ -8,9 +8,10 @@ defmodule HuddlzWeb.AuthLive.Register do
   alias AshPhoenix.Form
   alias Huddlz.Accounts.DisplayNameGenerator
   alias Huddlz.Accounts.User
+  alias HuddlzWeb.AuthReturnTo
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     strategy = AshAuthentication.Info.strategy!(User, :password)
 
     context = %{
@@ -37,6 +38,7 @@ defmodule HuddlzWeb.AuthLive.Register do
      |> assign(:page_title, "Create account")
      |> assign(:body_class, "is-auth")
      |> assign(:check_errors, false)
+     |> assign(:return_to, AuthReturnTo.validate(params["return_to"]))
      |> assign_form(password_form)}
   end
 
@@ -106,7 +108,7 @@ defmodule HuddlzWeb.AuthLive.Register do
       </.form>
 
       <div class="auth-aside">
-        Already have an account? <.link navigate={~p"/sign-in"}>Sign in</.link>
+        Already have an account? <.link navigate={sign_in_path(@return_to)}>Sign in</.link>
       </div>
     </Layouts.auth_shell>
     """
@@ -172,14 +174,14 @@ defmodule HuddlzWeb.AuthLive.Register do
     token = result.__metadata__.token
 
     if token do
-      redirect(socket, to: "/auth/user/password/sign_in_with_token?token=#{token}")
+      redirect(socket, to: sign_in_token_path(token, socket.assigns.return_to))
     else
       socket
       |> put_flash(
         :error,
         "Registration succeeded but automatic sign-in failed. Please sign in manually."
       )
-      |> redirect(to: "/sign-in")
+      |> redirect(to: sign_in_path(socket.assigns.return_to))
     end
   end
 
@@ -197,5 +199,16 @@ defmodule HuddlzWeb.AuthLive.Register do
     else
       "Registration failed. Please check your inputs and try again."
     end
+  end
+
+  defp sign_in_path(nil), do: ~p"/sign-in"
+
+  defp sign_in_path(return_to), do: ~p"/sign-in?#{[return_to: return_to]}"
+
+  defp sign_in_token_path(token, nil), do: "/auth/user/password/sign_in_with_token?token=#{token}"
+
+  defp sign_in_token_path(token, return_to) do
+    "/auth/user/password/sign_in_with_token?" <>
+      URI.encode_query(token: token, return_to: return_to)
   end
 end

--- a/lib/huddlz_web/live/auth_live/sign_in.ex
+++ b/lib/huddlz_web/live/auth_live/sign_in.ex
@@ -7,6 +7,7 @@ defmodule HuddlzWeb.AuthLive.SignIn do
 
   alias AshPhoenix.Form
   alias Huddlz.Accounts.User
+  alias HuddlzWeb.AuthReturnTo
 
   @impl true
   def render(assigns) do
@@ -22,7 +23,7 @@ defmodule HuddlzWeb.AuthLive.SignIn do
         phx-submit="sign_in_with_password"
         phx-change="validate_password"
         phx-trigger-action={@trigger_action}
-        action="/auth/user/password/sign_in"
+        action={sign_in_path(@return_to)}
         method="post"
         class="auth-card"
       >
@@ -46,14 +47,14 @@ defmodule HuddlzWeb.AuthLive.SignIn do
         <.link navigate={~p"/reset"}>Forgot your password?</.link>
       </div>
       <div class="auth-aside">
-        Don't have an account? <.link navigate={~p"/register"}>Sign up</.link>
+        Don't have an account? <.link navigate={register_path(@return_to)}>Sign up</.link>
       </div>
     </Layouts.auth_shell>
     """
   end
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     strategy = AshAuthentication.Info.strategy!(User, :password)
 
     context = %{
@@ -82,6 +83,7 @@ defmodule HuddlzWeb.AuthLive.SignIn do
      |> assign(:page_title, "Sign in")
      |> assign(:body_class, "is-auth")
      |> assign(:password_form, password_form)
+     |> assign(:return_to, AuthReturnTo.validate(params["return_to"]))
      |> assign(:trigger_action, false)}
   end
 
@@ -96,7 +98,7 @@ defmodule HuddlzWeb.AuthLive.SignIn do
 
           {:noreply,
            redirect(socket,
-             to: "/auth/user/password/sign_in_with_token?token=#{token}"
+             to: sign_in_token_path(token, socket.assigns.return_to)
            )}
 
         {:error, form} ->
@@ -132,4 +134,21 @@ defmodule HuddlzWeb.AuthLive.SignIn do
 
     {:noreply, assign(socket, :password_form, form)}
   end
+
+  defp sign_in_path(nil), do: "/auth/user/password/sign_in"
+
+  defp sign_in_path(return_to) do
+    "/auth/user/password/sign_in?" <> URI.encode_query(return_to: return_to)
+  end
+
+  defp sign_in_token_path(token, nil), do: "/auth/user/password/sign_in_with_token?token=#{token}"
+
+  defp sign_in_token_path(token, return_to) do
+    "/auth/user/password/sign_in_with_token?" <>
+      URI.encode_query(token: token, return_to: return_to)
+  end
+
+  defp register_path(nil), do: ~p"/register"
+
+  defp register_path(return_to), do: ~p"/register?#{[return_to: return_to]}"
 end

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -315,7 +315,11 @@ defmodule HuddlzWeb.HuddlLive.Show do
 
   defp render_rsvp_state(%{current_user: nil} = assigns) do
     ~H"""
-    <.button variant={:primary} navigate={~p"/sign-in"} class="rsvp-cta">
+    <.button
+      variant={:primary}
+      navigate={rsvp_sign_in_path(@huddl.group.slug, @huddl.id)}
+      class="rsvp-cta"
+    >
       Sign in to RSVP
     </.button>
     """
@@ -457,6 +461,11 @@ defmodule HuddlzWeb.HuddlLive.Show do
       </div>
       """
     end
+  end
+
+  defp rsvp_sign_in_path(group_slug, huddl_id) do
+    return_to = "/groups/#{group_slug}/huddlz/#{huddl_id}"
+    "/sign-in?" <> URI.encode_query(return_to: return_to)
   end
 
   @impl true

--- a/test/huddlz_web/auth_return_to_test.exs
+++ b/test/huddlz_web/auth_return_to_test.exs
@@ -1,0 +1,23 @@
+defmodule HuddlzWeb.AuthReturnToTest do
+  use ExUnit.Case, async: true
+
+  alias HuddlzWeb.AuthReturnTo
+
+  test "accepts local paths" do
+    assert AuthReturnTo.validate("/groups/book-club/huddlz/123?tab=rsvp") ==
+             "/groups/book-club/huddlz/123?tab=rsvp"
+  end
+
+  test "rejects external and malformed return paths" do
+    for path <- [
+          "https://evil.example",
+          "//evil.example",
+          "/\\evil.example",
+          "/%5C%5Cevil.example",
+          "relative/path",
+          nil
+        ] do
+      assert AuthReturnTo.validate(path) == nil
+    end
+  end
+end

--- a/test/huddlz_web/controllers/auth_controller_test.exs
+++ b/test/huddlz_web/controllers/auth_controller_test.exs
@@ -1,0 +1,44 @@
+defmodule HuddlzWeb.AuthControllerTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  alias Huddlz.Accounts.User
+  alias HuddlzWeb.AuthController
+
+  test "redirects after authentication only to a validated local path", %{conn: conn} do
+    user = create_test_user()
+
+    safe_conn = %{
+      (init_test_session(conn, %{})
+       |> Phoenix.Controller.fetch_flash([]))
+      | params: %{"return_to" => "/groups/book-club/huddlz/123"}
+    }
+
+    assert redirected_to(AuthController.success(safe_conn, {:password, :sign_in}, user, nil)) ==
+             "/groups/book-club/huddlz/123"
+
+    unsafe_conn = %{
+      (init_test_session(conn, %{})
+       |> Phoenix.Controller.fetch_flash([]))
+      | params: %{"return_to" => "https://evil.example"}
+    }
+
+    assert redirected_to(AuthController.success(unsafe_conn, {:password, :sign_in}, user, nil)) ==
+             "/"
+  end
+
+  defp create_test_user do
+    user =
+      User
+      |> Ash.Changeset.for_create(:create, %{
+        email: "user#{System.unique_integer([:positive])}@example.com",
+        display_name: "Test User",
+        role: :user
+      })
+      |> Ash.create!(authorize?: false)
+
+    {:ok, token, _claims} =
+      AshAuthentication.Jwt.token_for_user(user, %{}, domain: Huddlz.Accounts)
+
+    %{user | __metadata__: Map.put(user.__metadata__, :token, token)}
+  end
+end

--- a/test/huddlz_web/live/auth_live/return_to_test.exs
+++ b/test/huddlz_web/live/auth_live/return_to_test.exs
@@ -1,0 +1,34 @@
+defmodule HuddlzWeb.AuthLive.ReturnToTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import PhoenixTest
+
+  describe "authentication return paths" do
+    test "preserves a local huddl path between sign-in and registration", %{conn: conn} do
+      return_to = "/groups/book-club/huddlz/123"
+
+      conn
+      |> visit("/sign-in?" <> URI.encode_query(return_to: return_to))
+      |> assert_has(
+        "form[action='/auth/user/password/sign_in?return_to=%2Fgroups%2Fbook-club%2Fhuddlz%2F123']"
+      )
+      |> assert_has(
+        "a[href='/register?return_to=%2Fgroups%2Fbook-club%2Fhuddlz%2F123']",
+        text: "Sign up"
+      )
+      |> click_link("Sign up")
+      |> assert_path("/register", query_params: %{"return_to" => return_to})
+      |> assert_has(
+        "a[href='/sign-in?return_to=%2Fgroups%2Fbook-club%2Fhuddlz%2F123']",
+        text: "Sign in"
+      )
+    end
+
+    test "does not propagate external return paths", %{conn: conn} do
+      conn
+      |> visit("/sign-in?return_to=https%3A%2F%2Fevil.example")
+      |> assert_has("form[action='/auth/user/password/sign_in']")
+      |> assert_has("a[href='/register']", text: "Sign up")
+    end
+  end
+end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -327,7 +327,10 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
       |> assert_has(".facts .value .muted", text: "Sign in and RSVP to get virtual link")
       |> refute_has("button", text: "RSVP to this huddl")
-      |> assert_has("a", text: "Sign in to RSVP")
+      |> assert_has(
+        "a[href='/sign-in?return_to=%2Fgroups%2F#{group.slug}%2Fhuddlz%2F#{huddl.id}']",
+        text: "Sign in to RSVP"
+      )
     end
 
     test "handles different huddl types correctly", %{


### PR DESCRIPTION
## Summary\n- preserve the current huddl path when someone selects Sign in to RSVP\n- carry validated local return paths across sign-in and registration\n- reject unsafe redirect destinations before completing authentication\n\n## Verification\n- mix precommit\n\nCloses #271