### PR TITLE
Refresh project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,10 @@ This is a web application written using the Phoenix web framework.
 
 ### Commit Messages
 
-- Follow conventional commits format: `type(scope): concise description`
-- Do not include AI attribution lines or AI-generated signatures
-- "Co-Authored-By" is reserved for human collaborators only
-- Keep first line under 70 characters, no period at the end
-- Use imperative, present tense: "add" not "added" or "adds"
-- Include a descriptive body with bullet points for specific changes when appropriate
-- See `docs/commit-style.md` for complete guidelines
+- Use Conventional Commits
+- Do not add AI co-author trailers or generated signatures; reserve
+  `Co-Authored-By` trailers for human collaborators
+- Consult `docs/commit-style.md` before committing
 
 ### Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,136 +1,48 @@
 # huddlz
 
-huddlz is a social networking platform focused on facilitating real-life meetups and events, prioritizing in-person connections over digital interactions. The platform aims to support tech meetup organizers and other community builders with tools for event management and attendee coordination.
-
-> **Naming Convention**: In huddlz, a singular event is called a "huddl" and multiple events are called "huddlz", matching the platform name. For branding purposes, we always use lowercase in UI and documentation.
-
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-blue.svg)](LICENSE.md)
-
-## Current Features
-
-- **Huddl Listing** - Discover upcoming discussion events directly on the landing page
-- **Search Functionality** - Find huddls by keyword across titles and descriptions
-- **Password Authentication** - Secure login with password reset functionality
-
-### Project Status
-
-Huddlz is under active development. The landing page with huddl listings has been implemented, providing immediate value to users visiting the site. Users can browse available huddls and search for events matching their interests without requiring authentication.
-
-## Technology Stack
-
-- **Backend**: Elixir with Phoenix Framework
-- **Frontend**: Phoenix LiveView for interactive UI components
-- **Data Layer**: Ash Framework for domain modeling
-- **Authentication**: Ash Authentication with password-based login
-- **Database**: PostgreSQL
-- **Testing**: Cucumber/Gherkin for behavior-driven development
-
-## Dependencies
-
-### System Dependencies
-
-**macOS:**
-```bash
-brew bundle  # or: brew install vips
-```
-
-**Ubuntu/Debian:**
-```bash
-apt install libvips-dev
-```
-
-**Fedora:**
-```bash
-dnf install vips-devel
-```
-
-### Language Runtimes
-
-This project uses [mise](https://mise.jdx.dev/) for version management:
-```bash
-mise install
-```
-
-This installs Elixir 1.19.5 (OTP 28) and Erlang 28.4 as specified in `.mise.toml`.
-
-## Getting Started
-
-To start your Phoenix server:
-
-* Copy `.dev.env.example` to `.dev.env` and customize the local settings
-* Run `mix setup` to install and setup dependencies
-* Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
-
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
-### Google Maps in development
-
-Location search uses Google Places when `GOOGLE_MAPS_API_KEY` is set in
-`.dev.env`. Create a key in Google Cloud with the Places API (New) enabled,
-restrict it to the APIs used by huddlz, and set conservative usage quotas and
-billing alerts. The `.dev.env` file is ignored by Git and must not be committed.
-
-If the key is omitted, development automatically uses a fixed set of preset
-locations. This keyless mode avoids Google API usage and is useful for routine
-local development.
-
-## Development
-
-### Testing
-
-* Run all tests: `mix test`
-* Run a specific test file: `mix test path/to/test_file.exs`
-* Run Cucumber features: `mix test test/features/`
-
-### Code Quality
-
-* Format code: `mix format`
-
-## Contributing
-
-* [Commit Style Guidelines](docs/commit-style.md) - Please follow these guidelines when contributing to this project
-* This project follows behavior-driven development with Cucumber - see [Testing Guidelines](docs/testing.md)
+huddlz is a service that helps organizers and communities bring people
+together in person. This repository contains the application source and
+documentation for contributors and readers.
 
 ## Documentation
 
-* [Vision](docs/vision.md) - Project vision and goals
-* [Testing](docs/testing.md) - Testing approach and guidelines
-* [Testing Approach](docs/testing_approach.md) - PhoenixTest patterns and best practices
-* [PhoenixTest Migration](docs/phoenix_test_migration.md) - Guide for migrating tests to PhoenixTest
-* [Development Lifecycle](docs/development_lifecycle.md) - Complete development workflow from requirements to implementation
+### Project direction
 
-## Deployment
+- [Vision](docs/vision.md) describes the project's purpose, values, and goals.
+- [Domain model and access rules](docs/domain-model-and-access-rules.md)
+  documents the domain model and permissions.
 
-### Required Environment Variables
+### Domain and feature specifications
 
-The following environment variables must be set in production:
+- [Group membership](docs/group_membership.md) defines membership roles,
+  verification, and access rules.
+- [Email notifications](docs/notifications.md) specifies notification
+  categories, triggers, and delivery rules.
+- [API follow-ups](docs/api-followups.md) records deferred work for the
+  JSON:API and GraphQL surfaces.
 
-* `DATABASE_URL` - PostgreSQL database connection string
-* `SECRET_KEY_BASE` - Secret key for session encryption (generate with `mix phx.gen.secret`)
-* `TOKEN_SIGNING_SECRET` - Secret for signing authentication tokens
-* `SENDGRID_API_KEY` - SendGrid API key for sending emails (required for password reset functionality)
+### Contributing
 
-### Optional Environment Variables
+- [Testing](docs/testing.md) explains the project's test-first development
+  approach.
+- [Commit style](docs/commit-style.md) contains the commit-message guidelines.
 
-* `RENDER_EXTERNAL_HOSTNAME` - Hostname for the application (defaults to "huddlz.com")
-* `PORT` - Port to bind to (defaults to 4000)
-* `POOL_SIZE` - Database connection pool size (defaults to 10)
+## Local development
 
-Ready to run in production? Please [check the Phoenix deployment guides](https://hexdocs.pm/phoenix/deployment.html) for detailed instructions.
+Install `vips` and the language runtimes defined in
+[`.mise.toml`](.mise.toml), then run:
+
+```sh
+mise install
+mix setup
+mix phx.server
+```
+
+`mix setup` creates local environment files from the checked-in examples when
+needed. Run the test suite with `mix test`.
 
 ## License
 
-Huddlz is licensed under the [Business Source License 1.1](LICENSE.md) (BSL 1.1). This license:
-
-* Allows you to freely use, modify, and distribute the software for non-commercial purposes
-* Allows contributions to the project
-* Restricts commercial use without a separate agreement
-* Automatically converts to Apache License 2.0 5 years after the release of v1.0.0
-
-## Learn more
-
-* Official website: https://www.phoenixframework.org/
-* Guides: https://hexdocs.pm/phoenix/overview.html
-* Docs: https://hexdocs.pm/phoenix
-* Forum: https://elixirforum.com/c/phoenix-forum
-* Source: https://github.com/phoenixframework/phoenix
+The source is licensed under the [Business Source License 1.1](LICENSE.md).
+Review the license for the applicable use restrictions and change-license
+terms.

--- a/docs/domain-model-and-access-rules.md
+++ b/docs/domain-model-and-access-rules.md
@@ -1,4 +1,4 @@
-# Architecture
+# Domain Model and Access Rules
 
 ## Entity Relationships
 
@@ -120,4 +120,3 @@ stateDiagram-v2
 | `upcoming` | `starts_at > now()` |
 | `in_progress` | `starts_at <= now() <= ends_at` |
 | `completed` | `ends_at < now()` |
-

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,187 +1,101 @@
-# Test-First Development with Cucumber
+# Outside-In Behavior-Driven Testing
 
-We practice test-first development by starting with a feature description before writing any implementation code. Features are described in plain language using Gherkin syntax, making them easy to understand and review.
+huddlz develops features from observable behavior inward. Behavior tests are
+the primary specification and the starting point for feature work: describe
+what a person or external caller should observe in Cucumber/Gherkin before
+writing the implementation, then use that scenario to drive a vertical slice
+through the system.
 
-## Example Workflow
+Keep scenarios in the language of the domain. A scenario should explain the
+capability or rule without describing LiveView events, database writes, module
+calls, or other implementation details.
 
-1. **Write a Feature File**
+## The three testing rings
 
-Create a file in `test/features/` (e.g., `calculator.feature`):
+The test suite has three concentric rings, ordered from outside to inside.
 
-```gherkin
-Feature: Calculator
-  Scenario: Adding two numbers
-    Given I have entered 5 into the calculator
-    And I have entered 7 into the calculator
-    When I press add
-    Then the result should be 12
+### 1. Behavior tests
+
+Cucumber scenarios in `test/features/*.feature` express user-observable or
+externally observable behavior with Given/When/Then steps. Step definitions
+live in `test/features/step_definitions/`, with shared setup in
+`test/features/support/`.
+
+Start feature development here. Write one meaningful scenario, see it fail,
+implement the smallest vertical slice that makes it pass, and repeat.
+
+A Cucumber scenario does not have to drive every rule through a full browser
+or UI path. Use PhoenixTest when the behavior is genuinely about the web
+experience. For domain, notification, or other non-UI behavior, a step may use
+the appropriate public application boundary instead. The scenario must remain
+business-readable and verify an observable outcome regardless of the seam it
+drives.
+
+### 2. Integration tests
+
+Elixir integration tests exercise collaborations through public boundaries.
+They live primarily under `test/huddlz/` and `test/huddlz_web/` and use the
+project's ExUnit case modules, including `Huddlz.DataCase`,
+`HuddlzWeb.ConnCase`, and `HuddlzWeb.ApiCase`, where appropriate.
+
+Add integration tests when they provide faster feedback than a behavior
+scenario, isolate a boundary failure, or protect a contract such as an Ash
+action, policy, API, controller, LiveView, worker, or notification flow.
+
+### 3. Focused unit tests
+
+Use focused ExUnit tests for complex or high-value logic that benefits from
+fast, precise protection. Examples include calculations, transformations,
+parsing, recurrence rules, token handling, and other logic with meaningful
+edge cases.
+
+Unit tests are not automatically required for coverage. Add them when the
+smaller seam makes failures easier to diagnose or protects logic more clearly
+than the outer rings alone.
+
+## How the rings work together
+
+The ring order describes the order of intent and design, not a required ratio
+of behavior, integration, and unit tests. Begin with the behavior that matters,
+then add lower-level tests only where they contribute distinct confidence,
+feedback speed, or diagnostic value.
+
+Intentional overlap is acceptable. A Cucumber scenario can specify a huddl
+workflow while an integration test protects its authorization boundary and a
+unit test covers a difficult recurrence edge case. Avoid only overlap that
+repeats the same assertions against implementation details without adding
+distinct protection.
+
+Prefer stable behavior and contracts over internal structure. Tests should
+survive refactoring when externally observable behavior is unchanged. Avoid
+assertions about private functions, internal call order, incidental markup, or
+database representation unless that detail is itself a supported contract.
+
+## Development workflow
+
+1. Describe the next user-observable behavior in a focused Gherkin scenario.
+2. Choose the public seam that demonstrates that behavior at the appropriate
+   layer.
+3. Run the relevant test and confirm it fails for the expected reason.
+4. Implement the smallest vertical slice that makes it pass.
+5. Add integration or unit tests when they provide distinct protection.
+6. Continue in small red-to-green slices until the behavior is complete.
+
+During development, run the narrowest relevant ExUnit test with:
+
+```sh
+mix test path/to/test.exs
+mix test path/to/test.exs:line
 ```
 
-2. **Write a Test Module**
+Run `mix test` when broader suite feedback is useful. When the change is
+complete, run the full project validation once:
 
-Create a test file in `test/lib/` (e.g., `calculator_test.exs`):
-
-```elixir
-defmodule CalculatorTest do
-  use Cucumber, feature: "calculator.feature"
-
-  defstep "I have entered {int} into the calculator", context do
-    number = List.first(context.args)
-    numbers = Map.get(context, :numbers, [])
-    {:ok, %{numbers: numbers ++ [number]}}
-  end
-
-  defstep "I press add", context do
-    result = Enum.sum(context.numbers)
-    {:ok, %{result: result}}
-  end
-
-  defstep "the result should be {int}", context do
-    expected = List.first(context.args)
-    assert context.result == expected
-    :ok
-  end
-end
+```sh
+mix precommit
 ```
 
-## Writing Effective Feature Files
-
-Feature files are the single source of truth for new functionality. Each feature file should:
-
-- Be saved in `test/features/` as `{feature_name}.feature`.
-- Use clear Gherkin syntax (`Feature`, `Scenario`, `Given`, `When`, `Then`).
-- Cover all relevant scenarios, including both success and error cases.
-- Describe what the user will experience in each scenario, including edge cases and validation errors.
-- Be updated as understanding evolves—feature files are living documents.
-
-### Example Feature File
-
-```gherkin
-Feature: User Login
-
-  Scenario: Successful login
-    Given the user is on the login page
-    When the user enters valid credentials
-    Then the user is redirected to the dashboard
-
-  Scenario: Login with invalid password
-    Given the user is on the login page
-    When the user enters an incorrect password
-    Then an error message is displayed
-
-  Scenario: Login with missing fields
-    Given the user is on the login page
-    When the user submits the form without entering credentials
-    Then a validation error is shown
-```
-
-## Checklist for Feature Files
-
-- [ ] All user interactions are described
-- [ ] Both success and error scenarios are included
-- [ ] Edge cases and validation are covered
-- [ ] User experience is clear in each scenario
-- [ ] Gherkin syntax is used consistently
-
-3. **Run the Tests**
-
-Run your tests as usual:
-
-```
-mix test
-```
-
-This approach ensures that every feature starts with a clear specification and is always covered by automated tests.
-
-## Test Support Guidelines
-
-### Test Fixtures
-
-Create reusable test fixtures to set up test data consistently across test scenarios:
-
-1. Place fixtures in `test/support/` directory
-2. Create specific fixture modules for each domain concept (e.g., `SoireeFixture`)
-3. Design fixtures to be idempotent (can be run multiple times without side effects)
-4. Make fixtures flexible with optional parameters for different test needs
-
-Example fixture:
-```elixir
-defmodule Huddlz.SoireeFixture do
-  def create_sample_soirees(count \\ 3) do
-    # Create test host with consistent email for lookup
-    host = get_or_create_test_host("test.host@example.com")
-
-    # Create soirées with sequential information
-    for i <- 1..count do
-      create_soiree(%{
-        title: "Test Soirée #{i}",
-        host_id: host.id
-      })
-    end
-  end
-end
-```
-
-### Test Generators
-
-For more complex data needs, create generators that produce realistic test data:
-
-1. Use the `Ash.Generator` module to create test data generators
-2. Place generators in the appropriate domain module: `lib/huddlz/domain/generators/`
-3. Use libraries like `Faker` to create diverse, realistic test data
-4. Make generators customizable with options to override default values
-
-Example generator:
-```elixir
-defmodule Huddlz.Soirees.Generators.SoireeGenerator do
-  use Ash.Generator
-
-  def soiree(opts \\ []) do
-    seed_generator(
-      %Soiree{
-        title: sequence(:title, &"Soirée #{&1}"),
-        description: Faker.Lorem.paragraph(),
-        starts_at: random_future_date()
-      },
-      overrides: opts
-    )
-  end
-end
-```
-
-### LiveView Testing
-
-When testing LiveView components:
-
-1. Use `PhoenixTest` for all LiveView interactions (imported via `HuddlzWeb.ConnCase`)
-2. Test user interactions with `fill_in/3`, `select/3`, `click_button/2`, and `visit/2`
-3. Verify page content using `assert_has/3` and `refute_has/3`
-4. Structure assertions to verify behavior, not implementation
-5. Use background setup steps to establish a known state
-
-#### PhoenixTest Patterns
-
-```elixir
-# Basic navigation and assertions
-session = conn |> visit("/groups")
-assert_has(session, "h1", text: "Groups")
-
-# Form interactions
-session
-|> fill_in("Name", with: "Book Club")
-|> select("Group type", option: "Public")
-|> click_button("Create Group")
-|> assert_has(".alert", text: "Group created")
-
-# Authentication
-conn
-|> login(user)  # Helper from ConnCase
-|> visit("/protected/page")
-```
-
-**Note**: PhoenixTest requires proper labels with `for` attributes on form inputs. If your forms use placeholders without labels, add visually hidden labels:
-
-```html
-<label for="search-query" class="sr-only">Search</label>
-<input id="search-query" name="query" placeholder="Search..." />
-```
+`mix precommit` runs compilation with warnings as errors, formatting,
+dependency cleanup, the test suite, and Credo. Do not run all of those commands
+separately by default; rerun an individual command when diagnosing or fixing a
+specific validation failure.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,41 +1,51 @@
-# Huddlz
+# huddlz
 
 ## Elevator Pitch
-Huddlz is a social network that prioritizes real-life connections. Unlike traditional social networks that often keep people glued to their screens, Huddlz is designed to bring people together in person. It provides organizers with a simple, cost-effective platform to create and manage meetups, while offering attendees a privacy-conscious way to discover and join real-world events.
+huddlz is a social network built to help people form real-life connections. It
+offers organizers and communities an open, automation-ready platform for
+creating and managing huddlz, including integrations for AI and community
+workflows. Attendees can discover and join huddlz through a privacy-conscious
+experience.
 
 ## Core Values
 - **Real-Life First**: Technology should facilitate, not replace, human interaction
+- **Human Connection, Supported by Automation**: huddlz is for people and
+  real-world connection. AI and automation should reduce coordination work,
+  improve discovery, and help organizers and communities thrive without
+  replacing human relationships
 - **Privacy-Conscious**: Users control their visibility and personal information
 - **Simplicity**: Easy to use for both organizers and attendees
 - **Cost-Effective**: No extortionary fees for organizers
 - **Open Platform**: Extensible API for community innovation
 
 ## Current Focus
-Initial development focuses on supporting tech meetup organizers, specifically:
-- Group meetup management
+Initial development focuses on supporting tech community organizers,
+specifically:
+- Group huddl management
 - Technical presentation/workshop coordination
-- Social tech event organization
+- Social huddlz for tech communities
 
 ## Goals
 
 ### Short-term (1 year)
-- Build and maintain a stable, useful platform that serves the initial tech meetup use case
+- Build and maintain a stable, useful platform that serves the initial tech
+  community use case
 - Maintain active development and personal interest in the project
 - Establish a foundation for organic growth through word-of-mouth
-- Support basic event organization needs:
-  - Event creation and management
+- Support basic huddl organization needs:
+  - huddl creation and management
   - Attendee registration with privacy options
   - Simple communication tools
 
 ### Long-term (3-5 years)
 - Foster a community where users develop lasting relationships
-- Expand beyond tech meetups to support various group types:
+- Expand beyond tech communities to support various group types:
   - Social groups
   - Special interest communities
   - Sports teams
   - Study groups
   - Religious gatherings
-- Potentially scale to support larger events like conferences and concerts
+- Potentially scale to support larger huddlz such as conferences and concerts
 
 ## Success Metrics
 Success is measured qualitatively rather than quantitatively, focusing on:
@@ -47,8 +57,8 @@ Success is measured qualitatively rather than quantitatively, focusing on:
 - Platform stability and reliability
 
 ## Next Steps
-1. Develop core event management features
+1. Develop core huddl management features
 2. Implement privacy-conscious user system
 3. Create organizer tools
 4. Build API for extensibility
-5. Test with initial tech meetup use cases
+5. Test with initial tech community use cases


### PR DESCRIPTION
## Summary

- streamline the README into a concise documentation hub
- define outside-in BDD guidance and focused contributor commit rules
- rename the domain model and access rules guide
- update vision terminology and AI/automation positioning

## Validation

- `mix precommit` (1,395 tests passed; Credo clean)
- `git diff --check`
- verified changed Markdown links and removed old `ARCHITECTURE.md` references