### PR TITLE
fix(huddl): make detail media responsive

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -314,6 +314,7 @@ body .nav-scrim { display: none; }
     left: 0;
     bottom: 0;
     width: min(320px, 86vw);
+    height: auto;
     z-index: 60;
     transform: translateX(-100%);
     transition: transform 200ms ease;
@@ -631,6 +632,7 @@ body .topbar-brand {
 
 body .topbar-search {
   flex: 1 1 auto;
+  min-width: 0;
   max-width: 560px;
   margin: 0;
   display: flex;
@@ -1901,6 +1903,22 @@ body .hero-img {
   z-index: 0;
 }
 
+/* Huddl media keeps its full composition in a consistent 16:9 stage. */
+body .huddl-hero {
+  height: auto;
+  aspect-ratio: 16 / 9;
+  isolation: isolate;
+}
+
+body .huddl-hero .hero-media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: linear-gradient(135deg, #06424a 0%, #0c1c20 50%, #1a0c30 100%);
+}
+
+body .huddl-hero .hero-img { object-fit: contain; }
+
 body .hero::after {
   content: "";
   position: absolute;
@@ -1932,6 +1950,11 @@ body .hero-content .meta {
   color: var(--soft);
   font-size: 13px;
 }
+
+body .huddl-hero .hero-content,
+body .huddl-hero .meta,
+body .huddl-intro,
+body .huddl-side { min-width: 0; }
 
 body .huddl-frame {
   display: grid;
@@ -1993,7 +2016,7 @@ body .facts li {
 body .facts svg { width: 16px; height: 16px; flex: 0 0 auto; color: var(--cyan); margin-top: 2px; }
 
 body .facts .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
-body .facts .value { color: var(--text); font-weight: 600; }
+body .facts .value { color: var(--text); font-weight: 600; overflow-wrap: anywhere; }
 
 body .prose { color: var(--soft); font-size: 15px; line-height: 1.65; }
 body .prose p { margin: 0 0 16px; }
@@ -3192,7 +3215,8 @@ body .page-nav:disabled {
   body .page-head { flex-direction: column; align-items: stretch; gap: 16px; margin-bottom: 20px; }
   body .page-head h1 { font-size: 26px; }
   body .page-head .actions { flex-wrap: wrap; }
-  body .hero { height: 200px; margin-bottom: 20px; }
+  body .hero:not(.huddl-hero) { height: 200px; }
+  body .hero { margin-bottom: 20px; }
   body .hero-content { padding: 18px 16px; }
   body .hero-content h1 { font-size: 26px; }
   body .panel { padding: 14px 14px; }
@@ -3211,4 +3235,55 @@ body .page-nav:disabled {
   body .profile-head { flex-direction: column; align-items: flex-start; gap: 14px; }
   body .pagination { justify-content: center; flex-wrap: wrap; }
   body .pagination .page-numbers { order: -1; flex-basis: 100%; justify-content: center; flex-wrap: wrap; }
+}
+
+@media (max-width: 520px) {
+  body .huddl-hero {
+    display: block;
+    height: auto;
+    aspect-ratio: auto;
+    min-height: 0;
+    overflow: visible;
+    background: transparent;
+    margin-bottom: 24px;
+  }
+
+  body .huddl-hero::after { display: none; }
+
+  body .huddl-hero .hero-media {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+  }
+
+  body .huddl-hero .hero-content {
+    display: block;
+    position: relative;
+    padding: 18px 4px 0;
+    color: var(--text);
+  }
+
+  body .huddl-hero .hero-content .eyebrow {
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  body .huddl-hero .hero-content h1 {
+    font-size: clamp(24px, 8vw, 30px);
+    overflow-wrap: anywhere;
+    text-shadow: none;
+  }
+
+  body .huddl-hero .hero-content .meta {
+    display: grid;
+    gap: 4px;
+    margin-top: 12px;
+  }
+
+  body .huddl-hero .hero-content .meta > span { white-space: normal; }
+  body .huddl-hero .hero-content .meta .meta-sep { display: none; }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3237,7 +3237,7 @@ body .page-nav:disabled {
   body .pagination .page-numbers { order: -1; flex-basis: 100%; justify-content: center; flex-wrap: wrap; }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 760px) {
   body .huddl-hero {
     display: block;
     height: auto;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1903,7 +1903,7 @@ body .hero-img {
   z-index: 0;
 }
 
-/* Huddl media keeps its full composition in a consistent 16:9 stage. */
+/* huddl media keeps its full composition in a consistent 16:9 stage. */
 body .huddl-hero {
   height: auto;
   aspect-ratio: 16 / 9;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3284,6 +3284,9 @@ body .page-nav:disabled {
     margin-top: 12px;
   }
 
-  body .huddl-hero .hero-content .meta > span { white-space: normal; }
+  body .huddl-hero .hero-content .meta > span {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
   body .huddl-hero .hero-content .meta .meta-sep { display: none; }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,28 +26,26 @@ import topbar from "../vendor/topbar"
 
 const Hooks = {}
 
-Hooks.ImageFallback = {
-  mounted() {
-    this._hideBrokenImage = () => {
-      this.el.hidden = true
-    }
+const imageFallbackSelector = "img[data-image-fallback]"
 
-    this.el.addEventListener("error", this._hideBrokenImage)
-    this.updateVisibility()
-  },
-
-  updated() {
-    this.updateVisibility()
-  },
-
-  destroyed() {
-    this.el.removeEventListener("error", this._hideBrokenImage)
-  },
-
-  updateVisibility() {
-    this.el.hidden = this.el.complete && this.el.naturalWidth === 0
-  }
+const imageFallbackTarget = (event) => {
+  const image = event.target
+  return image.matches && image.matches(imageFallbackSelector) ? image : null
 }
+
+window.addEventListener("error", (event) => {
+  const image = imageFallbackTarget(event)
+  if (image) image.hidden = true
+}, true)
+
+window.addEventListener("load", (event) => {
+  const image = imageFallbackTarget(event)
+  if (image) image.hidden = false
+}, true)
+
+document.querySelectorAll(imageFallbackSelector).forEach((image) => {
+  image.hidden = image.complete && image.naturalWidth === 0
+})
 
 Hooks.LocationAutocomplete = {
   mounted() {
@@ -91,7 +89,14 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: Hooks
+  hooks: Hooks,
+  dom: {
+    onBeforeElUpdated(fromEl, toEl) {
+      if (fromEl.matches(imageFallbackSelector) && fromEl.hidden) {
+        toEl.hidden = true
+      }
+    }
+  }
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,29 @@ import topbar from "../vendor/topbar"
 
 const Hooks = {}
 
+Hooks.ImageFallback = {
+  mounted() {
+    this._hideBrokenImage = () => {
+      this.el.hidden = true
+    }
+
+    this.el.addEventListener("error", this._hideBrokenImage)
+    this.updateVisibility()
+  },
+
+  updated() {
+    this.updateVisibility()
+  },
+
+  destroyed() {
+    this.el.removeEventListener("error", this._hideBrokenImage)
+  },
+
+  updateVisibility() {
+    this.el.hidden = this.el.complete && this.el.naturalWidth === 0
+  }
+}
+
 Hooks.LocationAutocomplete = {
   mounted() {
     this.setupInput()

--- a/lib/huddlz_web/components/components.ex
+++ b/lib/huddlz_web/components/components.ex
@@ -20,6 +20,7 @@ defmodule HuddlzWeb.Components do
       import HuddlzWeb.Components.Card
       import HuddlzWeb.Components.Chip
       import HuddlzWeb.Components.Flash
+      import HuddlzWeb.Components.HuddlCoverImage
       import HuddlzWeb.Components.Icon
       import HuddlzWeb.Components.Input
       import HuddlzWeb.Components.ListRow

--- a/lib/huddlz_web/components/huddl_cover_image.ex
+++ b/lib/huddlz_web/components/huddl_cover_image.ex
@@ -1,0 +1,27 @@
+defmodule HuddlzWeb.Components.HuddlCoverImage do
+  @moduledoc """
+  Renders decorative huddl cover media with the shared browser fallback contract.
+
+  Failed images are hidden by the delegated handlers in `assets/js/app.js`, which
+  reveals the gradient supplied by the surrounding hero or card.
+  """
+  use Phoenix.Component
+
+  alias Huddlz.Storage.HuddlImages
+
+  attr :id, :string, required: true
+  attr :image_url, :string, required: true
+  attr :class, :any, required: true
+
+  def huddl_cover_image(assigns) do
+    ~H"""
+    <img
+      id={@id}
+      class={@class}
+      src={HuddlImages.url(@image_url)}
+      alt=""
+      data-image-fallback
+    />
+    """
+  end
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -390,9 +390,11 @@ defmodule HuddlzWeb.GroupLive.Show do
           <:cover>
             <img
               :if={huddl.display_image_url}
+              id={"group-huddl-card-cover-#{huddl.id}"}
               class="card-cover-img"
               src={HuddlImages.url(huddl.display_image_url)}
-              alt={huddl.title}
+              alt=""
+              phx-hook="ImageFallback"
             />
             <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
             <.card_tag variant={tag_variant(huddl.event_type)}>

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -395,6 +395,7 @@ defmodule HuddlzWeb.GroupLive.Show do
               src={HuddlImages.url(huddl.display_image_url)}
               alt=""
               phx-hook="ImageFallback"
+              phx-update="ignore"
             />
             <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
             <.card_tag variant={tag_variant(huddl.event_type)}>

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -395,7 +395,6 @@ defmodule HuddlzWeb.GroupLive.Show do
               src={HuddlImages.url(huddl.display_image_url)}
               alt=""
               phx-hook="ImageFallback"
-              phx-update="ignore"
             />
             <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
             <.card_tag variant={tag_variant(huddl.event_type)}>

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -9,7 +9,6 @@ defmodule HuddlzWeb.GroupLive.Show do
   alias Huddlz.Communities
   alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl}
   alias Huddlz.Storage.GroupImages
-  alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Avatar
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.MetaHelpers
@@ -388,13 +387,11 @@ defmodule HuddlzWeb.GroupLive.Show do
           gradient={Integer.mod(idx, 6) + 1}
         >
           <:cover>
-            <img
+            <.huddl_cover_image
               :if={huddl.display_image_url}
               id={"group-huddl-card-cover-#{huddl.id}"}
               class="card-cover-img"
-              src={HuddlImages.url(huddl.display_image_url)}
-              alt=""
-              phx-hook="ImageFallback"
+              image_url={huddl.display_image_url}
             />
             <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
             <.card_tag variant={tag_variant(huddl.event_type)}>

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -715,9 +715,11 @@ defmodule HuddlzWeb.HuddlLive do
       <:cover>
         <img
           :if={@huddl.display_image_url}
+          id={"huddl-card-cover-#{@huddl.id}"}
           class="card-cover-img"
           src={HuddlImages.url(@huddl.display_image_url)}
-          alt={@huddl.title}
+          alt=""
+          phx-hook="ImageFallback"
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -720,6 +720,7 @@ defmodule HuddlzWeb.HuddlLive do
           src={HuddlImages.url(@huddl.display_image_url)}
           alt=""
           phx-hook="ImageFallback"
+          phx-update="ignore"
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -720,7 +720,6 @@ defmodule HuddlzWeb.HuddlLive do
           src={HuddlImages.url(@huddl.display_image_url)}
           alt=""
           phx-hook="ImageFallback"
-          phx-update="ignore"
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -15,7 +15,6 @@ defmodule HuddlzWeb.HuddlLive do
 
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
-  alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Layouts
   require Logger
 
@@ -713,13 +712,11 @@ defmodule HuddlzWeb.HuddlLive do
       gradient={@gradient}
     >
       <:cover>
-        <img
+        <.huddl_cover_image
           :if={@huddl.display_image_url}
           id={"huddl-card-cover-#{@huddl.id}"}
           class="card-cover-img"
-          src={HuddlImages.url(@huddl.display_image_url)}
-          alt=""
-          phx-hook="ImageFallback"
+          image_url={@huddl.display_image_url}
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -73,13 +73,11 @@ defmodule HuddlzWeb.HuddlLive.Show do
     >
       <div class={["hero", "huddl-hero", status_hero_class(@huddl.status)]}>
         <div class="hero-media">
-          <img
+          <.huddl_cover_image
             :if={@huddl.display_image_url}
             id={"huddl-cover-#{@huddl.id}"}
             class="hero-img"
-            src={HuddlImages.url(@huddl.display_image_url)}
-            alt=""
-            phx-hook="ImageFallback"
+            image_url={@huddl.display_image_url}
           />
         </div>
         <div class="hero-content">

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -71,13 +71,17 @@ defmodule HuddlzWeb.HuddlLive.Show do
       sidebar_owned_groups={@sidebar_owned_groups}
       active="discover"
     >
-      <div class={["hero", status_hero_class(@huddl.status)]}>
-        <img
-          :if={@huddl.display_image_url}
-          class="hero-img"
-          src={HuddlImages.url(@huddl.display_image_url)}
-          alt={@huddl.title}
-        />
+      <div class={["hero", "huddl-hero", status_hero_class(@huddl.status)]}>
+        <div class="hero-media">
+          <img
+            :if={@huddl.display_image_url}
+            id={"huddl-cover-#{@huddl.id}"}
+            class="hero-img"
+            src={HuddlImages.url(@huddl.display_image_url)}
+            alt=""
+            phx-hook="ImageFallback"
+          />
+        </div>
         <div class="hero-content">
           <span class={["eyebrow", status_eyebrow_class(@huddl.status)]}>
             {hero_eyebrow(@huddl)}

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -80,6 +80,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
             src={HuddlImages.url(@huddl.display_image_url)}
             alt=""
             phx-hook="ImageFallback"
+            phx-update="ignore"
           />
         </div>
         <div class="hero-content">

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -80,7 +80,6 @@ defmodule HuddlzWeb.HuddlLive.Show do
             src={HuddlImages.url(@huddl.display_image_url)}
             alt=""
             phx-hook="ImageFallback"
-            phx-update="ignore"
           />
         </div>
         <div class="hero-content">

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -210,7 +210,6 @@ defmodule HuddlzWeb.MyHuddlzLive do
           src={HuddlImages.url(@huddl.display_image_url)}
           alt=""
           phx-hook="ImageFallback"
-          phx-update="ignore"
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -210,6 +210,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
           src={HuddlImages.url(@huddl.display_image_url)}
           alt=""
           phx-hook="ImageFallback"
+          phx-update="ignore"
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -14,7 +14,6 @@ defmodule HuddlzWeb.MyHuddlzLive do
   import HuddlzWeb.Live.Helpers.ParamHelpers
 
   alias Huddlz.Communities
-  alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Layouts
   require Logger
 
@@ -203,13 +202,11 @@ defmodule HuddlzWeb.MyHuddlzLive do
       gradient={@gradient}
     >
       <:cover>
-        <img
+        <.huddl_cover_image
           :if={@huddl.display_image_url}
           id={"my-huddl-card-cover-#{@huddl.id}"}
           class="card-cover-img"
-          src={HuddlImages.url(@huddl.display_image_url)}
-          alt=""
-          phx-hook="ImageFallback"
+          image_url={@huddl.display_image_url}
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -205,9 +205,11 @@ defmodule HuddlzWeb.MyHuddlzLive do
       <:cover>
         <img
           :if={@huddl.display_image_url}
+          id={"my-huddl-card-cover-#{@huddl.id}"}
           class="card-cover-img"
           src={HuddlImages.url(@huddl.display_image_url)}
-          alt={@huddl.title}
+          alt=""
+          phx-hook="ImageFallback"
         />
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -115,21 +115,25 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
       |> Ash.update!()
 
-      image_fallback_attributes = "[phx-hook='ImageFallback'][phx-update='ignore'][alt='']"
+      image_fallback_attributes = "[phx-hook='ImageFallback'][alt='']"
 
       session =
         conn
         |> login(member)
         |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
         |> assert_has("#huddl-cover-#{huddl.id}#{image_fallback_attributes}")
+        |> refute_has("#huddl-cover-#{huddl.id}[phx-update='ignore']")
 
       session
       |> visit(~p"/discover")
       |> assert_has("#huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+      |> refute_has("#huddl-card-cover-#{huddl.id}[phx-update='ignore']")
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("#group-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+      |> refute_has("#group-huddl-card-cover-#{huddl.id}[phx-update='ignore']")
       |> visit(~p"/my-huddlz")
       |> assert_has("#my-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+      |> refute_has("#my-huddl-card-cover-#{huddl.id}[phx-update='ignore']")
     end
 
     test "renders rich link preview metadata", %{conn: conn, group: group, huddl: huddl} do

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -94,7 +94,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has(".facts .value", text: "1 person attending")
     end
 
-    test "wires image fallback behavior across huddl surfaces", %{
+    test "renders image fallback behavior across huddl surfaces", %{
       conn: conn,
       member: member,
       group: group,
@@ -115,25 +115,21 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
       |> Ash.update!()
 
-      image_fallback_attributes = "[phx-hook='ImageFallback'][alt='']"
+      image_fallback_attributes = "[data-image-fallback][alt='']"
 
       session =
         conn
         |> login(member)
         |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
         |> assert_has("#huddl-cover-#{huddl.id}#{image_fallback_attributes}")
-        |> refute_has("#huddl-cover-#{huddl.id}[phx-update='ignore']")
 
       session
       |> visit(~p"/discover")
       |> assert_has("#huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
-      |> refute_has("#huddl-card-cover-#{huddl.id}[phx-update='ignore']")
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("#group-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
-      |> refute_has("#group-huddl-card-cover-#{huddl.id}[phx-update='ignore']")
       |> visit(~p"/my-huddlz")
       |> assert_has("#my-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
-      |> refute_has("#my-huddl-card-cover-#{huddl.id}[phx-update='ignore']")
     end
 
     test "renders rich link preview metadata", %{conn: conn, group: group, huddl: huddl} do

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -94,6 +94,44 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has(".facts .value", text: "1 person attending")
     end
 
+    test "wires image fallback behavior across huddl surfaces", %{
+      conn: conn,
+      member: member,
+      group: group,
+      huddl: huddl
+    } do
+      HuddlImage
+      |> Ash.Changeset.for_create(:create, %{
+        filename: "cover.jpg",
+        content_type: "image/jpeg",
+        size_bytes: 123,
+        storage_path: "/uploads/huddl_images/#{huddl.id}/cover.jpg",
+        thumbnail_path: "/uploads/huddl_images/#{huddl.id}/cover_thumb.jpg",
+        huddl_id: huddl.id
+      })
+      |> Ash.create!(authorize?: false)
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
+      |> Ash.update!()
+
+      image_fallback_attributes = "[phx-hook='ImageFallback'][phx-update='ignore'][alt='']"
+
+      session =
+        conn
+        |> login(member)
+        |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+        |> assert_has("#huddl-cover-#{huddl.id}#{image_fallback_attributes}")
+
+      session
+      |> visit(~p"/discover")
+      |> assert_has("#huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#group-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+      |> visit(~p"/my-huddlz")
+      |> assert_has("#my-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+    end
+
     test "renders rich link preview metadata", %{conn: conn, group: group, huddl: huddl} do
       html =
         conn


### PR DESCRIPTION
## Summary
- preserve full huddl cover media in a consistent 16:9 frame
- move title and metadata below the media frame on narrow screens
- prevent broken cover images from exposing raw fallback text in huddl cards
- keep the signed-in topbar within the viewport at 320px

## Verification
- `mix precommit` (1,410 tests, Credo)
- visually checked at 320px, 600px, and desktop widths
- confirmed zero horizontal overflow at 320px
- confirmed a 1.778 media ratio at 600px and desktop widths

Closes #272
