### PR TITLE
Add shared pull request guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@ This is a web application written using the Phoenix web framework.
   `Co-Authored-By` trailers for human collaborators
 - Consult `docs/commit-style.md` before committing
 
+### Pull Requests
+
+- Follow the shared pull request guidance in `CONTRIBUTING.md`.
+- Keep agent-authored PR descriptions concise and factual; do not invent
+  verification claims or paste routine command output.
+
 ### Naming Conventions
 
 **IMPORTANT: ALWAYS follow these naming conventions precisely**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to huddlz
+
+## Pull Requests
+
+Write PR descriptions for reviewers, not as a recap of the diff or CI.
+
+- Summarize the user-visible work completed.
+- Include practical manual verification steps only when they would help a
+  reviewer validate the change.
+- Capture context that is not clear from the diff or CI, such as noteworthy
+  tradeoffs, rollout considerations, or follow-up work.
+
+Avoid routine test totals or pass counts, line-number or file-change recaps,
+and implementation details that are already apparent in the diff. Let CI
+report automated verification.


### PR DESCRIPTION
Adds shared contribution guidance for concise, reviewer-focused PR descriptions and links agent workflow instructions to it.