### PR TITLE
feat(groups): add membership administration

### DIFF
--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -10,6 +10,8 @@ defmodule Huddlz.Communities.Group do
     authorizers: [Ash.Policy.Authorizer],
     extensions: [AshJsonApi.Resource, AshGraphql.Resource]
 
+  require Ash.Query
+
   graphql do
     type :group
 
@@ -224,6 +226,9 @@ defmodule Huddlz.Communities.Group do
           new_owner_id == changeset.data.owner_id ->
             {:error, field: :new_owner_id, message: "is already the group owner"}
 
+          not existing_member?(changeset.data.id, new_owner_id) ->
+            {:error, field: :new_owner_id, message: "must already be a member of this group"}
+
           true ->
             :ok
         end
@@ -231,6 +236,12 @@ defmodule Huddlz.Communities.Group do
 
       change Huddlz.Communities.Group.Changes.TransferOwnership
     end
+  end
+
+  defp existing_member?(group_id, user_id) do
+    Huddlz.Communities.GroupMember
+    |> Ash.Query.filter(group_id == ^group_id and user_id == ^user_id)
+    |> Ash.exists?(authorize?: false)
   end
 
   policies do

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -10,8 +10,6 @@ defmodule Huddlz.Communities.Group do
     authorizers: [Ash.Policy.Authorizer],
     extensions: [AshJsonApi.Resource, AshGraphql.Resource]
 
-  require Ash.Query
-
   graphql do
     type :group
 
@@ -216,32 +214,10 @@ defmodule Huddlz.Communities.Group do
         allow_nil? false
       end
 
-      validate fn changeset, _ctx ->
-        new_owner_id = Ash.Changeset.get_argument(changeset, :new_owner_id)
-
-        cond do
-          is_nil(new_owner_id) ->
-            {:error, field: :new_owner_id, message: "is required"}
-
-          new_owner_id == changeset.data.owner_id ->
-            {:error, field: :new_owner_id, message: "is already the group owner"}
-
-          not existing_member?(changeset.data.id, new_owner_id) ->
-            {:error, field: :new_owner_id, message: "must already be a member of this group"}
-
-          true ->
-            :ok
-        end
-      end
+      validate Huddlz.Communities.Group.Validations.NewOwnerIsExistingMember
 
       change Huddlz.Communities.Group.Changes.TransferOwnership
     end
-  end
-
-  defp existing_member?(group_id, user_id) do
-    Huddlz.Communities.GroupMember
-    |> Ash.Query.filter(group_id == ^group_id and user_id == ^user_id)
-    |> Ash.exists?(authorize?: false)
   end
 
   policies do

--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -4,8 +4,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
 
     * Sets `owner_id` to the new owner.
     * Demotes the previous owner's GroupMember row to `:organizer`.
-    * Promotes the new owner's GroupMember row to `:owner`, creating the
-      membership if the new owner is not already in the group.
+    * Promotes the new owner's existing GroupMember row to `:owner`.
     * Enqueues B7 notifications to both the previous and new owners.
 
   Runs as a single `after_action` hook so it lands inside the same Ash
@@ -18,6 +17,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
@@ -33,6 +33,14 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
         notify(group, previous_owner_id, new_owner_id)
         {:ok, group}
       end
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, group} = result ->
+        MembershipEvents.broadcast(group.id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 
@@ -92,13 +100,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
   defp promote(group_id, user_id) do
     case fetch_membership(group_id, user_id) do
       nil ->
-        GroupMember
-        |> Ash.Changeset.for_create(:add_owner, %{
-          group_id: group_id,
-          user_id: user_id
-        })
-        |> Ash.create(authorize?: false)
-        |> ok_or_error()
+        {:error, "new owner must already be a group member"}
 
       membership ->
         membership

--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -36,7 +36,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
     end)
     |> Ash.Changeset.after_transaction(fn
       _changeset, {:ok, group} = result ->
-        MembershipEvents.broadcast(group.id)
+        MembershipEvents.broadcast(group.id, [previous_owner_id, new_owner_id])
         result
 
       _changeset, result ->

--- a/lib/huddlz/communities/group/validations/new_owner_is_existing_member.ex
+++ b/lib/huddlz/communities/group/validations/new_owner_is_existing_member.ex
@@ -1,0 +1,40 @@
+defmodule Huddlz.Communities.Group.Validations.NewOwnerIsExistingMember do
+  @moduledoc """
+  Ensures ownership is transferred to a different user who already belongs to the group.
+  """
+
+  use Ash.Resource.Validation
+
+  alias Huddlz.Communities
+
+  @impl true
+  def init(opts), do: {:ok, opts}
+
+  @impl true
+  def supports(_opts), do: [Ash.Changeset]
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    new_owner_id = Ash.Changeset.get_argument(changeset, :new_owner_id)
+
+    cond do
+      is_nil(new_owner_id) ->
+        {:error, field: :new_owner_id, message: "is required"}
+
+      new_owner_id == changeset.data.owner_id ->
+        {:error, field: :new_owner_id, message: "is already the group owner"}
+
+      member_of_group?(changeset.data.id, new_owner_id) ->
+        :ok
+
+      true ->
+        {:error, field: :new_owner_id, message: "must already be a member of this group"}
+    end
+  end
+
+  defp member_of_group?(group_id, user_id) do
+    group_id
+    |> Communities.get_by_group!(authorize?: false)
+    |> Enum.any?(&(&1.user_id == user_id))
+  end
+end

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -84,18 +84,7 @@ defmodule Huddlz.Communities.GroupMember do
       # minted only by group creation and Group.:transfer_ownership (via the
       # internal :add_owner action). This mirrors :change_role, which also
       # refuses :owner.
-      validate fn changeset, _context ->
-        case Ash.Changeset.get_argument(changeset, :role) do
-          role when role in ["member", "organizer"] ->
-            :ok
-
-          _ ->
-            {:error,
-             field: :role,
-             message:
-               "must be \"member\" or \"organizer\" (use transfer_ownership to set the owner)"}
-        end
-      end
+      validate Huddlz.Communities.GroupMember.Validations.AssignableRole
 
       change manage_relationship(:group_id, :group, type: :append)
       change manage_relationship(:user_id, :user, type: :append)
@@ -167,13 +156,7 @@ defmodule Huddlz.Communities.GroupMember do
       accept [:role]
       require_atomic? false
 
-      validate fn changeset, _context ->
-        if changeset.data.role == :owner do
-          {:error, field: :role, message: "the group owner cannot be demoted"}
-        else
-          :ok
-        end
-      end
+      validate Huddlz.Communities.GroupMember.Validations.CurrentOwnerCannotChangeRole
 
       validate attribute_in(:role, [:member, :organizer]) do
         message "must be :member or :organizer (use transfer_ownership to change the owner)"

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -140,6 +140,10 @@ defmodule Huddlz.Communities.GroupMember do
       filter expr(group_id == ^arg(:group_id))
       filter expr(user_id == ^arg(:user_id))
 
+      validate attribute_does_not_equal(:role, :owner) do
+        message "the group owner cannot be removed; transfer ownership first"
+      end
+
       change Huddlz.Communities.GroupMember.Changes.NotifyRemoved
     end
 
@@ -162,6 +166,14 @@ defmodule Huddlz.Communities.GroupMember do
       description "Change a member's role within a group (owner only). Cannot promote to :owner — use Group.:transfer_ownership."
       accept [:role]
       require_atomic? false
+
+      validate fn changeset, _context ->
+        if changeset.data.role == :owner do
+          {:error, field: :role, message: "the group owner cannot be demoted"}
+        else
+          :ok
+        end
+      end
 
       validate attribute_in(:role, [:member, :organizer]) do
         message "must be :member or :organizer (use transfer_ownership to change the owner)"
@@ -252,9 +264,13 @@ defmodule Huddlz.Communities.GroupMember do
       forbid_if always()
     end
 
-    # Group owners can remove members
+    # Owners may remove organizers or members, but never the owner. Organizers
+    # may remove regular members only.
     policy action(:remove_member) do
+      forbid_if expr(role == :owner)
       authorize_if GroupOwner
+      forbid_if expr(role != :member)
+      authorize_if GroupOrganizer
     end
 
     # Group owners can change a member's role, but never their own.

--- a/lib/huddlz/communities/group_member/changes/notify_removed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_removed.ex
@@ -27,7 +27,7 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
     end)
     |> Ash.Changeset.after_transaction(fn
       _changeset, {:ok, member} = result ->
-        MembershipEvents.broadcast(member.group_id)
+        MembershipEvents.broadcast(member.group_id, member.user_id)
         result
 
       _changeset, result ->

--- a/lib/huddlz/communities/group_member/changes/notify_removed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_removed.ex
@@ -10,11 +10,13 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
   use Ash.Resource.Change
 
   alias Huddlz.Communities.Group
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
-    Ash.Changeset.after_action(changeset, fn cs, member ->
+    changeset
+    |> Ash.Changeset.after_action(fn cs, member ->
       actor_id = actor_id(cs)
 
       if member.user_id != actor_id do
@@ -22,6 +24,14 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
       end
 
       {:ok, member}
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, member} = result ->
+        MembershipEvents.broadcast(member.group_id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 

--- a/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
@@ -9,18 +9,28 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.Group
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
     previous_role = changeset.data.role
 
-    Ash.Changeset.after_action(changeset, fn _cs, member ->
+    changeset
+    |> Ash.Changeset.after_action(fn _cs, member ->
       if previous_role != member.role do
         deliver(member, previous_role)
       end
 
       {:ok, member}
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, member} = result when previous_role != member.role ->
+        MembershipEvents.broadcast(member.group_id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 

--- a/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
@@ -26,7 +26,7 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged do
     end)
     |> Ash.Changeset.after_transaction(fn
       _changeset, {:ok, member} = result when previous_role != member.role ->
-        MembershipEvents.broadcast(member.group_id)
+        MembershipEvents.broadcast(member.group_id, member.user_id)
         result
 
       _changeset, result ->

--- a/lib/huddlz/communities/group_member/validations/assignable_role.ex
+++ b/lib/huddlz/communities/group_member/validations/assignable_role.ex
@@ -1,0 +1,26 @@
+defmodule Huddlz.Communities.GroupMember.Validations.AssignableRole do
+  @moduledoc """
+  Prevents the public membership action from assigning the protected owner role.
+  """
+
+  use Ash.Resource.Validation
+
+  @impl true
+  def init(opts), do: {:ok, opts}
+
+  @impl true
+  def supports(_opts), do: [Ash.Changeset]
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    case Ash.Changeset.get_argument(changeset, :role) do
+      role when role in ["member", "organizer"] ->
+        :ok
+
+      _ ->
+        {:error,
+         field: :role,
+         message: "must be \"member\" or \"organizer\" (use transfer_ownership to set the owner)"}
+    end
+  end
+end

--- a/lib/huddlz/communities/group_member/validations/current_owner_cannot_change_role.ex
+++ b/lib/huddlz/communities/group_member/validations/current_owner_cannot_change_role.ex
@@ -1,0 +1,22 @@
+defmodule Huddlz.Communities.GroupMember.Validations.CurrentOwnerCannotChangeRole do
+  @moduledoc """
+  Requires ownership transfer instead of changing the current owner's membership role.
+  """
+
+  use Ash.Resource.Validation
+
+  @impl true
+  def init(opts), do: {:ok, opts}
+
+  @impl true
+  def supports(_opts), do: [Ash.Changeset]
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    if changeset.data.role == :owner do
+      {:error, field: :role, message: "the group owner cannot be demoted"}
+    else
+      :ok
+    end
+  end
+end

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -12,9 +12,25 @@ defmodule Huddlz.Communities.MembershipEvents do
     Phoenix.PubSub.subscribe(@pubsub, topic(group_id))
   end
 
-  def broadcast(group_id) when is_binary(group_id) do
+  def subscribe_to_user(user_id) when is_binary(user_id) do
+    Phoenix.PubSub.subscribe(@pubsub, user_topic(user_id))
+  end
+
+  def broadcast(group_id, affected_user_ids \\ []) when is_binary(group_id) do
     Phoenix.PubSub.broadcast(@pubsub, topic(group_id), {:group_membership_changed, group_id})
+
+    affected_user_ids
+    |> List.wrap()
+    |> Enum.uniq()
+    |> Enum.each(fn user_id ->
+      Phoenix.PubSub.broadcast(
+        @pubsub,
+        user_topic(user_id),
+        {:organizer_access_changed, user_id}
+      )
+    end)
   end
 
   defp topic(group_id), do: "group-membership:#{group_id}"
+  defp user_topic(user_id), do: "user-membership:#{user_id}"
 end

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -1,0 +1,20 @@
+defmodule Huddlz.Communities.MembershipEvents do
+  @moduledoc """
+  Publishes group membership changes to mounted LiveViews.
+
+  Domain actions remain the source of truth. The messages only prompt
+  connected views to re-read through those authorized actions.
+  """
+
+  @pubsub Huddlz.PubSub
+
+  def subscribe(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.subscribe(@pubsub, topic(group_id))
+  end
+
+  def broadcast(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.broadcast(@pubsub, topic(group_id), {:group_membership_changed, group_id})
+  end
+
+  defp topic(group_id), do: "group-membership:#{group_id}"
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -25,7 +25,10 @@ defmodule HuddlzWeb.GroupLive.Show do
     {:ok,
      socket
      |> assign(:leave_dialog_open, false)
-     |> assign(:subscribed_group_id, nil)}
+     |> assign(:subscribed_group_id, nil)
+     |> assign(:members_visible?, false)
+     |> assign(:member_grid_extras, 0)
+     |> stream(:member_grid, [])}
   end
 
   @impl true
@@ -44,7 +47,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> assign(:page_title, group.name)
          |> assign(:meta, group_meta(group))
          |> assign(:group, group)
-         |> assign(:members, members)
+         |> assign_member_grid(members)
          |> assign(:member_count, group.member_count)
          |> assign(:is_member, !is_nil(membership))
          |> assign_action_permissions(group, user, membership)
@@ -91,7 +94,7 @@ defmodule HuddlzWeb.GroupLive.Show do
 
         socket
         |> assign(:group, group)
-        |> assign(:members, get_members(group, user, !is_nil(membership)))
+        |> assign_member_grid(get_members(group, user, !is_nil(membership)))
         |> assign(:member_count, group.member_count)
         |> assign(:is_member, !is_nil(membership))
         |> assign_action_permissions(group, user, membership)
@@ -287,23 +290,28 @@ defmodule HuddlzWeb.GroupLive.Show do
 
           <div class="huddl-side-section">
             <h3>Members</h3>
-            <%= if @members do %>
-              <% {visible, extras} = split_members(@members) %>
+            <%= if @members_visible? do %>
               <div class="member-grid compact">
-                <div :for={{member, idx} <- Enum.with_index(visible)} class="member-mini">
+                <div id="member-grid" class="contents" phx-update="stream">
                   <div
-                    class={["member-mark", member_mark_variant(idx)]}
-                    title={member.display_name || "Member"}
+                    :for={{id, entry} <- @streams.member_grid}
+                    id={id}
+                    class="member-mini"
                   >
-                    <%= if url = Avatar.picture_url(member) do %>
-                      <img src={url} alt={member.display_name || ""} />
-                    <% else %>
-                      {member_initials(member)}
-                    <% end %>
+                    <div
+                      class={["member-mark", entry.mark_variant]}
+                      title={entry.member.display_name || "Member"}
+                    >
+                      <%= if url = Avatar.picture_url(entry.member) do %>
+                        <img src={url} alt={entry.member.display_name || ""} />
+                      <% else %>
+                        {member_initials(entry.member)}
+                      <% end %>
+                    </div>
                   </div>
                 </div>
-                <div :if={extras > 0} class="member-mini">
-                  <div class="member-mark m4">+{extras}</div>
+                <div :if={@member_grid_extras > 0} class="member-mini">
+                  <div class="member-mark m4">+{@member_grid_extras}</div>
                 </div>
               </div>
             <% else %>
@@ -525,7 +533,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> put_flash(:info, "Successfully joined the group!")
          |> assign(:group, group)
          |> assign(:is_member, true)
-         |> assign(:members, members)
+         |> assign_member_grid(members)
          |> assign(:member_count, group.member_count)
          |> assign_action_permissions(group, user, membership)}
 
@@ -557,7 +565,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> assign(:leave_dialog_open, false)
          |> assign(:group, group)
          |> assign(:is_member, false)
-         |> assign(:members, nil)
+         |> assign_member_grid(nil)
          |> assign(:member_count, group.member_count)
          |> assign_action_permissions(group, user, nil)}
 
@@ -681,10 +689,26 @@ defmodule HuddlzWeb.GroupLive.Show do
   defp role_pill(%{is_member: true}), do: "Joined"
   defp role_pill(_assigns), do: nil
 
-  defp split_members(members) do
-    visible = Enum.take(members, @member_grid_visible)
-    extras = max(length(members) - @member_grid_visible, 0)
-    {visible, extras}
+  defp assign_member_grid(socket, nil) do
+    socket
+    |> assign(:members_visible?, false)
+    |> assign(:member_grid_extras, 0)
+    |> stream(:member_grid, [], reset: true)
+  end
+
+  defp assign_member_grid(socket, members) do
+    entries =
+      members
+      |> Enum.take(@member_grid_visible)
+      |> Enum.with_index()
+      |> Enum.map(fn {member, index} ->
+        %{id: member.id, member: member, mark_variant: member_mark_variant(index)}
+      end)
+
+    socket
+    |> assign(:members_visible?, true)
+    |> assign(:member_grid_extras, max(length(members) - @member_grid_visible, 0))
+    |> stream(:member_grid, entries, reset: true)
   end
 
   defp member_mark_variant(idx), do: "m#{Integer.mod(idx, 5) + 1}"

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -7,7 +7,7 @@ defmodule HuddlzWeb.GroupLive.Show do
   import HuddlzWeb.Live.Helpers.HuddlCardHelpers
 
   alias Huddlz.Communities
-  alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl}
+  alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl, MembershipEvents}
   alias Huddlz.Storage.GroupImages
   alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Avatar
@@ -22,7 +22,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :leave_dialog_open, false)}
+    {:ok,
+     socket
+     |> assign(:leave_dialog_open, false)
+     |> assign(:subscribed_group_id, nil)}
   end
 
   @impl true
@@ -37,6 +40,7 @@ defmodule HuddlzWeb.GroupLive.Show do
 
         {:noreply,
          socket
+         |> subscribe_to_membership_changes(group)
          |> assign(:page_title, group.name)
          |> assign(:meta, group_meta(group))
          |> assign(:group, group)
@@ -56,6 +60,47 @@ defmodule HuddlzWeb.GroupLive.Show do
            resource_name: "Group",
            fallback_path: ~p"/discover?#{[scope: "groups"]}"
          )}
+    end
+  end
+
+  @impl true
+  def handle_info(
+        {:group_membership_changed, group_id},
+        %{assigns: %{group: %{id: group_id}}} = socket
+      ) do
+    {:noreply, refresh_membership_state(socket)}
+  end
+
+  def handle_info({:group_membership_changed, _group_id}, socket), do: {:noreply, socket}
+
+  defp subscribe_to_membership_changes(socket, group) do
+    if connected?(socket) and socket.assigns.subscribed_group_id != group.id do
+      :ok = MembershipEvents.subscribe(group.id)
+      assign(socket, :subscribed_group_id, group.id)
+    else
+      socket
+    end
+  end
+
+  defp refresh_membership_state(socket) do
+    user = socket.assigns.current_user
+
+    case get_group_by_slug(socket.assigns.group.slug, user) do
+      {:ok, group} ->
+        membership = current_user_membership(group, user)
+
+        socket
+        |> assign(:group, group)
+        |> assign(:members, get_members(group, user, !is_nil(membership)))
+        |> assign(:member_count, group.member_count)
+        |> assign(:is_member, !is_nil(membership))
+        |> assign_action_permissions(group, user, membership)
+
+      {:error, _reason} ->
+        handle_error(socket, :not_found,
+          resource_name: "Group",
+          fallback_path: ~p"/discover?#{[scope: "groups"]}"
+        )
     end
   end
 

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -41,6 +41,8 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:subscribed_group_id, nil)
      |> assign(:pending_member_action, nil)
      |> assign(:member_action_form, member_action_form())
+     |> assign(:transfer_target_form, transfer_target_form())
+     |> assign(:transfer_candidates, [])
      |> stream(:owner_members, [])
      |> stream(:organizer_members, [])
      |> stream(:regular_members, [])}
@@ -178,6 +180,8 @@ defmodule HuddlzWeb.OrganizeLive do
             organizer_members={@streams.organizer_members}
             regular_members={@streams.regular_members}
             role_counts={@member_role_counts}
+            transfer_candidates={@transfer_candidates}
+            transfer_target_form={@transfer_target_form}
             current_user={@current_user}
           />
       <% end %>
@@ -442,6 +446,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :organizer_members, :any, required: true
   attr :regular_members, :any, required: true
   attr :role_counts, :map, required: true
+  attr :transfer_candidates, :list, required: true
+  attr :transfer_target_form, Phoenix.HTML.Form, required: true
   attr :current_user, :map, required: true
 
   defp members_view(assigns) do
@@ -451,7 +457,17 @@ defmodule HuddlzWeb.OrganizeLive do
       {:member, assigns.regular_members, assigns.role_counts.member}
     ]
 
-    assigns = assign(assigns, :grouped, grouped)
+    assigns =
+      assigns
+      |> assign(:grouped, grouped)
+      |> assign(
+        :can_transfer_ownership,
+        assigns.group.owner_id == assigns.current_user.id and assigns.transfer_candidates != []
+      )
+      |> assign(
+        :transfer_candidate_options,
+        Enum.map(assigns.transfer_candidates, &{member_name(&1), &1.id})
+      )
 
     ~H"""
     <div class="page-head">
@@ -505,6 +521,45 @@ defmodule HuddlzWeb.OrganizeLive do
         </div>
       <% end %>
     </div>
+
+    <section
+      :if={@can_transfer_ownership}
+      id="ownership-danger-zone"
+      class="panel mt-6 border-error/40"
+      aria-labelledby="ownership-danger-zone-title"
+    >
+      <div class="panel-head">
+        <div>
+          <h2 id="ownership-danger-zone-title">Ownership</h2>
+          <p class="panel-sub">
+            Transfer final control of this group. You will remain an organizer.
+          </p>
+        </div>
+      </div>
+
+      <.form
+        for={@transfer_target_form}
+        id="transfer-ownership-target-form"
+        phx-submit="open_transfer_action"
+        class="mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end"
+      >
+        <.select
+          field={@transfer_target_form[:member_id]}
+          id="ownership-recipient"
+          label="New owner"
+          prompt="Choose an existing member"
+          options={@transfer_candidate_options}
+        />
+        <.button
+          id="open-transfer-ownership"
+          type="submit"
+          variant={:destructive}
+          class="md:mb-px"
+        >
+          Transfer group ownership
+        </.button>
+      </.form>
+    </section>
     """
   end
 
@@ -520,14 +575,12 @@ defmodule HuddlzWeb.OrganizeLive do
         can_demote:
           member_action_allowed?(:demote, assigns.entry, assigns.group, assigns.current_user),
         can_remove:
-          member_action_allowed?(:remove, assigns.entry, assigns.group, assigns.current_user),
-        can_transfer:
-          member_action_allowed?(:transfer, assigns.entry, assigns.group, assigns.current_user)
+          member_action_allowed?(:remove, assigns.entry, assigns.group, assigns.current_user)
       )
 
     ~H"""
     <div
-      :if={@can_promote or @can_demote or @can_remove or @can_transfer}
+      :if={@can_promote or @can_demote or @can_remove}
       class="flex flex-wrap justify-end gap-2"
       aria-label={"Manage #{member_name(@entry)}"}
     >
@@ -550,16 +603,6 @@ defmodule HuddlzWeb.OrganizeLive do
         class="text-sm"
       >
         Demote
-      </.button>
-      <.button
-        :if={@can_transfer}
-        id={"transfer-owner-#{@entry.id}"}
-        phx-click="open_member_action"
-        phx-value-id={@entry.id}
-        phx-value-action="transfer"
-        class="text-sm"
-      >
-        Transfer ownership
       </.button>
       <.button
         :if={@can_remove}
@@ -635,22 +678,25 @@ defmodule HuddlzWeb.OrganizeLive do
 
   @impl true
   def handle_event("open_member_action", %{"id" => id, "action" => action}, socket) do
-    with {:ok, action_type} <- parse_member_action(action),
-         %{} = member <- Map.get(socket.assigns.member_lookup, id),
-         true <-
-           member_action_allowed?(
-             action_type,
-             member,
-             socket.assigns.group,
-             socket.assigns.current_user
-           ) do
-      {:noreply,
-       socket
-       |> assign(:pending_member_action, %{type: action_type, member: member})
-       |> assign(:member_action_form, member_action_form())}
-    else
-      _ -> {:noreply, put_flash(socket, :error, "That membership action is not available.")}
+    case parse_member_action(action) do
+      {:ok, action_type} ->
+        open_member_action(socket, id, action_type)
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "That membership action is not available.")}
     end
+  end
+
+  def handle_event(
+        "open_transfer_action",
+        %{"transfer_target" => %{"member_id" => id}},
+        socket
+      ) do
+    open_member_action(socket, id, :transfer)
+  end
+
+  def handle_event("open_transfer_action", _params, socket) do
+    {:noreply, put_flash(socket, :error, "Choose a member to receive ownership.")}
   end
 
   def handle_event("cancel_member_action", _params, socket) do
@@ -685,6 +731,24 @@ defmodule HuddlzWeb.OrganizeLive do
       perform_member_action(socket, action)
     else
       {:noreply, put_flash(socket, :error, "Type the group name exactly to transfer ownership.")}
+    end
+  end
+
+  defp open_member_action(socket, id, action_type) do
+    with %{} = member <- Map.get(socket.assigns.member_lookup, id),
+         true <-
+           member_action_allowed?(
+             action_type,
+             member,
+             socket.assigns.group,
+             socket.assigns.current_user
+           ) do
+      {:noreply,
+       socket
+       |> assign(:pending_member_action, %{type: action_type, member: member})
+       |> assign(:member_action_form, member_action_form())}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "That membership action is not available.")}
     end
   end
 
@@ -769,6 +833,8 @@ defmodule HuddlzWeb.OrganizeLive do
 
     socket
     |> assign(:member_lookup, Map.new(members, &{&1.id, &1}))
+    |> assign(:transfer_candidates, Enum.reject(members, &(&1.role == :owner)))
+    |> assign(:transfer_target_form, transfer_target_form())
     |> assign(:member_role_counts, %{
       owner: length(Map.get(by_role, :owner, [])),
       organizer: length(Map.get(by_role, :organizer, [])),
@@ -819,6 +885,12 @@ defmodule HuddlzWeb.OrganizeLive do
     params
     |> Map.put_new("confirmation", "")
     |> to_form(as: :member_action)
+  end
+
+  defp transfer_target_form(params \\ %{}) do
+    params
+    |> Map.put_new("member_id", "")
+    |> to_form(as: :transfer_target)
   end
 
   defp member_action_title(%{type: :promote, member: member}),

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -14,6 +14,7 @@ defmodule HuddlzWeb.OrganizeLive do
   use HuddlzWeb, :live_view
 
   alias Huddlz.Communities
+  alias Huddlz.Communities.MembershipEvents
   alias HuddlzWeb.Layouts
 
   @group_loads [:member_count]
@@ -36,7 +37,10 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_filter, :live)
      |> assign(:upcoming_huddlz, [])
      |> assign(:open_rsvps, 0)
-     |> assign(:members, [])}
+     |> assign(:members, [])
+     |> assign(:subscribed_group_id, nil)
+     |> assign(:pending_member_action, nil)
+     |> assign(:ownership_confirmation, "")}
   end
 
   @impl true
@@ -64,6 +68,7 @@ defmodule HuddlzWeb.OrganizeLive do
     case load_group(slug, user) do
       {:ok, group} ->
         socket
+        |> subscribe_to_membership_changes(group)
         |> assign(:group, group)
         |> assign(:page_title, "#{group.name} · Organizer")
         |> load_section(action, group, user)
@@ -129,6 +134,15 @@ defmodule HuddlzWeb.OrganizeLive do
     )
   end
 
+  defp subscribe_to_membership_changes(socket, group) do
+    if connected?(socket) and socket.assigns.subscribed_group_id != group.id do
+      :ok = MembershipEvents.subscribe(group.id)
+      assign(socket, :subscribed_group_id, group.id)
+    else
+      socket
+    end
+  end
+
   defp parse_huddlz_filter("past"), do: :past
   defp parse_huddlz_filter(_), do: :live
 
@@ -157,8 +171,15 @@ defmodule HuddlzWeb.OrganizeLive do
         <% :huddlz -> %>
           <.huddlz_view group={@group} huddlz={@huddlz_list} filter={@huddlz_filter} />
         <% :members -> %>
-          <.members_view group={@group} members={@members} />
+          <.members_view group={@group} members={@members} current_user={@current_user} />
       <% end %>
+
+      <.member_action_dialog
+        :if={@pending_member_action}
+        action={@pending_member_action}
+        group={@group}
+        ownership_confirmation={@ownership_confirmation}
+      />
     </Layouts.app>
     """
   end
@@ -410,6 +431,7 @@ defmodule HuddlzWeb.OrganizeLive do
   # ─────────────────────────────────────────  MEMBERS  ───
   attr :group, :map, required: true
   attr :members, :list, required: true
+  attr :current_user, :map, required: true
 
   defp members_view(assigns) do
     by_role = Enum.group_by(assigns.members, & &1.role)
@@ -448,12 +470,19 @@ defmodule HuddlzWeb.OrganizeLive do
             <p class="muted role-section-empty">{role_empty_copy(role)}</p>
           <% else %>
             <div class="row-list">
-              <div :for={entry <- rows} class="row row-split">
+              <div :for={entry <- rows} class="row row-split gap-4">
                 <div>
                   <div class="row-title">{member_name(entry)}</div>
                   <div class="meta">{format_member_meta(entry)}</div>
                 </div>
-                <span class={["pill", role_pill_class(role)]}>{role_label(role)}</span>
+                <div class="flex flex-wrap items-center justify-end gap-2">
+                  <span class={["pill", role_pill_class(role)]}>{role_label(role)}</span>
+                  <.member_actions
+                    entry={entry}
+                    group={@group}
+                    current_user={@current_user}
+                  />
+                </div>
               </div>
             </div>
           <% end %>
@@ -462,6 +491,341 @@ defmodule HuddlzWeb.OrganizeLive do
     </div>
     """
   end
+
+  attr :entry, :map, required: true
+  attr :group, :map, required: true
+  attr :current_user, :map, required: true
+
+  defp member_actions(assigns) do
+    assigns =
+      assign(assigns,
+        can_promote:
+          member_action_allowed?(:promote, assigns.entry, assigns.group, assigns.current_user),
+        can_demote:
+          member_action_allowed?(:demote, assigns.entry, assigns.group, assigns.current_user),
+        can_remove:
+          member_action_allowed?(:remove, assigns.entry, assigns.group, assigns.current_user),
+        can_transfer:
+          member_action_allowed?(:transfer, assigns.entry, assigns.group, assigns.current_user)
+      )
+
+    ~H"""
+    <div
+      :if={@can_promote or @can_demote or @can_remove or @can_transfer}
+      class="flex flex-wrap justify-end gap-2"
+      aria-label={"Manage #{member_name(@entry)}"}
+    >
+      <.button
+        :if={@can_promote}
+        id={"promote-member-#{@entry.id}"}
+        phx-click="open_member_action"
+        phx-value-id={@entry.id}
+        phx-value-action="promote"
+        class="text-sm"
+      >
+        Promote
+      </.button>
+      <.button
+        :if={@can_demote}
+        id={"demote-member-#{@entry.id}"}
+        phx-click="open_member_action"
+        phx-value-id={@entry.id}
+        phx-value-action="demote"
+        class="text-sm"
+      >
+        Demote
+      </.button>
+      <.button
+        :if={@can_transfer}
+        id={"transfer-owner-#{@entry.id}"}
+        phx-click="open_member_action"
+        phx-value-id={@entry.id}
+        phx-value-action="transfer"
+        class="text-sm"
+      >
+        Transfer ownership
+      </.button>
+      <.button
+        :if={@can_remove}
+        id={"remove-member-#{@entry.id}"}
+        variant={:destructive}
+        phx-click="open_member_action"
+        phx-value-id={@entry.id}
+        phx-value-action="remove"
+        class="text-sm"
+      >
+        Remove
+      </.button>
+    </div>
+    """
+  end
+
+  attr :action, :map, required: true
+  attr :group, :map, required: true
+  attr :ownership_confirmation, :string, required: true
+
+  defp member_action_dialog(assigns) do
+    ~H"""
+    <.modal
+      id="member-action-dialog"
+      show
+      on_cancel={JS.push("cancel_member_action")}
+    >
+      <div class="pr-8">
+        <h2 id="member-action-dialog-title" class="text-xl font-bold text-base-content">
+          {member_action_title(@action)}
+        </h2>
+        <p class="mt-3 text-sm leading-6 text-base-content/70">
+          {member_action_description(@action, @group)}
+        </p>
+      </div>
+
+      <form
+        id="member-action-form"
+        phx-submit="confirm_member_action"
+        phx-change="validate_member_action_confirmation"
+        class="mt-6"
+      >
+        <.input
+          :if={@action.type == :transfer}
+          id="ownership-confirmation"
+          name="confirmation"
+          label={"Type #{@group.name} to confirm"}
+          value={@ownership_confirmation}
+          autocomplete="off"
+          help="Ownership transfer changes who controls the group immediately."
+        />
+
+        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <.button id="member-action-cancel" phx-click="cancel_member_action">
+            Cancel
+          </.button>
+          <.button
+            id="member-action-confirm"
+            type="submit"
+            variant={member_action_button_variant(@action.type)}
+            disabled={@action.type == :transfer and @ownership_confirmation != to_string(@group.name)}
+            phx-disable-with="Saving..."
+          >
+            {member_action_confirm_label(@action.type)}
+          </.button>
+        </div>
+      </form>
+    </.modal>
+    """
+  end
+
+  @impl true
+  def handle_event("open_member_action", %{"id" => id, "action" => action}, socket) do
+    with {:ok, action_type} <- parse_member_action(action),
+         %{} = member <- Enum.find(socket.assigns.members, &(&1.id == id)),
+         true <-
+           member_action_allowed?(
+             action_type,
+             member,
+             socket.assigns.group,
+             socket.assigns.current_user
+           ) do
+      {:noreply,
+       socket
+       |> assign(:pending_member_action, %{type: action_type, member: member})
+       |> assign(:ownership_confirmation, "")}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "That membership action is not available.")}
+    end
+  end
+
+  def handle_event("cancel_member_action", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:pending_member_action, nil)
+     |> assign(:ownership_confirmation, "")}
+  end
+
+  def handle_event(
+        "validate_member_action_confirmation",
+        %{"confirmation" => confirmation},
+        socket
+      ) do
+    {:noreply, assign(socket, :ownership_confirmation, confirmation)}
+  end
+
+  def handle_event("validate_member_action_confirmation", _params, socket), do: {:noreply, socket}
+
+  def handle_event(
+        "confirm_member_action",
+        _params,
+        %{assigns: %{pending_member_action: nil}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
+  def handle_event("confirm_member_action", _params, socket) do
+    action = socket.assigns.pending_member_action
+
+    if confirmation_valid?(action.type, socket) do
+      perform_member_action(socket, action)
+    else
+      {:noreply, put_flash(socket, :error, "Type the group name exactly to transfer ownership.")}
+    end
+  end
+
+  @impl true
+  def handle_info(
+        {:group_membership_changed, group_id},
+        %{assigns: %{group: %{id: group_id}}} = socket
+      ) do
+    {:noreply, refresh_after_membership_change(socket)}
+  end
+
+  def handle_info({:group_membership_changed, _group_id}, socket), do: {:noreply, socket}
+
+  defp perform_member_action(socket, action) do
+    case run_member_action(action, socket.assigns.group, socket.assigns.current_user) do
+      {:ok, _result} ->
+        {:noreply,
+         socket
+         |> assign(:pending_member_action, nil)
+         |> assign(:ownership_confirmation, "")
+         |> put_flash(:info, member_action_success(action))
+         |> refresh_after_membership_change()}
+
+      :ok ->
+        {:noreply,
+         socket
+         |> assign(:pending_member_action, nil)
+         |> assign(:ownership_confirmation, "")
+         |> put_flash(:info, member_action_success(action))
+         |> refresh_after_membership_change()}
+
+      {:error, _error} ->
+        {:noreply,
+         socket
+         |> assign(:pending_member_action, nil)
+         |> assign(:ownership_confirmation, "")
+         |> put_flash(:error, "The membership could not be updated. Please try again.")}
+    end
+  end
+
+  defp run_member_action(%{type: :promote, member: member}, _group, user) do
+    Communities.change_member_role(member, :organizer, actor: user)
+  end
+
+  defp run_member_action(%{type: :demote, member: member}, _group, user) do
+    Communities.change_member_role(member, :member, actor: user)
+  end
+
+  defp run_member_action(%{type: :remove, member: member}, group, user) do
+    Communities.remove_member(member, group.id, member.user_id, actor: user)
+  end
+
+  defp run_member_action(%{type: :transfer, member: member}, group, user) do
+    Communities.transfer_group_ownership(group, member.user_id, actor: user)
+  end
+
+  defp refresh_after_membership_change(socket) do
+    user = socket.assigns.current_user
+    group = socket.assigns.group
+
+    case load_group(group.slug, user) do
+      {:ok, reloaded_group} ->
+        socket
+        |> assign(:group, reloaded_group)
+        |> refresh_members_if_visible(reloaded_group, user)
+
+      :error ->
+        socket
+        |> put_flash(:error, "Your organizer access to #{group.name} has changed.")
+        |> push_navigate(to: ~p"/organize")
+    end
+  end
+
+  defp refresh_members_if_visible(%{assigns: %{live_action: :members}} = socket, group, user) do
+    assign(socket, :members, list_group_members(group, user))
+  end
+
+  defp refresh_members_if_visible(socket, _group, _user), do: socket
+
+  defp member_action_allowed?(:promote, %{role: :member} = member, _group, user) do
+    Ash.can?({member, :change_role, %{role: :organizer}}, user)
+  end
+
+  defp member_action_allowed?(:demote, %{role: :organizer} = member, _group, user) do
+    Ash.can?({member, :change_role, %{role: :member}}, user)
+  end
+
+  defp member_action_allowed?(:remove, %{role: role} = member, group, user)
+       when role in [:member, :organizer] do
+    Ash.can?(
+      {member, :remove_member, %{group_id: group.id, user_id: member.user_id}},
+      user
+    )
+  end
+
+  defp member_action_allowed?(:transfer, %{role: role} = member, group, user)
+       when role in [:member, :organizer] do
+    Ash.can?({group, :transfer_ownership, %{new_owner_id: member.user_id}}, user)
+  end
+
+  defp member_action_allowed?(_action, _member, _group, _user), do: false
+
+  defp parse_member_action("promote"), do: {:ok, :promote}
+  defp parse_member_action("demote"), do: {:ok, :demote}
+  defp parse_member_action("remove"), do: {:ok, :remove}
+  defp parse_member_action("transfer"), do: {:ok, :transfer}
+  defp parse_member_action(_action), do: :error
+
+  defp confirmation_valid?(:transfer, socket) do
+    socket.assigns.ownership_confirmation == to_string(socket.assigns.group.name)
+  end
+
+  defp confirmation_valid?(_action, _socket), do: true
+
+  defp member_action_title(%{type: :promote, member: member}),
+    do: "Promote #{member_name(member)}?"
+
+  defp member_action_title(%{type: :demote, member: member}),
+    do: "Demote #{member_name(member)}?"
+
+  defp member_action_title(%{type: :remove, member: member}),
+    do: "Remove #{member_name(member)}?"
+
+  defp member_action_title(%{type: :transfer, member: member}),
+    do: "Transfer ownership to #{member_name(member)}?"
+
+  defp member_action_description(%{type: :promote}, group),
+    do: "This person will be able to organize #{group.name} and manage regular members."
+
+  defp member_action_description(%{type: :demote}, group),
+    do: "This person will immediately lose organizer access to #{group.name}."
+
+  defp member_action_description(%{type: :remove}, group),
+    do:
+      "This person will lose access to private #{group.name} content. Their existing RSVP records are preserved."
+
+  defp member_action_description(%{type: :transfer}, group),
+    do:
+      "You will become an organizer. The new owner will control #{group.name}, including roles and ownership."
+
+  defp member_action_confirm_label(:promote), do: "Promote to organizer"
+  defp member_action_confirm_label(:demote), do: "Demote to member"
+  defp member_action_confirm_label(:remove), do: "Remove from group"
+  defp member_action_confirm_label(:transfer), do: "Transfer ownership"
+
+  defp member_action_button_variant(:promote), do: :primary
+  defp member_action_button_variant(_action), do: :destructive
+
+  defp member_action_success(%{type: :promote, member: member}),
+    do: "#{member_name(member)} is now an organizer."
+
+  defp member_action_success(%{type: :demote, member: member}),
+    do: "#{member_name(member)} is now a member."
+
+  defp member_action_success(%{type: :remove, member: member}),
+    do: "#{member_name(member)} was removed from the group."
+
+  defp member_action_success(%{type: :transfer, member: member}),
+    do: "Ownership transferred to #{member_name(member)}."
 
   defp role_heading(:owner), do: "Owner"
   defp role_heading(:organizer), do: "Organizers"

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -20,7 +20,6 @@ defmodule HuddlzWeb.OrganizeLive do
   @group_loads [:member_count]
   @huddl_loads [:rsvp_count, :status, :group]
   @upcoming_loads [:rsvp_count, :group]
-  @member_role_order [:owner, :organizer, :member]
   @upcoming_preview_limit 5
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
@@ -37,10 +36,14 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_filter, :live)
      |> assign(:upcoming_huddlz, [])
      |> assign(:open_rsvps, 0)
-     |> assign(:members, [])
+     |> assign(:member_lookup, %{})
+     |> assign(:member_role_counts, %{owner: 0, organizer: 0, member: 0})
      |> assign(:subscribed_group_id, nil)
      |> assign(:pending_member_action, nil)
-     |> assign(:ownership_confirmation, "")}
+     |> assign(:member_action_form, member_action_form())
+     |> stream(:owner_members, [])
+     |> stream(:organizer_members, [])
+     |> stream(:regular_members, [])}
   end
 
   @impl true
@@ -56,12 +59,10 @@ defmodule HuddlzWeb.OrganizeLive do
     {:noreply, socket}
   end
 
-  defp load_action(socket, :index, _params, user) do
-    owned_groups = Ash.load!(socket.assigns.sidebar_owned_groups, @group_loads, actor: user)
-
+  defp load_action(socket, :index, _params, _user) do
     socket
     |> assign(:group, nil)
-    |> assign(:owned_groups, owned_groups)
+    |> assign(:owned_groups, socket.assigns.sidebar_owned_groups)
   end
 
   defp load_action(socket, action, %{"group_slug" => slug}, user) do
@@ -97,7 +98,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp load_section(socket, :members, group, user) do
     members = list_group_members(group, user)
-    assign(socket, :members, members)
+    assign_members(socket, members)
   end
 
   defp load_group(slug, user) do
@@ -171,14 +172,21 @@ defmodule HuddlzWeb.OrganizeLive do
         <% :huddlz -> %>
           <.huddlz_view group={@group} huddlz={@huddlz_list} filter={@huddlz_filter} />
         <% :members -> %>
-          <.members_view group={@group} members={@members} current_user={@current_user} />
+          <.members_view
+            group={@group}
+            owner_members={@streams.owner_members}
+            organizer_members={@streams.organizer_members}
+            regular_members={@streams.regular_members}
+            role_counts={@member_role_counts}
+            current_user={@current_user}
+          />
       <% end %>
 
       <.member_action_dialog
         :if={@pending_member_action}
         action={@pending_member_action}
         group={@group}
-        ownership_confirmation={@ownership_confirmation}
+        form={@member_action_form}
       />
     </Layouts.app>
     """
@@ -430,12 +438,18 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # ─────────────────────────────────────────  MEMBERS  ───
   attr :group, :map, required: true
-  attr :members, :list, required: true
+  attr :owner_members, :any, required: true
+  attr :organizer_members, :any, required: true
+  attr :regular_members, :any, required: true
+  attr :role_counts, :map, required: true
   attr :current_user, :map, required: true
 
   defp members_view(assigns) do
-    by_role = Enum.group_by(assigns.members, & &1.role)
-    grouped = Enum.map(@member_role_order, fn role -> {role, Map.get(by_role, role, [])} end)
+    grouped = [
+      {:owner, assigns.owner_members, assigns.role_counts.owner},
+      {:organizer, assigns.organizer_members, assigns.role_counts.organizer},
+      {:member, assigns.regular_members, assigns.role_counts.member}
+    ]
 
     assigns = assign(assigns, :grouped, grouped)
 
@@ -460,32 +474,34 @@ defmodule HuddlzWeb.OrganizeLive do
         </div>
       </div>
 
-      <%= for {role, rows} <- @grouped do %>
+      <%= for {role, rows, count} <- @grouped do %>
         <div class="role-section">
           <div class="role-section-head">
             <h3>{role_heading(role)}</h3>
-            <span :if={role != :owner} class="muted count">({length(rows)})</span>
+            <span :if={role != :owner} class="muted count">({count})</span>
           </div>
-          <%= if rows == [] do %>
-            <p class="muted role-section-empty">{role_empty_copy(role)}</p>
-          <% else %>
-            <div class="row-list">
-              <div :for={entry <- rows} class="row row-split gap-4">
-                <div>
-                  <div class="row-title">{member_name(entry)}</div>
-                  <div class="meta">{format_member_meta(entry)}</div>
-                </div>
-                <div class="flex flex-wrap items-center justify-end gap-2">
-                  <span class={["pill", role_pill_class(role)]}>{role_label(role)}</span>
-                  <.member_actions
-                    entry={entry}
-                    group={@group}
-                    current_user={@current_user}
-                  />
-                </div>
+          <div id={"#{role}-member-rows"} class="row-list" phx-update="stream">
+            <p
+              id={"#{role}-member-rows-empty"}
+              class="hidden only:block muted role-section-empty"
+            >
+              {role_empty_copy(role)}
+            </p>
+            <div :for={{id, entry} <- rows} id={id} class="row row-split gap-4">
+              <div>
+                <div class="row-title">{member_name(entry)}</div>
+                <div class="meta">{format_member_meta(entry)}</div>
+              </div>
+              <div class="flex flex-wrap items-center justify-end gap-2">
+                <span class={["pill", role_pill_class(role)]}>{role_label(role)}</span>
+                <.member_actions
+                  entry={entry}
+                  group={@group}
+                  current_user={@current_user}
+                />
               </div>
             </div>
-          <% end %>
+          </div>
         </div>
       <% end %>
     </div>
@@ -562,9 +578,11 @@ defmodule HuddlzWeb.OrganizeLive do
 
   attr :action, :map, required: true
   attr :group, :map, required: true
-  attr :ownership_confirmation, :string, required: true
+  attr :form, Phoenix.HTML.Form, required: true
 
   defp member_action_dialog(assigns) do
+    assigns = assign(assigns, :ownership_confirmation, assigns.form[:confirmation].value || "")
+
     ~H"""
     <.modal
       id="member-action-dialog"
@@ -580,7 +598,8 @@ defmodule HuddlzWeb.OrganizeLive do
         </p>
       </div>
 
-      <form
+      <.form
+        for={@form}
         id="member-action-form"
         phx-submit="confirm_member_action"
         phx-change="validate_member_action_confirmation"
@@ -588,10 +607,9 @@ defmodule HuddlzWeb.OrganizeLive do
       >
         <.input
           :if={@action.type == :transfer}
+          field={@form[:confirmation]}
           id="ownership-confirmation"
-          name="confirmation"
           label={"Type #{@group.name} to confirm"}
-          value={@ownership_confirmation}
           autocomplete="off"
           help="Ownership transfer changes who controls the group immediately."
         />
@@ -610,7 +628,7 @@ defmodule HuddlzWeb.OrganizeLive do
             {member_action_confirm_label(@action.type)}
           </.button>
         </div>
-      </form>
+      </.form>
     </.modal>
     """
   end
@@ -618,7 +636,7 @@ defmodule HuddlzWeb.OrganizeLive do
   @impl true
   def handle_event("open_member_action", %{"id" => id, "action" => action}, socket) do
     with {:ok, action_type} <- parse_member_action(action),
-         %{} = member <- Enum.find(socket.assigns.members, &(&1.id == id)),
+         %{} = member <- Map.get(socket.assigns.member_lookup, id),
          true <-
            member_action_allowed?(
              action_type,
@@ -629,7 +647,7 @@ defmodule HuddlzWeb.OrganizeLive do
       {:noreply,
        socket
        |> assign(:pending_member_action, %{type: action_type, member: member})
-       |> assign(:ownership_confirmation, "")}
+       |> assign(:member_action_form, member_action_form())}
     else
       _ -> {:noreply, put_flash(socket, :error, "That membership action is not available.")}
     end
@@ -639,15 +657,15 @@ defmodule HuddlzWeb.OrganizeLive do
     {:noreply,
      socket
      |> assign(:pending_member_action, nil)
-     |> assign(:ownership_confirmation, "")}
+     |> assign(:member_action_form, member_action_form())}
   end
 
   def handle_event(
         "validate_member_action_confirmation",
-        %{"confirmation" => confirmation},
+        %{"member_action" => params},
         socket
       ) do
-    {:noreply, assign(socket, :ownership_confirmation, confirmation)}
+    {:noreply, assign(socket, :member_action_form, member_action_form(params))}
   end
 
   def handle_event("validate_member_action_confirmation", _params, socket), do: {:noreply, socket}
@@ -686,7 +704,7 @@ defmodule HuddlzWeb.OrganizeLive do
         {:noreply,
          socket
          |> assign(:pending_member_action, nil)
-         |> assign(:ownership_confirmation, "")
+         |> assign(:member_action_form, member_action_form())
          |> put_flash(:info, member_action_success(action))
          |> refresh_after_membership_change()}
 
@@ -694,7 +712,7 @@ defmodule HuddlzWeb.OrganizeLive do
         {:noreply,
          socket
          |> assign(:pending_member_action, nil)
-         |> assign(:ownership_confirmation, "")
+         |> assign(:member_action_form, member_action_form())
          |> put_flash(:info, member_action_success(action))
          |> refresh_after_membership_change()}
 
@@ -702,7 +720,7 @@ defmodule HuddlzWeb.OrganizeLive do
         {:noreply,
          socket
          |> assign(:pending_member_action, nil)
-         |> assign(:ownership_confirmation, "")
+         |> assign(:member_action_form, member_action_form())
          |> put_flash(:error, "The membership could not be updated. Please try again.")}
     end
   end
@@ -741,10 +759,25 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp refresh_members_if_visible(%{assigns: %{live_action: :members}} = socket, group, user) do
-    assign(socket, :members, list_group_members(group, user))
+    assign_members(socket, list_group_members(group, user))
   end
 
   defp refresh_members_if_visible(socket, _group, _user), do: socket
+
+  defp assign_members(socket, members) do
+    by_role = Enum.group_by(members, & &1.role)
+
+    socket
+    |> assign(:member_lookup, Map.new(members, &{&1.id, &1}))
+    |> assign(:member_role_counts, %{
+      owner: length(Map.get(by_role, :owner, [])),
+      organizer: length(Map.get(by_role, :organizer, [])),
+      member: length(Map.get(by_role, :member, []))
+    })
+    |> stream(:owner_members, Map.get(by_role, :owner, []), reset: true)
+    |> stream(:organizer_members, Map.get(by_role, :organizer, []), reset: true)
+    |> stream(:regular_members, Map.get(by_role, :member, []), reset: true)
+  end
 
   defp member_action_allowed?(:promote, %{role: :member} = member, _group, user) do
     Ash.can?({member, :change_role, %{role: :organizer}}, user)
@@ -776,10 +809,17 @@ defmodule HuddlzWeb.OrganizeLive do
   defp parse_member_action(_action), do: :error
 
   defp confirmation_valid?(:transfer, socket) do
-    socket.assigns.ownership_confirmation == to_string(socket.assigns.group.name)
+    socket.assigns.member_action_form[:confirmation].value ==
+      to_string(socket.assigns.group.name)
   end
 
   defp confirmation_valid?(_action, _socket), do: true
+
+  defp member_action_form(params \\ %{}) do
+    params
+    |> Map.put_new("confirmation", "")
+    |> to_form(as: :member_action)
+  end
 
   defp member_action_title(%{type: :promote, member: member}),
     do: "Promote #{member_name(member)}?"

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -8,6 +8,7 @@ defmodule HuddlzWeb.LiveUserAuth do
 
   alias AshAuthentication.Phoenix.LiveSession
   alias Huddlz.Accounts.User
+  alias Huddlz.Communities.MembershipEvents
 
   # This is used for nested liveviews to fetch the current user.
   # To use, place the following at the top of that liveview:
@@ -80,7 +81,8 @@ defmodule HuddlzWeb.LiveUserAuth do
      socket
      |> maybe_load_user_details()
      |> assign(:body_class, body_class)
-     |> assign_new(:sidebar_owned_groups, fn -> load_sidebar_owned_groups(socket) end)}
+     |> assign_new(:sidebar_owned_groups, fn -> load_sidebar_owned_groups(socket) end)
+     |> subscribe_to_organizer_access_changes()}
   end
 
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)
@@ -104,8 +106,51 @@ defmodule HuddlzWeb.LiveUserAuth do
   defp maybe_load_user_details(socket), do: socket
 
   defp load_sidebar_owned_groups(%{assigns: %{current_user: user}}) when not is_nil(user) do
-    Huddlz.Communities.get_organizable_groups!(actor: user, query: [sort: [name: :asc]])
+    Huddlz.Communities.get_organizable_groups!(
+      actor: user,
+      load: [:member_count],
+      query: [sort: [name: :asc]]
+    )
   end
 
   defp load_sidebar_owned_groups(_socket), do: []
+
+  defp subscribe_to_organizer_access_changes(%{assigns: %{current_user: %{id: user_id}}} = socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      :ok = MembershipEvents.subscribe_to_user(user_id)
+
+      Phoenix.LiveView.attach_hook(
+        socket,
+        :refresh_organizer_access,
+        :handle_info,
+        &refresh_organizer_access/2
+      )
+    else
+      socket
+    end
+  end
+
+  defp subscribe_to_organizer_access_changes(socket), do: socket
+
+  defp refresh_organizer_access(
+         {:organizer_access_changed, user_id},
+         %{assigns: %{current_user: %{id: user_id}}} = socket
+       ) do
+    groups = load_sidebar_owned_groups(socket)
+
+    socket =
+      socket
+      |> assign(:sidebar_owned_groups, groups)
+      |> maybe_assign_picker_groups(groups)
+
+    {:halt, socket}
+  end
+
+  defp refresh_organizer_access(_message, socket), do: {:cont, socket}
+
+  defp maybe_assign_picker_groups(%{assigns: %{owned_groups: _}} = socket, groups) do
+    assign(socket, :owned_groups, groups)
+  end
+
+  defp maybe_assign_picker_groups(socket, _groups), do: socket
 end

--- a/test/huddlz/communities/group_member_test.exs
+++ b/test/huddlz/communities/group_member_test.exs
@@ -3,6 +3,7 @@ defmodule Huddlz.Communities.GroupMemberTest do
 
   require Ash.Query
 
+  alias Huddlz.Communities
   alias Huddlz.Communities.GroupMember
 
   describe "group membership" do
@@ -113,6 +114,72 @@ defmodule Huddlz.Communities.GroupMemberTest do
       refute Enum.any?(memberships, fn m -> m.user_id == member.id end)
     end
 
+    test "organizer can remove regular members but not organizers", %{
+      owner: owner,
+      member: member,
+      non_member: organizer,
+      group: group
+    } do
+      organizer_membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: organizer.id,
+            role: :organizer,
+            actor: owner
+          )
+        )
+
+      member_membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: member.id,
+            role: :member,
+            actor: owner
+          )
+        )
+
+      assert :ok =
+               Communities.remove_member(
+                 member_membership,
+                 group.id,
+                 member.id,
+                 actor: organizer
+               )
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Communities.remove_member(
+                 organizer_membership,
+                 group.id,
+                 organizer.id,
+                 actor: organizer
+               )
+    end
+
+    test "even an admin cannot remove or demote the sole owner", %{
+      owner: owner,
+      group: group
+    } do
+      admin = generate(user(role: :admin))
+
+      owner_membership =
+        GroupMember
+        |> Ash.Query.filter(group_id: group.id, user_id: owner.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               Communities.remove_member(
+                 owner_membership,
+                 group.id,
+                 owner.id,
+                 actor: admin
+               )
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               Communities.change_member_role(owner_membership, :member, actor: admin)
+    end
+
     test "owner can change a member's role to organizer", %{
       owner: owner,
       member: member,
@@ -162,7 +229,7 @@ defmodule Huddlz.Communities.GroupMemberTest do
         |> Ash.Query.filter(group_id: group.id, user_id: owner.id)
         |> Ash.read_one!(authorize?: false)
 
-      assert {:error, %Ash.Error.Forbidden{}} =
+      assert {:error, %Ash.Error.Invalid{}} =
                owner_membership
                |> Ash.Changeset.for_update(:change_role, %{role: :organizer})
                |> Ash.update(actor: owner)

--- a/test/huddlz/communities/group_member_test.exs
+++ b/test/huddlz/communities/group_member_test.exs
@@ -157,6 +157,88 @@ defmodule Huddlz.Communities.GroupMemberTest do
                )
     end
 
+    test "owner can demote an organizer", %{
+      owner: owner,
+      non_member: organizer,
+      group: group
+    } do
+      organizer_membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: organizer.id,
+            role: :organizer,
+            actor: owner
+          )
+        )
+
+      assert {:ok, updated_membership} =
+               Communities.change_member_role(organizer_membership, :member, actor: owner)
+
+      assert updated_membership.role == :member
+    end
+
+    test "owner can remove an organizer", %{
+      owner: owner,
+      non_member: organizer,
+      group: group
+    } do
+      organizer_membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: organizer.id,
+            role: :organizer,
+            actor: owner
+          )
+        )
+
+      assert :ok =
+               Communities.remove_member(
+                 organizer_membership,
+                 group.id,
+                 organizer.id,
+                 actor: owner
+               )
+    end
+
+    test "regular members cannot remove another member", %{
+      owner: owner,
+      member: member,
+      non_member: target,
+      group: group
+    } do
+      member_membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: member.id,
+            role: :member,
+            actor: owner
+          )
+        )
+
+      target_membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: target.id,
+            role: :member,
+            actor: owner
+          )
+        )
+
+      assert member_membership.role == :member
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Communities.remove_member(
+                 target_membership,
+                 group.id,
+                 target.id,
+                 actor: member
+               )
+    end
+
     test "even an admin cannot remove or demote the sole owner", %{
       owner: owner,
       group: group

--- a/test/huddlz/communities/group_test.exs
+++ b/test/huddlz/communities/group_test.exs
@@ -1,8 +1,6 @@
 defmodule Huddlz.Communities.GroupTest do
   use Huddlz.DataCase, async: true
 
-  require Ash.Query
-
   alias Huddlz.Communities
   alias Huddlz.Communities.Group
 
@@ -627,30 +625,33 @@ defmodule Huddlz.Communities.GroupTest do
       assert Enum.any?(memberships, &(&1.user_id == owner.id and &1.role == :organizer))
     end
 
-    test "owner can transfer ownership to a non-member (auto-adds them)", %{
+    test "owner cannot transfer ownership to a non-member", %{
       owner: owner,
       group: group
     } do
       new_owner = generate(user(role: :user))
 
-      assert {:ok, transferred} =
+      assert {:error, %Ash.Error.Invalid{}} =
                group
                |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: new_owner.id})
                |> Ash.update(actor: owner)
 
-      assert transferred.owner_id == new_owner.id
-
-      new_owner_membership =
-        Huddlz.Communities.GroupMember
-        |> Ash.Query.filter(group_id: group.id, user_id: new_owner.id)
-        |> Ash.read_one!(authorize?: false)
-
-      assert new_owner_membership.role == :owner
+      assert Ash.get!(Group, group.id, authorize?: false).owner_id == owner.id
     end
 
     test "non-owner cannot transfer ownership", %{group: group} do
+      owner = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
       stranger = generate(user(role: :user))
       target = generate(user(role: :user))
+
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: target.id,
+          role: :member,
+          actor: owner
+        )
+      )
 
       assert {:error, %Ash.Error.Forbidden{}} =
                group

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -289,6 +289,15 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
       new_owner = generate(user(display_name: "New Owner"))
       group = generate(group(name: "Council", owner_id: previous_owner.id, actor: previous_owner))
 
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: new_owner.id,
+          role: :member,
+          actor: previous_owner
+        )
+      )
+
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
 

--- a/test/huddlz_web/live/organize_live_members_test.exs
+++ b/test/huddlz_web/live/organize_live_members_test.exs
@@ -46,7 +46,9 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     |> assert_has("#remove-member-#{member_membership.id}", text: "Remove")
     |> assert_has("#demote-member-#{organizer_membership.id}", text: "Demote")
     |> assert_has("#remove-member-#{organizer_membership.id}", text: "Remove")
-    |> assert_has("#transfer-owner-#{organizer_membership.id}", text: "Transfer ownership")
+    |> assert_has("#ownership-danger-zone")
+    |> assert_has("#open-transfer-ownership", text: "Transfer group ownership")
+    |> refute_has("[id^='transfer-owner-']")
     |> refute_has("[id^='remove-member-']", text: "Owner Olivia")
   end
 
@@ -135,7 +137,7 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     |> refute_has("#promote-member-#{member_membership.id}")
     |> refute_has("#demote-member-#{organizer_membership.id}")
     |> refute_has("#remove-member-#{organizer_membership.id}")
-    |> refute_has("[id^='transfer-owner-']")
+    |> refute_has("#ownership-danger-zone")
     |> click_button("Remove")
     |> assert_has("#member-action-dialog-title", text: "Remove Member Mia?")
     |> within("#member-action-dialog", fn session ->
@@ -182,17 +184,14 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     conn: conn,
     owner: owner,
     organizer: organizer,
-    group: group,
-    organizer_membership: organizer_membership
+    group: group
   } do
     session =
       conn
       |> login(owner)
       |> visit(~p"/organize/#{group.slug}/members")
-      |> click_button(
-        "#transfer-owner-#{organizer_membership.id}",
-        "Transfer ownership"
-      )
+      |> select("New owner", option: "Organizer Oscar")
+      |> click_button("#open-transfer-ownership", "Transfer group ownership")
       |> assert_has("#member-action-dialog-title", text: "Transfer ownership to Organizer Oscar?")
       |> assert_has("#member-action-confirm[disabled]", text: "Transfer ownership")
 

--- a/test/huddlz_web/live/organize_live_members_test.exs
+++ b/test/huddlz_web/live/organize_live_members_test.exs
@@ -1,0 +1,159 @@
+defmodule HuddlzWeb.OrganizeLiveMembersTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Huddlz.Communities
+  alias Huddlz.Communities.Group
+  alias Huddlz.Communities.GroupMember
+
+  setup do
+    owner = generate(user(role: :user, display_name: "Owner Olivia"))
+    organizer = generate(user(role: :user, display_name: "Organizer Oscar"))
+    member = generate(user(role: :user, display_name: "Member Mia"))
+
+    {group, [organizer_membership, member_membership]} =
+      generate_group_with_members(
+        owner: owner,
+        group: [name: "Community Council", slug: "community-council"],
+        members: [
+          %{user: organizer, role: :organizer},
+          %{user: member, role: :member}
+        ]
+      )
+
+    %{
+      group: group,
+      owner: owner,
+      organizer: organizer,
+      member: member,
+      organizer_membership: organizer_membership,
+      member_membership: member_membership
+    }
+  end
+
+  test "owner sees policy-backed controls for each manageable role", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    organizer_membership: organizer_membership,
+    member_membership: member_membership
+  } do
+    conn
+    |> login(owner)
+    |> visit(~p"/organize/#{group.slug}/members")
+    |> assert_has("#promote-member-#{member_membership.id}", text: "Promote")
+    |> assert_has("#remove-member-#{member_membership.id}", text: "Remove")
+    |> assert_has("#demote-member-#{organizer_membership.id}", text: "Demote")
+    |> assert_has("#remove-member-#{organizer_membership.id}", text: "Remove")
+    |> assert_has("#transfer-owner-#{organizer_membership.id}", text: "Transfer ownership")
+    |> refute_has("[id^='remove-member-']", text: "Owner Olivia")
+  end
+
+  test "owner can promote a member and the roster updates immediately", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    member_membership: member_membership
+  } do
+    conn
+    |> login(owner)
+    |> visit(~p"/organize/#{group.slug}/members")
+    |> click_button("Promote")
+    |> assert_has("#member-action-dialog-title", text: "Promote Member Mia?")
+    |> within("#member-action-dialog", fn session ->
+      click_button(session, "Promote to organizer")
+    end)
+    |> assert_has("div[role='alert']", text: "Member Mia is now an organizer.")
+    |> assert_has("#demote-member-#{member_membership.id}", text: "Demote")
+
+    assert Ash.get!(GroupMember, member_membership.id, authorize?: false).role == :organizer
+  end
+
+  test "organizer can remove a regular member but cannot manage privileged roles", %{
+    conn: conn,
+    organizer: organizer,
+    group: group,
+    organizer_membership: organizer_membership,
+    member_membership: member_membership
+  } do
+    conn
+    |> login(organizer)
+    |> visit(~p"/organize/#{group.slug}/members")
+    |> assert_has("#remove-member-#{member_membership.id}", text: "Remove")
+    |> refute_has("#promote-member-#{member_membership.id}")
+    |> refute_has("#demote-member-#{organizer_membership.id}")
+    |> refute_has("#remove-member-#{organizer_membership.id}")
+    |> refute_has("[id^='transfer-owner-']")
+    |> click_button("Remove")
+    |> assert_has("#member-action-dialog-title", text: "Remove Member Mia?")
+    |> within("#member-action-dialog", fn session ->
+      click_button(session, "Remove from group")
+    end)
+    |> assert_has("div[role='alert']", text: "Member Mia was removed from the group.")
+    |> refute_has(".role-section .row-title", text: "Member Mia")
+
+    assert Ash.get(GroupMember, member_membership.id,
+             authorize?: false,
+             not_found_error?: false
+           ) == {:ok, nil}
+  end
+
+  test "ownership transfer requires typed confirmation and swaps the roles", %{
+    conn: conn,
+    owner: owner,
+    organizer: organizer,
+    group: group,
+    organizer_membership: organizer_membership
+  } do
+    session =
+      conn
+      |> login(owner)
+      |> visit(~p"/organize/#{group.slug}/members")
+      |> click_button(
+        "#transfer-owner-#{organizer_membership.id}",
+        "Transfer ownership"
+      )
+      |> assert_has("#member-action-dialog-title", text: "Transfer ownership to Organizer Oscar?")
+      |> assert_has("#member-action-confirm[disabled]", text: "Transfer ownership")
+
+    session =
+      session
+      |> fill_in("Type Community Council to confirm", with: "Community Council")
+      |> assert_has("#member-action-confirm:not([disabled])", text: "Transfer ownership")
+
+    session
+    |> within("#member-action-dialog", fn session ->
+      click_button(session, "Transfer ownership")
+    end)
+    |> assert_has("div[role='alert']", text: "Ownership transferred to Organizer Oscar.")
+
+    reloaded_group = Ash.get!(Group, group.id, authorize?: false)
+    assert reloaded_group.owner_id == organizer.id
+
+    memberships =
+      Communities.get_by_group!(group.id, actor: organizer)
+      |> Map.new(&{&1.user_id, &1.role})
+
+    assert memberships[owner.id] == :organizer
+    assert memberships[organizer.id] == :owner
+  end
+
+  test "an already-mounted organizer workspace redirects after role loss", %{
+    conn: conn,
+    owner: owner,
+    organizer: organizer,
+    group: group,
+    organizer_membership: organizer_membership
+  } do
+    {:ok, view, _html} =
+      conn
+      |> login(organizer)
+      |> live(~p"/organize/#{group.slug}/members")
+
+    assert {:ok, _} =
+             Communities.change_member_role(organizer_membership, :member, actor: owner)
+
+    assert_redirect(view, ~p"/organize")
+  end
+end

--- a/test/huddlz_web/live/organize_live_members_test.exs
+++ b/test/huddlz_web/live/organize_live_members_test.exs
@@ -70,6 +70,57 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     assert Ash.get!(GroupMember, member_membership.id, authorize?: false).role == :organizer
   end
 
+  test "owner can demote an organizer after confirmation", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    organizer_membership: organizer_membership
+  } do
+    conn
+    |> login(owner)
+    |> visit(~p"/organize/#{group.slug}/members")
+    |> click_button("#demote-member-#{organizer_membership.id}", "Demote")
+    |> assert_has("#member-action-dialog-title", text: "Demote Organizer Oscar?")
+    |> within("#member-action-dialog", fn session ->
+      click_button(session, "Demote to member")
+    end)
+    |> assert_has("#promote-member-#{organizer_membership.id}", text: "Promote")
+  end
+
+  test "owner can remove a regular member after confirmation", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    member_membership: member_membership
+  } do
+    conn
+    |> login(owner)
+    |> visit(~p"/organize/#{group.slug}/members")
+    |> click_button("#remove-member-#{member_membership.id}", "Remove")
+    |> assert_has("#member-action-dialog-title", text: "Remove Member Mia?")
+    |> within("#member-action-dialog", fn session ->
+      click_button(session, "Remove from group")
+    end)
+    |> refute_has("#remove-member-#{member_membership.id}")
+  end
+
+  test "owner can remove an organizer after confirmation", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    organizer_membership: organizer_membership
+  } do
+    conn
+    |> login(owner)
+    |> visit(~p"/organize/#{group.slug}/members")
+    |> click_button("#remove-member-#{organizer_membership.id}", "Remove")
+    |> assert_has("#member-action-dialog-title", text: "Remove Organizer Oscar?")
+    |> within("#member-action-dialog", fn session ->
+      click_button(session, "Remove from group")
+    end)
+    |> refute_has("#remove-member-#{organizer_membership.id}")
+  end
+
   test "organizer can remove a regular member but cannot manage privileged roles", %{
     conn: conn,
     organizer: organizer,
@@ -183,6 +234,48 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
              Communities.change_member_role(organizer_membership, :member, actor: owner)
 
     assert_redirect(view, ~p"/organize")
+  end
+
+  test "an already-mounted organizer picker shows newly granted access", %{
+    conn: conn,
+    owner: owner,
+    member: member,
+    group: group,
+    member_membership: member_membership
+  } do
+    {:ok, view, _html} =
+      conn
+      |> login(member)
+      |> live(~p"/organize")
+
+    group_link = "a[href='/organize/#{group.slug}']"
+    refute has_element?(view, group_link)
+
+    assert {:ok, _membership} =
+             Communities.change_member_role(member_membership, :organizer, actor: owner)
+
+    assert has_element?(view, group_link)
+  end
+
+  test "an already-mounted organizer picker removes revoked access", %{
+    conn: conn,
+    owner: owner,
+    organizer: organizer,
+    group: group,
+    organizer_membership: organizer_membership
+  } do
+    {:ok, view, _html} =
+      conn
+      |> login(organizer)
+      |> live(~p"/organize")
+
+    group_link = "a[href='/organize/#{group.slug}']"
+    assert has_element?(view, group_link)
+
+    assert {:ok, _membership} =
+             Communities.change_member_role(organizer_membership, :member, actor: owner)
+
+    refute has_element?(view, group_link)
   end
 
   test "an already-mounted group page updates the affected member's access", %{

--- a/test/huddlz_web/live/organize_live_members_test.exs
+++ b/test/huddlz_web/live/organize_live_members_test.exs
@@ -99,6 +99,34 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
            ) == {:ok, nil}
   end
 
+  test "organizer cannot confirm a stale removal after the member is promoted", %{
+    conn: conn,
+    owner: owner,
+    organizer: organizer,
+    group: group,
+    member_membership: member_membership
+  } do
+    {:ok, view, _html} =
+      conn
+      |> login(organizer)
+      |> live(~p"/organize/#{group.slug}/members")
+
+    view
+    |> element("#remove-member-#{member_membership.id}")
+    |> render_click()
+
+    assert {:ok, _membership} =
+             Communities.change_member_role(member_membership, :organizer, actor: owner)
+
+    assert has_element?(view, "#member-action-dialog")
+
+    view
+    |> element("#member-action-form")
+    |> render_submit()
+
+    assert Ash.get!(GroupMember, member_membership.id, authorize?: false).role == :organizer
+  end
+
   test "ownership transfer requires typed confirmation and swaps the roles", %{
     conn: conn,
     owner: owner,
@@ -155,5 +183,42 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
              Communities.change_member_role(organizer_membership, :member, actor: owner)
 
     assert_redirect(view, ~p"/organize")
+  end
+
+  test "an already-mounted group page updates the affected member's access", %{
+    conn: conn,
+    owner: owner,
+    member: member,
+    group: group,
+    member_membership: member_membership
+  } do
+    {:ok, view, _html} =
+      conn
+      |> login(member)
+      |> live(~p"/groups/#{group.slug}")
+
+    create_huddl_selector = "a[href='/groups/#{group.slug}/huddlz/new']"
+    refute has_element?(view, create_huddl_selector)
+
+    assert {:ok, promoted_membership} =
+             Communities.change_member_role(member_membership, :organizer, actor: owner)
+
+    assert has_element?(view, create_huddl_selector)
+
+    assert :ok =
+             Communities.remove_member(
+               promoted_membership,
+               group.id,
+               member.id,
+               actor: owner
+             )
+
+    refute has_element?(view, create_huddl_selector)
+
+    assert has_element?(
+             view,
+             ".huddl-side-section .muted",
+             "Only members can see who's in this group."
+           )
   end
 end


### PR DESCRIPTION
## Summary

- Add policy-backed promote, demote, remove, and ownership-transfer controls to the organizer member roster.
- Use styled confirmations for consequential actions, including typed group-name confirmation before ownership transfer.
- Refresh mounted organizer workspaces after membership changes so role loss revokes access immediately.
- Preserve sole-owner safeguards and require ownership transfers to target an existing group member.

## Manual verification

1. Open a group’s organizer Members tab as its owner and verify controls match each member role.
2. Open the same tab as an organizer and verify only regular-member removal is available.
3. Demote an organizer with the workspace open in another session and verify that session returns to the organizer picker.

Closes #278