### PR TITLE
fix(ui): use huddl terminology in product copy

### DIFF
--- a/lib/huddlz_web/controllers/dev_design_html/clickthrough_help.html.heex
+++ b/lib/huddlz_web/controllers/dev_design_html/clickthrough_help.html.heex
@@ -23,7 +23,7 @@
       <div class="row">
         <div>
           <div class="row-title">What's a huddl?</div>
-          <div class="row-desc">Our word for an event — meetup, workshop, social, anything.</div>
+          <div class="row-desc">A huddl can be a meetup, workshop, social, or anything else.</div>
         </div>
         <span class="pill">Read</span>
       </div>
@@ -161,7 +161,7 @@
       <div>
         <h2>Follow huddlz</h2>
         <div class="panel-sub">
-          Keep up with releases, events worth knowing about, and the occasional dev rant.
+          Keep up with releases, huddlz worth knowing about, and the occasional dev rant.
         </div>
       </div>
     </div>

--- a/lib/huddlz_web/controllers/dev_design_html/clickthrough_huddl.html.heex
+++ b/lib/huddlz_web/controllers/dev_design_html/clickthrough_huddl.html.heex
@@ -51,7 +51,7 @@
 
       <h2>What you'll build</h2>
       <p>
-        A small "events" app — resources, custom actions, validations, and a LiveView page that talks to it. We'll cover the parts that get you to "wait, that worked?" the fastest, and skip the parts that don't matter on day one.
+        A small "huddlz" app — resources, custom actions, validations, and a LiveView page that talks to it. We'll cover the parts that get you to "wait, that worked?" the fastest, and skip the parts that don't matter on day one.
       </p>
 
       <h2>What to bring</h2>

--- a/lib/huddlz_web/controllers/dev_design_html/clickthrough_settings.html.heex
+++ b/lib/huddlz_web/controllers/dev_design_html/clickthrough_settings.html.heex
@@ -11,7 +11,7 @@
       <div>
         <h2>Transactional</h2>
         <div class="panel-sub">
-          Critical account and event updates. Always on — these can't be disabled.
+          Critical account and huddl updates. Always on — these can't be disabled.
         </div>
       </div>
     </div>

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -72,7 +72,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
       <form phx-submit="save">
         <.read_only_panel
           title="Transactional"
-          description="Critical account and event updates. Always on — these can't be disabled."
+          description="Critical account and huddl updates. Always on — these can't be disabled."
           triggers={@triggers_by_category.transactional}
         />
 

--- a/test/huddlz_web/controllers/dev_design_html_test.exs
+++ b/test/huddlz_web/controllers/dev_design_html_test.exs
@@ -1,0 +1,29 @@
+defmodule HuddlzWeb.DevDesignHTMLTest do
+  use ExUnit.Case, async: true
+
+  alias HuddlzWeb.DevDesignHTML
+  alias Phoenix.HTML.Safe
+
+  test "clickthrough surfaces use huddl product terminology" do
+    settings_html = render_surface(&DevDesignHTML.clickthrough_settings/1, "settings")
+    help_html = render_surface(&DevDesignHTML.clickthrough_help/1, "help")
+    huddl_html = render_surface(&DevDesignHTML.clickthrough_huddl/1, "huddl")
+
+    assert settings_html =~ "Critical account and huddl updates"
+    assert help_html =~ "A huddl can be a meetup, workshop, social, or anything else."
+    assert help_html =~ "huddlz worth knowing about"
+    assert huddl_html =~ ~s(A small "huddlz" app)
+
+    refute settings_html =~ "account and event updates"
+    refute help_html =~ "word for an event"
+    refute help_html =~ "events worth knowing about"
+    refute huddl_html =~ ~s(A small "events" app)
+  end
+
+  defp render_surface(surface, active) do
+    %{active: active, query: "", signed_in: true}
+    |> surface.()
+    |> Safe.to_iodata()
+    |> IO.iodata_to_binary()
+  end
+end

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -30,6 +30,7 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       |> login(user)
       |> visit("/profile/notifications")
       |> assert_has(".panel-head h2", text: "Transactional")
+      |> assert_has("*", text: "Critical account and huddl updates")
       |> assert_has(".panel-head h2", text: "Activity")
       |> assert_has(".panel-head h2", text: "Digest")
     end


### PR DESCRIPTION
## Summary
- replace generic event wording in notification settings with huddl terminology
- align Help and huddl development clickthrough copy with huddlz branding
- add focused regression coverage for live and clickthrough surfaces

## Verification
- mix precommit (1,411 tests, Credo)
- GitHub CI: test and seed jobs passed
- before/after desktop screenshots verified locally; the automation browser was signed out of GitHub, so it could not attach them without committing artifacts

Closes #281