### PR TITLE
fix(profile): allow invalid fields to be cleared

### DIFF
--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -180,7 +180,7 @@ defmodule Huddlz.Accounts.User do
       description "Update a user's display_name"
       accept [:display_name]
 
-      validate attribute_does_not_equal(:display_name, "")
+      validate present(:display_name), message: "is required"
       validate string_length(:display_name, min: 1, max: 70)
     end
 

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -54,6 +54,7 @@ defmodule HuddlzWeb.ProfileLive do
      |> assign(:form, form)
      |> assign(:email_form, email_form)
      |> assign(:password_form, password_form)
+     |> assign(:password_input_reset_generation, 0)
      |> assign(:current_user, user_with_avatar)
      |> assign(:avatar_error, nil)
      |> assign(:remove_avatar_dialog_open, false)
@@ -108,7 +109,7 @@ defmodule HuddlzWeb.ProfileLive do
         </form>
       </div>
 
-      <.form for={@form} phx-submit="save" phx-change="validate">
+      <.form for={@form} id="profile-form" phx-submit="save" phx-change="validate">
         <div class="panel">
           <div class="panel-head">
             <h2>Account information</h2>
@@ -126,6 +127,7 @@ defmodule HuddlzWeb.ProfileLive do
             </div>
             <.input
               field={@form[:display_name]}
+              value={form_value(@form, :display_name)}
               label="Display name"
               placeholder="Enter your display name"
               help="Names aren't unique on huddlz — pick anything you like."
@@ -224,7 +226,10 @@ defmodule HuddlzWeb.ProfileLive do
             <%= if @current_user.hashed_password do %>
               <.input
                 field={@password_form[:current_password]}
+                id={"password-#{@password_input_reset_generation}-current-password"}
+                value=""
                 type="password"
+                phx-update="ignore"
                 label="Current password"
                 placeholder="Enter your current password"
                 autocomplete="current-password"
@@ -232,7 +237,10 @@ defmodule HuddlzWeb.ProfileLive do
             <% end %>
             <.input
               field={@password_form[:password]}
+              id={"password-#{@password_input_reset_generation}-password"}
+              value=""
               type="password"
+              phx-update="ignore"
               label="New password"
               placeholder="Enter your new password"
               autocomplete="new-password"
@@ -240,7 +248,10 @@ defmodule HuddlzWeb.ProfileLive do
             />
             <.input
               field={@password_form[:password_confirmation]}
+              id={"password-#{@password_input_reset_generation}-password-confirmation"}
+              value=""
               type="password"
+              phx-update="ignore"
               label="Confirm new password"
               placeholder="Confirm your new password"
               autocomplete="new-password"
@@ -319,6 +330,10 @@ defmodule HuddlzWeb.ProfileLive do
 
   defp role_pill_color(:admin), do: "magenta"
   defp role_pill_color(_), do: "cyan"
+
+  defp form_value(form, field) do
+    Map.get(form.source.raw_params, to_string(field), form[field].value)
+  end
 
   @impl true
   def handle_event("validate", %{"form" => params}, socket) do
@@ -427,13 +442,15 @@ defmodule HuddlzWeb.ProfileLive do
          socket
          |> put_flash(:info, "Password updated successfully")
          |> assign(:current_user, updated_user)
-         |> assign(:password_form, password_form)}
+         |> assign(:password_form, password_form)
+         |> update(:password_input_reset_generation, &(&1 + 1))}
 
       {:error, form} ->
         {:noreply,
          socket
          |> put_flash(:error, "Failed to update password. Please check the errors below.")
-         |> assign(:password_form, form |> to_form())}
+         |> assign(:password_form, form |> to_form())
+         |> update(:password_input_reset_generation, &(&1 + 1))}
     end
   end
 

--- a/test/features/password_authentication.feature
+++ b/test/features/password_authentication.feature
@@ -46,6 +46,17 @@ Feature: Password Authentication
     And I click "Update password"
     Then I should see "Password updated successfully"
 
+  Scenario: Failed password change clears sensitive values
+    Given I am signed in as "failed-password@example.com" with password "OldPassword123!"
+    When I go to my profile page
+    And I fill in the password form with:
+      | current_password      | WrongPassword |
+      | password              | short         |
+      | password_confirmation | different     |
+    And I submit the password form
+    Then I should see "Failed to update password. Please check the errors below."
+    And the password fields should be empty
+
   Scenario: User requests password reset
     Given a user exists with email "forgetful@example.com" and password "ForgottenPassword123!"
     And I am on the sign-in page

--- a/test/features/step_definitions/password_authentication_steps.exs
+++ b/test/features/step_definitions/password_authentication_steps.exs
@@ -170,6 +170,17 @@ defmodule PasswordAuthenticationSteps do
     {:ok, Map.merge(context, %{session: session, conn: session})}
   end
 
+  step "the password fields should be empty", context do
+    session = context[:session] || context[:conn]
+
+    session
+    |> assert_has("#password-form input[name='form[current_password]'][value='']")
+    |> assert_has("#password-form input[name='form[password]'][value='']")
+    |> assert_has("#password-form input[name='form[password_confirmation]'][value='']")
+
+    {:ok, context}
+  end
+
   step "I submit the password sign-in form", context do
     session = context[:session] || context[:conn]
 

--- a/test/features/user_profile.feature
+++ b/test/features/user_profile.feature
@@ -71,6 +71,13 @@ Feature: User Profile Management
     Then I should see "Failed to update display name. Please check the errors below."
     And I should not see "Display name updated successfully"
 
+  Scenario: Clearing an invalid display name leaves it empty
+    Given I am on my profile page
+    When I fill in "Display name" with "Corrected Name"
+    And I fill in "Display name" with ""
+    Then I should see "is required"
+    And the display name field should contain ""
+
   Scenario: Display name validation - too long
     Given I am on my profile page
     When I fill in "Display name" with "This is a very long display name that definitely exceeds the seventy character maximum length allowed"

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -185,6 +185,170 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> fill_in("Display name", with: "")
       |> assert_has("form")
     end
+
+    test "keeps a cleared display name empty and shows a friendly error", %{
+      conn: conn,
+      user: user
+    } do
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#profile-form", %{"form" => %{"display_name" => "Corrected Name"}})
+      |> render_change()
+
+      view
+      |> form("#profile-form", %{"form" => %{"display_name" => ""}})
+      |> render_change()
+
+      assert has_element?(view, "#form_display_name[value='']")
+      assert has_element?(view, "#form_display_name-error-0", "is required")
+    end
+
+    test "shows a friendly error for a whitespace-only display name", %{
+      conn: conn,
+      user: user
+    } do
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#profile-form", %{"form" => %{"display_name" => "   "}})
+      |> render_change()
+
+      assert has_element?(view, "#form_display_name-error-0", "is required")
+      refute has_element?(view, "#profile-form", "must not equal")
+    end
+
+    test "never renders password values on load", %{conn: conn, user: user} do
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password]'][value='']"
+             )
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password_confirmation]'][value='']"
+             )
+    end
+
+    test "keeps cleared invalid password values empty", %{conn: conn, user: user} do
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "short",
+          "password_confirmation" => "different"
+        }
+      })
+      |> render_change()
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "",
+          "password_confirmation" => ""
+        }
+      })
+      |> render_change()
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password]'][value='']"
+             )
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password_confirmation]'][value='']"
+             )
+    end
+
+    test "clears password values after a successful submission", %{conn: conn, user: user} do
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "NewPassword123!",
+          "password_confirmation" => "NewPassword123!"
+        }
+      })
+      |> render_submit()
+
+      assert has_element?(view, "#password-form input[name='form[password]'][value='']")
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password_confirmation]'][value='']"
+             )
+    end
+
+    test "clears every password field while preserving errors after a failed submission", %{
+      conn: conn
+    } do
+      user =
+        Huddlz.Generator.generate(
+          Huddlz.Generator.user_with_password(password: "CurrentPassword123!")
+        )
+
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "current_password" => "WrongCurrentPassword",
+          "password" => "short",
+          "password_confirmation" => "different"
+        }
+      })
+      |> render_submit()
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[current_password]'][value='']"
+             )
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password]'][value='']"
+             )
+
+      assert has_element?(
+               view,
+               "#password-form input[name='form[password_confirmation]'][value='']"
+             )
+
+      assert has_element?(view, "[id$='current-password-error-0']")
+      assert has_element?(view, "[id$='password-error-0']")
+      assert has_element?(view, "[id$='password-confirmation-error-0']")
+    end
+
+    test "updates password validation errors as values are corrected", %{conn: conn, user: user} do
+      view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "short",
+          "password_confirmation" => "different"
+        }
+      })
+      |> render_change()
+
+      assert has_element?(view, "#password-form .form-error")
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "NewPassword123!",
+          "password_confirmation" => "NewPassword123!"
+        }
+      })
+      |> render_change()
+
+      refute has_element?(view, "#password-form .form-error")
+    end
   end
 
   describe "Email change" do

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -221,15 +221,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
     test "never renders password values on load", %{conn: conn, user: user} do
       view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
 
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password]'][value='']"
-             )
-
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password_confirmation]'][value='']"
-             )
+      assert_empty_password_inputs(view, 0, [:password, :password_confirmation])
     end
 
     test "keeps cleared invalid password values empty", %{conn: conn, user: user} do
@@ -253,19 +245,13 @@ defmodule HuddlzWeb.ProfileLiveTest do
       })
       |> render_change()
 
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password]'][value='']"
-             )
-
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password_confirmation]'][value='']"
-             )
+      assert_empty_password_inputs(view, 0, [:password, :password_confirmation])
     end
 
     test "clears password values after a successful submission", %{conn: conn, user: user} do
       view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
+
+      assert_empty_password_inputs(view, 0, [:password, :password_confirmation])
 
       view
       |> form("#password-form", %{
@@ -276,12 +262,9 @@ defmodule HuddlzWeb.ProfileLiveTest do
       })
       |> render_submit()
 
-      assert has_element?(view, "#password-form input[name='form[password]'][value='']")
-
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password_confirmation]'][value='']"
-             )
+      refute has_element?(view, "#password-0-password")
+      refute has_element?(view, "#password-0-password-confirmation")
+      assert_empty_password_inputs(view, 1, [:password, :password_confirmation])
     end
 
     test "clears every password field while preserving errors after a failed submission", %{
@@ -294,6 +277,12 @@ defmodule HuddlzWeb.ProfileLiveTest do
 
       view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
 
+      assert_empty_password_inputs(
+        view,
+        0,
+        [:current_password, :password, :password_confirmation]
+      )
+
       view
       |> form("#password-form", %{
         "form" => %{
@@ -304,24 +293,19 @@ defmodule HuddlzWeb.ProfileLiveTest do
       })
       |> render_submit()
 
-      assert has_element?(
-               view,
-               "#password-form input[name='form[current_password]'][value='']"
-             )
+      refute has_element?(view, "#password-0-current-password")
+      refute has_element?(view, "#password-0-password")
+      refute has_element?(view, "#password-0-password-confirmation")
 
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password]'][value='']"
-             )
+      assert_empty_password_inputs(
+        view,
+        1,
+        [:current_password, :password, :password_confirmation]
+      )
 
-      assert has_element?(
-               view,
-               "#password-form input[name='form[password_confirmation]'][value='']"
-             )
-
-      assert has_element?(view, "[id$='current-password-error-0']")
-      assert has_element?(view, "[id$='password-error-0']")
-      assert has_element?(view, "[id$='password-confirmation-error-0']")
+      assert has_element?(view, "#password-1-current-password-error-0")
+      assert has_element?(view, "#password-1-password-error-0")
+      assert has_element?(view, "#password-1-password-confirmation-error-0")
     end
 
     test "updates password validation errors as values are corrected", %{conn: conn, user: user} do
@@ -336,7 +320,20 @@ defmodule HuddlzWeb.ProfileLiveTest do
       })
       |> render_change()
 
-      assert has_element?(view, "#password-form .form-error")
+      assert has_element?(view, "#password-0-password-error-0")
+      assert has_element?(view, "#password-0-password-confirmation-error-0")
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "NewPassword123!",
+          "password_confirmation" => "different"
+        }
+      })
+      |> render_change()
+
+      refute has_element?(view, "#password-0-password-error-0")
+      assert has_element?(view, "#password-0-password-confirmation-error-0")
 
       view
       |> form("#password-form", %{
@@ -347,7 +344,26 @@ defmodule HuddlzWeb.ProfileLiveTest do
       })
       |> render_change()
 
-      refute has_element?(view, "#password-form .form-error")
+      refute has_element?(view, "#password-0-password-error-0")
+      refute has_element?(view, "#password-0-password-confirmation-error-0")
+    end
+
+    test "does not repopulate password values after reload", %{conn: conn, user: user} do
+      logged_in_conn = login(conn, user)
+      view = logged_in_conn |> visit("/profile") |> Map.fetch!(:view)
+
+      view
+      |> form("#password-form", %{
+        "form" => %{
+          "password" => "short",
+          "password_confirmation" => "different"
+        }
+      })
+      |> render_change()
+
+      reloaded_view = logged_in_conn |> visit("/profile") |> Map.fetch!(:view)
+
+      assert_empty_password_inputs(reloaded_view, 0, [:password, :password_confirmation])
     end
   end
 
@@ -577,5 +593,16 @@ defmodule HuddlzWeb.ProfileLiveTest do
       },
       actor: user
     )
+  end
+
+  defp assert_empty_password_inputs(view, generation, fields) do
+    Enum.each(fields, fn field ->
+      id = field |> to_string() |> String.replace("_", "-")
+
+      assert has_element?(
+               view,
+               "#password-#{generation}-#{id}[name='form[#{field}]'][value=''][phx-update='ignore']"
+             )
+    end)
   end
 end


### PR DESCRIPTION
## Summary

- Keep a cleared display name empty and show a friendly required-field message for blank or whitespace-only names.
- Keep password fields empty after validation and after successful or failed submissions.

Closes #283