### PR TITLE
Add secure sign out to authenticated navigation

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -133,6 +133,16 @@ defmodule HuddlzWeb.Layouts do
             <.nav_icon name="help" />
             <span class="label">Help</span>
           </a>
+          <.link
+            id="sign-out-link"
+            class="sb-item"
+            href={~p"/sign-out"}
+            method="delete"
+            aria-label="Sign out"
+          >
+            <.icon name="hero-arrow-right-start-on-rectangle" class="size-[18px]" />
+            <span class="label">Sign out</span>
+          </.link>
           <%= if User.admin?(@current_user) do %>
             <a class={["sb-item", @active == "admin" && "active"]} href="/admin">
               <.nav_icon name="shield" />

--- a/lib/huddlz_web/controllers/auth_controller.ex
+++ b/lib/huddlz_web/controllers/auth_controller.ex
@@ -25,6 +25,7 @@ defmodule HuddlzWeb.AuthController do
     conn
     |> delete_session(:return_to)
     |> store_in_session(user)
+    |> put_live_socket_id()
     # If your resource has a different name, update the assign name here (i.e :current_admin)
     |> assign(:current_user, user)
     |> put_flash(:info, message)
@@ -61,10 +62,34 @@ defmodule HuddlzWeb.AuthController do
     return_to = return_to(conn)
 
     conn
+    |> disconnect_live_views()
     |> clear_session(:huddlz)
     |> put_flash(:info, "You are now signed out")
     |> redirect(to: return_to)
   end
+
+  defp put_live_socket_id(conn) do
+    case get_session(conn, :user_token) do
+      token when is_binary(token) ->
+        put_session(conn, :live_socket_id, live_socket_id(token))
+
+      _ ->
+        conn
+    end
+  end
+
+  defp disconnect_live_views(conn) do
+    case get_session(conn, :live_socket_id) do
+      topic when is_binary(topic) ->
+        HuddlzWeb.Endpoint.broadcast(topic, "disconnect", %{})
+        conn
+
+      _ ->
+        conn
+    end
+  end
+
+  defp live_socket_id(token), do: "users_sessions:#{Base.url_encode64(token)}"
 
   defp return_to(conn) do
     [conn.params["return_to"], get_session(conn, :return_to)]

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -28,6 +28,7 @@ defmodule HuddlzWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :load_from_session
+    plug :prevent_authenticated_page_caching
   end
 
   pipeline :api do
@@ -168,6 +169,16 @@ defmodule HuddlzWeb.Router do
   # scope "/api", HuddlzWeb do
   #   pipe_through :api
   # end
+
+  defp prevent_authenticated_page_caching(
+         %{assigns: %{current_user: current_user}} = conn,
+         _opts
+       )
+       when not is_nil(current_user) do
+    Plug.Conn.put_resp_header(conn, "cache-control", "no-store")
+  end
+
+  defp prevent_authenticated_page_caching(conn, _opts), do: conn
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:huddlz, :dev_routes) do

--- a/test/huddlz_web/controllers/auth_controller_test.exs
+++ b/test/huddlz_web/controllers/auth_controller_test.exs
@@ -26,6 +26,53 @@ defmodule HuddlzWeb.AuthControllerTest do
              "/"
   end
 
+  describe "DELETE /sign-out" do
+    test "clears the session and protects authenticated pages from browser history", %{
+      conn: conn
+    } do
+      user = create_test_user()
+      conn = login(conn, user)
+
+      assert is_binary(get_session(conn, :user_token))
+
+      conn = get(conn, ~p"/profile")
+
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+
+      conn =
+        conn
+        |> recycle()
+        |> delete(~p"/sign-out")
+
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "You are now signed out"
+      refute get_session(conn, :user_token)
+
+      signed_out_conn =
+        conn
+        |> recycle()
+        |> get(~p"/profile")
+
+      assert redirected_to(signed_out_conn) == ~p"/sign-in"
+    end
+
+    test "disconnects LiveViews using the signed-in session", %{conn: conn} do
+      user = create_test_user()
+      conn = login(conn, user)
+      live_socket_id = get_session(conn, :live_socket_id)
+
+      Phoenix.PubSub.subscribe(Huddlz.PubSub, live_socket_id)
+
+      delete(conn, ~p"/sign-out")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^live_socket_id,
+        event: "disconnect",
+        payload: %{}
+      }
+    end
+  end
+
   defp create_test_user do
     user =
       User

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -27,6 +27,16 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> assert_has("h1", text: "Profile")
       |> assert_has("aside.sidebar")
       |> assert_has(".sb-item.active", text: "Profile")
+      |> assert_has(
+        "#sign-out-link[href='/sign-out'][data-method='delete'][data-csrf][aria-label='Sign out']",
+        text: "Sign out"
+      )
+    end
+
+    test "does not show sign out in signed-out navigation", %{conn: conn} do
+      conn
+      |> visit("/discover")
+      |> refute_has("a", text: "Sign out")
     end
 
     test "sidebar shows initials when the user has no profile picture", %{

--- a/test/support/helpers/authentication.ex
+++ b/test/support/helpers/authentication.ex
@@ -13,6 +13,7 @@ defmodule Huddlz.Test.Helpers.Authentication do
         conn
         |> Phoenix.ConnTest.init_test_session(%{})
         |> Plug.Conn.put_session(:user_token, token)
+        |> Plug.Conn.put_session(:live_socket_id, live_socket_id(token))
 
       :error ->
         raise "Failed to generate token for test user"
@@ -23,4 +24,6 @@ defmodule Huddlz.Test.Helpers.Authentication do
     opts = Enum.into(opts, [])
     Huddlz.Generator.generate(Huddlz.Generator.user(opts))
   end
+
+  defp live_socket_id(token), do: "users_sessions:#{Base.url_encode64(token)}"
 end


### PR DESCRIPTION
## Summary

- Add a visible Sign out action to the persistent authenticated navigation on desktop and mobile.
- End the session through the CSRF-protected DELETE route and disconnect open LiveView tabs so authenticated content cannot linger.

## Manual verification

Sign in, choose **Sign out** from the sidebar, and confirm the signed-out home page appears. Use browser Back and verify protected pages return to sign-in.

Closes #284