### PR TITLE
Add secure email change settings

### DIFF
--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -278,6 +278,20 @@ defmodule Huddlz.Accounts.User do
       validate {AshAuthentication.Strategy.Password.PasswordValidation,
                 strategy_name: :password, password_argument: :current_password}
 
+      validate fn changeset, _context ->
+        current_email = to_string(changeset.data.email)
+
+        requested_email =
+          Map.get(changeset.params, :email) || Map.get(changeset.params, "email")
+
+        if not is_nil(requested_email) and
+             String.downcase(to_string(requested_email)) == String.downcase(current_email) do
+          {:error, field: :email, message: "Enter a different email address."}
+        else
+          :ok
+        end
+      end
+
       change after_action(fn changeset, user, _ctx ->
                previous_email = to_string(changeset.data.email)
                new_email = to_string(user.email)

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -326,8 +326,8 @@ defmodule HuddlzWeb.ProfileLive do
   def handle_event("change_email", %{"email_change" => params}, socket) do
     case AshPhoenix.Form.submit(socket.assigns.email_form.source, params: params) do
       {:ok, updated_user} ->
-        {:ok, updated_user} =
-          Ash.load(
+        updated_user =
+          Ash.load!(
             updated_user,
             [:current_profile_picture_url, :home_location, :home_latitude, :home_longitude],
             actor: updated_user

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -37,6 +37,8 @@ defmodule HuddlzWeb.ProfileLive do
       )
       |> to_form()
 
+    email_form = email_form(user)
+
     # Load user with profile picture calculation
     {:ok, user_with_avatar} =
       Ash.load(
@@ -49,6 +51,7 @@ defmodule HuddlzWeb.ProfileLive do
      socket
      |> assign(:page_title, "Profile")
      |> assign(:form, form)
+     |> assign(:email_form, email_form)
      |> assign(:password_form, password_form)
      |> assign(:current_user, user_with_avatar)
      |> assign(:avatar_error, nil)
@@ -117,7 +120,7 @@ defmodule HuddlzWeb.ProfileLive do
                   {role_label(@current_user.role)}
                 </span>
               </div>
-              <p class="form-help">Your email can't be changed from this page.</p>
+              <p class="form-help">This is the email you use to sign in.</p>
             </div>
             <.input
               field={@form[:display_name]}
@@ -128,6 +131,44 @@ defmodule HuddlzWeb.ProfileLive do
           </div>
           <div class="form-foot">
             <.button variant={:primary} type="submit">Save changes</.button>
+          </div>
+        </div>
+      </.form>
+
+      <.form
+        for={@email_form}
+        id="email-change-form"
+        phx-submit="change_email"
+        phx-change="validate_email"
+      >
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Change email</h2>
+              <div class="panel-sub">
+                Update your sign-in email after confirming your current password.
+              </div>
+            </div>
+          </div>
+          <div class="form-grid">
+            <.input
+              field={@email_form[:email]}
+              type="text"
+              label="New email"
+              placeholder="Enter your new email"
+              autocomplete="email"
+              inputmode="email"
+            />
+            <.input
+              field={@email_form[:current_password]}
+              type="password"
+              label="Confirm current password"
+              placeholder="Enter your current password"
+              autocomplete="current-password"
+            />
+          </div>
+          <div class="form-foot">
+            <.button variant={:primary} type="submit">Change email</.button>
           </div>
         </div>
       </.form>
@@ -272,6 +313,46 @@ defmodule HuddlzWeb.ProfileLive do
   end
 
   @impl true
+  def handle_event("validate_email", %{"email_change" => params}, socket) do
+    form =
+      socket.assigns.email_form.source
+      |> AshPhoenix.Form.validate(params)
+      |> to_form()
+
+    {:noreply, assign(socket, :email_form, form)}
+  end
+
+  @impl true
+  def handle_event("change_email", %{"email_change" => params}, socket) do
+    case AshPhoenix.Form.submit(socket.assigns.email_form.source, params: params) do
+      {:ok, updated_user} ->
+        {:ok, updated_user} =
+          Ash.load(
+            updated_user,
+            [:current_profile_picture_url, :home_location, :home_latitude, :home_longitude],
+            actor: updated_user
+          )
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Email updated successfully")
+         |> assign(:current_user, updated_user)
+         |> assign(:email_form, email_form(updated_user))}
+
+      {:error, form} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Email could not be updated. Please check the errors below.")
+         |> assign(
+           :email_form,
+           form
+           |> AshPhoenix.Form.clear_value(:current_password)
+           |> to_form()
+         )}
+    end
+  end
+
+  @impl true
   def handle_event("validate_password", %{"form" => params}, socket) do
     form =
       socket.assigns.password_form.source
@@ -392,6 +473,34 @@ defmodule HuddlzWeb.ProfileLive do
         {:error, reason}
     end
   end
+
+  defp email_form(user) do
+    user
+    |> AshPhoenix.Form.for_update(:change_email,
+      domain: Huddlz.Accounts,
+      forms: [auto?: true],
+      actor: user,
+      as: "email_change",
+      params: %{"email" => ""},
+      post_process_errors: &email_change_error/3
+    )
+    |> to_form()
+  end
+
+  defp email_change_error(_form, _path, {:email, message, _vars} = error) do
+    cond do
+      String.starts_with?(message, "must match the pattern") ->
+        {:email, "Enter a valid email address.", []}
+
+      message == "has already been taken" ->
+        {:email, "That email is already in use.", []}
+
+      true ->
+        error
+    end
+  end
+
+  defp email_change_error(_form, _path, error), do: error
 
   defp handle_upload_progress(:avatar, entry, socket) do
     if entry.done? do

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -168,7 +168,9 @@ defmodule HuddlzWeb.ProfileLive do
             />
           </div>
           <div class="form-foot">
-            <.button variant={:primary} type="submit">Change email</.button>
+            <.button id="change-email-button" variant={:primary} type="submit">
+              Change email
+            </.button>
           </div>
         </div>
       </.form>
@@ -335,6 +337,7 @@ defmodule HuddlzWeb.ProfileLive do
 
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Email updated successfully")
          |> assign(:current_user, updated_user)
          |> assign(:email_form, email_form(updated_user))}

--- a/test/features/step_definitions/email_change_notification_steps.exs
+++ b/test/features/step_definitions/email_change_notification_steps.exs
@@ -28,9 +28,9 @@ defmodule EmailChangeNotificationSteps do
        %{args: [old_email, new_email, password]} = context do
     user = find_user!(context.users, old_email)
 
-    # Same-email scenarios succeed as a no-op (the unique-email identity
-    # excludes the row being updated). The after_action's
-    # `previous_email != new_email` guard is what skips the notification.
+    # Same-email requests are rejected by the action. This step intentionally
+    # ignores the result because the scenario verifies that no notification
+    # side effect occurs.
     user
     |> Ash.Changeset.for_update(
       :change_email,

--- a/test/features/user_profile.feature
+++ b/test/features/user_profile.feature
@@ -34,6 +34,36 @@ Feature: User Profile Management
     And a security notice should be sent to "alice@example.com" naming the new address "alice.changed@example.com"
     And a confirmation should be sent to "alice.changed@example.com" naming the previous address "alice@example.com"
 
+  Scenario: Rejecting an invalid sign-in email
+    Given the user "alice@example.com" has password "OldPassword123!"
+    And I am on my profile page
+    When I fill in "New email" with "not-an-email"
+    And I fill in "Confirm current password" with "OldPassword123!"
+    And I click the "Change email" button
+    Then I should see "Enter a valid email address."
+    And I should see "alice@example.com"
+
+  Scenario: Rejecting a sign-in email change with the wrong password
+    Given the user "alice@example.com" has password "OldPassword123!"
+    And I am on my profile page
+    When I fill in "New email" with "alice.changed@example.com"
+    And I fill in "Confirm current password" with "WrongPassword"
+    And I click the "Change email" button
+    Then I should see "Email could not be updated"
+    And I should see "alice@example.com"
+
+  Scenario: Rejecting a sign-in email already used by another person
+    Given the user "alice@example.com" has password "OldPassword123!"
+    And the following users exist:
+      | email             | role | display_name |
+      | taken@example.com | user | Taken Email  |
+    And I am on my profile page
+    When I fill in "New email" with "taken@example.com"
+    And I fill in "Confirm current password" with "OldPassword123!"
+    And I click the "Change email" button
+    Then I should see "That email is already in use."
+    And I should see "alice@example.com"
+
   Scenario: Display name validation - empty
     Given I am on my profile page
     When I fill in "Display name" with ""

--- a/test/features/user_profile.feature
+++ b/test/features/user_profile.feature
@@ -23,6 +23,17 @@ Feature: User Profile Management
     Then I should see "Display name updated successfully"
     And the display name field should contain "Alice Cooper"
 
+  Scenario: Changing my sign-in email securely
+    Given the user "alice@example.com" has password "OldPassword123!"
+    And I am on my profile page
+    When I fill in "New email" with "alice.changed@example.com"
+    And I fill in "Confirm current password" with "OldPassword123!"
+    And I click the "Change email" button
+    Then I should see "Email updated successfully"
+    And I should see "alice.changed@example.com"
+    And a security notice should be sent to "alice@example.com" naming the new address "alice.changed@example.com"
+    And a confirmation should be sent to "alice.changed@example.com" naming the previous address "alice@example.com"
+
   Scenario: Display name validation - empty
     Given I am on my profile page
     When I fill in "Display name" with ""

--- a/test/huddlz/accounts/user/change_email_test.exs
+++ b/test/huddlz/accounts/user/change_email_test.exs
@@ -64,6 +64,21 @@ defmodule Huddlz.Accounts.User.ChangeEmailTest do
                |> Ash.update()
     end
 
+    test "rejects the user's current email", %{user: user} do
+      assert {:error, %Ash.Error.Invalid{errors: errors}} =
+               Huddlz.Accounts.change_email(
+                 user,
+                 "alice@example.com",
+                 "OldPassword123!",
+                 actor: user
+               )
+
+      assert Enum.any?(errors, fn error ->
+               Map.get(error, :field) == :email and
+                 Exception.message(error) =~ "Enter a different email address."
+             end)
+    end
+
     test "forbids changing another user's email", %{user: user} do
       stranger = generate(user())
 

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -168,7 +168,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
         |> assert_has("#email-change-form")
         |> fill_in("New email", with: new_email)
         |> fill_in("Confirm current password", with: "OldPassword123!")
-        |> click_button("Change email")
+        |> click_button("#change-email-button", "Change email")
         |> assert_has("*", text: "Email updated successfully")
         |> assert_has("aside.sidebar .sb-user", text: new_email)
 
@@ -199,7 +199,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
         |> visit("/profile")
         |> fill_in("New email", with: "not-an-email")
         |> fill_in("Confirm current password", with: "OldPassword123!")
-        |> click_button("Change email")
+        |> click_button("#change-email-button", "Change email")
 
       session
       |> assert_has("#email_change_email[aria-invalid='true']")
@@ -215,7 +215,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> visit("/profile")
       |> fill_in("New email", with: to_string(user.email))
       |> fill_in("Confirm current password", with: "OldPassword123!")
-      |> click_button("Change email")
+      |> click_button("#change-email-button", "Change email")
       |> assert_has("#email_change_email-error-0", text: "Enter a different email address.")
 
       refute_enqueued(worker: DeliverWorker, args: %{"trigger" => "email_changed"})
@@ -230,7 +230,7 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> visit("/profile")
       |> fill_in("New email", with: taken_email)
       |> fill_in("Confirm current password", with: "OldPassword123!")
-      |> click_button("Change email")
+      |> click_button("#change-email-button", "Change email")
       |> assert_has("#email_change_email-error-0", text: "That email is already in use.")
 
       assert User |> Ash.get!(user.id, authorize?: false) |> Map.fetch!(:email) == user.email
@@ -249,13 +249,18 @@ defmodule HuddlzWeb.ProfileLiveTest do
           with: "wrong-password-#{System.unique_integer([:positive])}@example.com"
         )
         |> fill_in("Confirm current password", with: "WrongPassword")
-        |> click_button("Change email")
+        |> click_button("#change-email-button", "Change email")
         |> assert_has("*", text: "Email could not be updated")
         |> refute_has("#email_change_current_password[value='WrongPassword']")
 
       assert User |> Ash.get!(user.id, authorize?: false) |> Map.fetch!(:email) == user.email
       refute_enqueued(worker: DeliverWorker, args: %{"trigger" => "email_changed"})
-      assert_has(session, "#email-change-form")
+
+      session
+      |> fill_in("Confirm current password", with: "OldPassword123!")
+      |> click_button("#change-email-button", "Change email")
+      |> assert_has("*", text: "Email updated successfully")
+      |> refute_has("*", text: "Email could not be updated")
     end
   end
 

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -1,10 +1,14 @@
 defmodule HuddlzWeb.ProfileLiveTest do
   use HuddlzWeb.ConnCase, async: true
+  use Oban.Testing, repo: Huddlz.Repo
 
   import Mox
   import PhoenixTest
   import Phoenix.LiveViewTest
   import Huddlz.Test.Helpers.Authentication
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Notifications.DeliverWorker
 
   setup :verify_on_exit!
 
@@ -134,6 +138,124 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> visit("/profile")
       |> fill_in("Display name", with: "")
       |> assert_has("form")
+    end
+  end
+
+  describe "Email change" do
+    setup do
+      user =
+        generate(
+          user_with_password(
+            email: "profile-email-#{System.unique_integer([:positive])}@example.com",
+            display_name: "Email Change User",
+            password: "OldPassword123!"
+          )
+        )
+
+      %{user: user}
+    end
+
+    test "changes the signed-in identity and sends both security notices", %{
+      conn: conn,
+      user: user
+    } do
+      new_email = "changed-#{System.unique_integer([:positive])}@example.com"
+
+      session =
+        conn
+        |> login(user)
+        |> visit("/profile")
+        |> assert_has("#email-change-form")
+        |> fill_in("New email", with: new_email)
+        |> fill_in("Confirm current password", with: "OldPassword123!")
+        |> click_button("Change email")
+        |> assert_has("*", text: "Email updated successfully")
+        |> assert_has("aside.sidebar .sb-user", text: new_email)
+
+      session
+      |> visit("/profile/notifications")
+      |> assert_has("aside.sidebar .sb-user", text: new_email)
+      |> visit("/profile")
+      |> refute_has("#email_change_current_password[value='OldPassword123!']")
+
+      assert User |> Ash.get!(user.id, authorize?: false) |> Map.fetch!(:email) |> to_string() ==
+               new_email
+
+      enqueued =
+        all_enqueued(worker: DeliverWorker)
+        |> Enum.filter(&(&1.args["trigger"] == "email_changed"))
+
+      assert enqueued |> Enum.map(& &1.args["payload"]["audience"]) |> Enum.sort() ==
+               ["new", "old"]
+    end
+
+    test "shows a field error for an invalid email and clears the submitted password", %{
+      conn: conn,
+      user: user
+    } do
+      session =
+        conn
+        |> login(user)
+        |> visit("/profile")
+        |> fill_in("New email", with: "not-an-email")
+        |> fill_in("Confirm current password", with: "OldPassword123!")
+        |> click_button("Change email")
+
+      session
+      |> assert_has("#email_change_email[aria-invalid='true']")
+      |> assert_has("#email_change_email-error-0", text: "Enter a valid email address.")
+      |> refute_has("#email_change_current_password[value='OldPassword123!']")
+
+      assert User |> Ash.get!(user.id, authorize?: false) |> Map.fetch!(:email) == user.email
+    end
+
+    test "rejects the current email as the new email", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> fill_in("New email", with: to_string(user.email))
+      |> fill_in("Confirm current password", with: "OldPassword123!")
+      |> click_button("Change email")
+      |> assert_has("#email_change_email-error-0", text: "Enter a different email address.")
+
+      refute_enqueued(worker: DeliverWorker, args: %{"trigger" => "email_changed"})
+    end
+
+    test "shows a field error when the new email is already used", %{conn: conn, user: user} do
+      taken_email = "taken-#{System.unique_integer([:positive])}@example.com"
+      _other_user = create_user(%{email: taken_email})
+
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> fill_in("New email", with: taken_email)
+      |> fill_in("Confirm current password", with: "OldPassword123!")
+      |> click_button("Change email")
+      |> assert_has("#email_change_email-error-0", text: "That email is already in use.")
+
+      assert User |> Ash.get!(user.id, authorize?: false) |> Map.fetch!(:email) == user.email
+    end
+
+    test "wrong current password leaves the identity unchanged and clears the password", %{
+      conn: conn,
+      user: user
+    } do
+      session =
+        conn
+        |> login(user)
+        |> visit("/profile")
+        |> fill_in(
+          "New email",
+          with: "wrong-password-#{System.unique_integer([:positive])}@example.com"
+        )
+        |> fill_in("Confirm current password", with: "WrongPassword")
+        |> click_button("Change email")
+        |> assert_has("*", text: "Email could not be updated")
+        |> refute_has("#email_change_current_password[value='WrongPassword']")
+
+      assert User |> Ash.get!(user.id, authorize?: false) |> Map.fetch!(:email) == user.email
+      refute_enqueued(worker: DeliverWorker, args: %{"trigger" => "email_changed"})
+      assert_has(session, "#email-change-form")
     end
   end
 


### PR DESCRIPTION
## Summary

- add a protected Change email form to the profile page
- keep malformed, unchanged, and duplicate-email validation recoverable and field-level
- refresh the signed-in identity without a new session and send notices to both addresses
- clear the current-password value after every server submission

## Validation

- `env ERL_FLAGS="+S 4" mix precommit` (1,417 tests; strict Credo clean)
- focused LiveView and Ash domain suites (180 tests)
- Cucumber profile email-change scenario
- browser verification of application-backed invalid-email feedback and password clearing

## Screenshots

Before and after screenshots were captured outside the repository during browser verification. The available browser is not signed into GitHub, so the files could not be attached without adding artifacts to the repository; they are included in the automation handoff.

Closes #282