### PR TITLE
Clarify group visibility changes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2973,6 +2973,7 @@ body .visibility-selection {
 
 body .visibility-toggle {
   position: relative;
+  min-height: 44px;
 }
 
 body .visibility-toggle input[type="checkbox"] {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2950,6 +2950,75 @@ body .toggle .toggle-text {
 body .toggle input:checked ~ .toggle-text { color: var(--cyan); }
 body .toggle input:disabled ~ .toggle-text { color: var(--muted); opacity: 0.7; }
 
+/* Group visibility editor — makes saved vs selected state explicit. */
+body .visibility-current {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+body .visibility-current strong {
+  color: var(--cyan);
+  font-size: 11px;
+}
+
+body .visibility-selection {
+  cursor: default;
+}
+
+body .visibility-toggle {
+  position: relative;
+}
+
+body .visibility-toggle input[type="checkbox"] {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  opacity: 0;
+}
+
+body .visibility-toggle input[type="checkbox"]:focus-visible + .track {
+  outline: 2px solid var(--cyan);
+  outline-offset: 3px;
+}
+
+body .visibility-consequence {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+body .visibility-consequence-icon {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--soft);
+}
+
+body .visibility-consequence-pending {
+  border-color: var(--cyan-dim);
+  background: rgba(24, 203, 212, 0.055);
+  color: var(--soft);
+}
+
+body .visibility-consequence-pending .visibility-consequence-icon {
+  color: var(--cyan);
+}
+
 /* Insights chip strip on listing pages */
 body .insight-strip {
   display: flex;
@@ -3197,6 +3266,9 @@ body .page-nav:disabled {
   body .hero-content h1 { font-size: 26px; }
   body .panel { padding: 14px 14px; }
   body .panel.split { gap: 18px; }
+  body .visibility-panel-head { flex-direction: column; align-items: flex-start; gap: 10px; }
+  body .visibility-selection { grid-template-columns: 1fr; }
+  body .visibility-toggle { margin-top: 4px; }
   body .filters { gap: 6px; }
   body .insight-strip { gap: 8px; }
   /* Listings on org pages: collapse multi-column rows */

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -304,39 +304,73 @@ defmodule HuddlzWeb.GroupLive.Edit do
         </div>
 
         <div class="panel">
-          <div class="panel-head">
+          <div class="panel-head visibility-panel-head">
             <div>
               <h2>Visibility</h2>
               <div class="panel-sub">
-                Public groups are findable in Discover. Private groups are only visible to members.
+                Choose who can find this group and its huddlz.
               </div>
+            </div>
+            <div
+              id="group-visibility-current"
+              class="visibility-current"
+              data-visibility={visibility_value(@group.is_public)}
+            >
+              <span>Current visibility</span>
+              <strong>{visibility_label(@group.is_public)}</strong>
             </div>
           </div>
           <div class="settings-list row-list pref-list">
-            <div class="row">
+            <div
+              id="group-visibility-selection"
+              class="row visibility-selection"
+              data-visibility={visibility_value(public_group?(@form))}
+            >
               <div>
-                <label class="row-title" for="group-is-public">Public group</label>
-                <div class="row-desc">
-                  Anyone can find and join this group. Huddlz are visible without signing in.
+                <label id="group-visibility-label" class="row-title" for="group-is-public">
+                  {visibility_label(public_group?(@form))} group
+                </label>
+                <div id="group-visibility-description" class="row-desc">
+                  {visibility_description(public_group?(@form))}
                 </div>
               </div>
-              <label class="toggle">
+              <label class="toggle visibility-toggle">
                 <input type="hidden" name={@form[:is_public].name} value="false" />
                 <input
                   id="group-is-public"
                   type="checkbox"
                   name={@form[:is_public].name}
                   value="true"
-                  checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_public].value)}
+                  checked={public_group?(@form)}
+                  aria-labelledby="group-visibility-label"
+                  aria-describedby="group-visibility-description group-visibility-consequence"
                 />
                 <span class="track"></span>
                 <span class="toggle-text">
-                  {if Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_public].value),
-                    do: "On",
-                    else: "Off"}
+                  {visibility_label(public_group?(@form))}
                 </span>
               </label>
             </div>
+          </div>
+          <div
+            id="group-visibility-consequence"
+            class={[
+              "visibility-consequence",
+              visibility_changed?(@group.is_public, public_group?(@form)) &&
+                "visibility-consequence-pending"
+            ]}
+            role="status"
+            aria-live="polite"
+          >
+            <.icon
+              name={
+                if visibility_changed?(@group.is_public, public_group?(@form)),
+                  do: "hero-arrow-right",
+                  else: "hero-check"
+              }
+              class="visibility-consequence-icon size-4"
+            />
+            <span>{visibility_consequence(@group.is_public, public_group?(@form))}</span>
           </div>
         </div>
 
@@ -412,7 +446,10 @@ defmodule HuddlzWeb.GroupLive.Edit do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Group updated successfully")
+         |> put_flash(
+           :info,
+           "Group updated successfully. Visibility is now #{visibility_value(updated_group.is_public)}."
+         )
          |> redirect(to: ~p"/groups/#{updated_group.slug}")}
 
       {:error, form} ->
@@ -483,6 +520,36 @@ defmodule HuddlzWeb.GroupLive.Edit do
       nil
     end
   end
+
+  defp public_group?(form),
+    do: Phoenix.HTML.Form.normalize_value("checkbox", form[:is_public].value)
+
+  defp visibility_changed?(saved_public?, selected_public?),
+    do: saved_public? != selected_public?
+
+  defp visibility_label(true), do: "Public"
+  defp visibility_label(false), do: "Private"
+
+  defp visibility_value(true), do: "public"
+  defp visibility_value(false), do: "private"
+
+  defp visibility_description(true),
+    do: "Anyone can find and join this group. Its public huddlz are visible without signing in."
+
+  defp visibility_description(false),
+    do: "Only current members can access this group and its huddlz."
+
+  defp visibility_consequence(saved_public?, saved_public?),
+    do:
+      "No visibility change pending. Saving keeps this group #{visibility_value(saved_public?)}."
+
+  defp visibility_consequence(true, false),
+    do:
+      "When you save, this group and all existing huddlz will leave public discovery. Current members keep their memberships."
+
+  defp visibility_consequence(false, true),
+    do:
+      "When you save, this group and otherwise-public huddlz will become discoverable again. Current members keep their memberships."
 
   defp get_group_by_slug(slug, actor) do
     case Huddlz.Communities.get_by_slug(slug,

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -114,6 +114,16 @@ defmodule HuddlzWeb.GroupLive.Edit do
 
   @impl true
   def render(assigns) do
+    selected_public? = public_group?(assigns.form)
+
+    assigns =
+      assigns
+      |> assign(:selected_public?, selected_public?)
+      |> assign(
+        :visibility_changed?,
+        visibility_changed?(assigns.group.is_public, selected_public?)
+      )
+
     ~H"""
     <Layouts.app
       flash={@flash}
@@ -314,7 +324,6 @@ defmodule HuddlzWeb.GroupLive.Edit do
             <div
               id="group-visibility-current"
               class="visibility-current"
-              data-visibility={visibility_value(@group.is_public)}
             >
               <span>Current visibility</span>
               <strong>{visibility_label(@group.is_public)}</strong>
@@ -324,14 +333,13 @@ defmodule HuddlzWeb.GroupLive.Edit do
             <div
               id="group-visibility-selection"
               class="row visibility-selection"
-              data-visibility={visibility_value(public_group?(@form))}
             >
               <div>
                 <label id="group-visibility-label" class="row-title" for="group-is-public">
-                  {visibility_label(public_group?(@form))} group
+                  {visibility_label(@selected_public?)} group
                 </label>
                 <div id="group-visibility-description" class="row-desc">
-                  {visibility_description(public_group?(@form))}
+                  {visibility_description(@selected_public?)}
                 </div>
               </div>
               <label class="toggle visibility-toggle">
@@ -341,13 +349,13 @@ defmodule HuddlzWeb.GroupLive.Edit do
                   type="checkbox"
                   name={@form[:is_public].name}
                   value="true"
-                  checked={public_group?(@form)}
+                  checked={@selected_public?}
                   aria-labelledby="group-visibility-label"
                   aria-describedby="group-visibility-description group-visibility-consequence"
                 />
                 <span class="track"></span>
                 <span class="toggle-text">
-                  {visibility_label(public_group?(@form))}
+                  {visibility_label(@selected_public?)}
                 </span>
               </label>
             </div>
@@ -356,21 +364,20 @@ defmodule HuddlzWeb.GroupLive.Edit do
             id="group-visibility-consequence"
             class={[
               "visibility-consequence",
-              visibility_changed?(@group.is_public, public_group?(@form)) &&
-                "visibility-consequence-pending"
+              @visibility_changed? && "visibility-consequence-pending"
             ]}
             role="status"
             aria-live="polite"
           >
             <.icon
               name={
-                if visibility_changed?(@group.is_public, public_group?(@form)),
+                if @visibility_changed?,
                   do: "hero-arrow-right",
                   else: "hero-check"
               }
               class="visibility-consequence-icon size-4"
             />
-            <span>{visibility_consequence(@group.is_public, public_group?(@form))}</span>
+            <span>{visibility_consequence(@group.is_public, @selected_public?)}</span>
           </div>
         </div>
 
@@ -537,7 +544,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
     do: "Anyone can find and join this group. Its public huddlz are visible without signing in."
 
   defp visibility_description(false),
-    do: "Only current members can access this group and its huddlz."
+    do: "Access is limited to current members and platform admins for this group and its huddlz."
 
   defp visibility_consequence(saved_public?, saved_public?),
     do:

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -335,13 +335,16 @@ defmodule HuddlzWeb.GroupLive.Edit do
               class="row visibility-selection"
             >
               <div>
-                <label id="group-visibility-label" class="row-title" for="group-is-public">
+                <div id="group-visibility-label" class="row-title">
                   {visibility_label(@selected_public?)} group
-                </label>
+                </div>
                 <div id="group-visibility-description" class="row-desc">
                   {visibility_description(@selected_public?)}
                 </div>
               </div>
+              <label id="group-public-toggle-label" for="group-is-public" class="sr-only">
+                Public group
+              </label>
               <label class="toggle visibility-toggle">
                 <input type="hidden" name={@form[:is_public].name} value="false" />
                 <input
@@ -350,7 +353,8 @@ defmodule HuddlzWeb.GroupLive.Edit do
                   name={@form[:is_public].name}
                   value="true"
                   checked={@selected_public?}
-                  aria-labelledby="group-visibility-label"
+                  role="switch"
+                  aria-labelledby="group-public-toggle-label"
                   aria-describedby="group-visibility-description group-visibility-consequence"
                 />
                 <span class="track"></span>

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -89,7 +89,7 @@ Feature: Group Management
     When I visit the edit page for "Book Club"
     Then I should see "Current visibility"
     And I should see "Private"
-    When I check "Private group"
+    When I check "Public group"
     Then I should see "Public group"
     And I should see "Anyone can find and join this group"
     And I should see "otherwise-public huddlz will become discoverable again"

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -69,6 +69,33 @@ Feature: Group Management
     Then I should see "Group updated successfully"
     And I should see "Updated Book Club"
 
+  Scenario: Owner understands making a public group private
+    Given a public group "Book Club" exists with owner "verified@example.com"
+    And I am signed in as "verified@example.com"
+    When I visit the edit page for "Book Club"
+    Then I should see "Current visibility"
+    And I should see "Public"
+    When I uncheck "Public group"
+    Then I should see "Private group"
+    And I should see "Access is limited to current members and platform admins"
+    And I should see "all existing huddlz will leave public discovery"
+    And I should see "Current members keep their memberships"
+    When I click "Save Changes"
+    Then I should see "Visibility is now private"
+
+  Scenario: Owner understands making a private group public
+    Given a private group "Book Club" exists with owner "verified@example.com"
+    And I am signed in as "verified@example.com"
+    When I visit the edit page for "Book Club"
+    Then I should see "Current visibility"
+    And I should see "Private"
+    When I check "Private group"
+    Then I should see "Public group"
+    And I should see "Anyone can find and join this group"
+    And I should see "otherwise-public huddlz will become discoverable again"
+    When I click "Save Changes"
+    Then I should see "Visibility is now public"
+
   Scenario: Non-owner cannot edit group
     Given a public group "Book Club" exists with owner "verified@example.com"
     And I am signed in as "regular@example.com"

--- a/test/huddlz_web/live/group_live/edit_test.exs
+++ b/test/huddlz_web/live/group_live/edit_test.exs
@@ -32,8 +32,8 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> assert_has("h1", text: "Edit Group")
       |> assert_has("input[name='form[name]'][value='Test Group']")
       |> assert_has("input[name='form[slug]'][value='test-group']")
-      |> assert_has("#group-visibility-current[data-visibility='public']", text: "Public")
-      |> assert_has("#group-visibility-selection[data-visibility='public']", text: "Public group")
+      |> assert_has("#group-visibility-current", text: "Public")
+      |> assert_has("#group-visibility-selection", text: "Public group")
       |> assert_has(
         "#group-is-public[aria-labelledby='group-visibility-label'][aria-describedby='group-visibility-description group-visibility-consequence']"
       )
@@ -93,13 +93,11 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}/edit")
       |> uncheck("Public group")
-      |> assert_has("#group-visibility-current[data-visibility='public']", text: "Public")
-      |> assert_has("#group-visibility-selection[data-visibility='private']",
-        text: "Private group"
-      )
+      |> assert_has("#group-visibility-current", text: "Public")
+      |> assert_has("#group-visibility-selection", text: "Private group")
       |> assert_has(
         "#group-visibility-description",
-        text: "Only current members can access this group and its huddlz"
+        text: "Access is limited to current members and platform admins"
       )
       |> assert_has(
         "#group-visibility-consequence",
@@ -127,9 +125,9 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       conn
       |> login(owner)
       |> visit(~p"/groups/#{private_group.slug}/edit")
-      |> assert_has("#group-visibility-current[data-visibility='private']", text: "Private")
+      |> assert_has("#group-visibility-current", text: "Private")
       |> check("Private group")
-      |> assert_has("#group-visibility-selection[data-visibility='public']", text: "Public group")
+      |> assert_has("#group-visibility-selection", text: "Public group")
       |> assert_has(
         "#group-visibility-description",
         text: "Anyone can find and join this group"
@@ -167,8 +165,8 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> uncheck("Public group")
       |> click_link("Cancel")
       |> visit(~p"/groups/#{group.slug}/edit")
-      |> assert_has("#group-visibility-current[data-visibility='public']", text: "Public")
-      |> assert_has("#group-visibility-selection[data-visibility='public']", text: "Public group")
+      |> assert_has("#group-visibility-current", text: "Public")
+      |> assert_has("#group-visibility-selection", text: "Public group")
     end
 
     test "slug change shows warning", %{conn: conn, owner: owner, group: group} do

--- a/test/huddlz_web/live/group_live/edit_test.exs
+++ b/test/huddlz_web/live/group_live/edit_test.exs
@@ -35,7 +35,7 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> assert_has("#group-visibility-current", text: "Public")
       |> assert_has("#group-visibility-selection", text: "Public group")
       |> assert_has(
-        "#group-is-public[aria-labelledby='group-visibility-label'][aria-describedby='group-visibility-description group-visibility-consequence']"
+        "#group-is-public[role='switch'][aria-labelledby='group-public-toggle-label'][aria-describedby='group-visibility-description group-visibility-consequence']"
       )
       |> assert_has("#group-visibility-consequence", text: "No visibility change pending")
     end
@@ -126,7 +126,10 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> login(owner)
       |> visit(~p"/groups/#{private_group.slug}/edit")
       |> assert_has("#group-visibility-current", text: "Private")
-      |> check("Private group")
+      |> assert_has(
+        "#group-is-public[role='switch'][aria-labelledby='group-public-toggle-label']:not(:checked)"
+      )
+      |> check("Public group")
       |> assert_has("#group-visibility-selection", text: "Public group")
       |> assert_has(
         "#group-visibility-description",

--- a/test/huddlz_web/live/group_live/edit_test.exs
+++ b/test/huddlz_web/live/group_live/edit_test.exs
@@ -32,6 +32,12 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> assert_has("h1", text: "Edit Group")
       |> assert_has("input[name='form[name]'][value='Test Group']")
       |> assert_has("input[name='form[slug]'][value='test-group']")
+      |> assert_has("#group-visibility-current[data-visibility='public']", text: "Public")
+      |> assert_has("#group-visibility-selection[data-visibility='public']", text: "Public group")
+      |> assert_has(
+        "#group-is-public[aria-labelledby='group-visibility-label'][aria-describedby='group-visibility-description group-visibility-consequence']"
+      )
+      |> assert_has("#group-visibility-consequence", text: "No visibility change pending")
     end
 
     test "renders v3 chrome with the three panels in order", %{
@@ -76,6 +82,93 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> assert_has("h1", text: "Updated Group Name")
       |> assert_has("p", text: "Updated description")
       |> assert_has(".hero .meta span", text: "Updated location")
+    end
+
+    test "changing a public group to private explains the consequences", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/edit")
+      |> uncheck("Public group")
+      |> assert_has("#group-visibility-current[data-visibility='public']", text: "Public")
+      |> assert_has("#group-visibility-selection[data-visibility='private']",
+        text: "Private group"
+      )
+      |> assert_has(
+        "#group-visibility-description",
+        text: "Only current members can access this group and its huddlz"
+      )
+      |> assert_has(
+        "#group-visibility-consequence",
+        text: "this group and all existing huddlz will leave public discovery"
+      )
+      |> assert_has("#group-visibility-consequence",
+        text: "Current members keep their memberships"
+      )
+    end
+
+    test "changing a private group to public explains the consequences", %{
+      conn: conn,
+      owner: owner
+    } do
+      private_group =
+        generate(
+          group(
+            name: "Private Test Group",
+            slug: "private-test-group",
+            is_public: false,
+            actor: owner
+          )
+        )
+
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{private_group.slug}/edit")
+      |> assert_has("#group-visibility-current[data-visibility='private']", text: "Private")
+      |> check("Private group")
+      |> assert_has("#group-visibility-selection[data-visibility='public']", text: "Public group")
+      |> assert_has(
+        "#group-visibility-description",
+        text: "Anyone can find and join this group"
+      )
+      |> assert_has(
+        "#group-visibility-consequence",
+        text: "this group and otherwise-public huddlz will become discoverable again"
+      )
+    end
+
+    test "saving names the new visibility in the success feedback", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/edit")
+      |> uncheck("Public group")
+      |> click_button("Save Changes")
+      |> assert_has(
+        "div[role='alert']",
+        text: "Group updated successfully. Visibility is now private."
+      )
+    end
+
+    test "canceling a pending visibility change preserves the saved state", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/edit")
+      |> uncheck("Public group")
+      |> click_link("Cancel")
+      |> visit(~p"/groups/#{group.slug}/edit")
+      |> assert_has("#group-visibility-current[data-visibility='public']", text: "Public")
+      |> assert_has("#group-visibility-selection[data-visibility='public']", text: "Public group")
     end
 
     test "slug change shows warning", %{conn: conn, owner: owner, group: group} do


### PR DESCRIPTION
## Summary
- show the group's saved visibility separately from the pending selection
- explain how public/private transitions affect discovery and memberships
- keep the custom visibility toggle accessible and responsive
- name the resulting visibility in success feedback

## Testing
- `mix precommit` (1,414 tests, strict Credo)
- browser verification at desktop and 390px mobile widths

Closes #280