### PR TITLE
fix(ui): replace image removal browser alerts

### DIFF
--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -18,6 +18,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
   alias Huddlz.Storage.GroupImages
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.Live.Helpers.ImageUploadPipeline
+  alias Phoenix.LiveView.JS
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -62,6 +63,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
     |> assign(:original_slug, group.slug)
     |> assign(:slug_changed, false)
     |> assign(:image_error, nil)
+    |> assign(:remove_image_dialog_open, false)
     |> assign(:pending_image_id, nil)
     |> assign(:pending_preview_url, nil)
     |> assign(:selected_location_data, build_initial_location_data(group))
@@ -175,9 +177,9 @@ defmodule HuddlzWeb.GroupLive.Edit do
                     </label>
                     <.button
                       variant={:muted}
+                      id="open-remove-group-image-dialog"
                       type="button"
-                      phx-click="remove_image"
-                      data-confirm="Are you sure you want to remove this image?"
+                      phx-click={JS.push_focus() |> JS.push("open_remove_image_dialog")}
                     >
                       Remove
                     </.button>
@@ -349,6 +351,48 @@ defmodule HuddlzWeb.GroupLive.Edit do
           </.button>
         </div>
       </.form>
+
+      <.modal
+        :if={@remove_image_dialog_open}
+        id="remove-group-image-dialog"
+        show
+        on_cancel={JS.push("cancel_remove_image")}
+      >
+        <div class="delete-confirm">
+          <div class="delete-confirm-icon" aria-hidden="true">
+            <.icon name="hero-photo" class="h-6 w-6" />
+          </div>
+
+          <div class="delete-confirm-copy">
+            <span class="eyebrow eyebrow-magenta">Group cover</span>
+            <h2 id="remove-group-image-dialog-title">Remove this group cover image?</h2>
+            <p>
+              The current cover for <strong>{@group.name}</strong> will be removed. Group and
+              huddl cards will use the <strong>branded group fallback</strong> until a new cover
+              is uploaded.
+            </p>
+          </div>
+        </div>
+
+        <div class="delete-confirm-actions">
+          <.button
+            variant={:muted}
+            id="cancel-remove-group-image"
+            phx-click="cancel_remove_image"
+          >
+            Keep image
+          </.button>
+          <.button
+            variant={:destructive}
+            class="delete-confirm-submit"
+            id="confirm-remove-group-image"
+            phx-click="remove_image"
+            phx-disable-with="Removing…"
+          >
+            Remove image
+          </.button>
+        </div>
+      </.modal>
     </Layouts.app>
     """
   end
@@ -380,7 +424,26 @@ defmodule HuddlzWeb.GroupLive.Edit do
   end
 
   @impl true
-  def handle_event("remove_image", _params, socket) do
+  def handle_event("open_remove_image_dialog", _params, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :remove_image_dialog_open,
+       !is_nil(socket.assigns.group.current_image_url)
+     )}
+  end
+
+  @impl true
+  def handle_event("cancel_remove_image", _params, socket) do
+    {:noreply, assign(socket, :remove_image_dialog_open, false)}
+  end
+
+  @impl true
+  def handle_event(
+        "remove_image",
+        _params,
+        %{assigns: %{remove_image_dialog_open: true}} = socket
+      ) do
     group = socket.assigns.group
     user = socket.assigns.current_user
 
@@ -391,12 +454,18 @@ defmodule HuddlzWeb.GroupLive.Edit do
         {:noreply,
          socket
          |> put_flash(:info, "Image removed")
+         |> assign(:remove_image_dialog_open, false)
          |> assign(:group, updated_group)}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to remove image")}
+        {:noreply,
+         socket
+         |> assign(:remove_image_dialog_open, false)
+         |> put_flash(:error, "Failed to remove image")}
     end
   end
+
+  def handle_event("remove_image", _params, socket), do: {:noreply, socket}
 
   @impl true
   def handle_event("update_group", %{"form" => params}, socket) do

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -8,6 +8,7 @@ defmodule HuddlzWeb.ProfileLive do
   alias HuddlzWeb.Avatar
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.Live.Helpers.UploadHelpers
+  alias Phoenix.LiveView.JS
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -55,6 +56,7 @@ defmodule HuddlzWeb.ProfileLive do
      |> assign(:password_form, password_form)
      |> assign(:current_user, user_with_avatar)
      |> assign(:avatar_error, nil)
+     |> assign(:remove_avatar_dialog_open, false)
      |> assign(:location_error, nil)
      |> UploadHelpers.allow_image_upload(:avatar, &handle_upload_progress/3)}
   end
@@ -87,10 +89,10 @@ defmodule HuddlzWeb.ProfileLive do
             </label>
             <%= if @current_user.current_profile_picture_url do %>
               <button
+                id="open-remove-avatar-dialog"
                 type="button"
                 class="btn-secondary muted-btn"
-                phx-click="remove_avatar"
-                data-confirm="Are you sure you want to remove your profile picture?"
+                phx-click={JS.push_focus() |> JS.push("open_remove_avatar_dialog")}
               >
                 Remove
               </button>
@@ -251,6 +253,47 @@ defmodule HuddlzWeb.ProfileLive do
           </div>
         </div>
       </.form>
+
+      <.modal
+        :if={@remove_avatar_dialog_open}
+        id="remove-avatar-dialog"
+        show
+        on_cancel={JS.push("cancel_remove_avatar")}
+      >
+        <div class="delete-confirm">
+          <div class="delete-confirm-icon" aria-hidden="true">
+            <.icon name="hero-user-circle" class="h-6 w-6" />
+          </div>
+
+          <div class="delete-confirm-copy">
+            <span class="eyebrow eyebrow-magenta">Profile picture</span>
+            <h2 id="remove-avatar-dialog-title">Remove your profile picture?</h2>
+            <p>
+              Your current picture will be removed. Your <strong>initials will appear instead</strong>
+              everywhere your profile is shown.
+            </p>
+          </div>
+        </div>
+
+        <div class="delete-confirm-actions">
+          <.button
+            variant={:muted}
+            id="cancel-remove-avatar"
+            phx-click="cancel_remove_avatar"
+          >
+            Keep picture
+          </.button>
+          <.button
+            variant={:destructive}
+            class="delete-confirm-submit"
+            id="confirm-remove-avatar"
+            phx-click="remove_avatar"
+            phx-disable-with="Removing…"
+          >
+            Remove picture
+          </.button>
+        </div>
+      </.modal>
     </Layouts.app>
     """
   end
@@ -400,7 +443,26 @@ defmodule HuddlzWeb.ProfileLive do
   end
 
   @impl true
-  def handle_event("remove_avatar", _params, socket) do
+  def handle_event("open_remove_avatar_dialog", _params, socket) do
+    {:noreply,
+     assign(
+       socket,
+       :remove_avatar_dialog_open,
+       !is_nil(socket.assigns.current_user.current_profile_picture_url)
+     )}
+  end
+
+  @impl true
+  def handle_event("cancel_remove_avatar", _params, socket) do
+    {:noreply, assign(socket, :remove_avatar_dialog_open, false)}
+  end
+
+  @impl true
+  def handle_event(
+        "remove_avatar",
+        _params,
+        %{assigns: %{remove_avatar_dialog_open: true}} = socket
+      ) do
     user = socket.assigns.current_user
 
     # Soft-delete all profile pictures for the user
@@ -413,14 +475,18 @@ defmodule HuddlzWeb.ProfileLive do
         {:noreply,
          socket
          |> put_flash(:info, "Profile picture removed")
+         |> assign(:remove_avatar_dialog_open, false)
          |> assign(:current_user, updated_user)}
 
       {:error, _} ->
         {:noreply,
          socket
+         |> assign(:remove_avatar_dialog_open, false)
          |> put_flash(:error, "Failed to remove profile picture")}
     end
   end
+
+  def handle_event("remove_avatar", _params, socket), do: {:noreply, socket}
 
   @impl true
   def handle_info(

--- a/test/features/group_image.feature
+++ b/test/features/group_image.feature
@@ -97,12 +97,36 @@ Feature: Group Image Management
   Scenario: Owner can remove existing group image
     Given a public group "Remove Image Group" exists with owner "owner@example.com"
     And the group "Remove Image Group" has an image
+    And a huddl "Group Image Huddl" exists in "Remove Image Group" created by "owner@example.com"
     And I am signed in as "owner@example.com"
     When I visit the edit page for group "Remove Image Group"
     Then I should see "Current image"
     When I click the "Remove" button
+    Then I should see "Remove this group cover image?"
+    And I should see "branded group fallback"
+    When I click the "Remove image" button
     Then I should see "Image removed"
     And the group "Remove Image Group" should not have an image
+    When I visit the group page for "Remove Image Group"
+    Then I should not see the group image
+    And I should see the group name "Remove Image Group" in the placeholder
+    When I visit "/my-groups"
+    Then I should not see the group image
+    When I visit the huddl "Group Image Huddl" page
+    Then I should not see an image on the huddl page
+    When I visit the edit page for group "Remove Image Group"
+    Then I should see "Drop a 16:9 image"
+
+  Scenario: Canceling group image removal preserves the image
+    Given a public group "Keep Image Group" exists with owner "owner@example.com"
+    And the group "Keep Image Group" has an image
+    And I am signed in as "owner@example.com"
+    When I visit the edit page for group "Keep Image Group"
+    And I click the "Remove" button
+    Then I should see "Remove this group cover image?"
+    When I click the "Keep image" button
+    Then I should not see "Remove this group cover image?"
+    And the group "Keep Image Group" should have an image
 
   Scenario: Canceling a pending image shows current image again
     Given a public group "Cancel Replace Group" exists with owner "owner@example.com"

--- a/test/features/profile_picture.feature
+++ b/test/features/profile_picture.feature
@@ -64,13 +64,34 @@ Feature: Profile Picture Management
     Then I should see the creator avatar with image
 
   Scenario: Avatar shows initials after profile picture is removed
-    Given the following profile pictures exist:
+    Given the following groups exist:
+      | name       | slug       | owner_email       | visibility |
+      | Test Group | test-group | alice@example.com | public     |
+    And a huddl "Test Huddl" exists in "Test Group" created by "alice@example.com"
+    And the following profile pictures exist:
       | user_email          | storage_path                                      |
       | alice@example.com   | /uploads/profile_pictures/alice/avatar.jpg        |
     When I visit "/profile"
     And I click "Remove"
+    Then I should see "Remove your profile picture?"
+    And I should see "initials will appear instead"
+    When I click "Remove picture"
     Then I should see "Profile picture removed"
     And I should see the avatar fallback showing initials
+    And I should see the navbar avatar with initials "AU"
+    When I visit the huddl "Test Huddl" page
+    Then I should see the creator avatar with initials "AU"
+
+  Scenario: Canceling profile picture removal preserves the picture
+    Given the following profile pictures exist:
+      | user_email        | storage_path                               |
+      | alice@example.com | /uploads/profile_pictures/alice/avatar.jpg |
+    When I visit "/profile"
+    And I click "Remove"
+    Then I should see "Remove your profile picture?"
+    When I click "Keep picture"
+    Then I should not see "Remove your profile picture?"
+    And I should see the profile avatar with an image
 
   Scenario: Removing profile picture shows initials not previous picture
     Given the following profile pictures exist:
@@ -81,5 +102,7 @@ Feature: Profile Picture Management
       | alice@example.com   | /uploads/profile_pictures/alice/second.jpg       |
     When I visit "/profile"
     And I click "Remove"
+    Then I should see "Remove your profile picture?"
+    When I click "Remove picture"
     Then I should see "Profile picture removed"
     And I should see the avatar fallback showing initials

--- a/test/features/step_definitions/profile_picture_steps.exs
+++ b/test/features/step_definitions/profile_picture_steps.exs
@@ -45,6 +45,12 @@ defmodule ProfilePictureSteps do
     context
   end
 
+  step "I should see the profile avatar with an image", context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "main img.big-avatar")
+    context
+  end
+
   step "I should see the navbar avatar with image", context do
     # v3 chrome puts the user avatar in the sidebar's .sb-user link
     # rather than the topbar. Image users get an <img> with the thumbnail src.
@@ -122,6 +128,13 @@ defmodule ProfilePictureSteps do
     session = context[:session] || context[:conn]
     # Look for the "Organized by" section which contains the creator avatar
     assert_has(session, "main img[src*='_thumb.jpg']")
+    context
+  end
+
+  step "I should see the creator avatar with initials {string}",
+       %{args: [initials]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, ".creator-row > div", text: initials)
     context
   end
 end

--- a/test/huddlz_web/live/group_live_image_test.exs
+++ b/test/huddlz_web/live/group_live_image_test.exs
@@ -414,7 +414,11 @@ defmodule HuddlzWeb.GroupLiveImageTest do
       assert flash["error"] =~ "permission"
     end
 
-    test "removing existing image works", %{conn: conn, owner: owner, group: group} do
+    test "opens and cancels the styled image removal dialog", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
       # Add an existing image
       {:ok, _image} =
         Communities.create_group_image(
@@ -436,18 +440,78 @@ defmodule HuddlzWeb.GroupLiveImageTest do
 
       # Should show current image with remove button
       assert has_element?(view, "*", "Current image")
-      assert has_element?(view, "button[phx-click='remove_image']")
+      assert has_element?(view, "#open-remove-group-image-dialog")
 
-      # Remove the image
-      view |> element("button[phx-click='remove_image']") |> render_click()
+      view
+      |> element("#open-remove-group-image-dialog")
+      |> render_click()
 
-      # Verify image was removed
+      assert has_element?(view, "#remove-group-image-dialog [role='dialog']")
+
+      assert has_element?(
+               view,
+               "#remove-group-image-dialog-title",
+               "Remove this group cover image?"
+             )
+
+      assert has_element?(view, "#remove-group-image-dialog", to_string(group.name))
+      assert has_element?(view, "#remove-group-image-dialog", "branded group fallback")
+
+      view
+      |> element("#cancel-remove-group-image")
+      |> render_click()
+
+      refute has_element?(view, "#remove-group-image-dialog")
+
+      unchanged_group =
+        Group
+        |> Ash.get!(group.id, authorize?: false)
+        |> Ash.load!(:current_image_url, authorize?: false)
+
+      assert unchanged_group.current_image_url != nil
+    end
+
+    test "confirming image removal immediately shows the upload fallback", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      {:ok, _image} =
+        Communities.create_group_image(
+          %{
+            filename: "to_remove.jpg",
+            content_type: "image/jpeg",
+            size_bytes: 1000,
+            storage_path: "/uploads/group_images/#{group.id}/to_remove.jpg",
+            thumbnail_path: "/uploads/group_images/#{group.id}/to_remove_thumb.jpg",
+            group_id: group.id
+          },
+          actor: owner
+        )
+
+      {:ok, view, _html} =
+        conn
+        |> login(owner)
+        |> live(~p"/groups/#{group.slug}/edit")
+
+      view
+      |> element("#open-remove-group-image-dialog")
+      |> render_click()
+
+      view
+      |> element("#confirm-remove-group-image")
+      |> render_click()
+
       updated_group =
         Group
         |> Ash.get!(group.id, authorize?: false)
         |> Ash.load!(:current_image_url, authorize?: false)
 
       assert updated_group.current_image_url == nil
+      refute has_element?(view, "#remove-group-image-dialog")
+      refute has_element?(view, ".image-preview", "Current image")
+      assert has_element?(view, ".upload-zone", "Drop a 16:9 image")
+      assert has_element?(view, "*", "Image removed")
     end
   end
 

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -75,6 +75,52 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> assert_has("aside.sidebar .sb-user img.avatar[src*='_thumb.jpg']")
     end
 
+    test "opens and cancels the styled profile picture removal dialog", %{
+      conn: conn,
+      user: user
+    } do
+      create_profile_picture(user)
+
+      session =
+        conn
+        |> login(user)
+        |> visit("/profile")
+        |> refute_has("#remove-avatar-dialog")
+        |> click_button("Remove")
+        |> assert_has("#remove-avatar-dialog [role='dialog']")
+        |> assert_has("#remove-avatar-dialog-title", text: "Remove your profile picture?")
+        |> assert_has("#remove-avatar-dialog", text: "initials will appear instead")
+
+      session
+      |> within("#remove-avatar-dialog", fn session ->
+        click_button(session, "Keep picture")
+      end)
+      |> refute_has("#remove-avatar-dialog")
+      |> assert_has("main img.big-avatar[src*='_thumb.jpg']")
+      |> assert_has("aside.sidebar .sb-user img.avatar[src*='_thumb.jpg']")
+    end
+
+    test "confirming profile picture removal updates profile and sidebar fallbacks", %{
+      conn: conn,
+      user: user
+    } do
+      create_profile_picture(user)
+
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> click_button("Remove")
+      |> within("#remove-avatar-dialog", fn session ->
+        click_button(session, "Remove picture")
+      end)
+      |> refute_has("#remove-avatar-dialog")
+      |> assert_has("*", text: "Profile picture removed")
+      |> refute_has("main img.big-avatar")
+      |> assert_has("main .big-avatar", text: "TU")
+      |> refute_has("aside.sidebar .sb-user img.avatar")
+      |> assert_has("aside.sidebar .sb-user .avatar", text: "TU")
+    end
+
     test "displays user profile when authenticated", %{conn: conn, user: user} do
       conn
       |> login(user)
@@ -353,5 +399,19 @@ defmodule HuddlzWeb.ProfileLiveTest do
 
       refute has_element?(view, "p", "Location search is currently unavailable")
     end
+  end
+
+  defp create_profile_picture(user) do
+    Huddlz.Accounts.create_profile_picture!(
+      %{
+        filename: "avatar.jpg",
+        content_type: "image/jpeg",
+        size_bytes: 1000,
+        storage_path: "/uploads/profile_pictures/#{user.id}/avatar.jpg",
+        thumbnail_path: "/uploads/profile_pictures/#{user.id}/avatar_thumb.jpg",
+        user_id: user.id
+      },
+      actor: user
+    )
   end
 end


### PR DESCRIPTION
## Summary

- replace native profile-picture and group-cover removal prompts with the shared accessible huddlz dialog
- focus the safe action first and support cancel, Escape, backdrop dismissal, and focus restoration
- refresh avatar, sidebar, group, huddl, organizer, and edit fallbacks after confirmed removal
- cover cancellation, confirmation, fallback rendering, and cross-surface behavior without coupling tests to LiveView internals

## Manual verification

- Open each removal dialog and confirm the safe action receives focus.
- Dismiss with the safe action, Escape, and the backdrop; the image should remain.
- Confirm removal and navigate through the related profile, sidebar, group, huddl, organizer, and edit surfaces to confirm fallback rendering.

Closes #287