### PR TITLE
Allow individual notifications to be marked read

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1839,10 +1839,31 @@ body .huddl-side-section h3 {
 body .pref-list .row { grid-template-columns: 1fr auto; gap: 18px; }
 
 /* Notification row */
-body .row.notif-row { grid-template-columns: 14px 1fr 80px; gap: 14px; }
+body .row.notif-row { grid-template-columns: 14px minmax(0, 1fr) auto; gap: 14px; }
 body .row.notif-row.unread .row-title { color: var(--text); }
 body .row.notif-row:not(.unread) .row-title { color: var(--soft); }
 body .row.notif-row:not(.unread) .meta { color: var(--muted); }
+body .notif-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+body .notif-actions .pill {
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+}
+body .notif-actions a.pill:hover,
+body .notif-actions button.pill:hover {
+  color: var(--text);
+  border-color: var(--cyan-dim);
+  background: var(--cyan-soft);
+}
+body .notif-actions a.pill:focus-visible,
+body .notif-actions button.pill:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
 
 body .notif-mark {
   width: 8px;
@@ -3299,6 +3320,9 @@ body .page-nav:disabled {
   /* Listings on org pages: collapse multi-column rows */
   body .row.huddlz-row, body .row.members-row { grid-template-columns: 56px 1fr; row-gap: 8px; }
   body .row.members-row { grid-template-columns: 48px 1fr; }
+  body .row.notif-row { grid-template-columns: 14px minmax(0, 1fr); }
+  body .notif-actions { grid-column: 2; justify-content: flex-start; }
+  body .notif-actions .pill { min-width: 44px; height: 44px; justify-content: center; }
   /* Land marketing */
   body .land-topbar { height: 64px; padding: 0 16px; }
   body .land-hero { padding: 48px 16px 40px; }

--- a/lib/huddlz/notifications/notification.ex
+++ b/lib/huddlz/notifications/notification.ex
@@ -58,13 +58,14 @@ defmodule Huddlz.Notifications.Notification do
 
     read :invites_for_user do
       description """
-      Unread notifications that need a response from the actor — backs the
-      Invites tab on /me. The "needs response" trigger set is intentionally
-      narrow; revisit when new invitation flows ship.
+      Notifications that need a response from the actor — backs the Invites
+      filter. Read rows remain available as history; callers that need the
+      unread count add a read_at filter. The "needs response" trigger set is
+      intentionally narrow; revisit when new invitation flows ship.
       """
 
       filter expr(
-               user_id == ^actor(:id) and is_nil(read_at) and
+               user_id == ^actor(:id) and
                  trigger in ["waitlist_promoted", "group_member_added", "group_invitation"]
              )
 

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -238,19 +238,32 @@ defmodule HuddlzWeb.NotificationsLive do
         <div class="row-title">{@notification.title}</div>
         <div :if={meta_line(@notification)} class="meta">{meta_line(@notification)}</div>
       </div>
-      <%= if @notification.source_url do %>
-        <.link class="pill" navigate={@notification.source_url}>Open</.link>
-      <% else %>
+      <div
+        :if={@notification.source_url || @unread}
+        class="notif-actions"
+        id={"notification-actions-#{@notification.id}"}
+      >
+        <.link
+          :if={@notification.source_url}
+          class="pill"
+          navigate={@notification.source_url}
+          aria-label={"Open #{@notification.title}"}
+        >
+          Open
+        </.link>
         <button
           :if={@unread}
           type="button"
           class="pill"
+          id={"mark-notification-read-#{@notification.id}"}
           phx-click="mark_read"
           phx-value-id={@notification.id}
+          phx-disable-with="Marking…"
+          aria-label={"Mark #{@notification.title} as read"}
         >
           Mark read
         </button>
-      <% end %>
+      </div>
     </div>
     """
   end

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -118,6 +118,7 @@ defmodule HuddlzWeb.NotificationsLive do
   defp count_invites(user) do
     case Notifications.list_invites_for_user(
            actor: user,
+           query: [filter: [read_at: [is_nil: true]]],
            page: [limit: 1, offset: 0, count: true]
          ) do
       {:ok, %{count: count}} when is_integer(count) -> count

--- a/test/features/individual_notification_read.feature
+++ b/test/features/individual_notification_read.feature
@@ -1,0 +1,16 @@
+@async @database @conn
+Feature: Individual notification read state
+  As a huddlz user
+  I want to mark one linked notification read without leaving the page
+  So that I can clear its unread state and still understand what happened
+
+  Scenario: A read waitlist promotion remains visible in Invites
+    Given I am signed in as "reader@example.com" with password "Password123!"
+    And I have an unread waitlist promotion notification for "Elixir Picnic"
+    When I visit "/notifications?filter=invites"
+    Then I should see "Inbox · 1 unread"
+    When I click the "Mark read" button
+    Then I should see "Inbox · 0 unread"
+    And I should see "Waitlist promoted: Elixir Picnic"
+    And I should see "Open"
+    And the "Mark read" button should not be visible

--- a/test/features/step_definitions/individual_notification_read_steps.exs
+++ b/test/features/step_definitions/individual_notification_read_steps.exs
@@ -1,0 +1,18 @@
+defmodule IndividualNotificationReadSteps do
+  use Cucumber.StepDefinition
+
+  alias Huddlz.Notifications
+
+  step "I have an unread waitlist promotion notification for {string}",
+       %{args: [huddl_title]} = context do
+    {:ok, _job} =
+      Notifications.deliver(context.current_user, :waitlist_promoted, %{
+        "group_slug" => "elixir-picnic",
+        "huddl_id" => "00000000-0000-0000-0000-000000000000",
+        "huddl_title" => huddl_title,
+        "starts_at_iso" => "2026-08-01T16:00:00Z"
+      })
+
+    context
+  end
+end

--- a/test/huddlz_web/live/notifications_live_test.exs
+++ b/test/huddlz_web/live/notifications_live_test.exs
@@ -1,7 +1,8 @@
 defmodule HuddlzWeb.NotificationsLiveTest do
   use HuddlzWeb.ConnCase, async: false
 
-  import Phoenix.LiveViewTest, only: [has_element?: 2, has_element?: 3, live: 2, render_click: 3]
+  import Phoenix.LiveViewTest,
+    only: [element: 2, has_element?: 2, has_element?: 3, live: 2, render_click: 1]
 
   alias Huddlz.Notifications
 
@@ -19,6 +20,15 @@ defmodule HuddlzWeb.NotificationsLiveTest do
     deliver!(user, trigger, payload)
     {:ok, %{results: [n | _]}} = Notifications.list_for_user(actor: user, page: [limit: 100])
     n
+  end
+
+  defp rsvp_payload(group_slug \\ "phoenix-elixir") do
+    %{
+      "huddl_id" => "00000000-0000-0000-0000-000000000000",
+      "huddl_title" => "Boat Drinks",
+      "group_slug" => group_slug,
+      "starts_at_iso" => "2026-05-09T18:00:00Z"
+    }
   end
 
   describe "anonymous access" do
@@ -189,12 +199,7 @@ defmodule HuddlzWeb.NotificationsLiveTest do
 
   describe "row destinations" do
     test "rows with a source_url render an Open link", %{conn: conn, user: user} do
-      deliver!(user, :rsvp_confirmation, %{
-        "huddl_id" => "00000000-0000-0000-0000-000000000000",
-        "huddl_title" => "Boat Drinks",
-        "group_slug" => "phoenix-elixir",
-        "starts_at_iso" => "2026-05-09T18:00:00Z"
-      })
+      deliver!(user, :rsvp_confirmation, rsvp_payload())
 
       conn
       |> login(user)
@@ -210,12 +215,7 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       user: user
     } do
       linked =
-        seed_notification(user, :rsvp_confirmation, %{
-          "huddl_id" => "00000000-0000-0000-0000-000000000000",
-          "huddl_title" => "Boat Drinks",
-          "group_slug" => "phoenix-elixir",
-          "starts_at_iso" => "2026-05-09T18:00:00Z"
-        })
+        seed_notification(user, :rsvp_confirmation, rsvp_payload())
 
       unlinked = seed_notification(user, :group_member_removed, %{"group_name" => "Old Club"})
 
@@ -233,19 +233,16 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       user: user
     } do
       notification =
-        seed_notification(user, :rsvp_confirmation, %{
-          "huddl_id" => "00000000-0000-0000-0000-000000000000",
-          "huddl_title" => "Boat Drinks",
-          "group_slug" => "missing-group",
-          "starts_at_iso" => "2026-05-09T18:00:00Z"
-        })
+        seed_notification(user, :rsvp_confirmation, rsvp_payload("missing-group"))
 
       untouched = seed_notification(user, :password_changed, %{})
       {:ok, view, _html} = conn |> login(user) |> live("/notifications")
 
       assert has_element?(view, ".filters .chip", "Inbox · 2 unread")
 
-      render_click(view, "mark_read", %{"id" => notification.id})
+      view
+      |> element("#mark-notification-read-#{notification.id}")
+      |> render_click()
 
       assert has_element?(view, ".filters .chip", "Inbox · 1 unread")
       assert has_element?(view, "#notification-#{notification.id}")
@@ -254,14 +251,47 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       assert has_element?(view, "#mark-notification-read-#{untouched.id}", "Mark read")
     end
 
+    test "a read waitlist promotion remains visible in Invites", %{conn: conn, user: user} do
+      notification =
+        seed_notification(user, :waitlist_promoted, %{
+          "huddl_id" => "00000000-0000-0000-0000-000000000000",
+          "huddl_title" => "Elixir Picnic",
+          "group_slug" => "elixir-picnic",
+          "starts_at_iso" => "2026-08-01T16:00:00Z"
+        })
+
+      conn = login(conn, user)
+      {:ok, view, _html} = live(conn, "/notifications?filter=invites")
+
+      view
+      |> element("#mark-notification-read-#{notification.id}")
+      |> render_click()
+
+      assert has_element?(view, ".filters .chip", "Inbox · 0 unread")
+
+      assert has_element?(
+               view,
+               "#notification-#{notification.id}",
+               "Waitlist promoted: Elixir Picnic"
+             )
+
+      assert has_element?(view, "#notification-actions-#{notification.id} a", "Open")
+      refute has_element?(view, "#mark-notification-read-#{notification.id}")
+
+      {:ok, reloaded_view, _html} = live(conn, "/notifications?filter=invites")
+
+      assert has_element?(
+               reloaded_view,
+               "#notification-#{notification.id}",
+               "Waitlist promoted: Elixir Picnic"
+             )
+
+      refute has_element?(reloaded_view, "#mark-notification-read-#{notification.id}")
+    end
+
     test "Open and Mark read have distinct accessible names", %{conn: conn, user: user} do
       notification =
-        seed_notification(user, :rsvp_confirmation, %{
-          "huddl_id" => "00000000-0000-0000-0000-000000000000",
-          "huddl_title" => "Boat Drinks",
-          "group_slug" => "phoenix-elixir",
-          "starts_at_iso" => "2026-05-09T18:00:00Z"
-        })
+        seed_notification(user, :rsvp_confirmation, rsvp_payload())
 
       conn
       |> login(user)
@@ -272,18 +302,6 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       |> assert_has(
         "#mark-notification-read-#{notification.id}[aria-label=\"Mark RSVP confirmed: Boat Drinks as read\"]"
       )
-    end
-
-    test "repeated mark-read events are harmless", %{conn: conn, user: user} do
-      notification = seed_notification(user, :password_changed, %{})
-      conn = login(conn, user)
-      {:ok, view, _html} = live(conn, "/notifications")
-
-      render_click(view, "mark_read", %{"id" => notification.id})
-      assert has_element?(view, ".filters .chip", "Inbox · 0 unread")
-
-      render_click(view, "mark_read", %{"id" => notification.id})
-      assert has_element?(view, "#notification-#{notification.id}", "Password changed")
     end
   end
 

--- a/test/huddlz_web/live/notifications_live_test.exs
+++ b/test/huddlz_web/live/notifications_live_test.exs
@@ -1,6 +1,8 @@
 defmodule HuddlzWeb.NotificationsLiveTest do
   use HuddlzWeb.ConnCase, async: false
 
+  import Phoenix.LiveViewTest, only: [has_element?: 2, has_element?: 3, live: 2, render_click: 3]
+
   alias Huddlz.Notifications
 
   setup do
@@ -201,6 +203,87 @@ defmodule HuddlzWeb.NotificationsLiveTest do
         ~s|.notif-row a.pill[href="/groups/phoenix-elixir/huddlz/00000000-0000-0000-0000-000000000000"]|,
         text: "Open"
       )
+    end
+
+    test "linked and unlinked unread rows offer a separate Mark read action", %{
+      conn: conn,
+      user: user
+    } do
+      linked =
+        seed_notification(user, :rsvp_confirmation, %{
+          "huddl_id" => "00000000-0000-0000-0000-000000000000",
+          "huddl_title" => "Boat Drinks",
+          "group_slug" => "phoenix-elixir",
+          "starts_at_iso" => "2026-05-09T18:00:00Z"
+        })
+
+      unlinked = seed_notification(user, :group_member_removed, %{"group_name" => "Old Club"})
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has("#notification-actions-#{linked.id} a", text: "Open")
+      |> assert_has("#mark-notification-read-#{linked.id}", text: "Mark read")
+      |> assert_has("#mark-notification-read-#{unlinked.id}", text: "Mark read")
+      |> refute_has("#notification-actions-#{unlinked.id} a", text: "Open")
+    end
+
+    test "marking a linked notification read updates its row and unread count in place", %{
+      conn: conn,
+      user: user
+    } do
+      notification =
+        seed_notification(user, :rsvp_confirmation, %{
+          "huddl_id" => "00000000-0000-0000-0000-000000000000",
+          "huddl_title" => "Boat Drinks",
+          "group_slug" => "missing-group",
+          "starts_at_iso" => "2026-05-09T18:00:00Z"
+        })
+
+      untouched = seed_notification(user, :password_changed, %{})
+      {:ok, view, _html} = conn |> login(user) |> live("/notifications")
+
+      assert has_element?(view, ".filters .chip", "Inbox · 2 unread")
+
+      render_click(view, "mark_read", %{"id" => notification.id})
+
+      assert has_element?(view, ".filters .chip", "Inbox · 1 unread")
+      assert has_element?(view, "#notification-#{notification.id}")
+      assert has_element?(view, "#notification-actions-#{notification.id} a", "Open")
+      refute has_element?(view, "#mark-notification-read-#{notification.id}")
+      assert has_element?(view, "#mark-notification-read-#{untouched.id}", "Mark read")
+    end
+
+    test "Open and Mark read have distinct accessible names", %{conn: conn, user: user} do
+      notification =
+        seed_notification(user, :rsvp_confirmation, %{
+          "huddl_id" => "00000000-0000-0000-0000-000000000000",
+          "huddl_title" => "Boat Drinks",
+          "group_slug" => "phoenix-elixir",
+          "starts_at_iso" => "2026-05-09T18:00:00Z"
+        })
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(
+        "#notification-actions-#{notification.id} a[aria-label=\"Open RSVP confirmed: Boat Drinks\"]"
+      )
+      |> assert_has(
+        "#mark-notification-read-#{notification.id}[aria-label=\"Mark RSVP confirmed: Boat Drinks as read\"]"
+      )
+    end
+
+    test "repeated mark-read events are harmless", %{conn: conn, user: user} do
+      notification = seed_notification(user, :password_changed, %{})
+      conn = login(conn, user)
+      {:ok, view, _html} = live(conn, "/notifications")
+
+      render_click(view, "mark_read", %{"id" => notification.id})
+      assert has_element?(view, ".filters .chip", "Inbox · 0 unread")
+
+      render_click(view, "mark_read", %{"id" => notification.id})
+      assert has_element?(view, "#notification-#{notification.id}", "Password changed")
     end
   end
 


### PR DESCRIPTION
## Summary

- show a separate **Mark read** action on every unread notification, including notifications with an **Open** destination
- update the row and unread count in place without navigating away
- provide distinct accessible action names, responsive action layout, and retry-safe handling

## Testing

- `mix precommit` (1,415 checks; strict Credo)

Closes #291