### PR TITLE
fix(ui): make month calendar accessible

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1624,9 +1624,14 @@ body .cal-nav-today {
 
 body .cal-nav-today:hover { color: var(--cyan); border-color: var(--cyan); }
 
-body .cal-grid {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
+body .cal-calendar {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+body .cal-calendar caption {
+  caption-side: top;
 }
 
 body .cal-day-name {
@@ -1642,28 +1647,44 @@ body .cal-day-name {
   text-align: center;
 }
 
+body .cal-day-name abbr {
+  text-decoration: none;
+}
+
 body .cal-day-name:not(:last-child) { border-right: 1px solid var(--line); }
 
 body .cal-cell {
+  height: 100px;
+  padding: 0;
+  vertical-align: top;
+  border-bottom: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+  background: rgba(2, 4, 4, 0.3);
+}
+
+body .cal-cell-content {
   min-height: 100px;
   padding: 8px 8px 6px;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  background: rgba(2, 4, 4, 0.3);
 }
 
-body .cal-cell:nth-child(7n) { /* last column */
+body .cal-cell:last-child {
   border-right: 0;
 }
 
-body .cal-cell:not(:nth-child(7n)) { border-right: 1px solid var(--line); }
-
-body .cal-grid:nth-of-type(2) .cal-cell { border-bottom: 1px solid var(--line); }
-body .cal-grid:nth-of-type(2) .cal-cell:nth-last-child(-n+7) { border-bottom: 0; }
+body .cal-calendar tbody tr:last-child .cal-cell { border-bottom: 0; }
 
 body .cal-cell.out-of-month { background: rgba(2, 4, 4, 0.55); }
 body .cal-cell.out-of-month .cal-day-num { color: var(--muted); opacity: 0.5; }
+
+body .cal-day-heading {
+  min-height: 22px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
 
 body .cal-day-num {
   display: inline-flex;
@@ -1683,6 +1704,15 @@ body .cal-day-num.is-today {
   border: 1px solid var(--cyan);
   border-radius: 50%;
   box-shadow: 0 0 8px rgba(24, 203, 212, 0.4);
+}
+
+body .cal-day-context {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 body .cal-pill {
@@ -1749,11 +1779,14 @@ body .cal-legend-note { margin-left: auto; font-size: 12px; }
 
 @media (max-width: 760px) {
 
-  body .cal-cell { min-height: 64px; padding: 4px; }
+  body .cal-cell { height: 64px; }
+  body .cal-cell-content { min-height: 64px; padding: 4px; }
   body .cal-day-name { padding: 6px 2px; font-size: 10px; letter-spacing: 0.08em; }
   body .cal-pill { font-size: 10px; padding: 2px 4px; }
   body .cal-day-num { font-size: 11px; }
   body .cal-day-num.is-today { width: 18px; height: 18px; }
+  body .cal-day-heading { min-height: 18px; }
+  body .cal-day-context { font-size: 8px; }
   body .cal-legend-note { margin-left: 0; flex: 1 1 100%; }
 }
 

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -167,8 +167,26 @@ defmodule HuddlzWeb.CalendarLive do
     Enum.map(0..41, &Date.add(grid_start, &1))
   end
 
+  defp weeks_in_grid(grid_start) do
+    grid_start
+    |> days_in_grid()
+    |> Enum.chunk_every(7)
+  end
+
   defp day_in_focus?(%Date{} = day, %Date{year: y, month: m}),
     do: day.year == y and day.month == m
+
+  defp format_full_date(%Date{} = day), do: Calendar.strftime(day, "%A, %B %-d, %Y")
+
+  defp day_accessible_label(day, focus_month, today) do
+    [
+      format_full_date(day),
+      Date.compare(day, today) == :eq && "today",
+      !day_in_focus?(day, focus_month) && "outside the selected month"
+    ]
+    |> Enum.reject(&(&1 in [nil, false]))
+    |> Enum.join(", ")
+  end
 
   defp pill_class_for(entry, day, focus_month, today) do
     base = base_pill_class(entry, today)
@@ -189,6 +207,20 @@ defmodule HuddlzWeb.CalendarLive do
   defp format_pill_label(%{huddl: %{starts_at: dt, title: title}}) do
     time = Calendar.strftime(dt, "%-I:%M %p")
     "#{time} · #{title}"
+  end
+
+  defp format_calendar_link_label(entry, today) do
+    date_and_time = Calendar.strftime(entry.huddl.starts_at, "%A, %B %-d, %Y at %-I:%M %p")
+    "#{entry.huddl.title}, #{calendar_status_label(entry, today)}, #{date_and_time}"
+  end
+
+  defp calendar_status_label(%{role: role, huddl: %{starts_at: dt}}, today) do
+    cond do
+      Date.compare(DateTime.to_date(dt), today) == :lt -> "Past"
+      role == :hosting -> "Hosting"
+      role == :waitlisted -> "Waitlisted"
+      true -> "Going"
+    end
   end
 
   defp huddl_path(%{huddl: %{id: id, group: %{slug: slug}}}),
@@ -295,12 +327,14 @@ defmodule HuddlzWeb.CalendarLive do
           <.link
             patch={month_path(@focus_month, :month)}
             class={["scope-tab", @view_mode == :month && "is-active"]}
+            aria-current={if @view_mode == :month, do: "page"}
           >
             Month
           </.link>
           <.link
             patch={month_path(@focus_month, :agenda)}
             class={["scope-tab", @view_mode == :agenda && "is-active"]}
+            aria-current={if @view_mode == :agenda, do: "page"}
           >
             Agenda
           </.link>
@@ -341,33 +375,65 @@ defmodule HuddlzWeb.CalendarLive do
   defp month_grid(assigns) do
     ~H"""
     <div class="panel" style="padding:0">
-      <div class="cal-grid">
-        <div class="cal-day-name">Sun</div>
-        <div class="cal-day-name">Mon</div>
-        <div class="cal-day-name">Tue</div>
-        <div class="cal-day-name">Wed</div>
-        <div class="cal-day-name">Thu</div>
-        <div class="cal-day-name">Fri</div>
-        <div class="cal-day-name">Sat</div>
-      </div>
-      <div class="cal-grid">
-        <%= for day <- days_in_grid(@grid_start) do %>
-          <div class={cell_class(day, @focus_month)}>
-            <span class={day_num_class(day, @today)}>{day.day}</span>
-            <%= for entry <- Map.get(@entries_by_day, day, []) do %>
-              <.link
-                navigate={huddl_path(entry)}
-                class={pill_class_for(entry, day, @focus_month, @today)}
-                title={entry.huddl.title}
-              >
-                {format_pill_label(entry)}
-              </.link>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <table id="month-calendar" class="cal-calendar">
+        <caption class="sr-only">
+          Month calendar for {format_month(@focus_month)}
+        </caption>
+        <thead>
+          <tr>
+            <th :for={{short, full} <- weekday_names()} scope="col" class="cal-day-name">
+              <abbr title={full}>{short}</abbr>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={week <- weeks_in_grid(@grid_start)}>
+            <td
+              :for={day <- week}
+              class={cell_class(day, @focus_month)}
+              aria-label={day_accessible_label(day, @focus_month, @today)}
+              aria-current={if Date.compare(day, @today) == :eq, do: "date"}
+            >
+              <div class="cal-cell-content">
+                <div class="cal-day-heading" aria-hidden="true">
+                  <time datetime={Date.to_iso8601(day)} class={day_num_class(day, @today)}>
+                    {day.day}
+                  </time>
+                  <span :if={Date.compare(day, @today) == :eq} class="cal-day-context">
+                    Today
+                  </span>
+                  <span :if={!day_in_focus?(day, @focus_month)} class="cal-day-context">
+                    {Calendar.strftime(day, "%b")}
+                  </span>
+                </div>
+                <.link
+                  :for={entry <- Map.get(@entries_by_day, day, [])}
+                  navigate={huddl_path(entry)}
+                  class={pill_class_for(entry, day, @focus_month, @today)}
+                  aria-label={format_calendar_link_label(entry, @today)}
+                  title={entry.huddl.title}
+                >
+                  {format_pill_label(entry)}
+                </.link>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     """
+  end
+
+  defp weekday_names do
+    [
+      {"Sun", "Sunday"},
+      {"Mon", "Monday"},
+      {"Tue", "Tuesday"},
+      {"Wed", "Wednesday"},
+      {"Thu", "Thursday"},
+      {"Fri", "Friday"},
+      {"Sat", "Saturday"}
+    ]
   end
 
   defp cell_class(day, focus_month) do

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -214,14 +214,28 @@ defmodule HuddlzWeb.CalendarLive do
     "#{entry.huddl.title}, #{calendar_status_label(entry, today)}, #{date_and_time}"
   end
 
-  defp calendar_status_label(%{role: role, huddl: %{starts_at: dt}}, today) do
-    cond do
-      Date.compare(DateTime.to_date(dt), today) == :lt -> "Past"
-      role == :hosting -> "Hosting"
-      role == :waitlisted -> "Waitlisted"
-      true -> "Going"
-    end
+  defp attendance_status(%{role: role, huddl: %{starts_at: dt}}, today) do
+    period =
+      case Date.compare(DateTime.to_date(dt), today) do
+        :lt -> :past
+        _ -> :upcoming
+      end
+
+    {role, period}
   end
+
+  defp calendar_status_label(entry, today) do
+    entry
+    |> attendance_status(today)
+    |> calendar_status_label()
+  end
+
+  defp calendar_status_label({:hosting, :past}), do: "Hosted, past"
+  defp calendar_status_label({:attending, :past}), do: "Attended, past"
+  defp calendar_status_label({:waitlisted, :past}), do: "Waitlisted, past"
+  defp calendar_status_label({:hosting, :upcoming}), do: "Hosting"
+  defp calendar_status_label({:attending, :upcoming}), do: "Going"
+  defp calendar_status_label({:waitlisted, :upcoming}), do: "Waitlisted"
 
   defp huddl_path(%{huddl: %{id: id, group: %{slug: slug}}}),
     do: ~p"/groups/#{slug}/huddlz/#{id}"
@@ -242,16 +256,16 @@ defmodule HuddlzWeb.CalendarLive do
     end
   end
 
-  defp agenda_pill_label(%{role: role, huddl: %{starts_at: dt}}, %Date{} = today) do
-    past? = Date.compare(DateTime.to_date(dt), today) == :lt
-
-    cond do
-      past? -> "Past"
-      role == :hosting -> "Hosting"
-      role == :waitlisted -> "Waitlist"
-      true -> "Going"
-    end
+  defp agenda_pill_label(entry, %Date{} = today) do
+    entry
+    |> attendance_status(today)
+    |> agenda_pill_label()
   end
+
+  defp agenda_pill_label({_role, :past}), do: "Past"
+  defp agenda_pill_label({:hosting, :upcoming}), do: "Hosting"
+  defp agenda_pill_label({:attending, :upcoming}), do: "Going"
+  defp agenda_pill_label({:waitlisted, :upcoming}), do: "Waitlist"
 
   defp format_agenda_when(%DateTime{} = dt) do
     Calendar.strftime(dt, "%a %b %-d · %-I:%M %p")

--- a/test/features/calendar_accessibility.feature
+++ b/test/features/calendar_accessibility.feature
@@ -1,0 +1,16 @@
+@async @database @conn
+Feature: Accessible personal calendar
+  As a person using assistive technology
+  I want calendar huddl links to describe my relationship to each huddl
+  So that every link makes sense outside the visual layout
+
+  Background:
+    Given the following users exist:
+      | email                | display_name | role    |
+      | attendee@example.com | Calendar User | regular |
+    And I am signed in as "attendee@example.com"
+
+  Scenario: A past attended huddl keeps its attendance context
+    Given I attended a past huddl named "Retrospective"
+    When I open the calendar month containing that huddl
+    Then the "Retrospective" calendar link should identify it as attended and past

--- a/test/features/step_definitions/calendar_accessibility_steps.exs
+++ b/test/features/step_definitions/calendar_accessibility_steps.exs
@@ -1,0 +1,53 @@
+defmodule CalendarAccessibilitySteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import PhoenixTest
+
+  step "I attended a past huddl named {string}",
+       %{args: [title], current_user: attendee} = context do
+    host = generate(user(role: :user))
+    group = generate(group(owner_id: host.id, is_public: true, actor: host))
+    starts_at = DateTime.utc_now() |> DateTime.add(-2, :day) |> DateTime.truncate(:second)
+
+    huddl =
+      generate(
+        past_huddl(
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          title: title,
+          starts_at: starts_at,
+          ends_at: DateTime.add(starts_at, 1, :hour),
+          actor: host
+        )
+      )
+
+    huddl
+    |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+    |> Ash.update!()
+
+    Map.put(context, :calendar_huddl, huddl)
+  end
+
+  step "I open the calendar month containing that huddl",
+       %{conn: conn, calendar_huddl: huddl} = context do
+    date = DateTime.to_date(huddl.starts_at)
+    month = :io_lib.format("~4..0B-~2..0B", [date.year, date.month]) |> IO.iodata_to_binary()
+    session = visit(conn, "/calendar?month=#{month}")
+
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "the {string} calendar link should identify it as attended and past",
+       %{args: [title], session: session, calendar_huddl: huddl} = context do
+    when_label = Calendar.strftime(huddl.starts_at, "%A, %B %-d, %Y at %-I:%M %p")
+
+    assert_has(
+      session,
+      ~s(#month-calendar .cal-pill[aria-label="#{title}, Attended, past, #{when_label}"])
+    )
+
+    context
+  end
+end

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -90,8 +90,59 @@ defmodule HuddlzWeb.CalendarLiveTest do
         |> visit("/calendar")
 
       for day <- ~w(Sun Mon Tue Wed Thu Fri Sat) do
-        assert_has(session, ".cal-day-name", text: day)
+        assert_has(session, "#month-calendar th[scope='col']", text: day)
       end
+    end
+
+    test "month grid exposes native table semantics and full date labels", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      today = Date.utc_today()
+      today_label = Calendar.strftime(today, "%A, %B %-d, %Y") <> ", today"
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has("#month-calendar caption", text: current_month_name())
+      |> assert_has("#month-calendar thead")
+      |> assert_has("#month-calendar tbody tr", count: 6)
+      |> assert_has(~s(#month-calendar td[aria-label="#{today_label}"][aria-current="date"]))
+    end
+
+    test "overflow days name their month in text and accessibility metadata", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      session =
+        conn
+        |> login(attendee)
+        |> visit("/calendar")
+
+      document =
+        session.view
+        |> Phoenix.LiveViewTest.render()
+        |> LazyHTML.from_fragment()
+
+      overflow = LazyHTML.query(document, "#month-calendar td.out-of-month")
+
+      assert [label | _] = LazyHTML.attribute(overflow, "aria-label")
+      assert String.ends_with?(label, "outside the selected month")
+      assert overflow |> LazyHTML.query(".cal-day-context") |> Enum.any?()
+    end
+
+    test "only the selected calendar view is marked current", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has(".cal-view-tabs a[aria-current='page']", text: "Month")
+      |> refute_has(".cal-view-tabs a[aria-current]", text: "Agenda")
+      |> visit("/calendar?view=agenda")
+      |> assert_has(".cal-view-tabs a[aria-current='page']", text: "Agenda")
+      |> refute_has(".cal-view-tabs a[aria-current]", text: "Month")
     end
   end
 
@@ -228,6 +279,30 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> login(attendee)
       |> visit(calendar_path_for(tomorrow()))
       |> assert_has(~s(.cal-pill[href="/groups/#{public_group.slug}/huddlz/#{huddl.id}"]))
+    end
+
+    test "huddl links have date, time, title, and attendance context", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      date = tomorrow()
+      first = create_huddl(host, public_group, title: "Morning Pairing", date: date)
+      second = create_huddl(host, public_group, title: "Evening Pairing", date: date)
+      rsvp!(first, attendee, :rsvp)
+      rsvp!(second, attendee, :rsvp)
+      full_date = Calendar.strftime(date, "%A, %B %-d, %Y")
+
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(date))
+      |> assert_has(
+        ~s(#month-calendar td[aria-label^="#{full_date}"] .cal-pill[aria-label^="Morning Pairing, Going, #{full_date} at "])
+      )
+      |> assert_has(
+        ~s(#month-calendar td[aria-label^="#{full_date}"] .cal-pill[aria-label^="Evening Pairing, Going, #{full_date} at "])
+      )
     end
   end
 

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -199,6 +199,20 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> assert_has(".cal-pill.past", text: "Old Workshop")
     end
 
+    test "past hosted huddl link preserves hosting context", %{
+      conn: conn,
+      host: host,
+      public_group: public_group
+    } do
+      past = create_past_huddl(host, public_group, title: "Hosted Retrospective")
+      when_label = Calendar.strftime(past.starts_at, "%A, %B %-d, %Y at %-I:%M %p")
+
+      conn
+      |> login(host)
+      |> visit(calendar_path_for(DateTime.to_date(past.starts_at)))
+      |> assert_has(~s(.cal-pill[aria-label="Hosted Retrospective, Hosted, past, #{when_label}"]))
+    end
+
     test "hosting (creator) appears even without an RSVP", %{
       conn: conn,
       host: host,


### PR DESCRIPTION
## Summary

- render the month calendar as a semantic table with weekday headers and full-date cell labels
- expose today, overflow dates, and the selected Month/Agenda view without relying on styling alone
- give each huddl link a complete accessible name with title, attendance context, date, and time
- preserve the existing desktop and mobile visual treatment

## Verification

- `mix test test/huddlz_web/live/calendar_live_test.exs --max-cases 4` (174 tests)
- `mix precommit` (1,414 tests and Credo passed before rebasing onto the latest one-commit main update)
- desktop browser visual check
- 390px layout check with no horizontal overflow

Closes #288