### PR TITLE
Show unread notifications in persistent navigation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -705,6 +705,26 @@ body .icon-pill .dot {
   box-shadow: 0 0 8px var(--magenta);
 }
 
+body .icon-pill .notification-badge {
+  position: absolute;
+  top: -7px;
+  right: -9px;
+  min-width: 19px;
+  height: 19px;
+  padding: 0 5px;
+  border: 2px solid var(--bg);
+  border-radius: 999px;
+  background: var(--magenta);
+  color: white;
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--magenta) 55%, transparent);
+}
+
 body .btn-primary {
   height: 36px;
   padding: 0 16px;

--- a/lib/huddlz/notifications.ex
+++ b/lib/huddlz/notifications.ex
@@ -51,6 +51,8 @@ defmodule Huddlz.Notifications do
             ]}
 
   @unsubscribe_salt "notifications:unsubscribe"
+  @pubsub Huddlz.PubSub
+  @topic_prefix "notifications:unread:"
   # 30 days — long enough for an email to sit in an inbox over a vacation.
   @unsubscribe_max_age 60 * 60 * 24 * 30
 
@@ -111,6 +113,7 @@ defmodule Huddlz.Notifications do
     |> Ash.create()
     |> case do
       {:ok, _notification} ->
+        broadcast_unread_count_changed(user_id)
         :ok
 
       {:error, reason} ->
@@ -177,10 +180,59 @@ defmodule Huddlz.Notifications do
       return_errors?: true
     )
     |> case do
-      %Ash.BulkResult{status: :success} -> :ok
-      %Ash.BulkResult{errors: errors} -> {:error, errors}
+      %Ash.BulkResult{status: :success} ->
+        broadcast_unread_count_changed(user.id)
+        :ok
+
+      %Ash.BulkResult{errors: errors} ->
+        {:error, errors}
     end
   end
+
+  @doc """
+  Mark one notification as read and refresh the actor's live unread count.
+  """
+  @spec mark_read_and_notify(Notification.t(), User.t()) ::
+          {:ok, Notification.t()} | {:error, term()}
+  def mark_read_and_notify(%Notification{} = notification, %User{} = user) do
+    case mark_read(notification, actor: user) do
+      {:ok, _updated} = result ->
+        broadcast_unread_count_changed(user.id)
+        result
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Return the actor's unread in-app notification count.
+  """
+  @spec unread_count(User.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def unread_count(%User{} = user) do
+    Notification
+    |> Ash.Query.for_read(:for_user, %{}, actor: user)
+    |> Ash.Query.filter(is_nil(read_at))
+    |> Ash.count()
+  end
+
+  @doc """
+  Subscribe the current process to unread-count changes for one person.
+  """
+  @spec subscribe_to_unread_count(User.t()) :: :ok | {:error, term()}
+  def subscribe_to_unread_count(%User{id: user_id}) do
+    Phoenix.PubSub.subscribe(@pubsub, unread_count_topic(user_id))
+  end
+
+  defp broadcast_unread_count_changed(user_id) do
+    Phoenix.PubSub.broadcast(
+      @pubsub,
+      unread_count_topic(user_id),
+      {:notification_unread_count_changed, user_id}
+    )
+  end
+
+  defp unread_count_topic(user_id), do: @topic_prefix <> to_string(user_id)
 
   @doc """
   Pure decision function: should this email be sent?

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -23,6 +23,7 @@ defmodule HuddlzWeb.Layouts do
   """
   attr :flash, :map, required: true
   attr :current_user, :map, default: nil
+  attr :unread_notification_count, :integer, default: 0
 
   attr :active, :string,
     default: nil,
@@ -180,11 +181,20 @@ defmodule HuddlzWeb.Layouts do
         <div class="content-actions">
           <%= if @signed_in do %>
             <a
+              id="notification-nav-link"
               class={["icon-pill", @active == "notifications" && "active"]}
               href="/notifications"
-              aria-label="Notifications"
+              aria-label={notification_label(@unread_notification_count)}
             >
               <.nav_icon name="bell" />
+              <span
+                :if={@unread_notification_count > 0}
+                id="notification-nav-badge"
+                class="notification-badge"
+                aria-hidden="true"
+              >
+                {compact_notification_count(@unread_notification_count)}
+              </span>
             </a>
           <% else %>
             <a class="btn-secondary" href="/sign-in">Sign in</a>
@@ -200,6 +210,14 @@ defmodule HuddlzWeb.Layouts do
     </main>
     """
   end
+
+  defp notification_label(0), do: "Notifications"
+
+  defp notification_label(count),
+    do: "Notifications, #{count} unread"
+
+  defp compact_notification_count(count) when count > 99, do: "99+"
+  defp compact_notification_count(count), do: count
 
   @doc """
   V3 auth shell — chromeless wrapper used by `/sign-in`, `/register`, `/reset`,

--- a/lib/huddlz_web/live/admin_live.ex
+++ b/lib/huddlz_web/live/admin_live.ex
@@ -74,6 +74,7 @@ defmodule HuddlzWeb.AdminLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="admin"
     >

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -277,6 +277,7 @@ defmodule HuddlzWeb.CalendarLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="calendar"
     >

--- a/lib/huddlz_web/live/group_invitation_live.ex
+++ b/lib/huddlz_web/live/group_invitation_live.ex
@@ -132,6 +132,7 @@ defmodule HuddlzWeb.GroupInvitationLive do
       flash={@flash}
       current_user={@current_user}
       sidebar_owned_groups={@sidebar_owned_groups}
+      unread_notification_count={@unread_notification_count}
       active="notifications"
     >
       <div class="page-head">

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -130,6 +130,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-groups"
     >

--- a/lib/huddlz_web/live/group_live/locations.ex
+++ b/lib/huddlz_web/live/group_live/locations.ex
@@ -68,6 +68,7 @@ defmodule HuddlzWeb.GroupLive.Locations do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-groups"
     >

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -186,6 +186,7 @@ defmodule HuddlzWeb.GroupLive.New do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-groups"
     >

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -134,6 +134,7 @@ defmodule HuddlzWeb.GroupLive.Show do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="discover"
     >

--- a/lib/huddlz_web/live/help_live.ex
+++ b/lib/huddlz_web/live/help_live.ex
@@ -20,6 +20,7 @@ defmodule HuddlzWeb.HelpLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="help"
     >

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -524,6 +524,7 @@ defmodule HuddlzWeb.HuddlLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="discover"
       query={@search_query || ""}

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -178,6 +178,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-groups"
     >

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -148,6 +148,7 @@ defmodule HuddlzWeb.HuddlLive.New do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-groups"
     >

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -68,6 +68,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="discover"
     >

--- a/lib/huddlz_web/live/legal_live.ex
+++ b/lib/huddlz_web/live/legal_live.ex
@@ -29,6 +29,7 @@ defmodule HuddlzWeb.LegalLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="help"
     >

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -128,6 +128,7 @@ defmodule HuddlzWeb.MyGroupsLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-groups"
     >

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -147,6 +147,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="my-huddlz"
     >

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -16,7 +16,6 @@ defmodule HuddlzWeb.NotificationsLive do
   alias Huddlz.Notifications
   alias Huddlz.Notifications.Notification
   alias HuddlzWeb.Layouts
-  require Ash.Query
   require Logger
 
   @page_size 20
@@ -66,7 +65,7 @@ defmodule HuddlzWeb.NotificationsLive do
     user = socket.assigns.current_user
 
     with {:ok, notification} <- Ash.get(Notification, id, actor: user),
-         {:ok, _} <- Notifications.mark_read(notification, actor: user) do
+         {:ok, _} <- Notifications.mark_read_and_notify(notification, user) do
       {:noreply, refresh(socket, user)}
     else
       {:error, reason} ->
@@ -105,11 +104,7 @@ defmodule HuddlzWeb.NotificationsLive do
   end
 
   defp count_unread_inbox(user) do
-    Notification
-    |> Ash.Query.for_read(:for_user, %{}, actor: user)
-    |> Ash.Query.filter(is_nil(read_at))
-    |> Ash.count()
-    |> case do
+    case Notifications.unread_count(user) do
       {:ok, count} -> count
       _ -> 0
     end
@@ -178,6 +173,7 @@ defmodule HuddlzWeb.NotificationsLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="notifications"
     >

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -226,6 +226,7 @@ defmodule HuddlzWeb.OrganizeLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active_group_slug={@group && @group.slug}
       active_organize_section={active_section(@live_action)}

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -70,6 +70,7 @@ defmodule HuddlzWeb.ProfileLive do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="profile"
     >

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -59,6 +59,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
     <Layouts.app
       flash={@flash}
       current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
       active="settings"
     >

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -9,6 +9,7 @@ defmodule HuddlzWeb.LiveUserAuth do
   alias AshAuthentication.Phoenix.LiveSession
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.MembershipEvents
+  alias Huddlz.Notifications
 
   # This is used for nested liveviews to fetch the current user.
   # To use, place the following at the top of that liveview:
@@ -77,12 +78,16 @@ defmodule HuddlzWeb.LiveUserAuth do
   def on_mount(:app, _params, _session, socket) do
     body_class = if socket.assigns[:current_user], do: "", else: "is-signed-out"
 
-    {:cont,
-     socket
-     |> maybe_load_user_details()
-     |> assign(:body_class, body_class)
-     |> assign_new(:sidebar_owned_groups, fn -> load_sidebar_owned_groups(socket) end)
-     |> subscribe_to_organizer_access_changes()}
+    socket =
+      socket
+      |> maybe_load_user_details()
+      |> assign(:body_class, body_class)
+      |> assign_new(:sidebar_owned_groups, fn -> load_sidebar_owned_groups(socket) end)
+      |> assign_new(:unread_notification_count, fn -> load_unread_notification_count(socket) end)
+      |> subscribe_to_organizer_access_changes()
+      |> maybe_subscribe_to_unread_count()
+
+    {:cont, socket}
   end
 
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)
@@ -114,6 +119,41 @@ defmodule HuddlzWeb.LiveUserAuth do
   end
 
   defp load_sidebar_owned_groups(_socket), do: []
+
+  defp load_unread_notification_count(%{assigns: %{current_user: %User{} = user}}) do
+    case Notifications.unread_count(user) do
+      {:ok, count} -> count
+      {:error, _reason} -> 0
+    end
+  end
+
+  defp load_unread_notification_count(_socket), do: 0
+
+  defp maybe_subscribe_to_unread_count(
+         %{assigns: %{current_user: %User{id: user_id} = user}} = socket
+       ) do
+    if Phoenix.LiveView.connected?(socket) do
+      :ok = Notifications.subscribe_to_unread_count(user)
+
+      Phoenix.LiveView.attach_hook(
+        socket,
+        :unread_notification_count,
+        :handle_info,
+        fn
+          {:notification_unread_count_changed, ^user_id}, socket ->
+            {:halt,
+             assign(socket, :unread_notification_count, load_unread_notification_count(socket))}
+
+          _message, socket ->
+            {:cont, socket}
+        end
+      )
+    else
+      socket
+    end
+  end
+
+  defp maybe_subscribe_to_unread_count(socket), do: socket
 
   defp subscribe_to_organizer_access_changes(%{assigns: %{current_user: %{id: user_id}}} = socket) do
     if Phoenix.LiveView.connected?(socket) do

--- a/test/features/individual_notification_read.feature
+++ b/test/features/individual_notification_read.feature
@@ -9,8 +9,10 @@ Feature: Individual notification read state
     And I have an unread waitlist promotion notification for "Elixir Picnic"
     When I visit "/notifications?filter=invites"
     Then I should see "Inbox · 1 unread"
+    And persistent navigation should show one unread notification
     When I click the "Mark read" button
     Then I should see "Inbox · 0 unread"
+    And persistent navigation should show no unread notifications
     And I should see "Waitlist promoted: Elixir Picnic"
     And I should see "Open"
     And the "Mark read" button should not be visible

--- a/test/features/step_definitions/individual_notification_read_steps.exs
+++ b/test/features/step_definitions/individual_notification_read_steps.exs
@@ -1,5 +1,6 @@
 defmodule IndividualNotificationReadSteps do
   use Cucumber.StepDefinition
+  import PhoenixTest
 
   alias Huddlz.Notifications
 
@@ -13,6 +14,26 @@ defmodule IndividualNotificationReadSteps do
         "starts_at_iso" => "2026-08-01T16:00:00Z"
       })
 
+    context
+  end
+
+  step "persistent navigation should show one unread notification", context do
+    session = context[:session] || context[:conn]
+
+    assert_has(
+      session,
+      ~s|#notification-nav-link[aria-label="Notifications, 1 unread"]|
+    )
+
+    assert_has(session, "#notification-nav-badge", text: "1")
+    context
+  end
+
+  step "persistent navigation should show no unread notifications", context do
+    session = context[:session] || context[:conn]
+
+    assert_has(session, ~s|#notification-nav-link[aria-label="Notifications"]|)
+    refute_has(session, "#notification-nav-badge")
     context
   end
 end

--- a/test/huddlz_web/components/layouts_test.exs
+++ b/test/huddlz_web/components/layouts_test.exs
@@ -12,24 +12,30 @@ defmodule HuddlzWeb.LayoutsTest do
       one = render_app(1)
       capped = render_app(100)
 
-      assert zero =~ ~s|id="notification-nav-link"|
-      assert zero =~ ~s|aria-label="Notifications"|
-      refute zero =~ ~s|id="notification-nav-badge"|
+      assert has_selector?(zero, ~s|#notification-nav-link[aria-label="Notifications"]|)
+      refute has_selector?(zero, "#notification-nav-badge")
 
-      assert one =~ ~s|aria-label="Notifications, 1 unread"|
-      assert one =~ ~s|id="notification-nav-badge"|
+      assert has_selector?(
+               one,
+               ~s|#notification-nav-link[aria-label="Notifications, 1 unread"]|
+             )
+
+      assert has_selector?(one, "#notification-nav-badge")
       assert badge_text(one) == "1"
 
-      assert capped =~ ~s|aria-label="Notifications, 100 unread"|
+      assert has_selector?(
+               capped,
+               ~s|#notification-nav-link[aria-label="Notifications, 100 unread"]|
+             )
+
       assert badge_text(capped) == "99+"
     end
 
     test "keeps the badge in the responsive topbar rather than the desktop sidebar" do
-      html = render_app(3)
-      {:ok, document} = Floki.parse_document(html)
+      document = render_app(3)
 
-      assert Floki.find(document, ".content-topbar #notification-nav-badge") != []
-      assert Floki.find(document, ".sidebar #notification-nav-badge") == []
+      assert has_selector?(document, ".content-topbar #notification-nav-badge")
+      refute has_selector?(document, ".sidebar #notification-nav-badge")
     end
   end
 
@@ -48,14 +54,20 @@ defmodule HuddlzWeb.LayoutsTest do
       Content
     </Layouts.app>
     """)
+    |> LazyHTML.from_fragment()
   end
 
-  defp badge_text(html) do
-    {:ok, document} = Floki.parse_document(html)
-
+  defp badge_text(document) do
     document
-    |> Floki.find("#notification-nav-badge")
-    |> Floki.text()
+    |> LazyHTML.query("#notification-nav-badge")
+    |> LazyHTML.text()
     |> String.trim()
+  end
+
+  defp has_selector?(document, selector) do
+    document
+    |> LazyHTML.query(selector)
+    |> Enum.empty?()
+    |> Kernel.not()
   end
 end

--- a/test/huddlz_web/components/layouts_test.exs
+++ b/test/huddlz_web/components/layouts_test.exs
@@ -1,0 +1,61 @@
+defmodule HuddlzWeb.LayoutsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+
+  alias HuddlzWeb.Layouts
+
+  describe "app/1 notification navigation" do
+    test "renders zero, one, and capped unread states in the persistent topbar" do
+      zero = render_app(0)
+      one = render_app(1)
+      capped = render_app(100)
+
+      assert zero =~ ~s|id="notification-nav-link"|
+      assert zero =~ ~s|aria-label="Notifications"|
+      refute zero =~ ~s|id="notification-nav-badge"|
+
+      assert one =~ ~s|aria-label="Notifications, 1 unread"|
+      assert one =~ ~s|id="notification-nav-badge"|
+      assert badge_text(one) == "1"
+
+      assert capped =~ ~s|aria-label="Notifications, 100 unread"|
+      assert badge_text(capped) == "99+"
+    end
+
+    test "keeps the badge in the responsive topbar rather than the desktop sidebar" do
+      html = render_app(3)
+      {:ok, document} = Floki.parse_document(html)
+
+      assert Floki.find(document, ".content-topbar #notification-nav-badge") != []
+      assert Floki.find(document, ".sidebar #notification-nav-badge") == []
+    end
+  end
+
+  defp render_app(unread_notification_count) do
+    assigns = %{
+      current_user: %{email: "person@example.com", display_name: "Test Person"},
+      unread_notification_count: unread_notification_count
+    }
+
+    rendered_to_string(~H"""
+    <Layouts.app
+      flash={%{}}
+      current_user={@current_user}
+      unread_notification_count={@unread_notification_count}
+    >
+      Content
+    </Layouts.app>
+    """)
+  end
+
+  defp badge_text(html) do
+    {:ok, document} = Floki.parse_document(html)
+
+    document
+    |> Floki.find("#notification-nav-badge")
+    |> Floki.text()
+    |> String.trim()
+  end
+end

--- a/test/huddlz_web/live/group_invitation_live_test.exs
+++ b/test/huddlz_web/live/group_invitation_live_test.exs
@@ -61,6 +61,25 @@ defmodule HuddlzWeb.GroupInvitationLiveTest do
     assert Enum.any?(Communities.my_groups!(:all, actor: invitee), &(&1.id == group.id))
   end
 
+  test "invitation page keeps the unread notification badge", context do
+    %{conn: conn, owner: owner, invitee: invitee, group: group} = context
+
+    invitation =
+      Communities.invite_to_group!(group.id, invitee.id, :member, actor: owner)
+
+    {:ok, view, _html} =
+      conn
+      |> login(invitee)
+      |> live(~p"/invitations/#{invitation.id}")
+
+    assert has_element?(
+             view,
+             ~s|#notification-nav-link[aria-label="Notifications, 1 unread"]|
+           )
+
+    assert has_element?(view, "#notification-nav-badge", "1")
+  end
+
   test "organizers only see the member role option", context do
     %{conn: conn, owner: owner, invitee: invitee, group: group} = context
     organizer = generate(user())

--- a/test/huddlz_web/live/notification_navigation_test.exs
+++ b/test/huddlz_web/live/notification_navigation_test.exs
@@ -1,0 +1,101 @@
+defmodule HuddlzWeb.NotificationNavigationTest do
+  use HuddlzWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Huddlz.Notifications
+
+  setup do
+    user = generate(user(role: :user, confirmed_at: DateTime.utc_now()))
+    %{user: user}
+  end
+
+  test "signed-out navigation does not expose notification state", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/help")
+
+    refute has_element?(view, "#notification-nav-link")
+    refute has_element?(view, "#notification-nav-badge")
+  end
+
+  test "zero unread notifications renders no badge", %{conn: conn, user: user} do
+    {:ok, view, _html} = live(login(conn, user), ~p"/help")
+
+    assert has_element?(view, ~s|#notification-nav-link[aria-label="Notifications"]|)
+    refute has_element?(view, "#notification-nav-badge")
+  end
+
+  test "one unread notification renders an accessible badge", %{conn: conn, user: user} do
+    deliver!(user)
+
+    {:ok, view, _html} = live(login(conn, user), ~p"/help")
+
+    assert has_element?(
+             view,
+             ~s|#notification-nav-link[aria-label="Notifications, 1 unread"]|
+           )
+
+    assert has_element?(view, "#notification-nav-badge", "1")
+  end
+
+  test "large unread counts use a compact visual cap and retain the exact accessible count", %{
+    conn: conn,
+    user: user
+  } do
+    for _ <- 1..100, do: deliver!(user)
+
+    {:ok, view, _html} = live(login(conn, user), ~p"/help")
+
+    assert has_element?(
+             view,
+             ~s|#notification-nav-link[aria-label="Notifications, 100 unread"]|
+           )
+
+    assert has_element?(view, "#notification-nav-badge", "99+")
+  end
+
+  test "a new notification updates persistent navigation during an active session", %{
+    conn: conn,
+    user: user
+  } do
+    {:ok, view, _html} = live(login(conn, user), ~p"/help")
+    refute has_element?(view, "#notification-nav-badge")
+
+    deliver!(user)
+
+    assert has_element?(view, "#notification-nav-badge", "1")
+  end
+
+  test "individual and bulk read actions update the badge without reloading", %{
+    conn: conn,
+    user: user
+  } do
+    deliver!(user, :group_archived, %{"group_name" => "Past group"})
+    deliver!(user, :group_archived, %{"group_name" => "Other past group"})
+
+    {:ok, %{results: [notification | _]}} =
+      Notifications.list_for_user(actor: user, page: [limit: 10])
+
+    {:ok, view, _html} = live(login(conn, user), ~p"/notifications")
+    assert has_element?(view, "#notification-nav-badge", "2")
+
+    view
+    |> element("#notification-#{notification.id} button[phx-click=mark_read]")
+    |> render_click()
+
+    assert has_element?(view, "#notification-nav-badge", "1")
+
+    view
+    |> element(~s|button[phx-click="mark_all_read"]|)
+    |> render_click()
+
+    refute has_element?(view, "#notification-nav-badge")
+  end
+
+  defp deliver!(user) do
+    assert {:ok, _job} = Notifications.deliver(user, :password_changed, %{})
+  end
+
+  defp deliver!(user, trigger, payload) do
+    assert {:ok, _job} = Notifications.deliver(user, trigger, payload)
+  end
+end


### PR DESCRIPTION
## Summary

- show unread notification counts in the persistent signed-in navigation
- cap the visual badge at 99+ while keeping the exact count in its accessible name
- keep the badge synchronized when notifications arrive or are marked read
- keep signed-out navigation free of notification state

## Manual verification

- Sign in with unread notifications and confirm the badge appears in desktop and mobile navigation.
- Mark one notification, then all notifications, as read and confirm the badge updates without a reload.

Closes #292