### PR TITLE
fix(auth): handle denied admin access directly

### DIFF
--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -54,10 +54,12 @@ defmodule HuddlzWeb.LiveUserAuth do
   # so this hook stays in sync with the policy bypass that uses the same role
   # check on every Ash action.
   def on_mount(:admin_required, _params, _session, socket) do
-    if User.admin?(socket.assigns[:current_user]) do
-      {:cont, socket}
-    else
-      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+    case socket.assigns[:current_user] do
+      nil ->
+        {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+
+      user ->
+        authorize_admin(user, socket)
     end
   end
 
@@ -102,6 +104,17 @@ defmodule HuddlzWeb.LiveUserAuth do
   end
 
   defp maybe_load_user_details(socket), do: socket
+
+  defp authorize_admin(user, socket) do
+    if User.admin?(user) do
+      {:cont, socket}
+    else
+      {:halt,
+       socket
+       |> Phoenix.LiveView.put_flash(:error, "You don't have access to the admin area.")
+       |> Phoenix.LiveView.redirect(to: ~p"/my-huddlz")}
+    end
+  end
 
   defp load_sidebar_owned_groups(%{assigns: %{current_user: user}}) when not is_nil(user) do
     Huddlz.Communities.get_organizable_groups!(actor: user, query: [sort: [name: :asc]])

--- a/test/huddlz_web/live/admin_live_test.exs
+++ b/test/huddlz_web/live/admin_live_test.exs
@@ -1,6 +1,8 @@
 defmodule HuddlzWeb.AdminLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
+  import Phoenix.LiveViewTest
+
   alias Huddlz.Accounts.User
 
   # Sample user data
@@ -45,19 +47,25 @@ defmodule HuddlzWeb.AdminLiveTest do
     end
 
     test "redirects if user is a non-admin user", %{conn: conn, regular_user: regular_user} do
-      # With user in session, should redirect to home
-      conn
-      |> login(regular_user)
-      |> visit(~p"/admin")
-      |> assert_path(~p"/my-huddlz")
+      conn = login(conn, regular_user)
+
+      assert {:error,
+              {:redirect,
+               %{
+                 to: "/my-huddlz",
+                 flash: %{"error" => "You don't have access to the admin area."}
+               }}} = live(conn, ~p"/admin")
+
+      # The denied request must not clear the authenticated session.
+      assert {:ok, _view, _html} = live(conn, ~p"/profile")
     end
 
     test "redirects all non-admin users", %{conn: conn, verified_user: verified_user} do
-      # All non-admin users should be redirected
       conn
       |> login(verified_user)
       |> visit(~p"/admin")
       |> assert_path(~p"/my-huddlz")
+      |> assert_has("div[role='alert']", text: "You don't have access to the admin area.")
     end
 
     test "renders admin panel for admin users", %{conn: conn, admin_user: admin_user} do


### PR DESCRIPTION
## Summary

- Keep signed-in non-admins authenticated when they request the admin area.
- Send them directly to My huddlz with a neutral access-denied message.
- Preserve the existing sign-in requirement for signed-out people and normal access for admins.

## Manual verification

Sign in as a non-admin, open `/admin`, and confirm the app shows the access message on My huddlz without signing out.

Closes #295