### PR TITLE
fix(ui): make organizer choice controls keyboard accessible

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3312,15 +3312,10 @@ body .toggle .track {
   padding: 0;
   opacity: 1;
   rotate: 0deg;
-  transition: background 120ms ease, border-color 120ms ease;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
 }
 
 body .toggle input:checked + .track { border-color: var(--cyan); }
-
-body .toggle input:focus-visible + .track {
-  outline: 2px solid var(--cyan);
-  outline-offset: 3px;
-}
 
 body .toggle .track::after {
   content: "";
@@ -3337,6 +3332,11 @@ body .toggle .track::after {
 body .toggle input:checked + .track {
   background: var(--cyan);
   box-shadow: 0 0 12px rgba(24, 203, 212, 0.4);
+}
+
+body .toggle input:focus-visible + .track {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 3px var(--cyan-soft);
 }
 
 body .toggle input:checked + .track::after { transform: translateX(14px); }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3196,6 +3196,7 @@ body .event-type-grid {
 
 
 body .event-type-option {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 12px;
@@ -3207,6 +3208,14 @@ body .event-type-option {
   transition: border-color 120ms ease, background 120ms ease;
 }
 
+body .huddl-format-hitbox,
+body .toggle-hitbox {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  cursor: pointer;
+}
+
 body .event-type-option:hover { border-color: var(--line-strong); }
 
 body .event-type-option.is-active {
@@ -3214,7 +3223,32 @@ body .event-type-option.is-active {
   background: var(--cyan-soft);
 }
 
-body .event-type-option input { display: none; }
+body .huddl-format-fieldset {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+body .choice-control-input,
+body .toggle input[type="checkbox"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+body .event-type-option:has(.choice-control-input:focus-visible) {
+  border-color: var(--cyan);
+  outline: 2px solid var(--cyan);
+  outline-offset: 3px;
+}
 
 body .event-type-icon {
   width: 36px;
@@ -3248,6 +3282,7 @@ body .edit-scope-row strong { color: var(--text); }
    `.track` rect by ~4px on unchecked rows. Drop the whole daisy footprint
    until the migration retires daisy entirely. */
 body .toggle {
+  position: relative;
   display: inline-flex;
   align-items: center;
   align-self: flex-start;
@@ -3266,8 +3301,6 @@ body .toggle {
   place-content: normal;
 }
 
-body .toggle input { display: none; }
-
 body .toggle .track {
   position: relative;
   width: 36px;
@@ -3283,6 +3316,11 @@ body .toggle .track {
 }
 
 body .toggle input:checked + .track { border-color: var(--cyan); }
+
+body .toggle input:focus-visible + .track {
+  outline: 2px solid var(--cyan);
+  outline-offset: 3px;
+}
 
 body .toggle .track::after {
   content: "";

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -1,7 +1,7 @@
 defmodule HuddlzWeb.Components.HuddlForm do
   @moduledoc """
   Presentation primitives shared by the huddl create and edit forms:
-  the event-type radio cards and the duration select options.
+  the huddl-format radio cards and the duration select options.
 
   ```
   <.event_type_grid field={@form[:event_type]} />
@@ -34,24 +34,24 @@ defmodule HuddlzWeb.Components.HuddlForm do
     assigns = assign(assigns, :radio_id, radio_id)
 
     ~H"""
-    <label for={@radio_id} class="sr-only">{@title}</label>
-    <label
-      for={@radio_id}
-      class={["event-type-option", to_string(@field.value) == @value && "is-active"]}
-    >
+    <div class={["event-type-option", to_string(@field.value) == @value && "is-active"]}>
       <input
         id={@radio_id}
         type="radio"
         name={@field.name}
         value={@value}
         checked={to_string(@field.value) == @value}
+        class="choice-control-input"
       />
-      <div class="event-type-icon">{render_slot(@icon)}</div>
+      <label for={@radio_id} class="huddl-format-hitbox">
+        <span class="sr-only">{@title}</span>
+      </label>
+      <div class="event-type-icon" aria-hidden="true">{render_slot(@icon)}</div>
       <div>
         <div class="event-type-title">{@title}</div>
         <div class="event-type-desc">{@desc}</div>
       </div>
-    </label>
+    </div>
     """
   end
 
@@ -59,73 +59,76 @@ defmodule HuddlzWeb.Components.HuddlForm do
 
   def event_type_grid(assigns) do
     ~H"""
-    <div class="event-type-grid">
-      <.event_type_option
-        field={@field}
-        value="in_person"
-        title="In person"
-        desc="Single physical location."
-      >
-        <:icon>
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
-              cx="12"
-              cy="10"
-              r="3"
-            />
-          </svg>
-        </:icon>
-      </.event_type_option>
-      <.event_type_option
-        field={@field}
-        value="virtual"
-        title="Virtual"
-        desc="Online only — no physical address."
-      >
-        <:icon>
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
-          </svg>
-        </:icon>
-      </.event_type_option>
-      <.event_type_option
-        field={@field}
-        value="hybrid"
-        title="Hybrid"
-        desc="In-person plus an online stream."
-      >
-        <:icon>
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.8"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
-              cx="12"
-              cy="10"
-              r="3"
-            /><path d="m22 22-2-2" />
-          </svg>
-        </:icon>
-      </.event_type_option>
-    </div>
+    <fieldset class="huddl-format-fieldset">
+      <legend class="sr-only">Huddl format</legend>
+      <div class="event-type-grid">
+        <.event_type_option
+          field={@field}
+          value="in_person"
+          title="In person"
+          desc="Single physical location."
+        >
+          <:icon>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
+                cx="12"
+                cy="10"
+                r="3"
+              />
+            </svg>
+          </:icon>
+        </.event_type_option>
+        <.event_type_option
+          field={@field}
+          value="virtual"
+          title="Virtual"
+          desc="Online only — no physical address."
+        >
+          <:icon>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="3" y="6" width="13" height="12" rx="2" /><path d="m16 10 5-3v10l-5-3" />
+            </svg>
+          </:icon>
+        </.event_type_option>
+        <.event_type_option
+          field={@field}
+          value="hybrid"
+          title="Hybrid"
+          desc="In-person plus an online stream."
+        >
+          <:icon>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" /><circle
+                cx="12"
+                cy="10"
+                r="3"
+              /><path d="m22 22-2-2" />
+            </svg>
+          </:icon>
+        </.event_type_option>
+      </div>
+    </fieldset>
     """
   end
 

--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -12,6 +12,49 @@ defmodule HuddlzWeb.Components.Input do
   alias Phoenix.HTML.Form
   alias Phoenix.HTML.FormField
 
+  attr :field, FormField, required: true
+  attr :label, :string, required: true
+  attr :show_state_text, :boolean, default: false
+  attr :labelled_externally, :boolean, default: false
+  attr :disabled, :boolean, default: false
+
+  @doc """
+  Renders a native checkbox with switch semantics.
+
+  The input remains in the accessibility tree and keyboard order while the
+  visible track receives the focus treatment.
+  """
+  def toggle(assigns) do
+    checked = Form.normalize_value("checkbox", assigns.field.value) == true
+
+    assigns =
+      assigns
+      |> assign(:checked, checked)
+      |> assign(:visible_label, toggle_label(assigns.label, assigns.show_state_text, checked))
+
+    ~H"""
+    <div class="toggle">
+      <input type="hidden" name={@field.name} value="false" />
+      <input
+        id={@field.id}
+        type="checkbox"
+        role="switch"
+        name={@field.name}
+        value="true"
+        checked={@checked}
+        aria-checked={to_string(@checked)}
+        aria-label={!@labelled_externally && @label}
+        disabled={@disabled}
+      />
+      <span class="track" aria-hidden="true"></span>
+      <span class="toggle-text" aria-hidden="true">{@visible_label}</span>
+      <label for={@field.id} class="toggle-hitbox" aria-hidden={@labelled_externally}>
+        <span :if={!@labelled_externally} class="sr-only">{@label}</span>
+      </label>
+    </div>
+    """
+  end
+
   attr :id, :any, default: nil
   attr :name, :any
   attr :label, :string, default: nil
@@ -255,4 +298,8 @@ defmodule HuddlzWeb.Components.Input do
 
   defp help_id(id), do: "#{id}-help"
   defp error_id(id, index), do: "#{id}-error-#{index}"
+
+  defp toggle_label(_label, true, true), do: "On"
+  defp toggle_label(_label, true, false), do: "Off"
+  defp toggle_label(label, false, _checked), do: label
 end

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -354,6 +354,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
                   value="true"
                   checked={@selected_public?}
                   role="switch"
+                  aria-checked={to_string(@selected_public?)}
                   aria-labelledby="group-public-toggle-label"
                   aria-describedby="group-visibility-description group-visibility-consequence"
                 />

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -345,27 +345,17 @@ defmodule HuddlzWeb.GroupLive.New do
           <div class="settings-list row-list pref-list">
             <div class="row">
               <div>
-                <label class="row-title" for="group-is-public">Public group</label>
+                <label class="row-title" for={@form[:is_public].id}>Public group</label>
                 <div class="row-desc">
                   Anyone can find and join this group. Huddlz are visible without signing in.
                 </div>
               </div>
-              <label class="toggle">
-                <input type="hidden" name={@form[:is_public].name} value="false" />
-                <input
-                  id="group-is-public"
-                  type="checkbox"
-                  name={@form[:is_public].name}
-                  value="true"
-                  checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_public].value)}
-                />
-                <span class="track"></span>
-                <span class="toggle-text">
-                  {if Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_public].value),
-                    do: "On",
-                    else: "Off"}
-                </span>
-              </label>
+              <.toggle
+                field={@form[:is_public]}
+                label="Public group"
+                show_state_text
+                labelled_externally
+              />
             </div>
           </div>
         </div>

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -424,18 +424,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
             <%= if @huddl.group.is_public do %>
               <div class="form-row">
-                <label class="toggle">
-                  <input type="hidden" name={@form[:is_private].name} value="false" />
-                  <input
-                    id={@form[:is_private].id}
-                    type="checkbox"
-                    name={@form[:is_private].name}
-                    value="true"
-                    checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_private].value)}
-                  />
-                  <span class="track"></span>
-                  <span class="toggle-text">Members only</span>
-                </label>
+                <.toggle field={@form[:is_private]} label="Members only" />
                 <p class="form-help">
                   Only group members can RSVP. Useful for private workshops or socials.
                 </p>

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -221,18 +221,7 @@ defmodule HuddlzWeb.HuddlLive.New do
             </p>
 
             <div class="form-row">
-              <label class="toggle">
-                <input type="hidden" name={@form[:is_recurring].name} value="false" />
-                <input
-                  id={@form[:is_recurring].id}
-                  type="checkbox"
-                  name={@form[:is_recurring].name}
-                  value="true"
-                  checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_recurring].value)}
-                />
-                <span class="track"></span>
-                <span class="toggle-text">Recurring huddl</span>
-              </label>
+              <.toggle field={@form[:is_recurring]} label="Recurring huddl" />
               <p class="form-help">Repeats on a schedule until you stop it.</p>
             </div>
 
@@ -306,18 +295,7 @@ defmodule HuddlzWeb.HuddlLive.New do
 
             <%= if @group.is_public do %>
               <div class="form-row">
-                <label class="toggle">
-                  <input type="hidden" name={@form[:is_private].name} value="false" />
-                  <input
-                    id={@form[:is_private].id}
-                    type="checkbox"
-                    name={@form[:is_private].name}
-                    value="true"
-                    checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_private].value)}
-                  />
-                  <span class="track"></span>
-                  <span class="toggle-text">Members only</span>
-                </label>
+                <.toggle field={@form[:is_private]} label="Members only" />
                 <p class="form-help">
                   Only group members can RSVP. Useful for private workshops or socials.
                 </p>

--- a/test/huddlz_web/components/components_test.exs
+++ b/test/huddlz_web/components/components_test.exs
@@ -96,6 +96,25 @@ defmodule HuddlzWeb.ComponentsTest do
     end
   end
 
+  describe "toggle/1" do
+    test "renders a labeled native checkbox with switch state" do
+      form = to_form(%{"enabled" => "true"}, as: :settings)
+      assigns = %{field: form[:enabled]}
+
+      html =
+        rendered_to_string(~H"""
+        <.toggle field={@field} label="Email notifications" />
+        """)
+
+      assert html =~ ~s(type="checkbox")
+      assert html =~ ~s(role="switch")
+      assert html =~ ~s(aria-checked="true")
+      assert html =~ ~s(checked)
+      assert html =~ "Email notifications"
+      refute html =~ ~s(display: none)
+    end
+  end
+
   describe "panel/1" do
     test "renders panel with optional head and sub" do
       assigns = %{}

--- a/test/huddlz_web/live/group_live/edit_test.exs
+++ b/test/huddlz_web/live/group_live/edit_test.exs
@@ -35,7 +35,7 @@ defmodule HuddlzWeb.GroupLive.EditTest do
       |> assert_has("#group-visibility-current", text: "Public")
       |> assert_has("#group-visibility-selection", text: "Public group")
       |> assert_has(
-        "#group-is-public[role='switch'][aria-labelledby='group-public-toggle-label'][aria-describedby='group-visibility-description group-visibility-consequence']"
+        "#group-is-public[role='switch'][aria-checked='true'][aria-labelledby='group-public-toggle-label'][aria-describedby='group-visibility-description group-visibility-consequence']"
       )
       |> assert_has("#group-visibility-consequence", text: "No visibility change pending")
     end

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -3,6 +3,7 @@ defmodule HuddlzWeb.GroupLiveTest do
 
   import Huddlz.Generator
   import Huddlz.Test.Helpers.LocationSelection
+  import Phoenix.LiveViewTest
 
   alias Huddlz.Communities.Group
 
@@ -29,7 +30,31 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> assert_has("label.form-label", text: "Group name")
       |> assert_has("label.form-label", text: "Description")
       |> assert_has("label.form-label", text: "Location")
-      |> assert_has("label.row-title", text: "Public group")
+      |> assert_has(".row-title", text: "Public group")
+    end
+
+    test "exposes group visibility as a labeled keyboard-operable switch", %{
+      conn: conn,
+      verified: verified
+    } do
+      {:ok, view, _html} =
+        conn
+        |> login(verified)
+        |> live(~p"/groups/new")
+
+      assert has_element?(
+               view,
+               ".toggle input[name='form[is_public]'][type='checkbox'][role='switch'][aria-checked='true'][checked]"
+             )
+
+      view
+      |> form("#group-form", %{"form" => %{"is_public" => "false"}})
+      |> render_change()
+
+      assert has_element?(
+               view,
+               ".toggle input[name='form[is_public]'][role='switch'][aria-checked='false']:not([checked])"
+             )
     end
 
     test "allows all users to create groups", %{conn: conn, regular: regular} do

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -211,6 +211,12 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       assert_has(session, "input[name='form[title]']")
       assert_has(session, "textarea[name='form[description]']")
       assert_has(session, "input[name='form[event_type]'][type='radio']")
+      assert_has(session, "fieldset.huddl-format-fieldset legend", text: "Huddl format")
+
+      assert_has(
+        session,
+        ".toggle input[name='form[is_private]'][type='checkbox'][role='switch'][aria-checked='false']"
+      )
     end
 
     test "shows calculated end time", %{

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -155,6 +155,22 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       assert_has(session, "input[name='form[start_time]']")
       assert_has(session, "select[name='form[duration_minutes]']")
       assert_has(session, "input[name='form[event_type]'][type='radio']")
+      assert_has(session, "fieldset.huddl-format-fieldset legend", text: "Huddl format")
+
+      assert_has(
+        session,
+        ".event-type-option:has(label[for='event-type-in_person']) input#event-type-in_person[type='radio'][checked]"
+      )
+
+      assert_has(
+        session,
+        ".event-type-option:has(label[for='event-type-virtual']) input#event-type-virtual[type='radio']"
+      )
+
+      assert_has(
+        session,
+        ".toggle input[name='form[is_recurring]'][role='switch'][aria-checked='false']"
+      )
     end
 
     test "shows 16:9 ratio guidance for cover image", %{
@@ -180,8 +196,16 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
 
-      assert_has(session, "input[name='form[is_private]'][type='checkbox']")
-      assert session.conn.resp_body =~ "Members only"
+      assert_has(
+        session,
+        ".toggle input[name='form[is_private]'][type='checkbox'][role='switch'][aria-checked='false']"
+      )
+
+      session
+      |> check("Members only")
+      |> assert_has(
+        ".toggle input[name='form[is_private]'][role='switch'][aria-checked='true'][checked]"
+      )
     end
 
     test "shows private huddl notice for private groups", %{


### PR DESCRIPTION
## Summary

- preserve native radio and checkbox controls in the keyboard and accessibility trees
- group huddl format choices with native fieldset semantics and visible card focus states
- share labeled switch markup across group visibility, recurring huddl, and members-only controls
- cover create and edit forms with component, LiveView, and feature tests

## Verification

- mix precommit (1,419 tests, strict Credo)
- mix assets.build

Closes #297