### PR TITLE
fix: make huddl edit notifications accurate and concise

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -49,9 +49,9 @@ Each trigger has an ID (e.g. C3) used throughout the doc and the GitHub issues.
 | ID | Trigger | Recipient | Category | Notes |
 |---|---|---|---|---|
 | C1 | New huddl created in a group | All group members | Activity | Default ON. Body links to settings page. |
-| C2 | Huddl details meaningfully changed | All current RSVPs | Activity | "Meaningful" = `starts_at`, `ends_at`, `location`, `virtual_link`, `title`. Skip cosmetic edits. |
+| C2 | Huddl details meaningfully changed | All current RSVPs | Activity | "Meaningful" = `starts_at`, `ends_at`, `location`, `virtual_link`, `title`, `capacity`, or `privacy`. Skip cosmetic and no-op edits. |
 | C3 | Huddl cancelled / deleted | All current RSVPs | Transactional | Highest priority. People may have travel plans. |
-| C4 | Recurring series modified | RSVPs of the next upcoming instance only | Activity | Subsequent instances are covered by their own reminders (D1/D2). |
+| C4 | Recurring series modified | Deduplicated RSVPs across retained upcoming instances | Activity | One summary per person, linked to their next retained RSVP. Subsequent instances are covered by their own reminders (D1/D2). |
 
 ### D. Huddl reminders (time-based, Oban cron)
 
@@ -106,7 +106,7 @@ Locked for v1, no re-litigation:
 
 1. C1 audience = every group member. Mitigated by the settings page.
 2. E1/E2 volume = per-RSVP, no cap. Daily digest is a v2 idea.
-3. C4 = one email about the next upcoming instance. Later instances rely on D1/D2.
+3. C4 = one email per affected person about their next retained RSVP. Later instances rely on D1/D2.
 4. `.ics` attachments ship in v1 on E3, D1, D2.
 5. Defaults: Activity ON, Digest OFF, Transactional always on.
 

--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -34,6 +34,7 @@ defmodule Huddlz.Communities do
         args: [{:optional, :state}],
         get?: false
 
+      define :update_huddl, action: :update
       define :rsvp_huddl, action: :rsvp
       define :cancel_rsvp_huddl, action: :cancel_rsvp
       define :join_waitlist_huddl, action: :join_waitlist
@@ -98,6 +99,11 @@ defmodule Huddlz.Communities do
       define :check_user_rsvp, action: :check_rsvp, args: [:huddl_id]
       define :list_huddl_attendees, action: :by_huddl, args: [:huddl_id], get?: false
       define :list_huddl_waitlist, action: :waitlist_for_huddl, args: [:huddl_id], get?: false
+
+      define :list_huddl_notification_recipients,
+        action: :notification_recipients,
+        args: [:huddl_ids],
+        get?: false
     end
 
     resource Huddlz.Communities.HuddlTemplate

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -183,6 +183,12 @@ defmodule Huddlz.Communities.Huddl do
         default "instance"
       end
 
+      argument :suppress_update_notification, :boolean do
+        allow_nil? false
+        default false
+        public? false
+      end
+
       argument :provided_latitude, :float, allow_nil?: true, public?: false
       argument :provided_longitude, :float, allow_nil?: true, public?: false
 

--- a/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
+++ b/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
@@ -92,14 +92,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
     huddl
     |> RecipientHelpers.series_rsvp_targets(exclude: actor_id)
     |> Enum.each(fn {user_id, target} ->
-      payload = %{
-        "huddl_id" => target.id,
-        "huddl_title" => to_string(target.title),
-        "starts_at_iso" => DateTime.to_iso8601(target.starts_at),
-        "group_name" => to_string(huddl.group.name),
-        "group_slug" => to_string(huddl.group.slug),
-        "changed_fields" => Enum.map(changed_fields, &Atom.to_string/1)
-      }
+      payload = NotifyMeaningfulUpdate.payload(target, huddl.group, changed_fields)
 
       RecipientHelpers.deliver_each([user_id], :huddl_series_updated, payload)
     end)

--- a/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
+++ b/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
@@ -3,26 +3,31 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
   Propagates an "edit all" to the rest of a recurring series.
 
   Updates every later instance **in place** so subscribers keep their RSVPs and
-  are notified their event changed (see `RecurrenceHelper.reconcile_future_instances/3`);
-  it never deletes-and-recreates occupied occurrences.
+  are notified with one useful series summary per affected person (see
+  `RecurrenceHelper.reconcile_future_instances/3`); it never
+  deletes-and-recreates occupied occurrences.
   """
   use Ash.Resource.Change
 
+  alias Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate
+  alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
   alias Huddlz.Communities.Huddl.RecurrenceHelper
+  alias Huddlz.Communities.HuddlTemplate
 
   def change(changeset, _opts, context) do
     actor = context.actor
+    changed_fields = NotifyMeaningfulUpdate.changed_fields(changeset)
 
     Ash.Changeset.after_action(changeset, fn _changeset, huddl ->
       if Ash.Changeset.get_argument(changeset, :edit_type) == "all" do
-        reconcile_series(changeset, huddl, actor)
+        reconcile_series(changeset, huddl, actor, changed_fields)
       else
         {:ok, huddl}
       end
     end)
   end
 
-  defp reconcile_series(changeset, huddl, actor) do
+  defp reconcile_series(changeset, huddl, actor, changed_fields) do
     repeat_until = Ash.Changeset.get_argument(changeset, :repeat_until)
     frequency = Ash.Changeset.get_argument(changeset, :frequency)
 
@@ -36,6 +41,13 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
         {:ok, huddl}
 
       huddl_template ->
+        changed_fields =
+          if schedule_changed?(huddl_template, repeat_until, frequency) do
+            [:schedule | changed_fields]
+          else
+            changed_fields
+          end
+
         {:ok, huddl_template} =
           huddl_template
           |> Ash.Changeset.for_update(:update, %{
@@ -49,7 +61,47 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
         # path defers its fan-out to RegenerateRecurringSeries instead.
         RecurrenceHelper.reconcile_future_instances(huddl, huddl_template, actor)
 
+        notify_series(huddl, actor, changed_fields)
+
         {:ok, huddl}
     end
+  end
+
+  defp schedule_changed?(template, repeat_until, frequency) do
+    repeat_until_changed?(template, repeat_until) or frequency_changed?(template, frequency)
+  end
+
+  defp repeat_until_changed?(_template, nil), do: false
+
+  defp repeat_until_changed?(template, repeat_until) do
+    DateTime.to_date(template.repeat_until) != repeat_until
+  end
+
+  defp frequency_changed?(_template, nil), do: false
+
+  defp frequency_changed?(template, frequency) do
+    to_string(HuddlTemplate.cadence(template)) != to_string(frequency)
+  end
+
+  defp notify_series(_huddl, _actor, []), do: :ok
+
+  defp notify_series(huddl, actor, changed_fields) do
+    huddl = Ash.load!(huddl, :group, authorize?: false)
+    actor_id = if actor, do: actor.id
+
+    huddl
+    |> RecipientHelpers.series_rsvp_targets(exclude: actor_id)
+    |> Enum.each(fn {user_id, target} ->
+      payload = %{
+        "huddl_id" => target.id,
+        "huddl_title" => to_string(target.title),
+        "starts_at_iso" => DateTime.to_iso8601(target.starts_at),
+        "group_name" => to_string(huddl.group.name),
+        "group_slug" => to_string(huddl.group.slug),
+        "changed_fields" => Enum.map(changed_fields, &Atom.to_string/1)
+      }
+
+      RecipientHelpers.deliver_each([user_id], :huddl_series_updated, payload)
+    end)
   end
 end

--- a/lib/huddlz/communities/huddl/changes/notify_meaningful_update.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_meaningful_update.ex
@@ -47,6 +47,20 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
     end)
   end
 
+  @doc false
+  @spec payload(struct(), struct(), [atom()]) :: map()
+  def payload(huddl, group, changed_fields) do
+    %{
+      "huddl_id" => huddl.id,
+      "huddl_title" => to_string(huddl.title),
+      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
+      "group_name" => to_string(group.name),
+      "group_slug" => to_string(group.slug),
+      "changed_fields" => Enum.map(changed_fields, &Atom.to_string/1)
+    }
+    |> use_accessible_target(huddl)
+  end
+
   defp series_edit?(changeset), do: Ash.Changeset.get_argument(changeset, :edit_type) == "all"
 
   defp suppressed?(changeset) do
@@ -60,17 +74,15 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
     recipients =
       RecipientHelpers.rsvp_user_ids(huddl.id, exclude: RecipientHelpers.actor_id(cs))
 
-    payload = %{
-      "huddl_id" => huddl.id,
-      "huddl_title" => to_string(huddl.title),
-      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
-      "group_name" => to_string(huddl.group.name),
-      "group_slug" => to_string(huddl.group.slug),
-      "changed_fields" => Enum.map(changed_fields, &Atom.to_string/1)
-    }
+    payload = payload(huddl, huddl.group, changed_fields)
 
     RecipientHelpers.deliver_each(recipients, :huddl_updated, payload)
 
     {:ok, huddl}
   end
+
+  defp use_accessible_target(payload, %{is_private: true}),
+    do: Map.put(payload, "target_path", "/notifications")
+
+  defp use_accessible_target(payload, _huddl), do: payload
 end

--- a/lib/huddlz/communities/huddl/changes/notify_meaningful_update.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_meaningful_update.ex
@@ -2,37 +2,55 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate do
   @moduledoc """
   Enqueues notifications when a huddl is edited in a way that affects an
   attendee's plans — i.e. one of `:title`, `:starts_at`, `:ends_at`,
-  `:physical_location`, or `:virtual_link` is in the changeset. Cosmetic edits
-  (description, thumbnail, etc.) do not trigger an email.
+  `:physical_location`, `:virtual_link`, `:max_attendees`, or `:is_private` is
+  in the changeset. Cosmetic edits (description, thumbnail, etc.) do not
+  trigger a notification.
 
   Emails everyone who has RSVP'd to the huddl (except the person making the edit)
-  to tell them it changed. This fires for both a single-huddl edit and an "edit
-  all" on a series: the series edit updates each future occurrence through its
-  own `:update`, so every changed occurrence emails its own attendees from here.
-
-  In `docs/notifications.md` terms this is notification C2 (`:huddl_updated`). The
-  per-series digest C4 (`:huddl_series_updated`) is deliberately not sent for now;
-  its sender is kept for a possible future "one summary per attendee" option.
+  to tell them it changed. Whole-series edits are handled by
+  `EditRecurringHuddlz`, which sends one C4 summary per affected person instead
+  of allowing this C2 notifier to fan out once per occurrence.
   """
 
   use Ash.Resource.Change
 
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
 
-  @meaningful_attrs [:title, :starts_at, :ends_at, :physical_location, :virtual_link]
+  @attendee_affecting_attrs [
+    :title,
+    :starts_at,
+    :ends_at,
+    :physical_location,
+    :virtual_link,
+    :max_attendees,
+    :is_private
+  ]
 
   @impl true
   def change(changeset, _opts, _context) do
-    changed_fields =
-      Enum.filter(@meaningful_attrs, &Ash.Changeset.changing_attribute?(changeset, &1))
+    changed_fields = changed_fields(changeset)
 
-    if changed_fields == [] do
+    if changed_fields == [] or series_edit?(changeset) or suppressed?(changeset) do
       changeset
     else
       changeset
       |> Ash.Changeset.put_context(:huddl_updated_changed_fields, changed_fields)
       |> Ash.Changeset.after_action(&notify/2)
     end
+  end
+
+  @doc false
+  @spec changed_fields(Ash.Changeset.t()) :: [atom()]
+  def changed_fields(changeset) do
+    Enum.filter(@attendee_affecting_attrs, fn attribute ->
+      Ash.Changeset.changing_attribute?(changeset, attribute)
+    end)
+  end
+
+  defp series_edit?(changeset), do: Ash.Changeset.get_argument(changeset, :edit_type) == "all"
+
+  defp suppressed?(changeset) do
+    Ash.Changeset.get_argument(changeset, :suppress_update_notification) == true
   end
 
   defp notify(cs, huddl) do

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -8,10 +8,10 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   require Ash.Query
 
   alias Huddlz.Accounts.User
+  alias Huddlz.Communities
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.Huddl.RecurrenceHelper
-  alias Huddlz.Communities.HuddlAttendee
   alias Huddlz.Notifications
 
   @doc """
@@ -24,10 +24,8 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   def rsvp_user_ids(huddl_id, opts \\ []) do
     actor_id = Keyword.get(opts, :exclude)
 
-    HuddlAttendee
-    |> Ash.Query.filter(huddl_id == ^huddl_id)
-    |> Ash.Query.select([:user_id])
-    |> Ash.read!(authorize?: false)
+    [huddl_id]
+    |> Communities.list_huddl_notification_recipients!(authorize?: false)
     |> Enum.map(& &1.user_id)
     |> Enum.uniq()
     |> Enum.reject(&(&1 == actor_id))
@@ -48,10 +46,8 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
     huddlz_by_id = Map.new(huddlz, &{&1.id, &1})
     huddl_ids = Map.keys(huddlz_by_id)
 
-    HuddlAttendee
-    |> Ash.Query.filter(huddl_id in ^huddl_ids)
-    |> Ash.Query.select([:user_id, :huddl_id])
-    |> Ash.read!(authorize?: false)
+    huddl_ids
+    |> Communities.list_huddl_notification_recipients!(authorize?: false)
     |> Enum.reject(&(&1.user_id == actor_id))
     |> Enum.group_by(& &1.user_id)
     |> Enum.map(fn {user_id, attendances} ->

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -9,6 +9,8 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
+  alias Huddlz.Communities.Huddl
+  alias Huddlz.Communities.Huddl.RecurrenceHelper
   alias Huddlz.Communities.HuddlAttendee
   alias Huddlz.Notifications
 
@@ -29,6 +31,37 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
     |> Enum.map(& &1.user_id)
     |> Enum.uniq()
     |> Enum.reject(&(&1 == actor_id))
+  end
+
+  @doc """
+  Returns one next-upcoming huddl per person who has an RSVP on the source
+  occurrence or any later occurrence in its recurring series.
+
+  Choosing a target per recipient keeps a whole-series summary useful for
+  people who attend different dates and ensures the link points to a huddl
+  they can still access after reconciliation.
+  """
+  @spec series_rsvp_targets(Huddl.t(), keyword()) :: [{Ecto.UUID.t(), Huddl.t()}]
+  def series_rsvp_targets(%Huddl{} = source, opts \\ []) do
+    actor_id = Keyword.get(opts, :exclude)
+    huddlz = [source | RecurrenceHelper.future_instances(source)]
+    huddlz_by_id = Map.new(huddlz, &{&1.id, &1})
+    huddl_ids = Map.keys(huddlz_by_id)
+
+    HuddlAttendee
+    |> Ash.Query.filter(huddl_id in ^huddl_ids)
+    |> Ash.Query.select([:user_id, :huddl_id])
+    |> Ash.read!(authorize?: false)
+    |> Enum.reject(&(&1.user_id == actor_id))
+    |> Enum.group_by(& &1.user_id)
+    |> Enum.map(fn {user_id, attendances} ->
+      next_huddl =
+        attendances
+        |> Enum.map(&Map.fetch!(huddlz_by_id, &1.huddl_id))
+        |> Enum.min_by(& &1.starts_at, DateTime)
+
+      {user_id, next_huddl}
+    end)
   end
 
   @doc """

--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -49,10 +49,10 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
   preserving subscribers:
 
     * existing future instances are **updated in place** to the source's fields
-      and recomputed times (RSVPs untouched; each meaningful change emails that
-      instance's subscribers via the per-instance update notification)
+      and recomputed times (RSVPs untouched; the series change sends one summary
+      per affected person)
     * dates added by extending the series are **created**
-    * dates dropped by shortening the series / changing frequency are
+    * surplus dates dropped by shortening the series are
       **destroyed** (a real cancellation — their subscribers get the cancel notice)
 
   `actor` is the editor; it is threaded through so they are excluded from the
@@ -60,26 +60,57 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
   """
   def reconcile_future_instances(source, template, actor) do
     desired = desired_occurrences(source, template)
-    existing_by_date = Map.new(future_instances(source), &{occurrence_date(&1.starts_at), &1})
+    existing = Enum.sort_by(future_instances(source), & &1.starts_at, DateTime)
+    {retained, new_desired, obsolete_existing} = match_occurrences(existing, desired)
 
-    unmatched_existing =
-      Enum.reduce(desired, existing_by_date, fn {starts_at, ends_at}, remaining ->
-        case Map.pop(remaining, occurrence_date(starts_at)) do
+    Enum.each(retained, fn {instance, {starts_at, ends_at}} ->
+      update_instance!(instance, source, starts_at, ends_at, actor)
+    end)
+
+    Enum.each(new_desired, fn {starts_at, ends_at} ->
+      create_instance!(source, template, starts_at, ends_at)
+    end)
+
+    Enum.each(obsolete_existing, &destroy_instance!(&1, actor))
+
+    :ok
+  end
+
+  defp match_occurrences(existing, desired) do
+    # Preserve exact calendar-date matches first so repairing a missing
+    # occurrence never shifts a later RSVP onto the gap.
+    existing_by_date = Map.new(existing, &{DateTime.to_date(&1.starts_at), &1})
+
+    {exact_matches, unmatched_desired, remaining_by_date} =
+      Enum.reduce(desired, {[], [], existing_by_date}, fn desired_occurrence,
+                                                          {matches, unmatched, remaining} ->
+        {starts_at, _ends_at} = desired_occurrence
+
+        case Map.pop(remaining, DateTime.to_date(starts_at)) do
           {nil, remaining} ->
-            create_instance!(source, template, starts_at, ends_at)
-            remaining
+            {matches, [desired_occurrence | unmatched], remaining}
 
           {instance, remaining} ->
-            update_instance!(instance, source, starts_at, ends_at, actor)
-            remaining
+            {[{instance, desired_occurrence} | matches], unmatched, remaining}
         end
       end)
 
-    unmatched_existing
-    |> Map.values()
-    |> Enum.each(&destroy_instance!(&1, actor))
+    unmatched_desired = Enum.reverse(unmatched_desired)
 
-    :ok
+    unmatched_existing =
+      remaining_by_date |> Map.values() |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    # Pair anything left in chronological order. This preserves row identity
+    # when an edit shifts the whole schedule to dates with no exact matches.
+    {paired_existing, obsolete_existing} =
+      Enum.split(unmatched_existing, length(unmatched_desired))
+
+    {paired_desired, new_desired} =
+      Enum.split(unmatched_desired, length(paired_existing))
+
+    retained = Enum.reverse(exact_matches) ++ Enum.zip(paired_existing, paired_desired)
+
+    {retained, new_desired, obsolete_existing}
   end
 
   @doc """
@@ -138,8 +169,6 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     end)
     |> Enum.reverse()
   end
-
-  defp occurrence_date(datetime), do: DateTime.to_date(datetime)
 
   defp create_instance!(source, template, starts_at, ends_at) do
     instance =

--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -107,9 +107,10 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     end
   end
 
+  @doc false
   # Later instances in the series, read through the dedicated visibility-free
   # action so a private series is reached in full regardless of actor.
-  defp future_instances(source) do
+  def future_instances(source) do
     Huddl
     |> Ash.Query.for_read(:siblings_in_series, %{
       huddl_template_id: source.huddl_template_id,
@@ -215,6 +216,7 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     |> Ash.Changeset.new()
     |> Ash.Changeset.set_argument(:provided_latitude, source.latitude)
     |> Ash.Changeset.set_argument(:provided_longitude, source.longitude)
+    |> Ash.Changeset.set_argument(:suppress_update_notification, true)
     |> Ash.Changeset.for_update(
       :update,
       instance_attrs(source, starts_at, ends_at) |> Map.put(:edit_type, "instance")

--- a/lib/huddlz/communities/huddl_attendee.ex
+++ b/lib/huddlz/communities/huddl_attendee.ex
@@ -123,6 +123,17 @@ defmodule Huddlz.Communities.HuddlAttendee do
 
       filter expr(huddl_id == ^arg(:huddl_id) and user_id == ^actor(:id))
     end
+
+    read :notification_recipients do
+      description "Resolve RSVP and waitlist recipients for system-driven huddl notifications"
+
+      argument :huddl_ids, {:array, :uuid} do
+        allow_nil? false
+        constraints min_length: 1
+      end
+
+      filter expr(huddl_id in ^arg(:huddl_ids))
+    end
   end
 
   policies do

--- a/lib/huddlz/notifications.ex
+++ b/lib/huddlz/notifications.ex
@@ -53,6 +53,9 @@ defmodule Huddlz.Notifications do
   @unsubscribe_salt "notifications:unsubscribe"
   # 30 days — long enough for an email to sit in an inbox over a vacation.
   @unsubscribe_max_age 60 * 60 * 24 * 30
+  # Update notifications describe current state, so identical rapid retries
+  # should share both the email job and the canonical in-app row.
+  @deduplicated_in_app_triggers [:huddl_updated, :huddl_series_updated]
 
   @type deliver_result :: :sent | :skipped | {:error, term()}
 
@@ -72,16 +75,21 @@ defmodule Huddlz.Notifications do
   def deliver(%User{id: user_id}, trigger, payload \\ %{}) when is_atom(trigger) do
     _ = Triggers.fetch!(trigger)
 
-    persist_in_app_notification(user_id, trigger, payload)
-
     %{user_id: user_id, trigger: Atom.to_string(trigger), payload: payload}
     |> DeliverWorker.new()
     |> Oban.insert()
     |> case do
+      {:ok, %Oban.Job{conflict?: true} = job}
+      when trigger in @deduplicated_in_app_triggers ->
+        {:ok, job}
+
       {:ok, job} ->
+        persist_in_app_notification(user_id, trigger, payload)
         {:ok, job}
 
       {:error, reason} = err ->
+        persist_in_app_notification(user_id, trigger, payload)
+
         Logger.warning(
           "Failed to enqueue #{inspect(trigger)} notification for user #{user_id}: #{inspect(reason)}"
         )

--- a/lib/huddlz/notifications/senders/changed_fields.ex
+++ b/lib/huddlz/notifications/senders/changed_fields.ex
@@ -16,5 +16,8 @@ defmodule Huddlz.Notifications.Senders.ChangedFields do
   defp humanize("ends_at"), do: "the end time"
   defp humanize("physical_location"), do: "the location"
   defp humanize("virtual_link"), do: "the virtual link"
+  defp humanize("max_attendees"), do: "the capacity"
+  defp humanize("is_private"), do: "the privacy"
+  defp humanize("schedule"), do: "the recurring schedule"
   defp humanize(other) when is_binary(other), do: other
 end

--- a/lib/huddlz/notifications/senders/huddl_series_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_series_updated.ex
@@ -3,10 +3,10 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
   Sender for C4: a recurring huddl series was modified (the editor
   chose `edit_type: "all"`).
 
-  Sent to the RSVPs of the *next* upcoming instance in the series,
-  not to every instance's RSVPs — subsequent instances rely on their
-  own D1/D2 reminders to surface the new schedule. Activity category
-  — preferences and the unsubscribe footer apply.
+  Sent once to each person with an RSVP on a retained occurrence. The
+  payload points to that person's next upcoming RSVP, so the target remains
+  useful and authorized without sending one message per occurrence. Activity
+  category — preferences and the unsubscribe footer apply.
 
   Required payload keys are the same as C2 (`huddl_id`,
   `huddl_title`, `starts_at_iso`, `group_name`, `group_slug`,
@@ -61,8 +61,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
     is now scheduled for #{safe_when}. See it at
     <a href="#{huddl_url}">#{huddl_url}</a>.</p>
 
-    <p>Future instances in the series will be covered by their own
-    24-hour and 1-hour reminders.</p>
+    <p>You will still receive the usual reminders for each huddl you are attending.</p>
     #{footer_html}
     """)
     |> text_body("""
@@ -75,8 +74,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
     Your next upcoming instance, "#{huddl_title(payload)}", is now scheduled for
     #{when_text}. See it at #{huddl_url}.
 
-    Future instances in the series will be covered by their own 24-hour and
-    1-hour reminders.
+    You will still receive the usual reminders for each huddl you are attending.
     #{footer_text}
     """)
   end

--- a/lib/huddlz/notifications/senders/huddl_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_updated.ex
@@ -1,7 +1,8 @@
 defmodule Huddlz.Notifications.Senders.HuddlUpdated do
   @moduledoc """
   Sender for C2: a meaningful field on a huddl was changed (`title`,
-  `starts_at`, `ends_at`, `physical_location`, or `virtual_link`).
+  `starts_at`, `ends_at`, `physical_location`, `virtual_link`,
+  `max_attendees`, or `is_private`).
 
   Sent to every user who has currently RSVP'd, excluding the actor.
   Activity category — preferences and the unsubscribe footer apply.

--- a/lib/huddlz/notifications/senders/urls.ex
+++ b/lib/huddlz/notifications/senders/urls.ex
@@ -8,6 +8,8 @@ defmodule Huddlz.Notifications.Senders.Urls do
   use HuddlzWeb, :verified_routes
 
   @spec huddl_url(map()) :: String.t()
+  def huddl_url(%{"target_path" => "/notifications"}), do: url(~p"/notifications")
+
   def huddl_url(%{"group_slug" => slug, "huddl_id" => id})
       when is_binary(slug) and is_binary(id) do
     url(~p"/groups/#{slug}/huddlz/#{id}")

--- a/lib/huddlz/notifications/summary.ex
+++ b/lib/huddlz/notifications/summary.ex
@@ -12,7 +12,11 @@ defmodule Huddlz.Notifications.Summary do
   time-relative words ("tomorrow", "in 5 minutes", "now").
   """
 
+  alias Huddlz.Notifications.DateTimeFormatter
+  alias Huddlz.Notifications.Senders.ChangedFields
   alias Huddlz.Notifications.Triggers
+
+  @schedule_fields ["starts_at", "ends_at", "schedule"]
 
   @type result :: %{
           title: String.t(),
@@ -111,8 +115,11 @@ defmodule Huddlz.Notifications.Summary do
   defp description(:huddl_new, %{"starts_at_iso" => iso}),
     do: maybe_absolute_date("Starts ", iso)
 
-  defp description(:huddl_updated, %{"starts_at_iso" => iso}),
-    do: maybe_absolute_date("Now starts ", iso)
+  defp description(:huddl_updated, payload),
+    do: changed_description(payload, "Scheduled for ")
+
+  defp description(:huddl_series_updated, payload),
+    do: changed_description(payload, "Next huddl: ")
 
   defp description(:huddl_reminder_24h, %{"starts_at_iso" => iso}),
     do: maybe_absolute_date("Starts ", iso)
@@ -131,7 +138,32 @@ defmodule Huddlz.Notifications.Summary do
 
   defp maybe_absolute_date(_prefix, _), do: nil
 
+  defp changed_description(payload, schedule_prefix) do
+    changed = "Changed: #{ChangedFields.summary(payload)}."
+
+    if schedule_changed?(payload) do
+      changed <> " " <> schedule_prefix <> formatted_start(payload) <> "."
+    else
+      changed
+    end
+  end
+
+  defp schedule_changed?(%{"changed_fields" => fields}) when is_list(fields),
+    do: Enum.any?(fields, &(&1 in @schedule_fields))
+
+  defp schedule_changed?(_payload), do: false
+
+  defp formatted_start(payload) do
+    DateTimeFormatter.format_starts_at_iso(
+      payload["starts_at_iso"],
+      DateTimeFormatter.time_zone_from_payload(payload),
+      "the scheduled time"
+    )
+  end
+
   # ─── Source URLs ───────────────────────────────────────────────────────
+
+  defp source_url(_trigger, %{"target_path" => "/notifications"}), do: "/notifications"
 
   defp source_url(_trigger, %{"group_slug" => slug, "huddl_id" => huddl_id})
        when is_binary(slug) and is_binary(huddl_id),

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -184,8 +184,8 @@ defmodule HuddlzWeb.HuddlLive.Edit do
       <div class="page-head">
         <div>
           <h1>Editing {@huddl.title}</h1>
-          <p>
-            Updates to time, location, capacity, or privacy will email everyone who's RSVP'd.
+          <p id="attendee-notification-explanation">
+            Updates to the title, time, location, capacity, or privacy will notify affected people who've RSVP'd.
           </p>
         </div>
       </div>

--- a/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
+++ b/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
@@ -168,6 +168,48 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       end)
     end
 
+    test "includes capacity and privacy in the attendee-affecting change set" do
+      owner = generate(user(role: :user))
+      attendee = generate(user(display_name: "Attendee"))
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            max_attendees: 10
+          )
+        )
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      huddl
+      |> Ash.Changeset.for_update(
+        :update,
+        %{max_attendees: 5, is_private: true},
+        actor: owner
+      )
+      |> Ash.update!()
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.to == [{"", to_string(attendee.email)}] and
+          email.html_body =~ "the capacity" and
+          email.html_body =~ "the privacy"
+      end)
+    end
+
     test "skips notification when no meaningful field changes" do
       owner = generate(user(role: :user))
       attendee = generate(user())
@@ -192,6 +234,40 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       |> Ash.update!()
 
       refute_enqueued(worker: DeliverWorker)
+    end
+
+    test "deduplicates repeated stale submissions of the same meaningful update" do
+      owner = generate(user(role: :user))
+      attendee = generate(user())
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(huddl(title: "Saturday Soccer", group_id: group.id, actor: owner))
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      first_submission =
+        Ash.Changeset.for_update(huddl, :update, %{title: "Renamed"}, actor: owner)
+
+      repeated_stale_submission =
+        Ash.Changeset.for_update(huddl, :update, %{title: "Renamed"}, actor: owner)
+
+      Ash.update!(first_submission)
+      Ash.update!(repeated_stale_submission)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+
+      assert_email_sent(fn email ->
+        email.subject == "Updated: Renamed" and
+          email.to == [{"", to_string(attendee.email)}]
+      end)
     end
 
     test "skips the actor (the editor) even if they had RSVPd" do
@@ -226,7 +302,70 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
   end
 
   describe "edit_type=all: in-place updates preserve RSVPs and notify subscribers" do
-    test "emails the edited instance's own RSVPs" do
+    test "sends one series summary to a person attending multiple occurrences" do
+      owner = generate(user(role: :user))
+      attendee = generate(user(display_name: "Attendee"))
+
+      group =
+        generate(
+          group(
+            name: "Pickup Sports",
+            slug: "pickup-sports",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      original =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            date: Date.add(Date.utc_today(), 1),
+            is_recurring: true,
+            frequency: "weekly",
+            repeat_until: Date.add(Date.utc_today(), 30)
+          )
+        )
+
+      assert %{success: 1} = Oban.drain_queue(queue: :default)
+      occurrences = Enum.take(future_occurrences(original), 2)
+
+      for occurrence <- [original | occurrences] do
+        occurrence
+        |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+        |> Ash.update!()
+      end
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      original
+      |> Ash.Changeset.for_update(
+        :update,
+        %{
+          title: "Saturday Soccer (renamed)",
+          edit_type: "all",
+          repeat_until: Date.add(Date.utc_today(), 30),
+          frequency: "weekly"
+        },
+        actor: owner
+      )
+      |> Ash.update!()
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      emails = drain_mailbox()
+
+      assert Enum.count(emails) == 1
+      [email] = emails
+      assert email.subject == "Recurring series updated: Saturday Soccer (renamed)"
+      assert email.to == [{"", to_string(attendee.email)}]
+    end
+
+    test "includes the edited instance's own RSVPs in the series summary" do
       owner = generate(user(role: :user))
       attendee = generate(user(display_name: "Attendee"))
 
@@ -269,7 +408,7 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
           title: "Saturday Soccer (renamed)",
           edit_type: "all",
           repeat_until: Date.add(Date.utc_today(), 60),
-          frequency: "weekly"
+          frequency: "every_two_weeks"
         },
         actor: owner
       )
@@ -278,12 +417,13 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       assert %{success: 1} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
-        email.subject == "Updated: Saturday Soccer (renamed)" and
-          email.to == [{"", to_string(attendee.email)}]
+        email.subject == "Recurring series updated: Saturday Soccer (renamed)" and
+          email.to == [{"", to_string(attendee.email)}] and
+          email.html_body =~ "the recurring schedule"
       end)
     end
 
-    test "updates future occurrences in place, keeping their RSVPs, and emails those subscribers" do
+    test "updates future occurrences in place and summarizes changes for their subscribers" do
       owner = generate(user(role: :user))
       attendee = generate(user(display_name: "Attendee"))
 
@@ -343,8 +483,9 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       assert rsvped?(occurrence.id, attendee.id)
 
       assert_email_sent(fn email ->
-        email.subject == "Updated: Saturday Soccer (renamed)" and
-          email.to == [{"", to_string(attendee.email)}]
+        email.subject == "Recurring series updated: Saturday Soccer (renamed)" and
+          email.to == [{"", to_string(attendee.email)}] and
+          email.html_body =~ occurrence.id
       end)
     end
 

--- a/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
+++ b/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
@@ -12,8 +12,10 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
   import Swoosh.TestAssertions
   require Ash.Query
 
+  alias Huddlz.Communities
   alias Huddlz.Communities.Huddl
   alias Huddlz.Communities.HuddlAttendee
+  alias Huddlz.Notifications
   alias Huddlz.Notifications.DeliverWorker
 
   # Later instances of `source`'s series, oldest first.
@@ -142,9 +144,7 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
           )
         )
 
-      huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
-      |> Ash.update!()
+      Communities.rsvp_huddl!(huddl, %{}, actor: attendee)
 
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
@@ -193,21 +193,27 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
 
-      huddl
-      |> Ash.Changeset.for_update(
-        :update,
+      Communities.update_huddl!(
+        huddl,
         %{max_attendees: 5, is_private: true},
         actor: owner
       )
-      |> Ash.update!()
 
       assert %{success: 1} = Oban.drain_queue(queue: :notifications)
 
       assert_email_sent(fn email ->
         email.to == [{"", to_string(attendee.email)}] and
           email.html_body =~ "the capacity" and
-          email.html_body =~ "the privacy"
+          email.html_body =~ "the privacy" and
+          email.html_body =~ "/notifications" and
+          not String.contains?(email.html_body, "/huddlz/#{huddl.id}")
       end)
+
+      {:ok, %{results: notifications}} =
+        Notifications.list_for_user(actor: attendee, page: [limit: 10])
+
+      update = Enum.find(notifications, &(&1.trigger == "huddl_updated"))
+      assert update.source_url == "/notifications"
     end
 
     test "skips notification when no meaningful field changes" do
@@ -220,9 +226,7 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       huddl =
         generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
 
-      huddl
-      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
-      |> Ash.update!()
+      Communities.rsvp_huddl!(huddl, %{}, actor: attendee)
 
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
@@ -253,14 +257,8 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
 
-      first_submission =
-        Ash.Changeset.for_update(huddl, :update, %{title: "Renamed"}, actor: owner)
-
-      repeated_stale_submission =
-        Ash.Changeset.for_update(huddl, :update, %{title: "Renamed"}, actor: owner)
-
-      Ash.update!(first_submission)
-      Ash.update!(repeated_stale_submission)
+      Communities.update_huddl!(huddl, %{title: "Renamed"}, actor: owner)
+      Communities.update_huddl!(huddl, %{title: "Renamed"}, actor: owner)
 
       assert %{success: 1} = Oban.drain_queue(queue: :notifications)
 
@@ -268,6 +266,11 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
         email.subject == "Updated: Renamed" and
           email.to == [{"", to_string(attendee.email)}]
       end)
+
+      {:ok, %{results: notifications}} =
+        Notifications.list_for_user(actor: attendee, page: [limit: 10])
+
+      assert Enum.count(notifications, &(&1.trigger == "huddl_updated")) == 1
     end
 
     test "skips the actor (the editor) even if they had RSVPd" do
@@ -335,17 +338,14 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       occurrences = Enum.take(future_occurrences(original), 2)
 
       for occurrence <- [original | occurrences] do
-        occurrence
-        |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
-        |> Ash.update!()
+        Communities.rsvp_huddl!(occurrence, %{}, actor: attendee)
       end
 
       Oban.drain_queue(queue: :notifications)
       flush_mailbox()
 
-      original
-      |> Ash.Changeset.for_update(
-        :update,
+      Communities.update_huddl!(
+        original,
         %{
           title: "Saturday Soccer (renamed)",
           edit_type: "all",
@@ -354,7 +354,6 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
         },
         actor: owner
       )
-      |> Ash.update!()
 
       assert %{success: 1} = Oban.drain_queue(queue: :notifications)
       emails = drain_mailbox()
@@ -363,6 +362,78 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
       [email] = emails
       assert email.subject == "Recurring series updated: Saturday Soccer (renamed)"
       assert email.to == [{"", to_string(attendee.email)}]
+    end
+
+    test "moves future occurrences in place when the series date shifts" do
+      owner = generate(user(role: :user))
+      attendee = generate(user(display_name: "Attendee"))
+      start_date = Date.add(Date.utc_today(), 1)
+      repeat_until = Date.add(Date.utc_today(), 30)
+
+      group =
+        generate(
+          group(
+            name: "Pickup Sports",
+            slug: "pickup-sports",
+            is_public: true,
+            owner_id: owner.id,
+            actor: owner
+          )
+        )
+
+      original =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            date: start_date,
+            start_time: ~T[15:00:00],
+            is_recurring: true,
+            frequency: "weekly",
+            repeat_until: repeat_until
+          )
+        )
+
+      assert %{success: 1} = Oban.drain_queue(queue: :default)
+      [first_future | _] = future_occurrences(original)
+      Communities.rsvp_huddl!(first_future, %{}, actor: attendee)
+
+      Oban.drain_queue(queue: :notifications)
+      flush_mailbox()
+
+      updated =
+        Communities.update_huddl!(
+          original,
+          %{
+            date: Date.add(start_date, 1),
+            start_time: ~T[15:00:00],
+            duration_minutes: 60,
+            edit_type: "all",
+            repeat_until: repeat_until,
+            frequency: "weekly"
+          },
+          actor: owner
+        )
+
+      [shifted_first | _] = future_occurrences(updated)
+
+      assert shifted_first.id == first_future.id
+      assert rsvped?(shifted_first.id, attendee.id)
+
+      assert DateTime.to_date(shifted_first.starts_at) ==
+               Date.add(DateTime.to_date(first_future.starts_at), 1)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :notifications)
+      emails = drain_mailbox()
+
+      assert Enum.any?(emails, fn email ->
+               email.subject == "Recurring series updated: Saturday Soccer" and
+                 email.to == [{"", to_string(attendee.email)}]
+             end)
+
+      refute Enum.any?(emails, &(&1.subject == "Cancelled: Saturday Soccer"))
     end
 
     test "includes the edited instance's own RSVPs in the series summary" do

--- a/test/huddlz/notifications/notification_test.exs
+++ b/test/huddlz/notifications/notification_test.exs
@@ -27,6 +27,40 @@ defmodule Huddlz.Notifications.NotificationTest do
 
       assert is_nil(notification.read_at)
     end
+
+    test "does not persist a duplicate row when Oban rejects a duplicate job" do
+      user = generate(user(confirmed_at: DateTime.utc_now()))
+      payload = %{"huddl_title" => "Boat Drinks"}
+
+      assert {:ok, %Oban.Job{conflict?: false}} =
+               Notifications.deliver(user, :huddl_updated, payload)
+
+      assert {:ok, %Oban.Job{conflict?: true}} =
+               Notifications.deliver(user, :huddl_updated, payload)
+
+      {:ok, %{results: notifications}} =
+        Notifications.list_for_user(actor: user, page: [limit: 5])
+
+      assert [%Notification{trigger: "huddl_updated"}] = notifications
+    end
+
+    test "preserves distinct non-update activity when email jobs conflict" do
+      user = generate(user(confirmed_at: DateTime.utc_now()))
+
+      assert {:ok, %Oban.Job{conflict?: false}} =
+               Notifications.deliver(user, :password_changed)
+
+      assert {:ok, %Oban.Job{conflict?: true}} =
+               Notifications.deliver(user, :password_changed)
+
+      {:ok, %{results: notifications}} =
+        Notifications.list_for_user(actor: user, page: [limit: 5])
+
+      assert [
+               %Notification{trigger: "password_changed"},
+               %Notification{trigger: "password_changed"}
+             ] = notifications
+    end
   end
 
   describe "list_for_user :for_user" do

--- a/test/huddlz/notifications/senders/huddl_series_updated_test.exs
+++ b/test/huddlz/notifications/senders/huddl_series_updated_test.exs
@@ -43,7 +43,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdatedTest do
       assert email.subject == "Recurring series updated: Saturday Soccer"
     end
 
-    test "names the next upcoming instance and notes future instances cover themselves" do
+    test "names the next upcoming instance and notes normal reminders still apply" do
       user = generate(user())
 
       email =
@@ -55,8 +55,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdatedTest do
       assert email.html_body =~ "next upcoming instance"
       assert email.html_body =~ "Saturday Soccer"
       assert email.html_body =~ "Pickup Sports"
-      assert email.html_body =~ "Future instances"
-      assert email.html_body =~ "24-hour and 1-hour reminders"
+      assert email.html_body =~ "usual reminders"
     end
 
     test "humanizes the changed fields list" do
@@ -65,11 +64,15 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdatedTest do
       email =
         HuddlSeriesUpdated.build(
           user,
-          default_payload(%{"changed_fields" => ["starts_at", "physical_location"]})
+          default_payload(%{
+            "changed_fields" => ["starts_at", "physical_location", "max_attendees", "is_private"]
+          })
         )
 
       assert email.html_body =~ "the start time"
       assert email.html_body =~ "the location"
+      assert email.html_body =~ "the capacity"
+      assert email.html_body =~ "the privacy"
     end
 
     test "includes the unsubscribe footer (activity)" do

--- a/test/huddlz/notifications/senders/huddl_updated_test.exs
+++ b/test/huddlz/notifications/senders/huddl_updated_test.exs
@@ -67,6 +67,19 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdatedTest do
       assert email.html_body =~ "/groups/pickup-sports/huddlz/#{huddl_id}"
     end
 
+    test "links privacy-restricted recipients to their accessible updates page" do
+      user = generate(user())
+
+      email =
+        HuddlUpdated.build(
+          user,
+          default_payload(%{"target_path" => "/notifications"})
+        )
+
+      assert email.html_body =~ "/notifications"
+      refute email.html_body =~ "/groups/pickup-sports/huddlz/"
+    end
+
     test "includes the unsubscribe footer (activity)" do
       user = generate(user())
       email = HuddlUpdated.build(user, default_payload())

--- a/test/huddlz/notifications/summary_test.exs
+++ b/test/huddlz/notifications/summary_test.exs
@@ -37,6 +37,38 @@ defmodule Huddlz.Notifications.SummaryTest do
       assert result.description == "Starts May 10, 2026"
     end
 
+    test "huddl update copy identifies a time change and includes the new time" do
+      result =
+        Summary.summarize(:huddl_updated, %{
+          "changed_fields" => ["starts_at"],
+          "starts_at_iso" => "2026-05-10T09:30:00Z"
+        })
+
+      assert result.description ==
+               "Changed: the start time. Scheduled for Sun May 10, 2026 at 9:30 AM UTC."
+    end
+
+    test "huddl update copy identifies non-time changes without implying a schedule change" do
+      result =
+        Summary.summarize(:huddl_updated, %{
+          "changed_fields" => ["max_attendees", "is_private"],
+          "starts_at_iso" => "2026-05-10T09:30:00Z"
+        })
+
+      assert result.description == "Changed: the capacity, the privacy."
+    end
+
+    test "series update copy identifies the change and the next retained huddl" do
+      result =
+        Summary.summarize(:huddl_series_updated, %{
+          "changed_fields" => ["schedule"],
+          "starts_at_iso" => "2026-05-10T09:30:00Z"
+        })
+
+      assert result.description ==
+               "Changed: the recurring schedule. Next huddl: Sun May 10, 2026 at 9:30 AM UTC."
+    end
+
     test "description is nil when no date is present" do
       result = Summary.summarize(:rsvp_confirmation, %{"huddl_title" => "Boat Drinks"})
       assert is_nil(result.description)
@@ -50,6 +82,17 @@ defmodule Huddlz.Notifications.SummaryTest do
         })
 
       assert result.source_url == "/groups/phoenix-elixir-meetup/huddlz/abc"
+    end
+
+    test "source_url honors an accessible fallback target" do
+      result =
+        Summary.summarize(:huddl_updated, %{
+          "target_path" => "/notifications",
+          "huddl_id" => "abc",
+          "group_slug" => "phoenix-elixir-meetup"
+        })
+
+      assert result.source_url == "/notifications"
     end
 
     test "source_url falls back to a group page when only group_slug is present" do

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -213,6 +213,21 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       assert_has(session, "input[name='form[event_type]'][type='radio']")
     end
 
+    test "explains the same attendee-affecting changes as the domain", %{
+      conn: conn,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit")
+      |> assert_has(
+        "#attendee-notification-explanation",
+        text: "title, time, location, capacity, or privacy"
+      )
+    end
+
     test "shows calculated end time", %{
       conn: conn,
       owner: owner,


### PR DESCRIPTION
## Summary

- align the edit-page promise with attendee-affecting title, time, location, capacity, and privacy changes
- preserve recurring RSVP rows through schedule shifts and send one accessible series summary per affected person
- keep email and in-app copy accurate while deduplicating repeated update notifications

Closes #301