### PR TITLE
Make the mobile navigation drawer accessible

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -54,6 +54,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Test JavaScript components
+      run: npm test --prefix assets
+
     # Step: Copy test environment file
     - name: Setup test environment
       run: cp .test.env.example .test.env

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -279,10 +279,16 @@ body.is-signed-out .main { min-height: 100vh; }
   }
 }
 
-/* Mobile nav toggle (CSS-only checkbox hack) */
-body .nav-toggle { display: none; }
+/* Stateful mobile navigation */
 body .nav-trigger { display: none; }
 body .nav-scrim { display: none; }
+body .nav-close { display: none; }
+
+body .sidebar-brand > a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 
 @media (max-width: 760px) {
 
@@ -306,6 +312,11 @@ body .nav-scrim { display: none; }
 
   body .nav-trigger svg { width: 18px; height: 18px; }
   body .nav-trigger:hover { color: var(--cyan); border-color: var(--cyan); }
+  body .nav-trigger:focus-visible,
+  body .nav-close:focus-visible {
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+  }
 
   /* Sidebar becomes a slide-in drawer */
   body:not(.is-landing):not(.is-auth) .sidebar {
@@ -316,28 +327,73 @@ body .nav-scrim { display: none; }
     width: min(320px, 86vw);
     z-index: 60;
     transform: translateX(-100%);
-    transition: transform 200ms ease;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      transform 200ms ease,
+      visibility 0s linear 200ms;
     box-shadow: var(--shadow);
     background: var(--panel);
   }
 
+  body.mobile-nav-open:not(.is-landing):not(.is-auth) .sidebar {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+    transition-delay: 0s;
+  }
+
   /* Scrim */
   body .nav-scrim {
+    display: block;
     position: fixed;
     inset: 0;
     z-index: 50;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
     background: rgba(0, 0, 0, 0.55);
     opacity: 0;
+    visibility: hidden;
     pointer-events: none;
-    transition: opacity 200ms ease;
+    transition:
+      opacity 200ms ease,
+      visibility 0s linear 200ms;
   }
 
-  /* Open state */
-  body:not(.is-landing):not(.is-auth) .nav-toggle:checked ~ .sidebar { transform: translateX(0); }
-  body:not(.is-landing):not(.is-auth) .nav-toggle:checked ~ .nav-scrim {
-    display: block;
+  body.mobile-nav-open .nav-scrim {
     opacity: 1;
+    visibility: visible;
     pointer-events: auto;
+    transition-delay: 0s;
+  }
+
+  body.mobile-nav-open { overflow: hidden; }
+
+  body .nav-close {
+    display: inline-grid;
+    place-items: center;
+    width: 36px;
+    height: 36px;
+    margin-left: auto;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--soft);
+    cursor: pointer;
+  }
+
+  body .nav-close:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    body:not(.is-landing):not(.is-auth) .sidebar,
+    body .nav-scrim {
+      transition: none;
+    }
   }
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -551,10 +551,16 @@ body.is-signed-out .main { min-height: 100vh; }
   }
 }
 
-/* Mobile nav toggle (CSS-only checkbox hack) */
-body .nav-toggle { display: none; }
+/* Stateful mobile navigation */
 body .nav-trigger { display: none; }
 body .nav-scrim { display: none; }
+body .nav-close { display: none; }
+
+body .sidebar-brand > a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 
 @media (max-width: 760px) {
 
@@ -578,6 +584,11 @@ body .nav-scrim { display: none; }
 
   body .nav-trigger svg { width: 18px; height: 18px; }
   body .nav-trigger:hover { color: var(--cyan); border-color: var(--cyan); }
+  body .nav-trigger:focus-visible,
+  body .nav-close:focus-visible {
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+  }
 
   /* Sidebar becomes a slide-in drawer */
   body:not(.is-landing):not(.is-auth) .sidebar {
@@ -589,28 +600,73 @@ body .nav-scrim { display: none; }
     height: auto;
     z-index: 60;
     transform: translateX(-100%);
-    transition: transform 200ms ease;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      transform 200ms ease,
+      visibility 0s linear 200ms;
     box-shadow: var(--shadow);
     background: var(--panel);
   }
 
+  body.mobile-nav-open:not(.is-landing):not(.is-auth) .sidebar {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+    transition-delay: 0s;
+  }
+
   /* Scrim */
   body .nav-scrim {
+    display: block;
     position: fixed;
     inset: 0;
     z-index: 50;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
     background: rgba(0, 0, 0, 0.55);
     opacity: 0;
+    visibility: hidden;
     pointer-events: none;
-    transition: opacity 200ms ease;
+    transition:
+      opacity 200ms ease,
+      visibility 0s linear 200ms;
   }
 
-  /* Open state */
-  body:not(.is-landing):not(.is-auth) .nav-toggle:checked ~ .sidebar { transform: translateX(0); }
-  body:not(.is-landing):not(.is-auth) .nav-toggle:checked ~ .nav-scrim {
-    display: block;
+  body.mobile-nav-open .nav-scrim {
     opacity: 1;
+    visibility: visible;
     pointer-events: auto;
+    transition-delay: 0s;
+  }
+
+  body.mobile-nav-open { overflow: hidden; }
+
+  body .nav-close {
+    display: inline-grid;
+    place-items: center;
+    width: 36px;
+    height: 36px;
+    margin-left: auto;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--soft);
+    cursor: pointer;
+  }
+
+  body .nav-close:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    body:not(.is-landing):not(.is-auth) .sidebar,
+    body .nav-scrim {
+      transition: none;
+    }
   }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,6 +23,7 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import {mountMobileNavigation} from "./mobile_navigation.mjs"
 
 const Hooks = {}
 
@@ -166,6 +167,8 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()
+
+mountMobileNavigation()
 
 // "/" focuses the chrome search box, GitHub-style. Skipped while the user
 // is already typing in an editable field, or when modifier keys are held.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,6 +23,7 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import {mountMobileNavigation} from "./mobile_navigation.mjs"
 
 const Hooks = {}
 
@@ -78,6 +79,8 @@ window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()
+
+mountMobileNavigation()
 
 // "/" focuses the chrome search box, GitHub-style. Skipped while the user
 // is already typing in an editable field, or when modifier keys are held.

--- a/assets/js/mobile_navigation.mjs
+++ b/assets/js/mobile_navigation.mjs
@@ -1,0 +1,193 @@
+const MOBILE_NAVIGATION_QUERY = "(max-width: 760px)"
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])"
+].join(",")
+
+export class MobileNavigation {
+  constructor(documentRef = document, windowRef = window) {
+    this.document = documentRef
+    this.window = windowRef
+    this.listeners = []
+    this.opened = false
+
+    this.handleClick = this.handleClick.bind(this)
+    this.handleKeydown = this.handleKeydown.bind(this)
+    this.handleBreakpointChange = this.handleBreakpointChange.bind(this)
+  }
+
+  mount() {
+    this.trigger = this.document.querySelector("[data-mobile-nav-trigger]")
+    this.drawer = this.document.querySelector("#mobile-navigation-drawer")
+    this.scrim = this.document.querySelector("[data-mobile-nav-scrim]")
+    this.background = this.document.querySelector("[data-mobile-nav-background]")
+    this.closeButton = this.document.querySelector("[data-mobile-nav-close]")
+
+    if (!this.trigger || !this.drawer || !this.scrim || !this.background || !this.closeButton) {
+      return false
+    }
+
+    this.mobileQuery = this.window.matchMedia(MOBILE_NAVIGATION_QUERY)
+    this.listen(this.document, "click", this.handleClick)
+    this.listen(this.document, "keydown", this.handleKeydown)
+    this.listen(this.mobileQuery, "change", this.handleBreakpointChange)
+    this.syncResponsiveState()
+    this.observeLiveViewPatches()
+
+    return true
+  }
+
+  destroy() {
+    for (const removeListener of this.listeners) removeListener()
+    this.listeners = []
+    if (this.observer) this.observer.disconnect()
+    this.close({restoreFocus: false})
+  }
+
+  open() {
+    if (!this.mobileQuery.matches || this.opened) return
+
+    this.opened = true
+    this.syncDomState()
+    this.closeButton.focus()
+  }
+
+  close({restoreFocus = true} = {}) {
+    const wasOpen = this.opened
+
+    this.opened = false
+    this.syncDomState()
+
+    if (wasOpen && restoreFocus && this.mobileQuery.matches) this.trigger.focus()
+  }
+
+  syncResponsiveState() {
+    if (this.mobileQuery.matches) {
+      this.close({restoreFocus: false})
+    } else {
+      this.opened = false
+      this.syncDomState()
+    }
+  }
+
+  syncDomState() {
+    if (this.opened) {
+      this.setDatasetState("open")
+      this.setAttribute(this.drawer, "inert", false)
+      this.setAttribute(this.background, "inert", true)
+      this.setAttribute(this.trigger, "aria-expanded", "true")
+      this.document.body.classList.add("mobile-nav-open")
+    } else {
+      this.setDatasetState(this.mobileQuery.matches ? "closed" : "desktop")
+      this.setAttribute(this.drawer, "inert", this.mobileQuery.matches)
+      this.setAttribute(this.background, "inert", false)
+      this.setAttribute(this.trigger, "aria-expanded", "false")
+      this.document.body.classList.remove("mobile-nav-open")
+    }
+  }
+
+  handleClick(event) {
+    if (event.target.closest("[data-mobile-nav-trigger]")) {
+      if (this.opened) {
+        this.close()
+      } else {
+        this.open()
+      }
+
+      return
+    }
+
+    if (
+      event.target.closest("[data-mobile-nav-close]") ||
+      event.target.closest("[data-mobile-nav-scrim]")
+    ) {
+      this.close()
+      return
+    }
+
+    if (this.opened && event.target.closest("#mobile-navigation-drawer a[href]")) {
+      this.close({restoreFocus: false})
+    }
+  }
+
+  handleKeydown(event) {
+    if (!this.opened) return
+
+    if (event.key === "Escape") {
+      event.preventDefault()
+      this.close()
+      return
+    }
+
+    if (event.key !== "Tab") return
+
+    const focusable = this.focusableElements()
+    if (focusable.length === 0) {
+      event.preventDefault()
+      this.drawer.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const activeElement = this.document.activeElement
+
+    if (event.shiftKey && (activeElement === first || !this.drawer.contains(activeElement))) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && (activeElement === last || !this.drawer.contains(activeElement))) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  handleBreakpointChange() {
+    this.syncResponsiveState()
+  }
+
+  focusableElements() {
+    return Array.from(this.drawer.querySelectorAll(FOCUSABLE_SELECTOR)).filter(element => {
+      return !element.hasAttribute("hidden") && element.getClientRects().length > 0
+    })
+  }
+
+  listen(target, eventName, handler) {
+    target.addEventListener(eventName, handler)
+    this.listeners.push(() => target.removeEventListener(eventName, handler))
+  }
+
+  observeLiveViewPatches() {
+    if (!this.window.MutationObserver) return
+
+    this.observer = new this.window.MutationObserver(() => this.syncDomState())
+
+    for (const element of [this.trigger, this.drawer, this.background]) {
+      this.observer.observe(element, {attributes: true})
+    }
+  }
+
+  setDatasetState(state) {
+    if (this.drawer.dataset.mobileNavState !== state) {
+      this.drawer.dataset.mobileNavState = state
+    }
+  }
+
+  setAttribute(element, name, value) {
+    if (value === false) {
+      if (element.hasAttribute(name)) element.removeAttribute(name)
+    } else if (value === true) {
+      if (!element.hasAttribute(name)) element.setAttribute(name, "")
+    } else if (element.getAttribute(name) !== value) {
+      element.setAttribute(name, value)
+    }
+  }
+}
+
+export function mountMobileNavigation(documentRef = document, windowRef = window) {
+  const navigation = new MobileNavigation(documentRef, windowRef)
+  return navigation.mount() ? navigation : null
+}

--- a/assets/js/mobile_navigation_test.mjs
+++ b/assets/js/mobile_navigation_test.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {MobileNavigation} from "./mobile_navigation.mjs"
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set()
+  }
+
+  add(value) {
+    this.values.add(value)
+  }
+
+  remove(value) {
+    this.values.delete(value)
+  }
+
+  contains(value) {
+    return this.values.has(value)
+  }
+}
+
+class FakeElement {
+  constructor(documentRef) {
+    this.document = documentRef
+    this.attributes = new Map()
+    this.classList = new FakeClassList()
+    this.dataset = {}
+    this.focusable = []
+    this.closestMatches = new Set()
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, value)
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name)
+  }
+
+  hasAttribute(name) {
+    return this.attributes.has(name)
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null
+  }
+
+  focus() {
+    this.document.activeElement = this
+  }
+
+  contains(element) {
+    return element === this || this.focusable.includes(element)
+  }
+
+  querySelectorAll() {
+    return this.focusable
+  }
+
+  getClientRects() {
+    return [{}]
+  }
+
+  closest(selector) {
+    return this.closestMatches.has(selector) ? this : null
+  }
+}
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map()
+  }
+
+  addEventListener(name, handler) {
+    this.listeners.set(name, handler)
+  }
+
+  removeEventListener(name) {
+    this.listeners.delete(name)
+  }
+}
+
+function setup({mobile = true} = {}) {
+  const documentRef = new FakeEventTarget()
+  documentRef.body = new FakeElement(documentRef)
+  documentRef.activeElement = null
+
+  const trigger = new FakeElement(documentRef)
+  const drawer = new FakeElement(documentRef)
+  const scrim = new FakeElement(documentRef)
+  const background = new FakeElement(documentRef)
+  const closeButton = new FakeElement(documentRef)
+  const brandLink = new FakeElement(documentRef)
+  const firstLink = new FakeElement(documentRef)
+  const lastLink = new FakeElement(documentRef)
+  drawer.focusable = [brandLink, closeButton, firstLink, lastLink]
+
+  trigger.closestMatches.add("[data-mobile-nav-trigger]")
+  scrim.closestMatches.add("[data-mobile-nav-scrim]")
+  closeButton.closestMatches.add("[data-mobile-nav-close]")
+  firstLink.closestMatches.add("#mobile-navigation-drawer a[href]")
+
+  const elements = new Map([
+    ["[data-mobile-nav-trigger]", trigger],
+    ["#mobile-navigation-drawer", drawer],
+    ["[data-mobile-nav-scrim]", scrim],
+    ["[data-mobile-nav-background]", background],
+    ["[data-mobile-nav-close]", closeButton]
+  ])
+  documentRef.querySelector = selector => elements.get(selector)
+
+  const mediaQuery = new FakeEventTarget()
+  mediaQuery.matches = mobile
+  const windowRef = {matchMedia: () => mediaQuery}
+
+  const navigation = new MobileNavigation(documentRef, windowRef)
+  assert.equal(navigation.mount(), true)
+
+  return {
+    navigation,
+    documentRef,
+    mediaQuery,
+    trigger,
+    drawer,
+    scrim,
+    background,
+    closeButton,
+    brandLink,
+    firstLink,
+    lastLink
+  }
+}
+
+function keyEvent(key, {shiftKey = false} = {}) {
+  return {
+    key,
+    shiftKey,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    }
+  }
+}
+
+test("opens with focus in the drawer and makes the background inert", () => {
+  const {navigation, documentRef, trigger, drawer, background, closeButton} = setup()
+
+  assert.equal(drawer.hasAttribute("inert"), true)
+  navigation.open()
+
+  assert.equal(drawer.dataset.mobileNavState, "open")
+  assert.equal(drawer.hasAttribute("inert"), false)
+  assert.equal(background.hasAttribute("inert"), true)
+  assert.equal(trigger.attributes.get("aria-expanded"), "true")
+  assert.equal(documentRef.activeElement, closeButton)
+})
+
+test("Escape closes the drawer and restores focus to the hamburger", () => {
+  const {navigation, documentRef, trigger, drawer, background} = setup()
+  navigation.open()
+  const event = keyEvent("Escape")
+
+  navigation.handleKeydown(event)
+
+  assert.equal(event.defaultPrevented, true)
+  assert.equal(drawer.dataset.mobileNavState, "closed")
+  assert.equal(background.hasAttribute("inert"), false)
+  assert.equal(trigger.attributes.get("aria-expanded"), "false")
+  assert.equal(documentRef.activeElement, trigger)
+})
+
+test("Tab and Shift+Tab wrap within the drawer", () => {
+  const {navigation, documentRef, brandLink, lastLink} = setup()
+  navigation.open()
+
+  documentRef.activeElement = lastLink
+  const tab = keyEvent("Tab")
+  navigation.handleKeydown(tab)
+  assert.equal(tab.defaultPrevented, true)
+  assert.equal(documentRef.activeElement, brandLink)
+
+  documentRef.activeElement = brandLink
+  const shiftTab = keyEvent("Tab", {shiftKey: true})
+  navigation.handleKeydown(shiftTab)
+  assert.equal(shiftTab.defaultPrevented, true)
+  assert.equal(documentRef.activeElement, lastLink)
+})
+
+test("the trigger, close control, and backdrop all update drawer state", () => {
+  const {navigation, documentRef, trigger, scrim, closeButton} = setup()
+
+  navigation.handleClick({target: trigger})
+  assert.equal(navigation.opened, true)
+  assert.equal(documentRef.activeElement, closeButton)
+
+  navigation.handleClick({target: closeButton})
+  assert.equal(navigation.opened, false)
+  assert.equal(documentRef.activeElement, trigger)
+
+  navigation.handleClick({target: trigger})
+  navigation.handleClick({target: scrim})
+  assert.equal(navigation.opened, false)
+  assert.equal(documentRef.activeElement, trigger)
+})
+
+test("following a drawer link closes without stealing navigation focus", () => {
+  const {navigation, documentRef, firstLink, closeButton} = setup()
+  navigation.open()
+  firstLink.focus()
+
+  navigation.handleClick({target: firstLink})
+
+  assert.equal(navigation.opened, false)
+  assert.equal(documentRef.activeElement, firstLink)
+  assert.notEqual(documentRef.activeElement, closeButton)
+})
+
+test("switching to desktop removes drawer and background restrictions", () => {
+  const {navigation, mediaQuery, drawer, background, trigger} = setup()
+  navigation.open()
+
+  mediaQuery.matches = false
+  navigation.handleBreakpointChange()
+
+  assert.equal(drawer.dataset.mobileNavState, "desktop")
+  assert.equal(drawer.hasAttribute("inert"), false)
+  assert.equal(background.hasAttribute("inert"), false)
+  assert.equal(trigger.attributes.get("aria-expanded"), "false")
+})

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "node --test js/*_test.mjs"
+  }
+}

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -54,10 +54,9 @@ defmodule HuddlzWeb.Layouts do
         type="button"
         class="nav-scrim"
         data-mobile-nav-scrim
-        aria-label="Close navigation"
+        aria-hidden="true"
         tabindex="-1"
-      >
-      </button>
+      ></button>
       <aside
         id="mobile-navigation-drawer"
         class="sidebar"

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -49,28 +49,66 @@ defmodule HuddlzWeb.Layouts do
 
     ~H"""
     <%= if @signed_in do %>
-      <input type="checkbox" id="nav-toggle" class="nav-toggle" />
-      <label for="nav-toggle" class="nav-scrim" aria-hidden="true"></label>
-      <aside class="sidebar">
-        <a class="sidebar-brand" href="/">
-          <div class="brand-glyph">h</div>
-          <div class="brand-text">huddlz</div>
-        </a>
+      <button
+        type="button"
+        class="nav-scrim"
+        data-mobile-nav-scrim
+        aria-label="Close navigation"
+        tabindex="-1"
+      >
+      </button>
+      <aside
+        id="mobile-navigation-drawer"
+        class="sidebar"
+        data-mobile-nav-state="closed"
+        aria-label="Primary navigation"
+      >
+        <div class="sidebar-brand">
+          <a href="/" aria-label="huddlz home">
+            <div class="brand-glyph">h</div>
+            <div class="brand-text">huddlz</div>
+          </a>
+          <button
+            type="button"
+            id="mobile-nav-close"
+            class="nav-close"
+            data-mobile-nav-close
+            aria-label="Close navigation"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
 
         <nav class="sb-nav">
-          <a class={["sb-item", @active == "discover" && "active"]} href="/discover">
+          <a
+            class={["sb-item", @active == "discover" && "active"]}
+            href="/discover"
+            aria-current={@active == "discover" && "page"}
+          >
             <.nav_icon name="search" />
             <span class="label">Discover</span>
           </a>
-          <a class={["sb-item", @active == "my-huddlz" && "active"]} href="/my-huddlz">
+          <a
+            class={["sb-item", @active == "my-huddlz" && "active"]}
+            href="/my-huddlz"
+            aria-current={@active == "my-huddlz" && "page"}
+          >
             <.nav_icon name="ticket" />
             <span class="label">My huddlz</span>
           </a>
-          <a class={["sb-item", @active == "my-groups" && "active"]} href="/my-groups">
+          <a
+            class={["sb-item", @active == "my-groups" && "active"]}
+            href="/my-groups"
+            aria-current={@active == "my-groups" && "page"}
+          >
             <.nav_icon name="users" />
             <span class="label">My groups</span>
           </a>
-          <a class={["sb-item", @active == "calendar" && "active"]} href="/calendar">
+          <a
+            class={["sb-item", @active == "calendar" && "active"]}
+            href="/calendar"
+            aria-current={@active == "calendar" && "page"}
+          >
             <.nav_icon name="calendar" />
             <span class="label">My calendar</span>
           </a>
@@ -83,6 +121,9 @@ defmodule HuddlzWeb.Layouts do
                   @active_group_slug == group.slug && "active"
                 ]}
                 href={"/organize/#{group.slug}"}
+                aria-current={
+                  @active_group_slug == group.slug && is_nil(@active_organize_section) && "page"
+                }
               >
                 <div class={["group-mark", group_mark_variant(idx)]}>
                   {group_initials(group.name)}
@@ -93,18 +134,21 @@ defmodule HuddlzWeb.Layouts do
                 <a
                   class={["sb-sub-item", @active_organize_section == :overview && "active"]}
                   href={"/organize/#{group.slug}"}
+                  aria-current={@active_organize_section == :overview && "page"}
                 >
                   Overview
                 </a>
                 <a
                   class={["sb-sub-item", @active_organize_section == :huddlz && "active"]}
                   href={"/organize/#{group.slug}/huddlz"}
+                  aria-current={@active_organize_section == :huddlz && "page"}
                 >
                   Huddlz
                 </a>
                 <a
                   class={["sb-sub-item", @active_organize_section == :members && "active"]}
                   href={"/organize/#{group.slug}/members"}
+                  aria-current={@active_organize_section == :members && "page"}
                 >
                   Members
                 </a>
@@ -118,18 +162,27 @@ defmodule HuddlzWeb.Layouts do
         </nav>
 
         <div class="sb-account">
-          <a class={["sb-item", @active == "profile" && "active"]} href="/profile">
+          <a
+            class={["sb-item", @active == "profile" && "active"]}
+            href="/profile"
+            aria-current={@active == "profile" && "page"}
+          >
             <.nav_icon name="user" />
             <span class="label">Profile</span>
           </a>
           <a
             class={["sb-item", @active == "settings" && "active"]}
             href="/profile/notifications"
+            aria-current={@active == "settings" && "page"}
           >
             <.nav_icon name="cog" />
             <span class="label">Settings</span>
           </a>
-          <a class={["sb-item", @active == "help" && "active"]} href="/help">
+          <a
+            class={["sb-item", @active == "help" && "active"]}
+            href="/help"
+            aria-current={@active == "help" && "page"}
+          >
             <.nav_icon name="help" />
             <span class="label">Help</span>
           </a>
@@ -144,7 +197,11 @@ defmodule HuddlzWeb.Layouts do
             <span class="label">Sign out</span>
           </.link>
           <%= if User.admin?(@current_user) do %>
-            <a class={["sb-item", @active == "admin" && "active"]} href="/admin">
+            <a
+              class={["sb-item", @active == "admin" && "active"]}
+              href="/admin"
+              aria-current={@active == "admin" && "page"}
+            >
               <.nav_icon name="shield" />
               <span class="label">Admin</span>
             </a>
@@ -161,12 +218,20 @@ defmodule HuddlzWeb.Layouts do
       </aside>
     <% end %>
 
-    <main class="main">
+    <main class="main" data-mobile-nav-background>
       <header class="content-topbar">
         <%= if @signed_in do %>
-          <label for="nav-toggle" class="nav-trigger" aria-label="Open navigation">
+          <button
+            type="button"
+            id="mobile-nav-trigger"
+            class="nav-trigger"
+            data-mobile-nav-trigger
+            aria-label="Open navigation"
+            aria-controls="mobile-navigation-drawer"
+            aria-expanded="false"
+          >
             <.nav_icon name="bars" />
-          </label>
+          </button>
         <% else %>
           <a class="topbar-brand" href="/" aria-label="huddlz home">
             <div class="brand-glyph">h</div>

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -50,28 +50,66 @@ defmodule HuddlzWeb.Layouts do
 
     ~H"""
     <%= if @signed_in do %>
-      <input type="checkbox" id="nav-toggle" class="nav-toggle" />
-      <label for="nav-toggle" class="nav-scrim" aria-hidden="true"></label>
-      <aside class="sidebar">
-        <a class="sidebar-brand" href="/">
-          <div class="brand-glyph">h</div>
-          <div class="brand-text">huddlz</div>
-        </a>
+      <button
+        type="button"
+        class="nav-scrim"
+        data-mobile-nav-scrim
+        aria-label="Close navigation"
+        tabindex="-1"
+      >
+      </button>
+      <aside
+        id="mobile-navigation-drawer"
+        class="sidebar"
+        data-mobile-nav-state="closed"
+        aria-label="Primary navigation"
+      >
+        <div class="sidebar-brand">
+          <a href="/" aria-label="huddlz home">
+            <div class="brand-glyph">h</div>
+            <div class="brand-text">huddlz</div>
+          </a>
+          <button
+            type="button"
+            id="mobile-nav-close"
+            class="nav-close"
+            data-mobile-nav-close
+            aria-label="Close navigation"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+          </button>
+        </div>
 
         <nav class="sb-nav">
-          <a class={["sb-item", @active == "discover" && "active"]} href="/discover">
+          <a
+            class={["sb-item", @active == "discover" && "active"]}
+            href="/discover"
+            aria-current={@active == "discover" && "page"}
+          >
             <.nav_icon name="search" />
             <span class="label">Discover</span>
           </a>
-          <a class={["sb-item", @active == "my-huddlz" && "active"]} href="/my-huddlz">
+          <a
+            class={["sb-item", @active == "my-huddlz" && "active"]}
+            href="/my-huddlz"
+            aria-current={@active == "my-huddlz" && "page"}
+          >
             <.nav_icon name="ticket" />
             <span class="label">My huddlz</span>
           </a>
-          <a class={["sb-item", @active == "my-groups" && "active"]} href="/my-groups">
+          <a
+            class={["sb-item", @active == "my-groups" && "active"]}
+            href="/my-groups"
+            aria-current={@active == "my-groups" && "page"}
+          >
             <.nav_icon name="users" />
             <span class="label">My groups</span>
           </a>
-          <a class={["sb-item", @active == "calendar" && "active"]} href="/calendar">
+          <a
+            class={["sb-item", @active == "calendar" && "active"]}
+            href="/calendar"
+            aria-current={@active == "calendar" && "page"}
+          >
             <.nav_icon name="calendar" />
             <span class="label">My calendar</span>
           </a>
@@ -84,6 +122,9 @@ defmodule HuddlzWeb.Layouts do
                   @active_group_slug == group.slug && "active"
                 ]}
                 href={"/organize/#{group.slug}"}
+                aria-current={
+                  @active_group_slug == group.slug && is_nil(@active_organize_section) && "page"
+                }
               >
                 <div class={["group-mark", group_mark_variant(idx)]}>
                   {group_initials(group.name)}
@@ -94,18 +135,21 @@ defmodule HuddlzWeb.Layouts do
                 <a
                   class={["sb-sub-item", @active_organize_section == :overview && "active"]}
                   href={"/organize/#{group.slug}"}
+                  aria-current={@active_organize_section == :overview && "page"}
                 >
                   Overview
                 </a>
                 <a
                   class={["sb-sub-item", @active_organize_section == :huddlz && "active"]}
                   href={"/organize/#{group.slug}/huddlz"}
+                  aria-current={@active_organize_section == :huddlz && "page"}
                 >
                   Huddlz
                 </a>
                 <a
                   class={["sb-sub-item", @active_organize_section == :members && "active"]}
                   href={"/organize/#{group.slug}/members"}
+                  aria-current={@active_organize_section == :members && "page"}
                 >
                   Members
                 </a>
@@ -119,18 +163,27 @@ defmodule HuddlzWeb.Layouts do
         </nav>
 
         <div class="sb-account">
-          <a class={["sb-item", @active == "profile" && "active"]} href="/profile">
+          <a
+            class={["sb-item", @active == "profile" && "active"]}
+            href="/profile"
+            aria-current={@active == "profile" && "page"}
+          >
             <.nav_icon name="user" />
             <span class="label">Profile</span>
           </a>
           <a
             class={["sb-item", @active == "settings" && "active"]}
             href="/profile/notifications"
+            aria-current={@active == "settings" && "page"}
           >
             <.nav_icon name="cog" />
             <span class="label">Settings</span>
           </a>
-          <a class={["sb-item", @active == "help" && "active"]} href="/help">
+          <a
+            class={["sb-item", @active == "help" && "active"]}
+            href="/help"
+            aria-current={@active == "help" && "page"}
+          >
             <.nav_icon name="help" />
             <span class="label">Help</span>
           </a>
@@ -145,7 +198,11 @@ defmodule HuddlzWeb.Layouts do
             <span class="label">Sign out</span>
           </.link>
           <%= if User.admin?(@current_user) do %>
-            <a class={["sb-item", @active == "admin" && "active"]} href="/admin">
+            <a
+              class={["sb-item", @active == "admin" && "active"]}
+              href="/admin"
+              aria-current={@active == "admin" && "page"}
+            >
               <.nav_icon name="shield" />
               <span class="label">Admin</span>
             </a>
@@ -162,12 +219,20 @@ defmodule HuddlzWeb.Layouts do
       </aside>
     <% end %>
 
-    <main class="main">
+    <main class="main" data-mobile-nav-background>
       <header class="content-topbar">
         <%= if @signed_in do %>
-          <label for="nav-toggle" class="nav-trigger" aria-label="Open navigation">
+          <button
+            type="button"
+            id="mobile-nav-trigger"
+            class="nav-trigger"
+            data-mobile-nav-trigger
+            aria-label="Open navigation"
+            aria-controls="mobile-navigation-drawer"
+            aria-expanded="false"
+          >
             <.nav_icon name="bars" />
-          </label>
+          </button>
         <% else %>
           <a class="topbar-brand" href="/" aria-label="huddlz home">
             <div class="brand-glyph">h</div>

--- a/lib/huddlz_web/controllers/dev_design_html.ex
+++ b/lib/huddlz_web/controllers/dev_design_html.ex
@@ -36,12 +36,34 @@ defmodule HuddlzWeb.DevDesignHTML do
         {render_slot(@inner_block)}
       <% else %>
         <%= if @signed_in do %>
-          <input type="checkbox" id="nav-toggle" class="nav-toggle" />
-          <label for="nav-toggle" class="nav-scrim" aria-hidden="true"></label>
-          <aside class="sidebar">
+          <button
+            type="button"
+            class="nav-scrim"
+            data-mobile-nav-scrim
+            aria-label="Close navigation"
+            tabindex="-1"
+          >
+          </button>
+          <aside
+            id="mobile-navigation-drawer"
+            class="sidebar"
+            data-mobile-nav-state="closed"
+            aria-label="Primary navigation"
+          >
             <div class="sidebar-brand">
-              <div class="brand-glyph">h</div>
-              <div class="brand-text">huddlz</div>
+              <a href="/dev/design/clickthrough/explore" aria-label="huddlz home">
+                <div class="brand-glyph">h</div>
+                <div class="brand-text">huddlz</div>
+              </a>
+              <button
+                type="button"
+                id="mobile-nav-close"
+                class="nav-close"
+                data-mobile-nav-close
+                aria-label="Close navigation"
+              >
+                <.icon name="hero-x-mark" class="size-5" />
+              </button>
             </div>
 
             <nav class="sb-nav">
@@ -219,10 +241,18 @@ defmodule HuddlzWeb.DevDesignHTML do
           </aside>
         <% end %>
 
-        <main class="main">
+        <main class="main" data-mobile-nav-background>
           <header class="content-topbar">
             <%= if @signed_in do %>
-              <label for="nav-toggle" class="nav-trigger" aria-label="Open navigation">
+              <button
+                type="button"
+                id="mobile-nav-trigger"
+                class="nav-trigger"
+                data-mobile-nav-trigger
+                aria-label="Open navigation"
+                aria-controls="mobile-navigation-drawer"
+                aria-expanded="false"
+              >
                 <svg
                   viewBox="0 0 24 24"
                   fill="none"
@@ -233,7 +263,7 @@ defmodule HuddlzWeb.DevDesignHTML do
                 >
                   <path d="M4 7h16M4 12h16M4 17h16" />
                 </svg>
-              </label>
+              </button>
             <% else %>
               <a
                 class="topbar-brand"

--- a/lib/huddlz_web/controllers/dev_design_html.ex
+++ b/lib/huddlz_web/controllers/dev_design_html.ex
@@ -40,10 +40,9 @@ defmodule HuddlzWeb.DevDesignHTML do
             type="button"
             class="nav-scrim"
             data-mobile-nav-scrim
-            aria-label="Close navigation"
+            aria-hidden="true"
             tabindex="-1"
-          >
-          </button>
+          ></button>
           <aside
             id="mobile-navigation-drawer"
             class="sidebar"

--- a/lib/huddlz_web/controllers/dev_design_html.ex
+++ b/lib/huddlz_web/controllers/dev_design_html.ex
@@ -36,33 +36,12 @@ defmodule HuddlzWeb.DevDesignHTML do
         {render_slot(@inner_block)}
       <% else %>
         <%= if @signed_in do %>
-          <button
-            type="button"
-            class="nav-scrim"
-            data-mobile-nav-scrim
-            aria-hidden="true"
-            tabindex="-1"
-          ></button>
-          <aside
-            id="mobile-navigation-drawer"
-            class="sidebar"
-            data-mobile-nav-state="closed"
-            aria-label="Primary navigation"
-          >
+          <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+          <label for="nav-toggle" class="nav-scrim" aria-hidden="true"></label>
+          <aside class="sidebar">
             <div class="sidebar-brand">
-              <a href="/dev/design/clickthrough/explore" aria-label="huddlz home">
-                <div class="brand-glyph">h</div>
-                <div class="brand-text">huddlz</div>
-              </a>
-              <button
-                type="button"
-                id="mobile-nav-close"
-                class="nav-close"
-                data-mobile-nav-close
-                aria-label="Close navigation"
-              >
-                <.icon name="hero-x-mark" class="size-5" />
-              </button>
+              <div class="brand-glyph">h</div>
+              <div class="brand-text">huddlz</div>
             </div>
 
             <nav class="sb-nav">
@@ -240,18 +219,10 @@ defmodule HuddlzWeb.DevDesignHTML do
           </aside>
         <% end %>
 
-        <main class="main" data-mobile-nav-background>
+        <main class="main">
           <header class="content-topbar">
             <%= if @signed_in do %>
-              <button
-                type="button"
-                id="mobile-nav-trigger"
-                class="nav-trigger"
-                data-mobile-nav-trigger
-                aria-label="Open navigation"
-                aria-controls="mobile-navigation-drawer"
-                aria-expanded="false"
-              >
+              <label for="nav-toggle" class="nav-trigger" aria-label="Open navigation">
                 <svg
                   viewBox="0 0 24 24"
                   fill="none"
@@ -262,7 +233,7 @@ defmodule HuddlzWeb.DevDesignHTML do
                 >
                   <path d="M4 7h16M4 12h16M4 17h16" />
                 </svg>
-              </button>
+              </label>
             <% else %>
               <a
                 class="topbar-brand"

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -61,8 +61,15 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(attendee)
       |> visit("/my-huddlz")
       |> assert_has("h1", text: "My huddlz")
-      |> assert_has("aside.sidebar")
-      |> assert_has(".sb-item.active", text: "My huddlz")
+      |> assert_has(
+        "button#mobile-nav-trigger[aria-controls='mobile-navigation-drawer'][aria-expanded='false']"
+      )
+      |> assert_has(
+        "aside#mobile-navigation-drawer[aria-label='Primary navigation'][data-mobile-nav-state='closed']"
+      )
+      |> assert_has("button#mobile-nav-close[aria-label='Close navigation']")
+      |> assert_has(".sb-item.active[aria-current='page']", text: "My huddlz")
+      |> refute_has("input.nav-toggle")
     end
 
     test "shows three filter chips with counts", %{conn: conn, attendee: attendee} do

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -70,6 +70,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
         "aside#mobile-navigation-drawer[aria-label='Primary navigation'][data-mobile-nav-state='closed']"
       )
       |> assert_has("button#mobile-nav-close[aria-label='Close navigation']")
+      |> assert_has("button.nav-scrim[aria-hidden='true'][tabindex='-1']")
       |> assert_has(".sb-item.active[aria-current='page']", text: "My huddlz")
       |> refute_has("input.nav-toggle")
     end

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -63,8 +63,15 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(attendee)
       |> visit("/my-huddlz")
       |> assert_has("h1", text: "My huddlz")
-      |> assert_has("aside.sidebar")
-      |> assert_has(".sb-item.active", text: "My huddlz")
+      |> assert_has(
+        "button#mobile-nav-trigger[aria-controls='mobile-navigation-drawer'][aria-expanded='false']"
+      )
+      |> assert_has(
+        "aside#mobile-navigation-drawer[aria-label='Primary navigation'][data-mobile-nav-state='closed']"
+      )
+      |> assert_has("button#mobile-nav-close[aria-label='Close navigation']")
+      |> assert_has(".sb-item.active[aria-current='page']", text: "My huddlz")
+      |> refute_has("input.nav-toggle")
     end
 
     test "shows three filter chips with counts", %{conn: conn, attendee: attendee} do


### PR DESCRIPTION
## Summary

- replace the CSS-only checkbox toggle with semantic open, close, and backdrop controls
- contain keyboard focus, restore it on close, and make background content inert while the drawer is open
- close on Escape, backdrop interaction, or navigation while preserving the desktop sidebar and reduced-motion behavior
- expose current sidebar destinations to assistive technology and add dependency-free JavaScript component coverage in CI

## Verification

Browser-checked at 390px and 1280px: focus moves into the drawer on open, Tab and Shift+Tab stay inside it, Escape and the backdrop close it and return focus to the hamburger, following a link closes it, background content is inert while open, and the desktop sidebar is unchanged.

Closes #303
