### PR TITLE
fix(ui): improve keyboard focus management

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -242,6 +242,11 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+body :where(a, button, input, textarea, select, [tabindex]):focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 3px;
+}
+
 
 
 
@@ -258,6 +263,28 @@ body.is-signed-out {
 }
 
 body.is-signed-out .main { min-height: 100vh; }
+
+body .skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 100;
+  padding: 10px 14px;
+  border: 1px solid var(--cyan);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 800;
+  transform: translateY(calc(-100% - 20px));
+  transition: transform 120ms ease;
+}
+
+body .skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--text);
+  outline-offset: 3px;
+}
 
 @media (max-width: 1100px) {
   body { --rail-w: 240px; }
@@ -2584,6 +2611,40 @@ body .form-textarea { min-height: 120px; resize: vertical; line-height: 1.5; }
 
 body .form-help { color: var(--muted); font-size: 12px; }
 body .form-error { color: var(--warn); font-size: 12px; }
+
+body .form-error-summary {
+  max-width: 560px;
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
+  border-left: 3px solid var(--warn);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--warn) 8%, transparent);
+  color: var(--soft);
+  font-size: 13px;
+}
+
+body .form-error-summary:focus {
+  outline: 2px solid var(--warn);
+  outline-offset: 3px;
+}
+
+body .form-error-summary-title {
+  margin: 0 0 6px;
+  color: var(--text);
+  font-weight: 800;
+}
+
+body .form-error-summary ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+body .form-error-summary a {
+  color: var(--warn);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
 
 body .form-control.read-only {
   display: flex;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,52 @@ import topbar from "../vendor/topbar"
 
 const Hooks = {}
 
+const focusWithoutScrolling = (element) => {
+  if (!element) return
+
+  try {
+    element.focus({preventScroll: true})
+  } catch (_error) {
+    element.focus()
+  }
+}
+
+Hooks.FocusManagement = {
+  mounted() {
+    this.submittedForm = null
+    this.submittedFormId = null
+    this.handleSubmit = (event) => {
+      this.submittedForm = event.target
+      this.submittedFormId = event.target.id || null
+    }
+
+    this.el.addEventListener("submit", this.handleSubmit, true)
+  },
+
+  updated() {
+    if (!this.submittedForm) return
+
+    const submittedForm =
+      (this.submittedFormId && document.getElementById(this.submittedFormId)) ||
+      (this.submittedForm.isConnected && this.submittedForm)
+
+    const focusTarget =
+      submittedForm?.querySelector("[data-error-summary]") ||
+      submittedForm?.querySelector("[aria-invalid='true']") ||
+      this.el.querySelector("[role='alert']:not([hidden])")
+
+    if (focusTarget) {
+      window.requestAnimationFrame(() => focusTarget.focus())
+      this.submittedForm = null
+      this.submittedFormId = null
+    }
+  },
+
+  destroyed() {
+    this.el.removeEventListener("submit", this.handleSubmit, true)
+  }
+}
+
 Hooks.LocationAutocomplete = {
   mounted() {
     this.setupInput()
@@ -75,6 +121,28 @@ const liveSocket = new LiveSocket("/live", Socket, {
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
+
+let liveNavigationPending = false
+
+window.addEventListener("phx:page-loading-start", ({detail}) => {
+  if (detail?.kind === "redirect") {
+    liveNavigationPending = true
+  }
+})
+
+window.addEventListener("phx:page-loading-stop", () => {
+  if (!liveNavigationPending) return
+
+  liveNavigationPending = false
+  window.requestAnimationFrame(() => {
+    const main = document.getElementById("main-content")
+    focusWithoutScrolling(main)
+
+    const announcer = document.getElementById("page-change-announcer")
+    const heading = main?.querySelector("h1")
+    if (announcer) announcer.textContent = heading?.textContent?.trim() || document.title
+  })
+})
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/lib/huddlz_web/components/flash.ex
+++ b/lib/huddlz_web/components/flash.ex
@@ -27,6 +27,7 @@ defmodule HuddlzWeb.Components.Flash do
       id={@id}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
+      tabindex="-1"
       class="w-full cursor-pointer mb-4"
       {@rest}
     >

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -59,7 +59,15 @@ defmodule HuddlzWeb.Components.HuddlForm do
 
   def event_type_grid(assigns) do
     ~H"""
-    <div class="event-type-grid">
+    <div
+      id={@field.id}
+      class="event-type-grid"
+      role="radiogroup"
+      aria-label="Choose a huddl format"
+      aria-invalid={HuddlzWeb.Components.Input.field_invalid?(@field) && "true"}
+      aria-describedby={HuddlzWeb.Components.Input.field_error_ids(@field)}
+      tabindex="-1"
+    >
       <.event_type_option
         field={@field}
         value="in_person"

--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -179,7 +179,73 @@ defmodule HuddlzWeb.Components.Input do
     assigns = Phoenix.Component.assign(assigns, :errors, errors)
 
     ~H"""
-    <p :for={msg <- @errors} class="form-error">{msg}</p>
+    <p
+      :for={{msg, index} <- Enum.with_index(@errors)}
+      id={error_id(@field.id, index)}
+      class="form-error"
+    >
+      {msg}
+    </p>
+    """
+  end
+
+  def field_invalid?(%FormField{} = field) do
+    Phoenix.Component.used_input?(field) && field.errors != []
+  end
+
+  def field_error_ids(%FormField{} = field) do
+    if Phoenix.Component.used_input?(field) do
+      field.errors
+      |> Enum.with_index()
+      |> Enum.map_join(" ", fn {_error, index} -> error_id(field.id, index) end)
+    end
+  end
+
+  attr :form, Phoenix.HTML.Form, required: true
+
+  @doc """
+  Summarizes the form's visible validation errors and links each one to its
+  field. The focus-management hook moves focus here after a failed submit.
+  """
+  def error_summary(assigns) do
+    entries =
+      Enum.flat_map(assigns.form.errors, fn {field_name, error} ->
+        field = assigns.form[field_name]
+
+        if Phoenix.Component.used_input?(field) do
+          [
+            %{
+              field_name: field_name,
+              field_id: field.id,
+              label: Phoenix.Naming.humanize(field_name),
+              message: translate_error(error)
+            }
+          ]
+        else
+          []
+        end
+      end)
+
+    assigns = assign(assigns, :entries, entries)
+
+    ~H"""
+    <div
+      :if={@entries != []}
+      id={"#{@form.id}-error-summary"}
+      class="form-error-summary"
+      role="alert"
+      tabindex="-1"
+      data-error-summary
+    >
+      <p class="form-error-summary-title">Please fix the following:</p>
+      <ul>
+        <li :for={entry <- @entries}>
+          <a id={"#{@form.id}-error-link-#{entry.field_name}"} href={"##{entry.field_id}"}>
+            {entry.label}: {entry.message}
+          </a>
+        </li>
+      </ul>
+    </div>
     """
   end
 

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -49,6 +49,9 @@ defmodule HuddlzWeb.Layouts do
 
     ~H"""
     <%= if @signed_in do %>
+      <a class="skip-link" href="#main-content" phx-click={JS.focus(to: "#main-content")}>
+        Skip to main content
+      </a>
       <input type="checkbox" id="nav-toggle" class="nav-toggle" />
       <label for="nav-toggle" class="nav-scrim" aria-hidden="true"></label>
       <aside class="sidebar">
@@ -161,7 +164,13 @@ defmodule HuddlzWeb.Layouts do
       </aside>
     <% end %>
 
-    <main class="main">
+    <main
+      id="main-content"
+      class="main"
+      tabindex="-1"
+      aria-label="Main content"
+      phx-hook="FocusManagement"
+    >
       <header class="content-topbar">
         <%= if @signed_in do %>
           <label for="nav-toggle" class="nav-trigger" aria-label="Open navigation">
@@ -224,9 +233,15 @@ defmodule HuddlzWeb.Layouts do
         </a>
       </header>
 
-      <div class="auth-frame">
+      <main
+        id="main-content"
+        class="auth-frame"
+        tabindex="-1"
+        aria-label="Main content"
+        phx-hook="FocusManagement"
+      >
         {render_slot(@inner_block)}
-      </div>
+      </main>
     </div>
     """
   end

--- a/lib/huddlz_web/components/layouts/root.html.heex
+++ b/lib/huddlz_web/components/layouts/root.html.heex
@@ -43,6 +43,7 @@
     </script>
   </head>
   <body class={Map.get(assigns, :body_class, "")}>
+    <div id="page-change-announcer" class="sr-only" aria-live="polite" aria-atomic="true"></div>
     {@inner_content}
   </body>
 </html>

--- a/lib/huddlz_web/live/auth_live/register.ex
+++ b/lib/huddlz_web/live/auth_live/register.ex
@@ -57,6 +57,8 @@ defmodule HuddlzWeb.AuthLive.Register do
         phx-submit="register"
         class="auth-card"
       >
+        <.error_summary form={@form} />
+
         <div class="form-grid">
           <.input
             field={@form[:email]}
@@ -109,6 +111,8 @@ defmodule HuddlzWeb.AuthLive.Register do
                 id={@form[:legal_acceptance].id}
                 name={@form[:legal_acceptance].name}
                 value="true"
+                aria-invalid={field_invalid?(@form[:legal_acceptance]) && "true"}
+                aria-describedby={field_error_ids(@form[:legal_acceptance])}
                 checked={
                   Phoenix.HTML.Form.normalize_value(
                     "checkbox",

--- a/lib/huddlz_web/live/auth_live/reset_password.ex
+++ b/lib/huddlz_web/live/auth_live/reset_password.ex
@@ -47,6 +47,8 @@ defmodule HuddlzWeb.AuthLive.ResetPassword do
           phx-submit="request_reset"
           class="auth-card"
         >
+          <.error_summary form={@form} />
+
           <div class="form-grid">
             <.input
               field={@form[:email]}

--- a/lib/huddlz_web/live/auth_live/reset_password_confirm.ex
+++ b/lib/huddlz_web/live/auth_live/reset_password_confirm.ex
@@ -69,6 +69,8 @@ defmodule HuddlzWeb.AuthLive.ResetPasswordConfirm do
           id="reset-password-confirm-form"
           class="auth-card"
         >
+          <.error_summary form={@form} />
+
           <input
             type="hidden"
             name={Phoenix.HTML.Form.input_name(f, :reset_token)}

--- a/lib/huddlz_web/live/auth_live/sign_in.ex
+++ b/lib/huddlz_web/live/auth_live/sign_in.ex
@@ -27,6 +27,8 @@ defmodule HuddlzWeb.AuthLive.SignIn do
         method="post"
         class="auth-card"
       >
+        <.error_summary form={@password_form} />
+
         <div class="form-grid">
           <.input field={f[:email]} type="email" label="Email" autocomplete="email" />
           <.input

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -129,6 +129,8 @@ defmodule HuddlzWeb.GroupLive.Edit do
       </div>
 
       <.form for={@form} id="edit-group-form" phx-change="validate" phx-submit="update_group">
+        <.error_summary form={@form} />
+
         <div class="panel">
           <div class="panel-head">
             <h2>Cover image</h2>
@@ -259,10 +261,13 @@ defmodule HuddlzWeb.GroupLive.Edit do
                   name={@form[:slug].name}
                   value={@form[:slug].value}
                   class="form-input"
+                  aria-invalid={field_invalid?(@form[:slug]) && "true"}
+                  aria-describedby={field_error_ids(@form[:slug])}
                   pattern="[a-z0-9-]+"
                   title="Only lowercase letters, numbers, and hyphens allowed"
                 />
               </div>
+              <.field_errors field={@form[:slug]} />
               <p :if={!@slug_changed} class="form-help">
                 Your group is available at: {url(~p"/groups/#{@form[:slug].value || "..."}")}
               </p>
@@ -280,7 +285,13 @@ defmodule HuddlzWeb.GroupLive.Edit do
               rows="4"
             />
 
-            <div class="form-row">
+            <div
+              id={@form[:location].id}
+              class="form-row"
+              tabindex="-1"
+              aria-invalid={field_invalid?(@form[:location]) && "true"}
+              aria-describedby={field_error_ids(@form[:location])}
+            >
               <label class="form-label" for="group-location-input">Location</label>
               <.live_component
                 module={HuddlzWeb.Live.LocationAutocomplete}

--- a/lib/huddlz_web/live/group_live/locations.ex
+++ b/lib/huddlz_web/live/group_live/locations.ex
@@ -84,7 +84,11 @@ defmodule HuddlzWeb.GroupLive.Locations do
           </p>
         </div>
         <div class="actions">
-          <.button variant={:primary} patch={~p"/groups/#{@group.slug}/locations/new"}>
+          <.button
+            variant={:primary}
+            patch={~p"/groups/#{@group.slug}/locations/new"}
+            phx-click={JS.push_focus()}
+          >
             Add Address
           </.button>
         </div>
@@ -109,7 +113,11 @@ defmodule HuddlzWeb.GroupLive.Locations do
           <div class="row-list">
             <.list_row :for={loc <- @locations} class="location-row">
               <%= if @editing_location_id == loc.id do %>
-                <form phx-submit="save_rename" class="location-rename">
+                <form
+                  id={"rename-location-#{loc.id}"}
+                  phx-submit="save_rename"
+                  class="location-rename"
+                >
                   <input type="hidden" name="location_id" value={loc.id} />
                   <input
                     type="text"
@@ -169,7 +177,12 @@ defmodule HuddlzWeb.GroupLive.Locations do
           Saved venues show up in the venue picker for everyone in your group.
         </p>
 
-        <form phx-submit="save_new_location" phx-change="modal_form_changed" class="form-grid">
+        <form
+          id="new-saved-location-form"
+          phx-submit="save_new_location"
+          phx-change="modal_form_changed"
+          class="form-grid"
+        >
           <div class="form-row">
             <label class="form-label" for="modal-address-autocomplete-input">
               Search for an address

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -199,6 +199,8 @@ defmodule HuddlzWeb.GroupLive.New do
       </div>
 
       <.form for={@form} id="group-form" phx-change="validate" phx-submit="save">
+        <.error_summary form={@form} />
+
         <div class="panel">
           <div class="panel-head">
             <h2>The basics</h2>
@@ -222,7 +224,13 @@ defmodule HuddlzWeb.GroupLive.New do
               placeholder="Tell people what your group is about, what huddlz to expect, and who should join."
               help="Up to 5,000 characters."
             />
-            <div class="form-row">
+            <div
+              id={@form[:location].id}
+              class="form-row"
+              tabindex="-1"
+              aria-invalid={field_invalid?(@form[:location]) && "true"}
+              aria-describedby={field_error_ids(@form[:location])}
+            >
               <label class="form-label" for="group-location-input">Location</label>
               <.live_component
                 module={HuddlzWeb.Live.LocationAutocomplete}

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -191,6 +191,8 @@ defmodule HuddlzWeb.HuddlLive.Edit do
       </div>
 
       <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save">
+        <.error_summary form={@form} />
+
         <%= if @huddl.huddl_template_id do %>
           <div class="panel">
             <div class="edit-scope-row">
@@ -384,7 +386,13 @@ defmodule HuddlzWeb.HuddlLive.Edit do
           </div>
           <div class="form-grid">
             <%= if @show_physical_location do %>
-              <div class="form-row">
+              <div
+                id={@form[:physical_location].id}
+                class="form-row"
+                tabindex="-1"
+                aria-invalid={field_invalid?(@form[:physical_location]) && "true"}
+                aria-describedby={field_error_ids(@form[:physical_location])}
+              >
                 <.live_component
                   module={HuddlzWeb.Live.SavedLocationPicker}
                   id="saved-location-picker"
@@ -469,7 +477,12 @@ defmodule HuddlzWeb.HuddlLive.Edit do
       >
         <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
 
-        <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
+        <form
+          id="new-saved-location-form"
+          phx-submit="save_location"
+          phx-change="modal_form_changed"
+          class="form-grid"
+        >
           <div class="form-row">
             <label class="form-label" for="modal-address-autocomplete-input">
               Search for an address

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -161,6 +161,8 @@ defmodule HuddlzWeb.HuddlLive.New do
       </div>
 
       <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save">
+        <.error_summary form={@form} />
+
         <div class="panel">
           <div class="panel-head">
             <h2>The basics</h2>
@@ -267,7 +269,13 @@ defmodule HuddlzWeb.HuddlLive.New do
           </div>
           <div class="form-grid">
             <%= if @show_physical_location do %>
-              <div class="form-row">
+              <div
+                id={@form[:physical_location].id}
+                class="form-row"
+                tabindex="-1"
+                aria-invalid={field_invalid?(@form[:physical_location]) && "true"}
+                aria-describedby={field_error_ids(@form[:physical_location])}
+              >
                 <.live_component
                   module={HuddlzWeb.Live.SavedLocationPicker}
                   id="saved-location-picker"
@@ -435,7 +443,12 @@ defmodule HuddlzWeb.HuddlLive.New do
       >
         <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
 
-        <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
+        <form
+          id="new-saved-location-form"
+          phx-submit="save_location"
+          phx-change="modal_form_changed"
+          class="form-grid"
+        >
           <div class="form-row">
             <label class="form-label" for="modal-address-autocomplete-input">
               Search for an address

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -103,7 +103,9 @@ defmodule HuddlzWeb.ProfileLive do
         </form>
       </div>
 
-      <.form for={@form} phx-submit="save" phx-change="validate">
+      <.form for={@form} id="profile-form" phx-submit="save" phx-change="validate">
+        <.error_summary form={@form} />
+
         <div class="panel">
           <div class="panel-head">
             <h2>Account information</h2>
@@ -162,6 +164,8 @@ defmodule HuddlzWeb.ProfileLive do
         phx-submit="update_password"
         phx-change="validate_password"
       >
+        <.error_summary form={@password_form} />
+
         <div class="panel">
           <div class="panel-head">
             <div>

--- a/lib/huddlz_web/live/saved_location_picker.ex
+++ b/lib/huddlz_web/live/saved_location_picker.ex
@@ -103,7 +103,11 @@ defmodule HuddlzWeb.Live.SavedLocationPicker do
             >
               Change address…
             </button>
-            <.link patch={@new_location_path} class="btn-secondary">
+            <.link
+              patch={@new_location_path}
+              class="btn-secondary"
+              phx-click={JS.push_focus()}
+            >
               Add new address
             </.link>
           </div>
@@ -175,7 +179,11 @@ defmodule HuddlzWeb.Live.SavedLocationPicker do
           No matching locations found
         </p>
 
-        <.link patch={@new_location_path} class="btn-secondary saved-location-add">
+        <.link
+          patch={@new_location_path}
+          class="btn-secondary saved-location-add"
+          phx-click={JS.push_focus()}
+        >
           Add new address
         </.link>
       <% end %>

--- a/test/huddlz_web/components/components_test.exs
+++ b/test/huddlz_web/components/components_test.exs
@@ -6,6 +6,40 @@ defmodule HuddlzWeb.ComponentsTest do
 
   use HuddlzWeb.Components
 
+  describe "app layout accessibility" do
+    test "puts a skip link before signed-in navigation and exposes a focusable main landmark" do
+      assigns = %{
+        flash: %{},
+        current_user: %Huddlz.Accounts.User{
+          email: "person@example.com",
+          display_name: "A Person",
+          role: :user
+        }
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <HuddlzWeb.Layouts.app flash={@flash} current_user={@current_user}>
+          <h1>Dashboard</h1>
+        </HuddlzWeb.Layouts.app>
+        """)
+
+      document = LazyHTML.from_fragment(html)
+
+      assert LazyHTML.filter(
+               document,
+               "a.skip-link[href='#main-content'] + #nav-toggle + .nav-scrim + aside.sidebar"
+             )
+             |> Enum.any?()
+
+      assert LazyHTML.filter(document, "#main-content[tabindex='-1'][aria-label='Main content']")
+             |> Enum.any?()
+
+      assert LazyHTML.filter(document, "#main-content[phx-hook='FocusManagement']")
+             |> Enum.any?()
+    end
+  end
+
   describe "pill/1" do
     test "renders default pill with no extra variant class" do
       assigns = %{}
@@ -199,6 +233,49 @@ defmodule HuddlzWeb.ComponentsTest do
       assert html =~ ~s(class="form-input)
       assert html =~ ~s(name="title")
       assert html =~ ~s(class="form-help")
+    end
+
+    test "summarizes invalid fields with focusable links" do
+      assigns = %{
+        form:
+          to_form(
+            %{"email" => "", "display_name" => ""},
+            as: :user,
+            errors: [
+              email: {"can't be blank", []},
+              display_name: {"is too short", []}
+            ]
+          )
+      }
+
+      html = rendered_to_string(~H"<.error_summary form={@form} />")
+      document = LazyHTML.from_fragment(html)
+
+      assert LazyHTML.filter(
+               document,
+               "#user-error-summary[role='alert'][tabindex='-1'][data-error-summary]"
+             )
+             |> Enum.any?()
+
+      assert LazyHTML.query(document, "#user-error-summary a")
+             |> Enum.count() == 2
+    end
+
+    test "gives custom-field errors stable IDs for aria-describedby" do
+      assigns = %{
+        form:
+          to_form(
+            %{"choice" => ""},
+            as: :settings,
+            errors: [choice: {"must be selected", []}]
+          )
+      }
+
+      html = rendered_to_string(~H"<.field_errors field={@form[:choice]} />")
+      document = LazyHTML.from_fragment(html)
+
+      assert LazyHTML.filter(document, "#settings_choice-error-0")
+             |> Enum.any?()
     end
   end
 

--- a/test/huddlz_web/live/group_live/locations_test.exs
+++ b/test/huddlz_web/live/group_live/locations_test.exs
@@ -121,6 +121,8 @@ defmodule HuddlzWeb.GroupLive.LocationsTest do
         |> login(owner)
         |> live(~p"/groups/#{group.slug}/locations")
 
+      assert has_element?(view, "a[phx-click*='push_focus']", "Add Address")
+
       # Click the "Add Address" link — it's a live_patch
       view
       |> element("a", "Add Address")
@@ -129,6 +131,7 @@ defmodule HuddlzWeb.GroupLive.LocationsTest do
       # Modal should now be visible
       assert has_element?(view, "#new-location-modal")
       assert has_element?(view, "h2", "Add New Address")
+      assert has_element?(view, "#new-location-modal[phx-remove*='pop_focus']")
     end
 
     test "add address modal renders autocomplete inside a form", %{

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -73,6 +73,10 @@ defmodule HuddlzWeb.GroupLiveTest do
 
       session
       |> assert_has(
+        "#form-error-summary[role='alert'][tabindex='-1'][data-error-summary] a[href='#form_name']",
+        text: "Name: is required"
+      )
+      |> assert_has(
         "input[name='form[name]'][aria-invalid='true'][aria-describedby='form_name-help form_name-error-0']"
       )
       |> assert_has("#form_name-help", text: "3–100 characters.")

--- a/test/huddlz_web/live/huddl_live/new_location_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_location_test.exs
@@ -23,6 +23,24 @@ defmodule HuddlzWeb.HuddlLive.NewLocationTest do
 
       assert has_element?(view, "#new-location-modal")
       assert has_element?(view, "h2", "Add New Address")
+      assert has_element?(view, "#new-location-modal[phx-remove*='pop_focus']")
+    end
+
+    test "modal trigger saves focus for restoration", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      {:ok, view, _html} =
+        conn
+        |> login(owner)
+        |> live(~p"/groups/#{group.slug}/huddlz/new")
+
+      assert has_element?(
+               view,
+               "#saved-location-picker a.saved-location-add[phx-click*='push_focus']",
+               "Add new address"
+             )
     end
 
     test "modal contains autocomplete inside a form", %{


### PR DESCRIPTION
## Summary

- add keyboard-first skip navigation and consistent focus and announcement behavior across LiveView page changes
- move failed submissions to linked error summaries or the first invalid control across authentication, profile, group, and huddl forms
- preserve logical focus across saved-location dialog interactions without treating URL-only patches as page changes

## Manual verification

1. Tab to and activate “Skip to main content” on a signed-in page.
2. Submit Create group without a name; confirm focus moves to the error summary and its link focuses Group name.
3. Open and dismiss Add Address; confirm focus enters the dialog and returns to the Add Address trigger.
4. Follow a LiveView navigation link; confirm focus moves to main content without changing the scroll position.

Closes #304