### PR TITLE
feat(ui): add branded recovery pages

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -242,11 +242,281 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* ─────────────────────────────────────────────  ERROR RECOVERY  ─────
+   A self-contained, static shell: no LiveView or JavaScript required. */
+body.error-page {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+  overflow-x: hidden;
+  background:
+    linear-gradient(rgba(24, 203, 212, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 203, 212, 0.025) 1px, transparent 1px),
+    radial-gradient(circle at 72% 18%, rgba(24, 203, 212, 0.12), transparent 32rem),
+    #020404;
+  background-size: 3rem 3rem, 3rem 3rem, auto, auto;
+}
+
+.error-topbar,
+.error-footer {
+  width: min(100% - 2rem, 78rem);
+  margin-inline: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.error-topbar {
+  min-height: 5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.error-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.error-brand .brand-glyph {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--cyan);
+  color: #020404;
+  font-weight: 900;
+}
+
+.error-brand .brand-text {
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.error-topbar-label,
+.error-kicker,
+.error-footer {
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.error-topbar-label {
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.error-main {
+  width: min(100% - 2rem, 78rem);
+  margin-inline: auto;
+  display: grid;
+  align-items: center;
+  padding-block: clamp(3rem, 9vw, 8rem);
+}
+
+.error-panel {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.9fr) minmax(22rem, 1.1fr);
+  align-items: center;
+  gap: clamp(3rem, 9vw, 8rem);
+}
+
+.error-status {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(3.5rem, 1fr) auto;
+  align-items: center;
+  color: var(--text);
+  font-size: clamp(7rem, 18vw, 15rem);
+  font-weight: 900;
+  line-height: 0.72;
+  letter-spacing: -0.1em;
+  text-shadow: 0 0 4rem rgba(24, 203, 212, 0.12);
+}
+
+.error-signal {
+  height: 0.7em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.25rem, 0.8vw, 0.65rem);
+  margin-inline: 0.12em 0.06em;
+}
+
+.error-signal i {
+  width: clamp(0.25rem, 0.7vw, 0.55rem);
+  height: clamp(0.25rem, 0.7vw, 0.55rem);
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 0 0 1.25rem rgba(24, 203, 212, 0.45);
+}
+
+.error-signal i:nth-child(2) {
+  opacity: 0.55;
+}
+
+.error-signal i:nth-child(3) {
+  opacity: 0.2;
+}
+
+.error-copy {
+  max-width: 37rem;
+  padding-left: clamp(1.5rem, 4vw, 3.5rem);
+  border-left: 1px solid var(--line-strong);
+}
+
+.error-kicker {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0 0 1.25rem;
+  color: var(--cyan);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.error-kicker-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 0 0 0 0.3rem rgba(24, 203, 212, 0.1);
+}
+
+.error-copy h1 {
+  max-width: 11ch;
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(2.5rem, 6vw, 5.25rem);
+  font-weight: 900;
+  line-height: 0.96;
+  letter-spacing: -0.06em;
+}
+
+.error-copy > p:not(.error-kicker) {
+  max-width: 35rem;
+  margin: 1.5rem 0 0;
+  color: var(--soft);
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
+  line-height: 1.7;
+}
+
+.error-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 2rem;
+}
+
+.error-action {
+  min-height: 2.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  text-decoration: none;
+}
+
+.error-text-link {
+  min-height: 2.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-inline: 0.35rem;
+  color: var(--soft);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.error-text-link:hover {
+  color: var(--cyan);
+}
+
+.error-brand:focus-visible,
+.error-action:focus-visible,
+.error-text-link:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 4px;
+}
+
+.error-footer {
+  min-height: 4.5rem;
+  justify-content: flex-start;
+  gap: 0.7rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.62rem;
+}
+
+@media (max-width: 760px) {
+  body.error-page {
+    background-size: 2rem 2rem, 2rem 2rem, auto, auto;
+  }
+
+  .error-panel {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+
+  .error-status {
+    width: min(100%, 24rem);
+    font-size: clamp(7rem, 38vw, 11rem);
+  }
+
+  .error-copy {
+    padding: 1.75rem 0 0;
+    border-top: 1px solid var(--line-strong);
+    border-left: 0;
+  }
+
+  .error-copy h1 {
+    max-width: 12ch;
+  }
+}
+
+@media (max-width: 440px) {
+  .error-topbar,
+  .error-footer,
+  .error-main {
+    width: min(100% - 1.5rem, 78rem);
+  }
+
+  .error-main {
+    padding-block: 2.5rem;
+  }
+
+  .error-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .error-action,
+  .error-text-link {
+    width: 100%;
+  }
+
+  .error-text-link {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-text-link {
+    transition: none;
+  }
+}
+
 
 
 
 /* ─────────────────────────────────────────────  APP SHELL  ───── */
-body:not(.is-landing):not(.is-auth):not(.is-signed-out) {
+body:not(.is-landing):not(.is-auth):not(.is-signed-out):not(.error-page) {
   display: grid;
   grid-template-columns: var(--rail-w) 1fr;
   min-height: 100vh;
@@ -262,7 +532,9 @@ body.is-signed-out .main { min-height: 100vh; }
 @media (max-width: 1100px) {
   body { --rail-w: 240px; }
 
-  body:not(.is-landing):not(.is-auth):not(.is-signed-out) { grid-template-columns: var(--rail-w) 1fr; }
+  body:not(.is-landing):not(.is-auth):not(.is-signed-out):not(.error-page) {
+    grid-template-columns: var(--rail-w) 1fr;
+  }
 }
 
 /* `<.modal>` centers via `fixed inset-0`, which spans the full viewport
@@ -286,7 +558,7 @@ body .nav-scrim { display: none; }
 
 @media (max-width: 760px) {
 
-  body:not(.is-landing):not(.is-auth):not(.is-signed-out) {
+  body:not(.is-landing):not(.is-auth):not(.is-signed-out):not(.error-page) {
     grid-template-columns: 1fr;
   }
 

--- a/lib/huddlz_web/controllers/error_html.ex
+++ b/lib/huddlz_web/controllers/error_html.ex
@@ -1,24 +1,136 @@
 defmodule HuddlzWeb.ErrorHTML do
   @moduledoc """
-  This module is invoked by your endpoint in case of errors on HTML requests.
+  Static, dependency-light recovery pages for HTML requests.
 
-  See config/config.exs.
+  These pages deliberately do not use the application or LiveView layouts:
+  they must remain useful when the normal rendering stack is unavailable.
   """
   use HuddlzWeb, :html
 
-  # If you want to customize your error pages,
-  # uncomment the embed_templates/1 call below
-  # and add pages to the error directory:
-  #
-  #   * lib/huddlz_web/controllers/error_html/404.html.heex
-  #   * lib/huddlz_web/controllers/error_html/500.html.heex
-  #
-  # embed_templates "error_html/*"
-
-  # The default is to render a plain text page based on
-  # the template name. For example, "404.html" becomes
-  # "Not Found".
-  def render(template, _assigns) do
-    Phoenix.Controller.status_message_from_template(template)
+  def render("404.html", assigns) do
+    error_page(assigns,
+      code: "404",
+      title: "This path doesn’t lead to a huddl.",
+      message:
+        "The page may have moved, or the address may be incomplete. Private and missing pages look the same here.",
+      marker: "route not found",
+      retry?: false
+    )
   end
+
+  def render("500.html", assigns) do
+    error_page(assigns,
+      code: "500",
+      title: "We lost the thread.",
+      message:
+        "huddlz hit an unexpected problem. Try this page again, or step back to a familiar place.",
+      marker: "temporary interruption",
+      retry?: true
+    )
+  end
+
+  def render(template, _assigns), do: Phoenix.Controller.status_message_from_template(template)
+
+  defp error_page(assigns, options) do
+    current_user = assigns[:current_user]
+    {home_path, home_label} = home_destination(current_user)
+
+    assigns =
+      Map.merge(assigns, %{
+        code: options[:code],
+        title: options[:title],
+        message: options[:message],
+        marker: options[:marker],
+        retry?: options[:retry?],
+        current_user: current_user,
+        home_path: home_path,
+        home_label: home_label,
+        retry_path: safe_retry_path(assigns[:error_request_path])
+      })
+
+    ~H"""
+    <!DOCTYPE html>
+    <html lang="en" data-theme="dark">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex, nofollow" />
+        <title>{@code} · huddlz</title>
+        <link rel="icon" href={~p"/favicon.png"} type="image/png" sizes="512x512" />
+        <link rel="alternate icon" href={~p"/favicon.ico"} sizes="16x16 32x32 48x48" />
+        <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
+      </head>
+      <body class="error-page">
+        <header class="error-topbar">
+          <a id="error-brand" class="error-brand" href={@home_path} aria-label={@home_label}>
+            <span class="brand-glyph" aria-hidden="true">h</span>
+            <span class="brand-text">huddlz</span>
+          </a>
+          <span class="error-topbar-label">recovery</span>
+        </header>
+
+        <main class="error-main">
+          <section class="error-panel" aria-labelledby="error-title">
+            <p class="sr-only">Error {@code}</p>
+            <div class="error-status" aria-hidden="true">
+              <span>{@code |> String.first()}</span>
+              <span class="error-signal">
+                <i></i>
+                <i></i>
+                <i></i>
+              </span>
+              <span>{@code |> String.last()}</span>
+            </div>
+
+            <div class="error-copy">
+              <p class="error-kicker">
+                <span class="error-kicker-dot" aria-hidden="true"></span>
+                {@marker}
+              </p>
+              <h1 id="error-title">{@title}</h1>
+              <p>{@message}</p>
+
+              <nav class="error-actions" aria-label="Recovery options">
+                <a
+                  :if={@retry?}
+                  id="error-retry"
+                  class={["btn-primary", "error-action"]}
+                  href={@retry_path}
+                >
+                  <.icon name="hero-arrow-path" class="size-4" /> Try this page again
+                </a>
+                <a
+                  id="error-home"
+                  class={[@retry? && "btn-secondary", !@retry? && "btn-primary", "error-action"]}
+                  href={@home_path}
+                >
+                  <.icon name="hero-home" class="size-4" />
+                  {@home_label}
+                </a>
+                <a id="error-discover" class="error-text-link" href={~p"/discover"}>
+                  Discover huddlz <.icon name="hero-arrow-right" class="size-4" />
+                </a>
+              </nav>
+            </div>
+          </section>
+        </main>
+
+        <footer class="error-footer">
+          <span>huddlz</span>
+          <span aria-hidden="true">/</span>
+          <span>Find your people.</span>
+        </footer>
+      </body>
+    </html>
+    """
+  end
+
+  defp home_destination(nil), do: {~p"/", "huddlz home"}
+  defp home_destination(_current_user), do: {~p"/my-huddlz", "Back to My huddlz"}
+
+  defp safe_retry_path("//" <> _path), do: ~p"/"
+  defp safe_retry_path("/\\" <> _path), do: ~p"/"
+  defp safe_retry_path("/" <> path) when path != "", do: "/" <> path
+
+  defp safe_retry_path(_path), do: ~p"/"
 end

--- a/lib/huddlz_web/endpoint.ex
+++ b/lib/huddlz_web/endpoint.ex
@@ -71,5 +71,6 @@ defmodule HuddlzWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
+  plug HuddlzWeb.ErrorContext
   plug HuddlzWeb.Router
 end

--- a/lib/huddlz_web/error_context.ex
+++ b/lib/huddlz_web/error_context.ex
@@ -1,0 +1,51 @@
+defmodule HuddlzWeb.ErrorContext do
+  @moduledoc """
+  Captures the small amount of safe browser context needed by static error pages.
+
+  This plug runs before the router so an unknown route can still distinguish an
+  authenticated browser session from a signed-out request. API and GraphQL
+  requests keep their existing bearer-token authentication paths.
+  """
+
+  import Plug.Conn
+
+  alias AshAuthentication.Phoenix.Plug, as: AuthenticationPlug
+
+  @non_browser_prefixes ~w(/api /gql /ws)
+
+  @spec init(keyword()) :: keyword()
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    conn = assign(conn, :error_request_path, conn.request_path)
+
+    if browser_request?(conn) do
+      conn
+      |> fetch_session()
+      |> AuthenticationPlug.load_from_session([])
+    else
+      conn
+    end
+  end
+
+  defp browser_request?(conn) do
+    browser_path?(conn.request_path) and accepts_html?(get_req_header(conn, "accept"))
+  end
+
+  defp browser_path?("/healthz"), do: false
+
+  defp browser_path?(path) do
+    Enum.all?(@non_browser_prefixes, fn prefix ->
+      path != prefix and not String.starts_with?(path, prefix <> "/")
+    end)
+  end
+
+  defp accepts_html?([]), do: true
+
+  defp accepts_html?(headers) do
+    Enum.any?(headers, fn header ->
+      String.contains?(header, "text/html") or String.contains?(header, "*/*")
+    end)
+  end
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -57,11 +57,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> assign(:past_total_pages, 0)}
 
       {:error, _reason} ->
-        {:noreply,
-         handle_error(socket, :not_found,
-           resource_name: "Group",
-           fallback_path: ~p"/discover?#{[scope: "groups"]}"
-         )}
+        not_found!()
     end
   end
 

--- a/lib/huddlz_web/live/helpers/error_helpers.ex
+++ b/lib/huddlz_web/live/helpers/error_helpers.ex
@@ -3,9 +3,11 @@ defmodule HuddlzWeb.Live.ErrorHelpers do
   Centralized error handling helpers for LiveViews.
 
   Provides consistent error handling patterns including flash messages
-  and redirects for common error scenarios like :not_found and :not_authorized.
+  and redirects for common error scenarios like `:not_found` and `:not_authorized`.
   """
   import Phoenix.LiveView
+
+  alias HuddlzWeb.NotFoundError
 
   @doc """
   Handles common error scenarios with appropriate flash messages and redirects.
@@ -79,4 +81,9 @@ defmodule HuddlzWeb.Live.ErrorHelpers do
   def authorize(action_tuple, actor) do
     if Ash.can?(action_tuple, actor), do: :ok, else: {:error, :not_authorized}
   end
+
+  @doc """
+  Raises a status-aware exception for a missing or inaccessible detail page.
+  """
+  def not_found!, do: raise(NotFoundError)
 end

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -65,19 +65,10 @@ defmodule HuddlzWeb.HuddlLive.Show do
          )}
 
       {:error, :not_found} ->
-        {:noreply,
-         handle_error(socket, :not_found,
-           resource_name: "Huddl",
-           fallback_path: ~p"/groups/#{group_slug}"
-         )}
+        not_found!()
 
       {:error, :not_authorized} ->
-        {:noreply,
-         handle_error(socket, :not_authorized,
-           resource_name: "huddl",
-           action: "access",
-           fallback_path: ~p"/discover?#{[scope: "groups"]}"
-         )}
+        not_found!()
     end
   end
 

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -27,7 +27,7 @@ defmodule HuddlzWeb.Router do
     plug :put_root_layout, html: {HuddlzWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
-    plug :load_from_session
+    plug :load_from_session_unless_loaded
     plug :prevent_authenticated_page_caching
   end
 
@@ -167,6 +167,14 @@ defmodule HuddlzWeb.Router do
     end
   end
 
+  if Application.compile_env(:huddlz, :env) == :test do
+    scope "/__test__", HuddlzWeb do
+      pipe_through :browser
+
+      get "/errors/500", TestErrorController, :show
+    end
+  end
+
   # Other scopes may use custom stacks.
   # scope "/api", HuddlzWeb do
   #   pipe_through :api
@@ -181,6 +189,11 @@ defmodule HuddlzWeb.Router do
   end
 
   defp prevent_authenticated_page_caching(conn, _opts), do: conn
+
+  defp load_from_session_unless_loaded(%{assigns: %{current_user: _current_user}} = conn, _opts),
+    do: conn
+
+  defp load_from_session_unless_loaded(conn, _opts), do: load_from_session(conn, [])
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:huddlz, :dev_routes) do

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -51,9 +51,8 @@ Feature: Group Management
   Scenario: Cannot view private group as non-member
     Given a private group "VIP Club" exists with owner "admin@example.com"
     And I am signed in as "regular@example.com"
-    When I visit the group page for "VIP Club"
-    Then I should be redirected to "/discover?scope=groups"
-    And I should see "Group not found"
+    When I try to visit the group page for "VIP Club"
+    Then I should see the branded not found recovery page
 
   Scenario: Owner can edit group details
     Given a public group "Book Club" exists with owner "verified@example.com"

--- a/test/features/private_group_invitations.feature
+++ b/test/features/private_group_invitations.feature
@@ -16,8 +16,8 @@ Feature: Private group invitations
     Then I should see "Invitation sent to invitee@example.com."
     And an invitation email should be sent to "invitee@example.com" for "Quiet Makers"
     Given I am signed in as "invitee@example.com"
-    When I visit the group page for "Quiet Makers"
-    Then I should see "Group not found"
+    When I try to visit the group page for "Quiet Makers"
+    Then I should see the branded not found recovery page
     When I open my invitation to "Quiet Makers"
     And I click "Accept invitation"
     Then I should see "Welcome to Quiet Makers."

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -1,6 +1,7 @@
 defmodule GroupManagementSteps do
   use Cucumber.StepDefinition
   import PhoenixTest
+  import Phoenix.ConnTest, only: [assert_error_sent: 2, dispatch: 4]
 
   import Huddlz.Generator
   import Huddlz.Test.Helpers.LocationSelection, only: [select_location: 2]
@@ -43,6 +44,20 @@ defmodule GroupManagementSteps do
     session = context[:session] || context[:conn]
     session = session |> visit("/groups/#{group.slug}")
     Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I try to visit the group page for {string}",
+       %{args: [group_name]} = context do
+    groups = Map.get(context, :groups, [])
+    group = Enum.find(groups, fn group -> to_string(group.name) == group_name end)
+    session = context[:session] || context[:conn]
+
+    {404, _headers, body} =
+      assert_error_sent 404, fn ->
+        dispatch(session.conn, HuddlzWeb.Endpoint, :get, "/groups/#{group.slug}")
+      end
+
+    Map.put(context, :error_body, body)
   end
 
   # Form interaction steps

--- a/test/features/step_definitions/shared_ui_steps.exs
+++ b/test/features/step_definitions/shared_ui_steps.exs
@@ -16,6 +16,7 @@ defmodule SharedUISteps do
   """
   use Cucumber.StepDefinition
   import PhoenixTest
+  import ExUnit.Assertions, only: [assert: 1]
 
   import Phoenix.ConnTest, only: [build_conn: 0]
 
@@ -93,6 +94,11 @@ defmodule SharedUISteps do
   step "I should see {string} in the flash", %{args: [message]} = context do
     session = context[:session] || context[:conn]
     assert_has(session, "*", text: message)
+    context
+  end
+
+  step "I should see the branded not found recovery page", context do
+    assert context.error_body =~ "This path doesn’t lead to a huddl."
     context
   end
 

--- a/test/features/step_definitions/view_past_huddlz_steps.exs
+++ b/test/features/step_definitions/view_past_huddlz_steps.exs
@@ -1,6 +1,7 @@
 defmodule ViewPastHuddlzSteps do
   use Cucumber.StepDefinition
   import PhoenixTest
+  import Phoenix.ConnTest, only: [assert_error_sent: 2, dispatch: 4]
   import Huddlz.Generator
   import ExUnit.Assertions
 
@@ -172,10 +173,19 @@ defmodule ViewPastHuddlzSteps do
     {:ok, %{conn: conn}}
   end
 
-  # Try to visit a private group page (expecting redirect)
+  # Try to visit a private group page (expecting a neutral 404)
   step "I try to visit that private group page", %{conn: conn, non_member_group: non_member_group} do
-    conn = conn |> visit("/groups/#{non_member_group.slug}")
-    {:ok, %{conn: conn}}
+    {404, _headers, body} =
+      assert_error_sent 404, fn ->
+        dispatch(
+          conn.conn,
+          HuddlzWeb.Endpoint,
+          :get,
+          "/groups/#{non_member_group.slug}"
+        )
+      end
+
+    {:ok, %{error_body: body}}
   end
 
   # Click on the Past Events tab

--- a/test/features/view_past_huddlz.feature
+++ b/test/features/view_past_huddlz.feature
@@ -29,8 +29,7 @@ Feature: View Past Huddlz on Group Pages
     Given I am signed in as "nonmember@example.com"
     And there is a private group with past huddlz I'm not a member of
     When I try to visit that private group page
-    Then I should be redirected to the groups index
-    And I should see an error message
+    Then I should see the branded not found recovery page
 
   Scenario: Anonymous users can see past public huddlz
     When I visit a public group page

--- a/test/huddlz_web/controllers/error_html_test.exs
+++ b/test/huddlz_web/controllers/error_html_test.exs
@@ -1,14 +1,149 @@
 defmodule HuddlzWeb.ErrorHTMLTest do
   use HuddlzWeb.ConnCase, async: true
 
-  # Bring render_to_string/4 for testing custom views
   import Phoenix.Template, only: [render_to_string: 4]
 
-  test "renders 404.html" do
-    assert render_to_string(HuddlzWeb.ErrorHTML, "404", "html", []) == "Not Found"
+  describe "404 recovery page" do
+    test "renders a branded, private recovery page" do
+      html =
+        render_to_string(HuddlzWeb.ErrorHTML, "404", "html",
+          reason: "secret exception detail",
+          stack: ["private stack"],
+          current_user: nil
+        )
+
+      assert html =~ "<title>404 · huddlz</title>"
+      assert html =~ "This path doesn’t lead to a huddl."
+      assert html =~ "Private and missing pages look the same here."
+      assert html =~ ~s(aria-label="Recovery options")
+      assert html =~ ~s(href="/">)
+      assert html =~ "huddlz home"
+      assert html =~ "Discover huddlz"
+      assert html =~ ~s(id="error-home")
+      assert html =~ ~s(id="error-discover")
+      refute html =~ ~s(id="error-retry")
+      assert html =~ ~s(name="robots" content="noindex, nofollow")
+      refute html =~ "secret exception detail"
+      refute html =~ "private stack"
+    end
+
+    test "uses the signed-in recovery destination" do
+      html =
+        render_to_string(HuddlzWeb.ErrorHTML, "404", "html", current_user: %{id: "person-id"})
+
+      assert html =~ ~s(href="/my-huddlz")
+      assert html =~ "Back to My huddlz"
+      refute html =~ "huddlz home"
+    end
   end
 
-  test "renders 500.html" do
-    assert render_to_string(HuddlzWeb.ErrorHTML, "500", "html", []) == "Internal Server Error"
+  describe "500 recovery page" do
+    test "renders a safe retry path without query parameters" do
+      html =
+        render_to_string(HuddlzWeb.ErrorHTML, "500", "html",
+          error_request_path: "/groups/example",
+          current_user: nil,
+          reason: "password=do-not-render",
+          status: 500
+        )
+
+      assert html =~ "<title>500 · huddlz</title>"
+      assert html =~ "We lost the thread."
+      assert html =~ "Try this page again"
+      assert html =~ ~s(id="error-retry")
+      assert html =~ ~s(href="/groups/example")
+      refute html =~ "password=do-not-render"
+    end
+
+    test "falls back to home for unsafe network-path retry URLs" do
+      for unsafe_path <- ["//outside.example/path", "/\\outside.example/path"] do
+        html =
+          render_to_string(HuddlzWeb.ErrorHTML, "500", "html",
+            error_request_path: unsafe_path,
+            current_user: nil
+          )
+
+        refute html =~ ~s(href="#{unsafe_path}")
+        assert html =~ ~r/<a id="error-retry"[^>]*href="\/">/
+      end
+    end
+  end
+
+  test "keeps Phoenix status messages for errors outside the requested scope" do
+    assert render_to_string(HuddlzWeb.ErrorHTML, "422", "html", []) ==
+             "Unprocessable Content"
+  end
+
+  describe "endpoint rendering" do
+    test "returns the branded page and correct status for an unknown route", %{conn: conn} do
+      conn = get(conn, "/a-route-that-does-not-exist?token=private")
+
+      assert html_response(conn, 404) =~ "This path doesn’t lead to a huddl."
+      refute response(conn, 404) =~ "token=private"
+    end
+
+    test "preserves a signed-in browser recovery destination", %{conn: conn} do
+      user = create_user()
+
+      conn =
+        conn
+        |> login(user)
+        |> get("/another-route-that-does-not-exist")
+
+      assert html_response(conn, 404) =~ "Back to My huddlz"
+      refute response(conn, 404) =~ "huddlz home"
+    end
+
+    test "returns the branded page and correct status for a missing group", %{conn: conn} do
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 get(conn, ~p"/groups/group-that-does-not-exist")
+               end)
+
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ "Group not found"
+    end
+
+    test "uses the signed-in shell for a missing huddl", %{conn: conn} do
+      user = create_user()
+
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 conn
+                 |> login(user)
+                 |> get(~p"/groups/missing-group/huddlz/#{Ash.UUID.generate()}")
+               end)
+
+      assert body =~ "Back to My huddlz"
+      refute body =~ "huddlz home"
+    end
+
+    test "renders a safe 500 response through the endpoint", %{conn: conn} do
+      assert {500, _headers, body} =
+               assert_error_sent(500, fn ->
+                 get(conn, "/__test__/errors/500?token=private")
+               end)
+
+      assert body =~ "We lost the thread."
+      assert body =~ ~s(href="/__test__/errors/500")
+      refute body =~ "token=private"
+      refute body =~ "private runtime failure"
+    end
+
+    test "preserves the signed-in recovery destination after an unexpected failure", %{
+      conn: conn
+    } do
+      user = create_user()
+
+      assert {500, _headers, body} =
+               assert_error_sent(500, fn ->
+                 conn
+                 |> login(user)
+                 |> get("/__test__/errors/500")
+               end)
+
+      assert body =~ "Back to My huddlz"
+      refute body =~ "huddlz home"
+    end
   end
 end

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -289,10 +289,15 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       non_member: non_member,
       private_group: private_group
     } do
-      conn = login(conn, non_member)
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 conn
+                 |> login(non_member)
+                 |> get(~p"/groups/#{private_group.slug}")
+               end)
 
-      {:error, {:redirect, %{to: "/discover?scope=groups"}}} =
-        live(conn, ~p"/groups/#{private_group.slug}")
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ to_string(private_group.name)
     end
 
     test "group members can access private group tabs", %{

--- a/test/huddlz_web/live/group_live_permissions_test.exs
+++ b/test/huddlz_web/live/group_live_permissions_test.exs
@@ -173,11 +173,15 @@ defmodule HuddlzWeb.GroupLivePermissionsTest do
       verified_non_member: user,
       private_group: group
     } do
-      # Verified non-members should not be able to see private groups
-      conn
-      |> login(user)
-      |> visit(~p"/groups/#{group.slug}")
-      |> assert_has("h1", text: "Browse groups")
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 conn
+                 |> login(user)
+                 |> get(~p"/groups/#{group.slug}")
+               end)
+
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ to_string(group.name)
     end
 
     test "regular non-member cannot access private group", %{
@@ -185,11 +189,15 @@ defmodule HuddlzWeb.GroupLivePermissionsTest do
       regular_non_member: user,
       private_group: group
     } do
-      # Regular non-members should not be able to see private groups
-      conn
-      |> login(user)
-      |> visit(~p"/groups/#{group.slug}")
-      |> assert_has("h1", text: "Browse groups")
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 conn
+                 |> login(user)
+                 |> get(~p"/groups/#{group.slug}")
+               end)
+
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ to_string(group.name)
     end
 
     test "anonymous user cannot see member list in public group", %{
@@ -203,10 +211,13 @@ defmodule HuddlzWeb.GroupLivePermissionsTest do
     end
 
     test "anonymous user cannot access private group", %{conn: conn, private_group: group} do
-      # Anonymous users should see not found for private groups
-      conn
-      |> visit(~p"/groups/#{group.slug}")
-      |> assert_has("h1", text: "Browse groups")
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 get(conn, ~p"/groups/#{group.slug}")
+               end)
+
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ to_string(group.name)
     end
 
     test "member count is consistent for visitors and every group role", %{

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -266,20 +266,20 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> assert_has(".role-pill .pill", text: "Owner")
     end
 
-    test "redirects non-members from private groups", %{
+    test "private groups are indistinguishable from missing groups", %{
       conn: conn,
       non_member: non_member,
       private_group: group
     } do
-      session =
-        conn
-        |> login(non_member)
-        |> visit(~p"/groups/#{group.slug}")
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 conn
+                 |> login(non_member)
+                 |> get(~p"/groups/#{group.slug}")
+               end)
 
-      assert_path(session, ~p"/discover", query_params: %{"scope" => "groups"})
-
-      assert Phoenix.Flash.get(session.conn.assigns.flash, :error) =~
-               "Group not found"
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ to_string(group.name)
     end
 
     test "allows owner to view private group", %{
@@ -296,10 +296,12 @@ defmodule HuddlzWeb.GroupLiveTest do
     end
 
     test "handles non-existent group", %{conn: conn} do
-      session = conn |> visit(~p"/groups/#{Ash.UUID.generate()}")
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 get(conn, ~p"/groups/#{Ash.UUID.generate()}")
+               end)
 
-      assert_path(session, ~p"/discover", query_params: %{"scope" => "groups"})
-      assert Phoenix.Flash.get(session.conn.assigns.flash, :error) =~ "Group not found"
+      assert body =~ "This path doesn’t lead to a huddl."
     end
   end
 end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -434,7 +434,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has("a.virtual-link-text", text: "Join virtually")
     end
 
-    test "cannot access private huddl without membership", %{
+    test "private huddl is indistinguishable from a missing huddl", %{
       conn: conn,
       non_member: non_member,
       owner: owner
@@ -473,14 +473,15 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
         )
         |> Ash.create!()
 
-      # Non-member should be redirected
-      session =
-        conn
-        |> login(non_member)
-        |> visit(~p"/groups/#{private_group.slug}/huddlz/#{private_huddl.id}")
+      assert {404, _headers, body} =
+               assert_error_sent(404, fn ->
+                 conn
+                 |> login(non_member)
+                 |> get(~p"/groups/#{private_group.slug}/huddlz/#{private_huddl.id}")
+               end)
 
-      # Should redirect to the groups scope of /discover when huddl is not found (due to authorization)
-      assert_path(session, ~p"/discover", query_params: %{"scope" => "groups"})
+      assert body =~ "This path doesn’t lead to a huddl."
+      refute body =~ to_string(private_huddl.title)
     end
 
     test "shows Cancel RSVP button when user has RSVPed", %{

--- a/test/support/test_error_controller.ex
+++ b/test/support/test_error_controller.ex
@@ -1,0 +1,7 @@
+defmodule HuddlzWeb.TestErrorController do
+  @moduledoc false
+
+  use HuddlzWeb, :controller
+
+  def show(_conn, _params), do: raise("private runtime failure")
+end


### PR DESCRIPTION
## Summary

- replace plain-text HTML errors with branded, static 404 and 500 recovery pages
- return the same privacy-preserving 404 for unknown routes and missing or inaccessible group and huddl detail pages
- preserve safe signed-in recovery destinations without changing API or GraphQL authentication
- keep other HTML status responses on Phoenix defaults and exercise unexpected failures through the endpoint

Closes #306