### PR TITLE
Fix stale group membership state

### DIFF
--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -18,6 +18,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
@@ -33,6 +34,14 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
         notify(group, previous_owner_id, new_owner_id)
         {:ok, group}
       end
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, group} = result ->
+        MembershipEvents.broadcast(group.id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -62,7 +62,11 @@ defmodule Huddlz.Communities.GroupMember do
   end
 
   actions do
-    defaults [:create, :read, :destroy]
+    defaults [:create, :read]
+
+    destroy :destroy do
+      require_atomic? false
+    end
 
     create :add_member do
       description "Add a user to a group"
@@ -196,6 +200,7 @@ defmodule Huddlz.Communities.GroupMember do
 
     destroy :leave_group do
       description "Leave a group (member removes themselves; owners must transfer ownership first)"
+      require_atomic? false
 
       # Encoded as a validation, not just a policy guard, so the admin bypass
       # cannot delete an owner's membership row and corrupt group state.
@@ -317,6 +322,11 @@ defmodule Huddlz.Communities.GroupMember do
       description "Default read — only your own membership records"
       authorize_if relates_to_actor_via(:user)
     end
+  end
+
+  changes do
+    change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged,
+      on: [:create, :update, :destroy]
   end
 
   attributes do

--- a/lib/huddlz/communities/group_member/changes/broadcast_membership_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/broadcast_membership_changed.ex
@@ -1,0 +1,21 @@
+defmodule Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged do
+  @moduledoc """
+  Notifies mounted group surfaces after a membership mutation commits.
+  """
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Communities.MembershipEvents
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_transaction(changeset, fn
+      _changeset, {:ok, member} = result ->
+        MembershipEvents.broadcast(member.group_id)
+        result
+
+      _changeset, result ->
+        result
+    end)
+  end
+end

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -1,0 +1,20 @@
+defmodule Huddlz.Communities.MembershipEvents do
+  @moduledoc """
+  Publishes group membership changes to mounted LiveViews.
+
+  Domain actions remain the source of truth. Messages only prompt connected
+  views to re-read membership-dependent state through authorized actions.
+  """
+
+  @pubsub Huddlz.PubSub
+
+  def subscribe(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.subscribe(@pubsub, topic(group_id))
+  end
+
+  def broadcast(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.broadcast(@pubsub, topic(group_id), {:group_membership_changed, group_id})
+  end
+
+  defp topic(group_id), do: "group-membership:#{group_id}"
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -7,7 +7,7 @@ defmodule HuddlzWeb.GroupLive.Show do
   import HuddlzWeb.Live.Helpers.HuddlCardHelpers
 
   alias Huddlz.Communities
-  alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl}
+  alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl, MembershipEvents}
   alias Huddlz.Storage.GroupImages
   alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Avatar
@@ -22,7 +22,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :leave_dialog_open, false)}
+    {:ok,
+     socket
+     |> assign(:leave_dialog_open, false)
+     |> assign(:subscribed_group_id, nil)}
   end
 
   @impl true
@@ -37,6 +40,7 @@ defmodule HuddlzWeb.GroupLive.Show do
 
         {:noreply,
          socket
+         |> subscribe_to_membership_changes(group)
          |> assign(:page_title, group.name)
          |> assign(:meta, group_meta(group))
          |> assign(:group, group)
@@ -56,6 +60,56 @@ defmodule HuddlzWeb.GroupLive.Show do
            resource_name: "Group",
            fallback_path: ~p"/discover?#{[scope: "groups"]}"
          )}
+    end
+  end
+
+  @impl true
+  def handle_info(
+        {:group_membership_changed, group_id},
+        %{assigns: %{group: %{id: group_id}}} = socket
+      ) do
+    {:noreply, refresh_membership_state(socket)}
+  end
+
+  def handle_info({:group_membership_changed, _group_id}, socket), do: {:noreply, socket}
+
+  defp subscribe_to_membership_changes(socket, group) do
+    if connected?(socket) and socket.assigns.subscribed_group_id != group.id do
+      :ok = MembershipEvents.subscribe(group.id)
+      assign(socket, :subscribed_group_id, group.id)
+    else
+      socket
+    end
+  end
+
+  defp refresh_membership_state(socket) do
+    user = socket.assigns.current_user
+
+    case get_group_by_slug(socket.assigns.group.slug, user) do
+      {:ok, group} ->
+        membership = current_user_membership(group, user)
+        member? = !is_nil(membership)
+
+        {past_huddlz, past_total_pages} =
+          get_past_group_huddlz_paginated(group, user, page: 1, per_page: 10)
+
+        socket
+        |> assign(:group, group)
+        |> assign(:members, get_members(group, user, member?))
+        |> assign(:member_count, group.member_count)
+        |> assign(:is_member, member?)
+        |> assign(:leave_dialog_open, socket.assigns.leave_dialog_open && member?)
+        |> assign_action_permissions(group, user, membership)
+        |> assign(:upcoming_huddlz, get_upcoming_group_huddlz(group, user, limit: 10))
+        |> assign(:past_huddlz, past_huddlz)
+        |> assign(:past_page, 1)
+        |> assign(:past_total_pages, past_total_pages)
+
+      {:error, _reason} ->
+        handle_error(socket, :not_found,
+          resource_name: "Group",
+          fallback_path: ~p"/discover?#{[scope: "groups"]}"
+        )
     end
   end
 
@@ -471,18 +525,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
     case join_group(socket.assigns.group, user) do
       {:ok, _} ->
-        group = reload_group(socket.assigns.group, user)
-        membership = current_user_membership(group, user)
-        members = get_members(group, user, true)
-
         {:noreply,
          socket
          |> put_flash(:info, "Successfully joined the group!")
-         |> assign(:group, group)
-         |> assign(:is_member, true)
-         |> assign(:members, members)
-         |> assign(:member_count, group.member_count)
-         |> assign_action_permissions(group, user, membership)}
+         |> refresh_membership_state()}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to join group")}
@@ -504,17 +550,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
     case leave_group(socket.assigns.group, user) do
       :ok ->
-        group = reload_group(socket.assigns.group, user)
-
         {:noreply,
          socket
          |> put_flash(:info, "Successfully left the group")
-         |> assign(:leave_dialog_open, false)
-         |> assign(:group, group)
-         |> assign(:is_member, false)
-         |> assign(:members, nil)
-         |> assign(:member_count, group.member_count)
-         |> assign_action_permissions(group, user, nil)}
+         |> refresh_membership_state()}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to leave group")}
@@ -532,10 +571,6 @@ defmodule HuddlzWeb.GroupLive.Show do
       {:error, %Ash.Error.Query.NotFound{}} -> {:error, :not_found}
       {:error, _} -> {:error, :not_found}
     end
-  end
-
-  defp reload_group(%{slug: slug}, actor) do
-    Communities.get_by_slug!(slug, actor: actor, load: @group_loads)
   end
 
   defp group_meta(group) do

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -85,10 +85,38 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
         )
       )
 
-      conn
-      |> login(member)
-      |> visit(~p"/groups/#{group.slug}")
-      |> assert_has(".facts li", text: "Members 2")
+      private_huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            is_private: true,
+            title: "Members Only Planning"
+          )
+        )
+
+      private_past_huddl =
+        generate(
+          past_huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            is_private: true,
+            title: "Members Only Retrospective"
+          )
+        )
+
+      session =
+        conn
+        |> login(member)
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has(".facts li", text: "Members 2")
+        |> assert_has("h3", text: private_huddl.title)
+        |> click_button("Past")
+        |> assert_has("h3", text: private_past_huddl.title)
+        |> click_button("Upcoming")
+
+      session
       |> click_button("Leave Group")
       |> within("#leave-group-dialog", fn session ->
         click_button(session, "Yes, leave group")
@@ -97,23 +125,105 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> assert_has(".facts li", text: "Members 1")
       |> refute_has("button", text: "Leave Group")
       |> assert_has("button", text: "Join Group")
+      |> refute_has("h3", text: private_huddl.title)
+      |> click_button("Past")
+      |> refute_has("h3", text: private_past_huddl.title)
       |> visit(~p"/my-groups")
       |> refute_has("*", text: "Membership Test Group")
     end
 
-    test "joining updates the member count without a refresh", %{
+    test "joining refreshes the member count and reveals members-only huddlz", %{
       conn: conn,
+      owner: owner,
       group: group
     } do
       visitor = generate(user(role: :user))
+
+      private_huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            is_private: true,
+            title: "Private Member Welcome"
+          )
+        )
 
       conn
       |> login(visitor)
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has(".facts li", text: "Members 1")
+      |> refute_has("h3", text: private_huddl.title)
       |> click_button("Join Group")
       |> assert_has("*", text: "Successfully joined the group!")
       |> assert_has(".facts li", text: "Members 2")
+      |> assert_has("h3", text: private_huddl.title)
+    end
+
+    test "external role loss and removal refresh an already-mounted page", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      organizer = generate(user(role: :user))
+
+      membership =
+        generate(
+          group_member(
+            group_id: group.id,
+            user_id: organizer.id,
+            role: :organizer,
+            actor: owner
+          )
+        )
+
+      private_huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            is_private: true,
+            title: "Organizer Planning Huddl"
+          )
+        )
+
+      session =
+        conn
+        |> login(organizer)
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has("a", text: "Create Huddl")
+        |> assert_has("h3", text: private_huddl.title)
+
+      membership =
+        membership
+        |> Ash.Changeset.for_update(:change_role, %{role: :member}, actor: owner)
+        |> Ash.update!()
+
+      session =
+        session
+        |> refute_has("a", text: "Create Huddl", timeout: 1_000)
+        |> click_button("Leave Group")
+        |> assert_has("#leave-group-dialog")
+
+      membership
+      |> Ash.Changeset.for_destroy(
+        :remove_member,
+        %{group_id: group.id, user_id: organizer.id},
+        actor: owner
+      )
+      |> Ash.destroy!()
+
+      session
+      |> refute_has("#leave-group-dialog", timeout: 1_000)
+      |> assert_has(".facts li", text: "Members 1")
+      |> refute_has("h3", text: private_huddl.title)
+      |> assert_has("button", text: "Join Group")
+      |> unwrap(fn view ->
+        Phoenix.LiveViewTest.render_hook(view, "switch_tab", %{"tab" => "past"})
+      end)
+      |> refute_has("h3", text: private_huddl.title)
     end
 
     test "owner cannot open the leave dialog", %{conn: conn, owner: owner, group: group} do


### PR DESCRIPTION
## Summary

Refresh group membership, permissions, member details, and visible huddlz after membership changes, including changes made from another mounted view. This removes members-only huddlz immediately after departure and reveals them immediately after joining.

Closes #311