### PR TITLE
fix(groups): enforce organizer workspace permissions

### DIFF
--- a/lib/huddlz/communities/group/changes/transfer_ownership.ex
+++ b/lib/huddlz/communities/group/changes/transfer_ownership.ex
@@ -18,6 +18,7 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupMember
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
@@ -33,6 +34,14 @@ defmodule Huddlz.Communities.Group.Changes.TransferOwnership do
         notify(group, previous_owner_id, new_owner_id)
         {:ok, group}
       end
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, group} = result ->
+        MembershipEvents.broadcast(group.id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 

--- a/lib/huddlz/communities/group_member/changes/notify_removed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_removed.ex
@@ -10,11 +10,13 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
   use Ash.Resource.Change
 
   alias Huddlz.Communities.Group
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
-    Ash.Changeset.after_action(changeset, fn cs, member ->
+    changeset
+    |> Ash.Changeset.after_action(fn cs, member ->
       actor_id = actor_id(cs)
 
       if member.user_id != actor_id do
@@ -22,6 +24,14 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRemoved do
       end
 
       {:ok, member}
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, member} = result ->
+        MembershipEvents.broadcast(member.group_id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 

--- a/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/notify_role_changed.ex
@@ -9,18 +9,28 @@ defmodule Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged do
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.Group
+  alias Huddlz.Communities.MembershipEvents
   alias Huddlz.Notifications
 
   @impl true
   def change(changeset, _opts, _context) do
     previous_role = changeset.data.role
 
-    Ash.Changeset.after_action(changeset, fn _cs, member ->
+    changeset
+    |> Ash.Changeset.after_action(fn _cs, member ->
       if previous_role != member.role do
         deliver(member, previous_role)
       end
 
       {:ok, member}
+    end)
+    |> Ash.Changeset.after_transaction(fn
+      _changeset, {:ok, member} = result when previous_role != member.role ->
+        MembershipEvents.broadcast(member.group_id)
+        result
+
+      _changeset, result ->
+        result
     end)
   end
 

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -1,0 +1,20 @@
+defmodule Huddlz.Communities.MembershipEvents do
+  @moduledoc """
+  Publishes group membership changes to mounted LiveViews.
+
+  Domain actions remain the source of truth. The messages only prompt
+  connected views to re-read through those authorized actions.
+  """
+
+  @pubsub Huddlz.PubSub
+
+  def subscribe(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.subscribe(@pubsub, topic(group_id))
+  end
+
+  def broadcast(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.broadcast(@pubsub, topic(group_id), {:group_membership_changed, group_id})
+  end
+
+  defp topic(group_id), do: "group-membership:#{group_id}"
+end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -14,6 +14,7 @@ defmodule HuddlzWeb.OrganizeLive do
   use HuddlzWeb, :live_view
 
   alias Huddlz.Communities
+  alias Huddlz.Communities.{Group, Huddl, MembershipEvents}
   alias HuddlzWeb.Layouts
 
   @group_loads [:member_count]
@@ -36,7 +37,12 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_filter, :live)
      |> assign(:upcoming_huddlz, [])
      |> assign(:open_rsvps, 0)
-     |> assign(:members, [])}
+     |> assign(:members, [])
+     |> assign(:can_create_group, false)
+     |> assign(:can_edit_group, false)
+     |> assign(:can_create_huddl, false)
+     |> assign(:editable_huddl_ids, MapSet.new())
+     |> assign(:subscribed_group_id, nil)}
   end
 
   @impl true
@@ -58,14 +64,17 @@ defmodule HuddlzWeb.OrganizeLive do
     socket
     |> assign(:group, nil)
     |> assign(:owned_groups, owned_groups)
+    |> assign(:can_create_group, Ash.can?({Group, :create_group}, user))
   end
 
   defp load_action(socket, action, %{"group_slug" => slug}, user) do
     case load_group(slug, user) do
       {:ok, group} ->
         socket
+        |> subscribe_to_membership_changes(group)
         |> assign(:group, group)
         |> assign(:page_title, "#{group.name} · Organizer")
+        |> assign_group_permissions(group, user)
         |> load_section(action, group, user)
 
       :error ->
@@ -87,7 +96,10 @@ defmodule HuddlzWeb.OrganizeLive do
   defp load_section(socket, :huddlz, group, user) do
     state = socket.assigns.huddlz_filter
     huddlz = list_group_huddlz(group, state, user)
-    assign(socket, :huddlz_list, huddlz)
+
+    socket
+    |> assign(:huddlz_list, huddlz)
+    |> assign(:editable_huddl_ids, editable_huddl_ids(huddlz, user))
   end
 
   defp load_section(socket, :members, group, user) do
@@ -129,6 +141,27 @@ defmodule HuddlzWeb.OrganizeLive do
     )
   end
 
+  defp assign_group_permissions(socket, group, user) do
+    socket
+    |> assign(:can_edit_group, Ash.can?({group, :update_details}, user))
+    |> assign(:can_create_huddl, Ash.can?({Huddl, :create, %{group_id: group.id}}, user))
+  end
+
+  defp editable_huddl_ids(huddlz, user) do
+    huddlz
+    |> Enum.filter(&Ash.can?({&1, :update}, user))
+    |> MapSet.new(& &1.id)
+  end
+
+  defp subscribe_to_membership_changes(socket, group) do
+    if connected?(socket) and socket.assigns.subscribed_group_id != group.id do
+      :ok = MembershipEvents.subscribe(group.id)
+      assign(socket, :subscribed_group_id, group.id)
+    else
+      socket
+    end
+  end
+
   defp parse_huddlz_filter("past"), do: :past
   defp parse_huddlz_filter(_), do: :live
 
@@ -147,17 +180,25 @@ defmodule HuddlzWeb.OrganizeLive do
     >
       <%= case @live_action do %>
         <% :index -> %>
-          <.picker_view groups={@owned_groups} />
+          <.picker_view groups={@owned_groups} can_create_group={@can_create_group} />
         <% :overview -> %>
           <.overview_view
             group={@group}
             upcoming_huddlz={@upcoming_huddlz}
             open_rsvps={@open_rsvps}
+            can_edit_group={@can_edit_group}
+            can_create_huddl={@can_create_huddl}
           />
         <% :huddlz -> %>
-          <.huddlz_view group={@group} huddlz={@huddlz_list} filter={@huddlz_filter} />
+          <.huddlz_view
+            group={@group}
+            huddlz={@huddlz_list}
+            filter={@huddlz_filter}
+            can_create_huddl={@can_create_huddl}
+            editable_huddl_ids={@editable_huddl_ids}
+          />
         <% :members -> %>
-          <.members_view group={@group} members={@members} />
+          <.members_view group={@group} members={@members} can_edit_group={@can_edit_group} />
       <% end %>
     </Layouts.app>
     """
@@ -170,6 +211,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # ─────────────────────────────────────────  PICKER (/organize)  ───
   attr :groups, :list, required: true
+  attr :can_create_group, :boolean, required: true
 
   defp picker_view(assigns) do
     ~H"""
@@ -178,8 +220,10 @@ defmodule HuddlzWeb.OrganizeLive do
         <h1>Organizer workspace</h1>
         <p>Pick a group to manage, or start a new one.</p>
       </div>
-      <div :if={@groups != []} class="actions">
-        <a class="btn-primary" href={~p"/groups/new"}>+ Create group</a>
+      <div :if={@groups != [] and @can_create_group} class="actions">
+        <a id="organize-create-group" class="btn-primary" href={~p"/groups/new"}>
+          + Create group
+        </a>
       </div>
     </div>
 
@@ -192,8 +236,10 @@ defmodule HuddlzWeb.OrganizeLive do
           You don't organize any groups yet. Create a group to start hosting huddlz —
           each group gets its own workspace here.
         </p>
-        <div class="panel-cta">
-          <a class="btn-primary" href={~p"/groups/new"}>Create your first group</a>
+        <div :if={@can_create_group} class="panel-cta">
+          <a id="organize-create-first-group" class="btn-primary" href={~p"/groups/new"}>
+            Create your first group
+          </a>
         </div>
       </div>
     <% else %>
@@ -226,6 +272,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :group, :map, required: true
   attr :upcoming_huddlz, :list, required: true
   attr :open_rsvps, :integer, required: true
+  attr :can_edit_group, :boolean, required: true
+  attr :can_create_huddl, :boolean, required: true
 
   defp overview_view(assigns) do
     assigns =
@@ -240,8 +288,20 @@ defmodule HuddlzWeb.OrganizeLive do
         <p>A scannable summary of this group's huddlz and members.</p>
       </div>
       <div class="actions">
-        <a class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
-        <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>
+        <a
+          :if={@can_edit_group}
+          id="organize-edit-group"
+          class="btn-secondary"
+          href={~p"/groups/#{@group.slug}/edit"}
+        >
+          Edit group
+        </a>
+        <a
+          :if={@can_create_huddl}
+          id="organize-create-huddl"
+          class="btn-primary"
+          href={~p"/groups/#{@group.slug}/huddlz/new"}
+        >
           + Create huddl
         </a>
       </div>
@@ -313,6 +373,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :group, :map, required: true
   attr :huddlz, :list, required: true
   attr :filter, :atom, required: true
+  attr :can_create_huddl, :boolean, required: true
+  attr :editable_huddl_ids, :any, required: true
 
   defp huddlz_view(assigns) do
     ~H"""
@@ -322,7 +384,12 @@ defmodule HuddlzWeb.OrganizeLive do
         <p>Every huddl in {@group.name}. Click one to manage it.</p>
       </div>
       <div class="actions">
-        <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>
+        <a
+          :if={@can_create_huddl}
+          id="organize-schedule-huddl"
+          class="btn-primary"
+          href={~p"/groups/#{@group.slug}/huddlz/new"}
+        >
           + Schedule huddl
         </a>
       </div>
@@ -343,8 +410,12 @@ defmodule HuddlzWeb.OrganizeLive do
           <h2>{empty_huddlz_heading(@filter)}</h2>
         </div>
         <p class="muted">{empty_huddlz_body(@filter)}</p>
-        <div :if={@filter == :live} class="panel-cta">
-          <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>
+        <div :if={@filter == :live and @can_create_huddl} class="panel-cta">
+          <a
+            id="organize-create-first-huddl"
+            class="btn-primary"
+            href={~p"/groups/#{@group.slug}/huddlz/new"}
+          >
             Create your first huddl
           </a>
         </div>
@@ -362,9 +433,16 @@ defmodule HuddlzWeb.OrganizeLive do
           >
             <div>
               <div class="row-title">
-                <.link navigate={~p"/groups/#{@group.slug}/huddlz/#{huddl.id}/edit"}>
+                <.link
+                  :if={MapSet.member?(@editable_huddl_ids, huddl.id)}
+                  id={"organize-edit-huddl-#{huddl.id}"}
+                  navigate={~p"/groups/#{@group.slug}/huddlz/#{huddl.id}/edit"}
+                >
                   {huddl.title}
                 </.link>
+                <span :if={!MapSet.member?(@editable_huddl_ids, huddl.id)}>
+                  {huddl.title}
+                </span>
               </div>
               <div class="meta">{format_starts_at(huddl.starts_at)}</div>
             </div>
@@ -410,6 +488,7 @@ defmodule HuddlzWeb.OrganizeLive do
   # ─────────────────────────────────────────  MEMBERS  ───
   attr :group, :map, required: true
   attr :members, :list, required: true
+  attr :can_edit_group, :boolean, required: true
 
   defp members_view(assigns) do
     by_role = Enum.group_by(assigns.members, & &1.role)
@@ -424,7 +503,14 @@ defmodule HuddlzWeb.OrganizeLive do
         <p>Who's part of {@group.name}.</p>
       </div>
       <div class="actions">
-        <a class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
+        <a
+          :if={@can_edit_group}
+          id="organize-edit-group"
+          class="btn-secondary"
+          href={~p"/groups/#{@group.slug}/edit"}
+        >
+          Edit group
+        </a>
       </div>
     </div>
 
@@ -514,4 +600,36 @@ defmodule HuddlzWeb.OrganizeLive do
   defp rsvp_label(0), do: "0 RSVPs"
   defp rsvp_label(1), do: "1 RSVP"
   defp rsvp_label(n), do: "#{n} RSVPs"
+
+  @impl true
+  def handle_info(
+        {:group_membership_changed, group_id},
+        %{assigns: %{group: %{id: group_id}}} = socket
+      ) do
+    {:noreply, refresh_after_membership_change(socket)}
+  end
+
+  def handle_info({:group_membership_changed, _group_id}, socket), do: {:noreply, socket}
+
+  defp refresh_after_membership_change(socket) do
+    user = socket.assigns.current_user
+    group = socket.assigns.group
+
+    case load_group(group.slug, user) do
+      {:ok, reloaded_group} ->
+        sidebar_groups =
+          Communities.get_organizable_groups!(actor: user, query: [sort: [name: :asc]])
+
+        socket
+        |> assign(:group, reloaded_group)
+        |> assign(:sidebar_owned_groups, sidebar_groups)
+        |> assign_group_permissions(reloaded_group, user)
+        |> load_section(socket.assigns.live_action, reloaded_group, user)
+
+      :error ->
+        socket
+        |> put_flash(:error, "Your organizer access to #{group.name} has changed.")
+        |> push_navigate(to: ~p"/organize")
+    end
+  end
 end

--- a/test/huddlz_web/live/organize_live_permissions_test.exs
+++ b/test/huddlz_web/live/organize_live_permissions_test.exs
@@ -1,0 +1,178 @@
+defmodule HuddlzWeb.OrganizeLivePermissionsTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Huddlz.Communities
+  alias Huddlz.Communities.MembershipEvents
+
+  setup do
+    owner = generate(user(role: :user))
+    organizer = generate(user(role: :user))
+    member = generate(user(role: :user))
+    admin = generate(user(role: :admin))
+
+    {group, [organizer_membership, _member_membership]} =
+      generate_group_with_members(
+        owner: owner,
+        group: [name: "Permission-aware Group", is_public: true],
+        members: [
+          %{user: organizer, role: :organizer},
+          %{user: member, role: :member}
+        ]
+      )
+
+    huddl =
+      generate(
+        huddl(
+          title: "Permission-aware Huddl",
+          group_id: group.id,
+          creator_id: owner.id,
+          actor: owner
+        )
+      )
+
+    %{
+      admin: admin,
+      group: group,
+      huddl: huddl,
+      member: member,
+      organizer: organizer,
+      organizer_membership: organizer_membership,
+      owner: owner
+    }
+  end
+
+  test "owner sees each action permitted by the domain", %{
+    conn: conn,
+    group: group,
+    huddl: huddl,
+    owner: owner
+  } do
+    {:ok, overview, _html} = live(login(conn, owner), ~p"/organize/#{group.slug}")
+
+    assert has_element?(
+             overview,
+             "#organize-edit-group[href='/groups/#{group.slug}/edit']"
+           )
+
+    assert has_element?(
+             overview,
+             "#organize-create-huddl[href='/groups/#{group.slug}/huddlz/new']"
+           )
+
+    {:ok, huddlz_view, _html} =
+      live(login(conn, owner), ~p"/organize/#{group.slug}/huddlz")
+
+    assert has_element?(
+             huddlz_view,
+             "#organize-schedule-huddl[href='/groups/#{group.slug}/huddlz/new']"
+           )
+
+    assert has_element?(
+             huddlz_view,
+             "#organize-edit-huddl-#{huddl.id}[href='/groups/#{group.slug}/huddlz/#{huddl.id}/edit']"
+           )
+  end
+
+  test "organizer sees huddl actions but not owner-only group editing", %{
+    conn: conn,
+    group: group,
+    huddl: huddl,
+    organizer: organizer
+  } do
+    {:ok, overview, _html} = live(login(conn, organizer), ~p"/organize/#{group.slug}")
+
+    refute has_element?(overview, "#organize-edit-group")
+    assert has_element?(overview, "#organize-create-huddl")
+
+    {:ok, members_view, _html} =
+      live(login(conn, organizer), ~p"/organize/#{group.slug}/members")
+
+    refute has_element?(members_view, "#organize-edit-group")
+
+    {:ok, huddlz_view, _html} =
+      live(login(conn, organizer), ~p"/organize/#{group.slug}/huddlz")
+
+    assert has_element?(huddlz_view, "#organize-schedule-huddl")
+    assert has_element?(huddlz_view, "#organize-edit-huddl-#{huddl.id}")
+  end
+
+  test "admin sees actions allowed by the policy bypass", %{
+    conn: conn,
+    group: group,
+    admin: admin
+  } do
+    {:ok, view, _html} = live(login(conn, admin), ~p"/organize/#{group.slug}")
+
+    assert has_element?(view, "#organize-edit-group")
+    assert has_element?(view, "#organize-create-huddl")
+  end
+
+  test "member and signed-out person cannot enter the workspace", %{
+    conn: conn,
+    group: group,
+    member: member
+  } do
+    assert {:error, {:live_redirect, %{to: "/organize"}}} =
+             live(login(conn, member), ~p"/organize/#{group.slug}")
+
+    assert {:error, {:redirect, %{to: "/sign-in"}}} =
+             live(conn, ~p"/organize/#{group.slug}")
+  end
+
+  test "organizer remains blocked from the direct group edit route", %{
+    conn: conn,
+    group: group,
+    organizer: organizer
+  } do
+    conn
+    |> login(organizer)
+    |> visit(~p"/groups/#{group.slug}/edit")
+    |> assert_has("*", text: "You don't have permission to edit this group")
+    |> refute_has("#edit-group-form")
+  end
+
+  test "demotion removes an already-mounted organizer workspace", %{
+    conn: conn,
+    group: group,
+    organizer: organizer,
+    organizer_membership: organizer_membership,
+    owner: owner
+  } do
+    Process.flag(:trap_exit, true)
+    :ok = MembershipEvents.subscribe(group.id)
+    group_id = group.id
+
+    {:ok, view, _html} =
+      live(login(conn, organizer), ~p"/organize/#{group.slug}/members")
+
+    assert has_element?(view, "h1", "Members")
+    refute has_element?(view, "#organize-edit-group")
+
+    assert {:ok, %{role: :member}} =
+             Communities.change_member_role(organizer_membership, :member, actor: owner)
+
+    assert {:error, _reason} =
+             Communities.get_group_for_organize(group.slug, actor: organizer)
+
+    assert_receive {:group_membership_changed, ^group_id}
+
+    assert_receive {_ref, {:redirect, _live_view_topic, %{kind: :push, to: "/organize"}}}
+  end
+
+  test "ownership transfer reveals the owner action in an already-mounted workspace", %{
+    conn: conn,
+    group: group,
+    organizer: organizer,
+    owner: owner
+  } do
+    {:ok, view, _html} = live(login(conn, organizer), ~p"/organize/#{group.slug}")
+    refute has_element?(view, "#organize-edit-group")
+
+    assert {:ok, _group} =
+             Communities.transfer_group_ownership(group, organizer.id, actor: owner)
+
+    assert has_element?(view, "#organize-edit-group")
+  end
+end


### PR DESCRIPTION
## Summary

- derive every organizer-workspace resource action from its Ash authorization policy
- hide owner-only group editing from organizers while preserving permitted huddl actions
- refresh or revoke mounted workspaces after membership and ownership changes
- cover owner, organizer, member, admin, signed-out, direct-route, and live role-change behavior

## Verification

- `mix precommit` (1,434 checks; strict Credo clean)

Closes #314