### PR TITLE
feat: support every-N-weeks recurring huddlz

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -131,11 +131,17 @@ defmodule Huddlz.Communities.Huddl do
       argument :repeat_until, :date, allow_nil?: true
       argument :frequency, :string, allow_nil?: true
 
+      argument :recurrence_interval, :integer do
+        allow_nil? true
+        constraints min: 1, max: 4
+      end
+
       argument :provided_latitude, :float, allow_nil?: true, public?: false
       argument :provided_longitude, :float, allow_nil?: true, public?: false
       argument :pending_image_id, :uuid, allow_nil?: true, public?: false
 
       validate Huddlz.Communities.Huddl.Validations.FutureDateValidation
+      validate Huddlz.Communities.Huddl.Validations.RecurrenceIntervalValidation
       change Huddlz.Communities.Huddl.Changes.SetCreatorToActor
       change Huddlz.Communities.Huddl.Changes.AddCreatorAsAttendee
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
@@ -178,6 +184,11 @@ defmodule Huddlz.Communities.Huddl do
       argument :repeat_until, :date
       argument :frequency, :string
 
+      argument :recurrence_interval, :integer do
+        allow_nil? true
+        constraints min: 1, max: 4
+      end
+
       argument :edit_type, :string do
         constraints allow_empty?: true
         default "instance"
@@ -188,6 +199,7 @@ defmodule Huddlz.Communities.Huddl do
 
       require_atomic? false
 
+      validate Huddlz.Communities.Huddl.Validations.RecurrenceIntervalValidation
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFields

--- a/lib/huddlz/communities/huddl/changes/add_huddl_template.ex
+++ b/lib/huddlz/communities/huddl/changes/add_huddl_template.ex
@@ -22,16 +22,23 @@ defmodule Huddlz.Communities.Huddl.Changes.AddHuddlTemplate do
   # and set the id directly. This avoids the re-entrant :update that previously
   # ran inside the :create transaction to backfill huddl_template_id.
   defp create_and_link_template(changeset) do
-    template =
-      HuddlTemplate
-      |> Ash.Changeset.for_create(:create, %{
+    template_attrs =
+      %{
         repeat_until: Ash.Changeset.get_argument(changeset, :repeat_until),
         frequency: Ash.Changeset.get_argument(changeset, :frequency)
-      })
+      }
+      |> maybe_put_interval(Ash.Changeset.get_argument(changeset, :recurrence_interval))
+
+    template =
+      HuddlTemplate
+      |> Ash.Changeset.for_create(:create, template_attrs)
       |> Ash.create!(authorize?: false)
 
     Ash.Changeset.force_change_attribute(changeset, :huddl_template_id, template.id)
   end
+
+  defp maybe_put_interval(attrs, nil), do: attrs
+  defp maybe_put_interval(attrs, interval), do: Map.put(attrs, :interval, interval)
 
   # Generating up to 104 instances (each a full create) is too much work for the
   # request transaction, so defer it to Oban once the parent huddl commits. The

--- a/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
+++ b/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
@@ -25,6 +25,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
   defp reconcile_series(changeset, huddl, actor) do
     repeat_until = Ash.Changeset.get_argument(changeset, :repeat_until)
     frequency = Ash.Changeset.get_argument(changeset, :frequency)
+    recurrence_interval = Ash.Changeset.get_argument(changeset, :recurrence_interval)
 
     # The update result doesn't carry loaded relationships, and API/GraphQL
     # callers may not have preloaded the template, so load it here.
@@ -36,12 +37,16 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
         {:ok, huddl}
 
       huddl_template ->
-        {:ok, huddl_template} =
-          huddl_template
-          |> Ash.Changeset.for_update(:update, %{
+        template_attrs =
+          %{
             repeat_until: repeat_until,
             frequency: frequency
-          })
+          }
+          |> maybe_put_interval(recurrence_interval)
+
+        {:ok, huddl_template} =
+          huddl_template
+          |> Ash.Changeset.for_update(:update, template_attrs)
           |> Ash.update(authorize?: false)
 
         # Synchronous: "edit all" is a rare organizer action, bounded at the
@@ -52,4 +57,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
         {:ok, huddl}
     end
   end
+
+  defp maybe_put_interval(attrs, nil), do: attrs
+  defp maybe_put_interval(attrs, interval), do: Map.put(attrs, :interval, interval)
 end

--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -95,16 +95,14 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     do: :ok
 
   def generate_huddlz_from_template(template, source, count) do
-    interval_days = interval_days(template)
-    starts_at = DateTime.add(source.starts_at, interval_days, :day)
-    ends_at = DateTime.add(source.ends_at, interval_days, :day)
+    source
+    |> desired_occurrences(template)
+    |> Enum.drop(count)
+    |> Enum.each(fn {starts_at, ends_at} ->
+      create_instance!(source, template, starts_at, ends_at)
+    end)
 
-    if Date.before?(DateTime.to_date(starts_at), template.repeat_until) do
-      new_huddl = create_instance!(source, template, starts_at, ends_at)
-      generate_huddlz_from_template(template, new_huddl, count + 1)
-    else
-      :ok
-    end
+    :ok
   end
 
   # Later instances in the series, read through the dedicated visibility-free
@@ -122,12 +120,11 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
   # at @max_instances. Times shift with the source, so editing the time moves
   # every future occurrence.
   defp desired_occurrences(source, template) do
-    interval_days = interval_days(template)
     duration = DateTime.diff(source.ends_at, source.starts_at, :second)
 
     1..@max_instances
     |> Enum.reduce_while([], fn k, acc ->
-      starts_at = DateTime.add(source.starts_at, k * interval_days, :day)
+      starts_at = shift_datetime(source.starts_at, template, k)
 
       if Date.before?(DateTime.to_date(starts_at), template.repeat_until) do
         {:cont, [{starts_at, DateTime.add(starts_at, duration, :second)} | acc]}
@@ -239,4 +236,25 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
 
   defp interval_days(%{interval: interval, unit: :week}), do: interval * 7
   defp interval_days(%{interval: interval, unit: :month}), do: interval * 30
+
+  defp shift_datetime(datetime, %{unit: :week} = template, occurrence_number) do
+    shifted_date =
+      datetime
+      |> DateTime.to_date()
+      |> Date.add(occurrence_number * interval_days(template))
+
+    new_datetime(shifted_date, DateTime.to_time(datetime), datetime.time_zone)
+  end
+
+  defp shift_datetime(datetime, %{unit: :month} = template, occurrence_number) do
+    DateTime.add(datetime, occurrence_number * interval_days(template), :day)
+  end
+
+  defp new_datetime(date, time, time_zone) do
+    case DateTime.new(date, time, time_zone) do
+      {:ok, datetime} -> datetime
+      {:ambiguous, first, _second} -> first
+      {:gap, _before, after_gap} -> after_gap
+    end
+  end
 end

--- a/lib/huddlz/communities/huddl/validations/recurrence_interval_validation.ex
+++ b/lib/huddlz/communities/huddl/validations/recurrence_interval_validation.ex
@@ -1,0 +1,34 @@
+defmodule Huddlz.Communities.Huddl.Validations.RecurrenceIntervalValidation do
+  @moduledoc """
+  Requires an explicit interval when a weekly series is created or edited.
+  """
+
+  use Ash.Resource.Validation
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    frequency = Ash.Changeset.get_argument(changeset, :frequency)
+    interval = Ash.Changeset.get_argument(changeset, :recurrence_interval)
+
+    if weekly_series_change?(changeset, frequency) and is_nil(interval) and
+         recurrence_interval_missing?(changeset) do
+      {:error,
+       field: :recurrence_interval, message: "Choose how many weeks apart this huddl repeats."}
+    else
+      :ok
+    end
+  end
+
+  defp weekly_series_change?(changeset, frequency) when frequency in ["weekly", :weekly] do
+    Ash.Changeset.get_argument(changeset, :is_recurring) == true or
+      Ash.Changeset.get_argument(changeset, :edit_type) == "all"
+  end
+
+  defp weekly_series_change?(_changeset, _frequency), do: false
+
+  defp recurrence_interval_missing?(changeset) do
+    changeset.params
+    |> Map.get(:recurrence_interval, Map.get(changeset.params, "recurrence_interval"))
+    |> then(&(&1 in [nil, ""]))
+  end
+end

--- a/lib/huddlz/communities/huddl_template.ex
+++ b/lib/huddlz/communities/huddl_template.ex
@@ -79,7 +79,7 @@ defmodule Huddlz.Communities.HuddlTemplate do
 
     attribute :interval, :integer do
       allow_nil? false
-      constraints min: 1
+      constraints min: 1, max: 4
       default 1
     end
 
@@ -93,7 +93,6 @@ defmodule Huddlz.Communities.HuddlTemplate do
   @doc """
   Returns the form-facing cadence represented by an explicit interval and unit.
   """
-  def cadence(%__MODULE__{interval: 1, unit: :week}), do: :weekly
-  def cadence(%__MODULE__{interval: 2, unit: :week}), do: :every_two_weeks
-  def cadence(%__MODULE__{interval: 1, unit: :month}), do: :monthly
+  def cadence(%__MODULE__{unit: :week}), do: :weekly
+  def cadence(%__MODULE__{unit: :month}), do: :monthly
 end

--- a/lib/huddlz/communities/huddl_template/changes/set_recurrence_from_frequency.ex
+++ b/lib/huddlz/communities/huddl_template/changes/set_recurrence_from_frequency.ex
@@ -11,7 +11,9 @@ defmodule Huddlz.Communities.HuddlTemplate.Changes.SetRecurrenceFromFrequency do
     set_recurrence(changeset, Ash.Changeset.get_argument(changeset, :frequency))
   end
 
-  defp set_recurrence(changeset, :weekly), do: set_recurrence(changeset, 1, :week)
+  defp set_recurrence(changeset, :weekly),
+    do: Ash.Changeset.change_attribute(changeset, :unit, :week)
+
   defp set_recurrence(changeset, :every_two_weeks), do: set_recurrence(changeset, 2, :week)
   defp set_recurrence(changeset, :monthly), do: set_recurrence(changeset, 1, :month)
   defp set_recurrence(changeset, nil), do: changeset

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -1,7 +1,6 @@
 defmodule HuddlzWeb.Components.HuddlForm do
   @moduledoc """
-  Presentation primitives shared by the huddl create and edit forms:
-  the event-type radio cards and the duration select options.
+  Presentation primitives shared by the huddl create and edit forms.
 
   ```
   <.event_type_grid field={@form[:event_type]} />
@@ -11,6 +10,8 @@ defmodule HuddlzWeb.Components.HuddlForm do
   ```
   """
   use Phoenix.Component
+
+  import HuddlzWeb.Components.Input, only: [input: 1, select: 1]
 
   @duration_options [
     {"30 minutes", "30"},
@@ -128,6 +129,90 @@ defmodule HuddlzWeb.Components.HuddlForm do
     </div>
     """
   end
+
+  attr :frequency_field, Phoenix.HTML.FormField, required: true
+  attr :interval_field, Phoenix.HTML.FormField, required: true
+  attr :repeat_until_field, Phoenix.HTML.FormField, required: true
+  attr :date_field, Phoenix.HTML.FormField, required: true
+
+  def recurrence_fields(assigns) do
+    assigns =
+      assigns
+      |> assign(:weekly?, field_value(assigns.frequency_field) != "monthly")
+      |> assign(:cadence_summary, cadence_summary(assigns))
+
+    ~H"""
+    <div class="form-row form-row-inline" id="recurring-fields">
+      <div class="form-col-md">
+        <.select
+          field={@frequency_field}
+          label="Frequency"
+          options={[
+            {"Weekly", "weekly"},
+            {"Monthly", "monthly"}
+          ]}
+        />
+      </div>
+      <div :if={@weekly?} class="form-col-md">
+        <.select
+          field={@interval_field}
+          label="Repeat every"
+          options={[
+            {"1 week", "1"},
+            {"2 weeks", "2"},
+            {"3 weeks", "3"},
+            {"4 weeks", "4"}
+          ]}
+        />
+      </div>
+      <div class="form-col-md">
+        <.input field={@repeat_until_field} type="date" label="Repeat until" />
+      </div>
+    </div>
+    <p id="recurring-cadence-summary" class="form-help" aria-live="polite">
+      {@cadence_summary}
+    </p>
+    """
+  end
+
+  defp cadence_summary(assigns) do
+    case field_value(assigns.frequency_field) do
+      "monthly" ->
+        "Monthly on day #{day_of_month(assigns.date_field)}"
+
+      _ ->
+        interval = field_value(assigns.interval_field) || "1"
+        unit = if interval == "1", do: "week", else: "weeks"
+        "Every #{interval} #{unit} on #{weekday(assigns.date_field)}"
+    end
+  end
+
+  defp field_value(field), do: field.value && to_string(field.value)
+
+  defp weekday(field) do
+    case parse_date(field.value) do
+      {:ok, date} -> Calendar.strftime(date, "%A")
+      :error -> "the selected weekday"
+    end
+  end
+
+  defp day_of_month(field) do
+    case parse_date(field.value) do
+      {:ok, date} -> date.day
+      :error -> "the selected date"
+    end
+  end
+
+  defp parse_date(%Date{} = date), do: {:ok, date}
+
+  defp parse_date(value) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> {:ok, date}
+      _ -> :error
+    end
+  end
+
+  defp parse_date(_value), do: :error
 
   def duration_options, do: @duration_options
 end

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -121,7 +121,8 @@ defmodule HuddlzWeb.HuddlLive.Edit do
     if huddl.huddl_template_id do
       Map.merge(params, %{
         "repeat_until" => huddl.huddl_template.repeat_until,
-        "frequency" => huddl.huddl_template |> HuddlTemplate.cadence() |> to_string()
+        "frequency" => huddl.huddl_template |> HuddlTemplate.cadence() |> to_string(),
+        "recurrence_interval" => to_string(huddl.huddl_template.interval)
       })
     else
       params
@@ -354,26 +355,12 @@ defmodule HuddlzWeb.HuddlLive.Edit do
             </p>
 
             <%= if @huddl.huddl_template_id && edit_type_value(@form) == "all" do %>
-              <div class="form-row form-row-inline">
-                <div class="form-col-md">
-                  <.select
-                    field={@form[:frequency]}
-                    label="Frequency"
-                    options={[
-                      {"Weekly", "weekly"},
-                      {"Every two weeks", "every_two_weeks"},
-                      {"Monthly", "monthly"}
-                    ]}
-                  />
-                </div>
-                <div class="form-col-md">
-                  <.input
-                    field={@form[:repeat_until]}
-                    type="date"
-                    label="Repeat until"
-                  />
-                </div>
-              </div>
+              <.recurrence_fields
+                frequency_field={@form[:frequency]}
+                interval_field={@form[:recurrence_interval]}
+                repeat_until_field={@form[:repeat_until]}
+                date_field={@form[:date]}
+              />
             <% end %>
           </div>
         </div>

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -73,7 +73,9 @@ defmodule HuddlzWeb.HuddlLive.New do
           "group_id" => group.id,
           "date" => Date.to_iso8601(tomorrow),
           "start_time" => Time.to_iso8601(default_time) |> String.slice(0..4),
-          "duration_minutes" => "60"
+          "duration_minutes" => "60",
+          "frequency" => "weekly",
+          "recurrence_interval" => "1"
         }
       )
 
@@ -237,26 +239,12 @@ defmodule HuddlzWeb.HuddlLive.New do
             </div>
 
             <%= if Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_recurring].value) do %>
-              <div class="form-row form-row-inline">
-                <div class="form-col-md">
-                  <.select
-                    field={@form[:frequency]}
-                    label="Frequency"
-                    options={[
-                      {"Weekly", "weekly"},
-                      {"Every two weeks", "every_two_weeks"},
-                      {"Monthly", "monthly"}
-                    ]}
-                  />
-                </div>
-                <div class="form-col-md">
-                  <.input
-                    field={@form[:repeat_until]}
-                    type="date"
-                    label="Repeat until"
-                  />
-                </div>
-              </div>
+              <.recurrence_fields
+                frequency_field={@form[:frequency]}
+                interval_field={@form[:recurrence_interval]}
+                repeat_until_field={@form[:repeat_until]}
+                date_field={@form[:date]}
+              />
             <% end %>
           </div>
         </div>

--- a/test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs
+++ b/test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs
@@ -77,7 +77,8 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
         title: "Renamed series",
         edit_type: "all",
         repeat_until: repeat_until,
-        frequency: "weekly"
+        frequency: "weekly",
+        recurrence_interval: 1
       },
       actor: owner
     )

--- a/test/huddlz/communities/huddl/recurrence_helper_test.exs
+++ b/test/huddlz/communities/huddl/recurrence_helper_test.exs
@@ -112,6 +112,67 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelperTest do
 
       assert Enum.all?(dates, &(Date.day_of_week(&1) == Date.day_of_week(source_date)))
     end
+
+    test "supports a three-week interval", ctx do
+      source_date = DateTime.to_date(ctx.starts_at)
+
+      template =
+        HuddlTemplate
+        |> Ash.Changeset.for_create(:create, %{
+          interval: 3,
+          unit: :week,
+          repeat_until: Date.add(source_date, 64)
+        })
+        |> Ash.create!(authorize?: false)
+
+      RecurrenceHelper.generate_huddlz_from_template(template, ctx.huddl)
+
+      dates =
+        Huddl
+        |> Ash.Query.filter(huddl_template_id == ^template.id)
+        |> Ash.read!(authorize?: false)
+        |> Enum.map(&DateTime.to_date(&1.starts_at))
+        |> Enum.sort(Date)
+
+      assert dates == [
+               Date.add(source_date, 21),
+               Date.add(source_date, 42),
+               Date.add(source_date, 63)
+             ]
+    end
+
+    test "preserves local wall-clock time across daylight-saving changes", ctx do
+      starts_at = DateTime.new!(~D[2026-03-01], ~T[09:00:00], "America/New_York")
+      ends_at = DateTime.add(starts_at, 1, :hour)
+      source = %{ctx.huddl | starts_at: starts_at, ends_at: ends_at}
+
+      template =
+        HuddlTemplate
+        |> Ash.Changeset.for_create(:create, %{
+          interval: 1,
+          unit: :week,
+          repeat_until: ~D[2026-03-17]
+        })
+        |> Ash.create!(authorize?: false)
+
+      RecurrenceHelper.generate_huddlz_from_template(template, source)
+
+      local_starts =
+        Huddl
+        |> Ash.Query.filter(huddl_template_id == ^template.id)
+        |> Ash.read!(authorize?: false)
+        |> Enum.map(fn huddl ->
+          huddl.starts_at
+          |> DateTime.shift_zone!("America/New_York")
+          |> then(&{DateTime.to_date(&1), DateTime.to_time(&1)})
+        end)
+        |> Enum.sort()
+
+      assert local_starts == [
+               {~D[2026-03-08], ~T[09:00:00]},
+               {~D[2026-03-15], ~T[09:00:00]}
+             ]
+    end
   end
 
   describe "generate_huddlz_from_template/2 monthly" do
@@ -180,5 +241,41 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelperTest do
       assert new_huddl.group_id == ctx.huddl.group_id
       assert new_huddl.creator_id == ctx.huddl.creator_id
     end
+  end
+
+  describe "weekly recurrence interval validation" do
+    test "accepts intervals one through four and rejects missing or unsupported values", ctx do
+      Enum.each(1..4, fn interval ->
+        assert {:ok, huddl} = create_recurring_huddl(ctx, interval)
+        template = Ash.load!(huddl, :huddl_template, authorize?: false).huddl_template
+        assert template.interval == interval
+        assert template.unit == :week
+      end)
+
+      for interval <- [nil, 0, -1, 5] do
+        assert {:error, %Ash.Error.Invalid{}} = create_recurring_huddl(ctx, interval)
+      end
+    end
+  end
+
+  defp create_recurring_huddl(ctx, interval) do
+    attrs = %{
+      title: "Interval #{inspect(interval)} #{System.unique_integer([:positive])}",
+      date: Date.add(Date.utc_today(), 1),
+      start_time: ~T[09:00:00],
+      duration_minutes: 60,
+      event_type: :in_person,
+      physical_location: "123 Main St",
+      group_id: ctx.group.id,
+      is_recurring: true,
+      frequency: "weekly",
+      repeat_until: Date.add(Date.utc_today(), 90)
+    }
+
+    attrs = if is_nil(interval), do: attrs, else: Map.put(attrs, :recurrence_interval, interval)
+
+    Huddl
+    |> Ash.Changeset.for_create(:create, attrs, actor: ctx.owner)
+    |> Ash.create()
   end
 end

--- a/test/huddlz/communities/workers/regenerate_recurring_series_test.exs
+++ b/test/huddlz/communities/workers/regenerate_recurring_series_test.exs
@@ -124,6 +124,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
           group_id: group.id,
           is_recurring: true,
           frequency: "weekly",
+          recurrence_interval: 1,
           repeat_until: Date.add(Date.utc_today(), 22)
         },
         actor: owner
@@ -279,6 +280,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
           group_id: group.id,
           is_recurring: true,
           frequency: "weekly",
+          recurrence_interval: 1,
           repeat_until: Date.add(Date.utc_today(), 22)
         },
         actor: owner

--- a/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
+++ b/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
@@ -269,7 +269,8 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
           title: "Saturday Soccer (renamed)",
           edit_type: "all",
           repeat_until: Date.add(Date.utc_today(), 60),
-          frequency: "weekly"
+          frequency: "weekly",
+          recurrence_interval: 1
         },
         actor: owner
       )
@@ -330,7 +331,8 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
           title: "Saturday Soccer (renamed)",
           edit_type: "all",
           repeat_until: Date.add(Date.utc_today(), 30),
-          frequency: "weekly"
+          frequency: "weekly",
+          recurrence_interval: 1
         },
         actor: owner
       )
@@ -394,7 +396,8 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
         %{
           edit_type: "all",
           repeat_until: Date.add(Date.utc_today(), 16),
-          frequency: "weekly"
+          frequency: "weekly",
+          recurrence_interval: 1
         },
         actor: owner
       )

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -282,26 +282,28 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       assert_has(session, "*", text: "Editing every upcoming date")
       assert_has(session, "input[type='hidden'][name='form[edit_type]'][value='all']")
       assert_has(session, "select[name='form[frequency]']")
+      assert_has(session, "select[name='form[recurrence_interval]']")
       assert_has(session, "input[name='form[repeat_until]']")
     end
 
-    test "whole-series editing preserves an every-two-weeks cadence", %{
+    test "whole-series editing preserves a four-week cadence", %{
       conn: conn,
       owner: owner,
       group: group
     } do
       every_other_week_huddl =
         create_recurring_huddl(owner, group,
-          title: "Every Other Week Series",
-          frequency: :every_two_weeks,
-          repeat_until: Date.utc_today() |> Date.add(60)
+          title: "Every Four Weeks Series",
+          frequency: :weekly,
+          recurrence_interval: 4,
+          repeat_until: Date.utc_today() |> Date.add(120)
         )
 
       session = open_whole_series_edit(conn, owner, group, every_other_week_huddl)
 
       assert_has(
         session,
-        "select[name='form[frequency]'] option[value='every_two_weeks'][selected]"
+        "select[name='form[recurrence_interval]'] option[value='4'][selected]"
       )
 
       save_whole_series(session)
@@ -312,7 +314,7 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
         |> Ash.load!(:huddl_template, actor: owner)
         |> Map.fetch!(:huddl_template)
 
-      assert template.interval == 2
+      assert template.interval == 4
       assert template.unit == :week
 
       dates =
@@ -323,7 +325,7 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
 
       assert dates
              |> Enum.chunk_every(2, 1, :discard)
-             |> Enum.all?(fn [first, second] -> Date.diff(second, first) == 14 end)
+             |> Enum.all?(fn [first, second] -> Date.diff(second, first) == 28 end)
     end
 
     test "whole-series editing keeps virtual controls and their value", %{

--- a/test/huddlz_web/live/huddl_live/new_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_test.exs
@@ -319,25 +319,32 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
       |> assert_has("*", text: "1/5 spots filled")
     end
 
-    test "creates an every-two-weeks recurring huddl", %{
+    test "creates an every-three-weeks recurring huddl and describes its cadence", %{
       conn: conn,
       owner: owner,
       group: group
     } do
       first_date = Date.utc_today() |> Date.add(1)
-      repeat_until = Date.add(first_date, 43)
+      repeat_until = Date.add(first_date, 64)
+      weekday = Calendar.strftime(first_date, "%A")
 
       session =
         conn
         |> login(owner)
         |> visit(~p"/groups/#{group.slug}/huddlz/new")
-        |> fill_in("Title", with: "Every Other Week Huddl")
+        |> fill_in("Title", with: "Every Three Weeks Huddl")
         |> fill_in("Date", with: Date.to_iso8601(first_date))
         |> fill_in("Start time", with: "14:30")
         |> select("Duration", option: "2 hours")
         |> check("Recurring huddl")
-        |> select("Frequency", option: "Every two weeks")
+        |> select("Repeat every", option: "3 weeks")
         |> fill_in("Repeat until", with: Date.to_iso8601(repeat_until))
+
+      assert_has(
+        session,
+        "#recurring-cadence-summary",
+        text: "Every 3 weeks on #{weekday}"
+      )
 
       select_physical_location(session.view, "123 Main St")
 
@@ -347,13 +354,53 @@ defmodule HuddlzWeb.HuddlLive.NewTest do
 
       template =
         Huddl
-        |> Ash.Query.filter(title == "Every Other Week Huddl" and group_id == ^group.id)
+        |> Ash.Query.filter(title == "Every Three Weeks Huddl" and group_id == ^group.id)
         |> Ash.read_one!(actor: owner)
         |> Ash.load!(:huddl_template, actor: owner)
         |> Map.fetch!(:huddl_template)
 
-      assert template.interval == 2
+      assert template.interval == 3
       assert template.unit == :week
+    end
+
+    test "shows an inline error for an unsupported weekly interval", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      first_date = Date.utc_today() |> Date.add(1)
+
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/huddlz/new")
+        |> fill_in("Title", with: "Invalid Recurrence Huddl")
+        |> fill_in("Date", with: Date.to_iso8601(first_date))
+        |> fill_in("Start time", with: "14:30")
+        |> select("Duration", option: "2 hours")
+        |> check("Recurring huddl")
+
+      select_physical_location(session.view, "123 Main St")
+
+      render_change(session.view, "validate", %{
+        "form" => %{
+          "title" => "Invalid Recurrence Huddl",
+          "date" => Date.to_iso8601(first_date),
+          "start_time" => "14:30",
+          "duration_minutes" => "120",
+          "event_type" => "in_person",
+          "is_recurring" => "true",
+          "frequency" => "weekly",
+          "recurrence_interval" => "5",
+          "repeat_until" => Date.to_iso8601(Date.add(first_date, 40))
+        }
+      })
+
+      assert has_element?(
+               session.view,
+               "#form_recurrence_interval-error-0",
+               "must be less than or equal to 4"
+             )
     end
 
     test "creates private huddl for private group", %{conn: conn, owner: owner} do

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -307,6 +307,7 @@ defmodule Huddlz.Generator do
         is_private: false,
         huddl_template_id: nil,
         is_recurring: false,
+        recurrence_interval: 1,
         max_attendees: nil
       ],
       overrides: opts,


### PR DESCRIPTION
## Summary

- add weekly recurrence intervals from one through four weeks to huddl create and whole-series edit flows
- show a live plain-language cadence summary derived from the first huddl date
- preserve local wall-clock time across daylight-saving transitions and validate missing or unsupported intervals through Ash
- retain compatibility with existing weekly, every-two-weeks, and monthly recurrence data

## Verification

- `env ERL_FLAGS="+S 2:2" mix precommit` (1,431 checks; strict Credo clean)
- `mix ash.codegen --check`
- focused recurring-series, worker, domain-edit, and LiveView coverage (228 checks)

Closes #312