### PR TITLE
chore(runtime): upgrade Elixir and Erlang patch releases

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -40,8 +40,8 @@ jobs:
       # Specify the OTP and Elixir versions to use when building
       # and running the workflow steps.
       matrix:
-        otp: ['29.0.1']       # Define the OTP version [required]
-        elixir: ['1.20.0']    # Define the elixir version [required]
+        otp: ['29.0.3']       # Define the OTP version [required]
+        elixir: ['1.20.2']    # Define the elixir version [required]
     steps:
     # Step: Setup Elixir + Erlang image as the base.
     - name: Set up Elixir
@@ -134,8 +134,8 @@ jobs:
       MIX_ENV: dev
     strategy:
       matrix:
-        otp: ['29.0.1']
-        elixir: ['1.20.0']
+        otp: ['29.0.3']
+        elixir: ['1.20.2']
     steps:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
-elixir = "1.20.0-otp-29"
-erlang = "29.0.1"
+elixir = "1.20.2-otp-29"
+erlang = "29.0.3"
 
 [tasks.sync-rules]
 description = "Sync AGENTS.md and .agents/skills/ from mix.exs usage_rules config"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
 #   - https://hub.docker.com/_/debian/tags?name=trixie-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: docker.io/hexpm/elixir:1.20.0-erlang-29.0.1-debian-trixie-20260518-slim
+#   - Ex: docker.io/hexpm/elixir:1.20.2-erlang-29.0.3-debian-trixie-20260713-slim
 #
-ARG ELIXIR_VERSION=1.20.0
-ARG OTP_VERSION=29.0.1
-ARG DEBIAN_VERSION=trixie-20260518-slim
+ARG ELIXIR_VERSION=1.20.2
+ARG OTP_VERSION=29.0.3
+ARG DEBIAN_VERSION=trixie-20260713-slim
 
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
## Summary

- upgrade local development and both CI jobs to Elixir 1.20.2 with Erlang/OTP 29.0.3
- refresh the production builder and runner to the matching Debian Trixie 20260713 snapshot
- keep the existing `~> 1.20` Mix requirement because it already expresses the selected stable release line without over-constraining patch updates

## Release verification

The selected releases were rechecked immediately before implementation:

- Elixir 1.20.2 is the newest stable Elixir release: https://github.com/elixir-lang/elixir/releases/tag/v1.20.2
- Erlang/OTP 29.0.3 is the newest stable OTP 29 patch: https://github.com/erlang/otp/releases/tag/OTP-29.0.3
- Elixir 1.20 supports OTP 27 through 29: https://hexdocs.pm/elixir/main/compatibility-and-deprecations.html
- Docker Hub exposes the selected builder and runner tags for linux/amd64 and linux/arm64

## Validation

- clean dependency fetch under Elixir 1.20.2 / OTP 29.0.3
- clean `mix compile --warnings-as-errors`; huddlz emits no application warnings, while new type/deprecation warnings remain confined to third-party dependencies and were not globally suppressed
- `mix precommit` (1,427 checks, strict Credo clean)
- native compilation for `bcrypt_elixir`, `picosat_elixir`, and `image`/libvips
- Req HTTPS/certificate, DNS resolution, and crypto smoke checks
- production assets and release assembly
- release migration command and production boot
- `GET /healthz` returned 200 on alternate port 43123

The Docker Hub manifests were verified directly. A local Docker image pull stalled in the daemon before layer transfer, so the deploy workflow remains the final container-build confirmation.

Closes #323