### PR TITLE
fix(groups): show actual membership roles

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -493,6 +493,17 @@ body .sb-org-row .name {
   text-overflow: ellipsis;
 }
 
+body .sb-org-row .group-role {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 body .sb-org-row:hover {
   background: rgba(24, 203, 212, 0.06);
   color: var(--text);

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -101,6 +101,7 @@ defmodule Huddlz.Communities.GroupMember do
       change manage_relationship(:user_id, :user, type: :append)
       change set_attribute(:role, arg(:role))
       change Huddlz.Communities.GroupMember.Changes.NotifyAdded
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     create :add_owner do
@@ -123,6 +124,7 @@ defmodule Huddlz.Communities.GroupMember do
       change manage_relationship(:user_id, :user, type: :append)
       change set_attribute(:role, :owner)
       change Huddlz.Communities.GroupMember.Changes.NotifyAdded
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     destroy :remove_member do
@@ -141,6 +143,7 @@ defmodule Huddlz.Communities.GroupMember do
       filter expr(user_id == ^arg(:user_id))
 
       change Huddlz.Communities.GroupMember.Changes.NotifyRemoved
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     action :remove_member_by_ids, :struct do
@@ -168,6 +171,7 @@ defmodule Huddlz.Communities.GroupMember do
       end
 
       change Huddlz.Communities.GroupMember.Changes.NotifyRoleChanged
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     update :set_role do
@@ -179,6 +183,7 @@ defmodule Huddlz.Communities.GroupMember do
 
       accept [:role]
       require_atomic? false
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     create :join_group do
@@ -192,16 +197,20 @@ defmodule Huddlz.Communities.GroupMember do
       change relate_actor(:user)
       change set_attribute(:role, :member)
       change Huddlz.Communities.GroupMember.Changes.NotifyJoined
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     destroy :leave_group do
       description "Leave a group (member removes themselves; owners must transfer ownership first)"
+      require_atomic? false
 
       # Encoded as a validation, not just a policy guard, so the admin bypass
       # cannot delete an owner's membership row and corrupt group state.
       validate attribute_does_not_equal(:role, :owner) do
         message "owners cannot leave their own group; transfer ownership first"
       end
+
+      change Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged
     end
 
     read :get_by_group do

--- a/lib/huddlz/communities/group_member/changes/broadcast_membership_changed.ex
+++ b/lib/huddlz/communities/group_member/changes/broadcast_membership_changed.ex
@@ -1,0 +1,21 @@
+defmodule Huddlz.Communities.GroupMember.Changes.BroadcastMembershipChanged do
+  @moduledoc """
+  Broadcasts a committed membership create, update, or destroy.
+  """
+
+  use Ash.Resource.Change
+
+  alias Huddlz.Communities.MembershipEvents
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_transaction(changeset, fn
+      _changeset, {:ok, member} = result ->
+        MembershipEvents.broadcast(member.group_id, member.user_id)
+        result
+
+      _changeset, result ->
+        result
+    end)
+  end
+end

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -1,0 +1,35 @@
+defmodule Huddlz.Communities.MembershipEvents do
+  @moduledoc """
+  Prompts connected group surfaces to re-read membership state after commits.
+
+  Ash actions and policies remain the source of truth. PubSub messages carry
+  identifiers only and never substitute for an authorized read.
+  """
+
+  @pubsub Huddlz.PubSub
+
+  def subscribe(group_id) when is_binary(group_id) do
+    Phoenix.PubSub.subscribe(@pubsub, group_topic(group_id))
+  end
+
+  def subscribe_user(user_id) when is_binary(user_id) do
+    Phoenix.PubSub.subscribe(@pubsub, user_topic(user_id))
+  end
+
+  def broadcast(group_id, user_id) when is_binary(group_id) and is_binary(user_id) do
+    Phoenix.PubSub.broadcast(
+      @pubsub,
+      group_topic(group_id),
+      {:group_membership_changed, group_id}
+    )
+
+    Phoenix.PubSub.broadcast(
+      @pubsub,
+      user_topic(user_id),
+      {:user_group_membership_changed, user_id, group_id}
+    )
+  end
+
+  defp group_topic(group_id), do: "group-membership:#{group_id}"
+  defp user_topic(user_id), do: "user-group-memberships:#{user_id}"
+end

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -6,6 +6,7 @@ defmodule HuddlzWeb.Layouts do
 
   alias Huddlz.Accounts.User
   alias HuddlzWeb.Avatar
+  alias HuddlzWeb.GroupRole
 
   embed_templates "layouts/*"
 
@@ -88,6 +89,9 @@ defmodule HuddlzWeb.Layouts do
                   {group_initials(group.name)}
                 </div>
                 <span class="name">{group.name}</span>
+                <span class="group-role">
+                  {group |> GroupRole.for_group(@current_user) |> GroupRole.label()}
+                </span>
               </a>
               <div :if={@active_group_slug == group.slug} class="sb-sub">
                 <a

--- a/lib/huddlz_web/group_role.ex
+++ b/lib/huddlz_web/group_role.ex
@@ -1,0 +1,33 @@
+defmodule HuddlzWeb.GroupRole do
+  @moduledoc """
+  Presents a person's actual membership role consistently across group UI.
+
+  Permission checks remain the authority for available actions. These helpers
+  only describe the persisted owner or membership relationship and therefore
+  never turn an admin override into an implied group role.
+  """
+
+  def for_group(%{owner_id: user_id}, %{id: user_id}), do: :owner
+
+  def for_group(%{group_members: memberships}, %{id: user_id}) when is_list(memberships) do
+    case Enum.find(memberships, &(&1.user_id == user_id)) do
+      %{role: role} -> role
+      nil -> nil
+    end
+  end
+
+  def for_group(_group, _user), do: nil
+
+  def label(:owner), do: "Owner"
+  def label(:organizer), do: "Organizer"
+  def label(:member), do: "Member"
+  def label(_role), do: nil
+
+  def pill_variant(:owner), do: :cyan
+  def pill_variant(:organizer), do: :warn
+  def pill_variant(:member), do: :magenta
+
+  def card_class(:owner), do: "hybrid"
+  def card_class(:organizer), do: "online"
+  def card_class(:member), do: "in-person"
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -7,10 +7,11 @@ defmodule HuddlzWeb.GroupLive.Show do
   import HuddlzWeb.Live.Helpers.HuddlCardHelpers
 
   alias Huddlz.Communities
-  alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl}
+  alias Huddlz.Communities.{GroupLocation, GroupMember, Huddl, MembershipEvents}
   alias Huddlz.Storage.GroupImages
   alias Huddlz.Storage.HuddlImages
   alias HuddlzWeb.Avatar
+  alias HuddlzWeb.GroupRole
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.MetaHelpers
   alias Phoenix.LiveView.JS
@@ -22,7 +23,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :leave_dialog_open, false)}
+    {:ok,
+     socket
+     |> assign(:leave_dialog_open, false)
+     |> assign(:subscribed_group_id, nil)}
   end
 
   @impl true
@@ -37,12 +41,14 @@ defmodule HuddlzWeb.GroupLive.Show do
 
         {:noreply,
          socket
+         |> subscribe_to_membership_changes(group)
          |> assign(:page_title, group.name)
          |> assign(:meta, group_meta(group))
          |> assign(:group, group)
          |> assign(:members, members)
          |> assign(:member_count, group.member_count)
          |> assign(:is_member, !is_nil(membership))
+         |> assign(:membership_role, membership && membership.role)
          |> assign_action_permissions(group, user, membership)
          |> assign(:active_tab, "upcoming")
          |> assign(:upcoming_huddlz, upcoming_huddlz)
@@ -56,6 +62,47 @@ defmodule HuddlzWeb.GroupLive.Show do
            resource_name: "Group",
            fallback_path: ~p"/discover?#{[scope: "groups"]}"
          )}
+    end
+  end
+
+  @impl true
+  def handle_info(
+        {:group_membership_changed, group_id},
+        %{assigns: %{group: %{id: group_id}}} = socket
+      ) do
+    {:noreply, refresh_current_role(socket)}
+  end
+
+  def handle_info({:group_membership_changed, _group_id}, socket), do: {:noreply, socket}
+
+  defp subscribe_to_membership_changes(socket, group) do
+    if connected?(socket) and socket.assigns.subscribed_group_id != group.id do
+      :ok = MembershipEvents.subscribe(group.id)
+      assign(socket, :subscribed_group_id, group.id)
+    else
+      socket
+    end
+  end
+
+  defp refresh_current_role(socket) do
+    user = socket.assigns.current_user
+
+    case get_group_by_slug(socket.assigns.group.slug, user) do
+      {:ok, group} ->
+        membership = current_user_membership(group, user)
+
+        socket
+        |> assign(:group, group)
+        |> assign(:member_count, group.member_count)
+        |> assign(:is_member, !is_nil(membership))
+        |> assign(:membership_role, membership && membership.role)
+        |> assign_action_permissions(group, user, membership)
+
+      {:error, _reason} ->
+        handle_error(socket, :not_found,
+          resource_name: "Group",
+          fallback_path: ~p"/discover?#{[scope: "groups"]}"
+        )
     end
   end
 
@@ -197,8 +244,13 @@ defmodule HuddlzWeb.GroupLive.Show do
           </ul>
 
           <%= if @current_user do %>
-            <div :if={role_pill(assigns)} class="role-pill">
-              <.pill variant={:cyan}>{role_pill(assigns)}</.pill>
+            <div :if={@membership_role} class="role-pill">
+              <.pill
+                id="current-group-role"
+                variant={GroupRole.pill_variant(@membership_role)}
+              >
+                {GroupRole.label(@membership_role)}
+              </.pill>
             </div>
             <div class="side-actions">
               <.button
@@ -480,6 +532,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> put_flash(:info, "Successfully joined the group!")
          |> assign(:group, group)
          |> assign(:is_member, true)
+         |> assign(:membership_role, membership.role)
          |> assign(:members, members)
          |> assign(:member_count, group.member_count)
          |> assign_action_permissions(group, user, membership)}
@@ -512,6 +565,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> assign(:leave_dialog_open, false)
          |> assign(:group, group)
          |> assign(:is_member, false)
+         |> assign(:membership_role, nil)
          |> assign(:members, nil)
          |> assign(:member_count, group.member_count)
          |> assign_action_permissions(group, user, nil)}
@@ -631,10 +685,6 @@ defmodule HuddlzWeb.GroupLive.Show do
 
   defp parse_page(val) when is_integer(val) and val >= 1, do: val
   defp parse_page(_), do: 1
-
-  defp role_pill(%{can_edit_group: true}), do: "Owner"
-  defp role_pill(%{is_member: true}), do: "Joined"
-  defp role_pill(_assigns), do: nil
 
   defp split_members(members) do
     visible = Enum.take(members, @member_grid_visible)

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -14,10 +14,11 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   alias Huddlz.Communities
   alias Huddlz.Storage.GroupImages
+  alias HuddlzWeb.GroupRole
   alias HuddlzWeb.Layouts
   require Logger
 
-  @group_loads [:current_image_url, :member_count]
+  @group_loads [:current_image_url, :member_count, :group_members]
   @page_size 20
   @valid_filters ~w(all hosting joined)
 
@@ -59,6 +60,28 @@ defmodule HuddlzWeb.MyGroupsLive do
   def handle_event("change_page", %{"page" => page_str}, socket) do
     page = parse_page(page_str)
     {:noreply, push_patch(socket, to: filter_path(socket.assigns.filter, page))}
+  end
+
+  @impl true
+  def handle_info(
+        {:user_group_membership_changed, user_id, _group_id},
+        %{assigns: %{current_user: %{id: user_id}}} = socket
+      ) do
+    user = socket.assigns.current_user
+    filter = socket.assigns.filter
+    page = socket.assigns.page_info.current_page
+
+    socket =
+      socket
+      |> assign(:counts, load_counts(user))
+      |> load_results(filter, page, user)
+
+    if page > socket.assigns.page_info.total_pages do
+      {:noreply,
+       push_patch(socket, to: filter_path(filter, socket.assigns.page_info.total_pages))}
+    else
+      {:noreply, socket}
+    end
   end
 
   defp parse_filter(value) when value in @valid_filters, do: String.to_existing_atom(value)
@@ -118,10 +141,6 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   defp filter_path(filter, _page), do: ~p"/my-groups?#{[filter: filter]}"
 
-  defp role_for(group, user) do
-    if group.owner_id == user.id, do: :hosting, else: :joined
-  end
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -160,7 +179,7 @@ defmodule HuddlzWeb.MyGroupsLive do
           <%= for {group, idx} <- Enum.with_index(@groups) do %>
             <.my_group_card
               group={group}
-              role={role_for(group, @current_user)}
+              role={GroupRole.for_group(group, @current_user)}
               gradient={Integer.mod(idx, 6) + 1}
             />
           <% end %>
@@ -190,7 +209,7 @@ defmodule HuddlzWeb.MyGroupsLive do
           src={GroupImages.url(@group.current_image_url)}
           alt={@group.name}
         />
-        <span class={["card-tag", role_class(@role)]}>{role_label(@role)}</span>
+        <span class={["card-tag", GroupRole.card_class(@role)]}>{GroupRole.label(@role)}</span>
       </:cover>
       <:body>
         <span :if={@group.location} class="card-group">{@group.location}</span>
@@ -212,12 +231,6 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   defp empty_message(:hosting), do: "You haven't created a group yet."
   defp empty_message(:joined), do: "You haven't joined any groups yet."
-
-  defp role_class(:hosting), do: "hybrid"
-  defp role_class(:joined), do: "in-person"
-
-  defp role_label(:hosting), do: "Hosting"
-  defp role_label(:joined), do: "Joined"
 
   defp member_count_label(group) do
     case Map.get(group, :member_count) do

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -14,9 +14,11 @@ defmodule HuddlzWeb.OrganizeLive do
   use HuddlzWeb, :live_view
 
   alias Huddlz.Communities
+  alias Huddlz.Communities.MembershipEvents
+  alias HuddlzWeb.GroupRole
   alias HuddlzWeb.Layouts
 
-  @group_loads [:member_count]
+  @group_loads [:member_count, :group_members]
   @huddl_loads [:rsvp_count, :status, :group]
   @upcoming_loads [:rsvp_count, :group]
   @member_role_order [:owner, :organizer, :member]
@@ -36,7 +38,8 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_filter, :live)
      |> assign(:upcoming_huddlz, [])
      |> assign(:open_rsvps, 0)
-     |> assign(:members, [])}
+     |> assign(:members, [])
+     |> assign(:subscribed_group_id, nil)}
   end
 
   @impl true
@@ -64,6 +67,7 @@ defmodule HuddlzWeb.OrganizeLive do
     case load_group(slug, user) do
       {:ok, group} ->
         socket
+        |> subscribe_to_membership_changes(group)
         |> assign(:group, group)
         |> assign(:page_title, "#{group.name} · Organizer")
         |> load_section(action, group, user)
@@ -129,6 +133,49 @@ defmodule HuddlzWeb.OrganizeLive do
     )
   end
 
+  @impl true
+  def handle_info(
+        {:group_membership_changed, group_id},
+        %{assigns: %{group: %{id: group_id}}} = socket
+      ) do
+    user = socket.assigns.current_user
+
+    case load_group(socket.assigns.group.slug, user) do
+      {:ok, group} ->
+        {:noreply,
+         socket
+         |> assign(:group, group)
+         |> load_section(socket.assigns.live_action, group, user)}
+
+      :error ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Your organizer access to this group has changed.")
+         |> push_navigate(to: ~p"/organize")}
+    end
+  end
+
+  def handle_info(
+        {:user_group_membership_changed, user_id, _group_id},
+        %{assigns: %{current_user: %{id: user_id}, live_action: :index}} = socket
+      ) do
+    {:noreply, load_action(socket, :index, %{}, socket.assigns.current_user)}
+  end
+
+  def handle_info({:user_group_membership_changed, _user_id, _group_id}, socket),
+    do: {:noreply, socket}
+
+  def handle_info({:group_membership_changed, _group_id}, socket), do: {:noreply, socket}
+
+  defp subscribe_to_membership_changes(socket, group) do
+    if connected?(socket) and socket.assigns.subscribed_group_id != group.id do
+      :ok = MembershipEvents.subscribe(group.id)
+      assign(socket, :subscribed_group_id, group.id)
+    else
+      socket
+    end
+  end
+
   defp parse_huddlz_filter("past"), do: :past
   defp parse_huddlz_filter(_), do: :live
 
@@ -147,7 +194,7 @@ defmodule HuddlzWeb.OrganizeLive do
     >
       <%= case @live_action do %>
         <% :index -> %>
-          <.picker_view groups={@owned_groups} />
+          <.picker_view groups={@owned_groups} current_user={@current_user} />
         <% :overview -> %>
           <.overview_view
             group={@group}
@@ -170,6 +217,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # ─────────────────────────────────────────  PICKER (/organize)  ───
   attr :groups, :list, required: true
+  attr :current_user, :map, required: true
 
   defp picker_view(assigns) do
     ~H"""
@@ -214,7 +262,15 @@ defmodule HuddlzWeb.OrganizeLive do
                 {member_label(group.member_count)} · {visibility_label(group.is_public)}
               </div>
             </div>
-            <span class="pill">Open →</span>
+            <div class="flex items-center gap-2">
+              <.pill
+                class="group-role"
+                variant={GroupRole.pill_variant(GroupRole.for_group(group, @current_user))}
+              >
+                {group |> GroupRole.for_group(@current_user) |> GroupRole.label()}
+              </.pill>
+              <span class="pill">Open →</span>
+            </div>
           </a>
         </div>
       </div>

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -8,6 +8,7 @@ defmodule HuddlzWeb.LiveUserAuth do
 
   alias AshAuthentication.Phoenix.LiveSession
   alias Huddlz.Accounts.User
+  alias Huddlz.Communities.MembershipEvents
 
   # This is used for nested liveviews to fetch the current user.
   # To use, place the following at the top of that liveview:
@@ -76,11 +77,19 @@ defmodule HuddlzWeb.LiveUserAuth do
   def on_mount(:app, _params, _session, socket) do
     body_class = if socket.assigns[:current_user], do: "", else: "is-signed-out"
 
-    {:cont,
-     socket
-     |> maybe_load_user_details()
-     |> assign(:body_class, body_class)
-     |> assign_new(:sidebar_owned_groups, fn -> load_sidebar_owned_groups(socket) end)}
+    socket =
+      socket
+      |> maybe_load_user_details()
+      |> assign(:body_class, body_class)
+      |> assign_new(:sidebar_owned_groups, fn -> load_sidebar_owned_groups(socket) end)
+      |> subscribe_to_membership_changes()
+      |> Phoenix.LiveView.attach_hook(
+        :refresh_group_navigation,
+        :handle_info,
+        &refresh_group_navigation/2
+      )
+
+    {:cont, socket}
   end
 
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)
@@ -104,8 +113,37 @@ defmodule HuddlzWeb.LiveUserAuth do
   defp maybe_load_user_details(socket), do: socket
 
   defp load_sidebar_owned_groups(%{assigns: %{current_user: user}}) when not is_nil(user) do
-    Huddlz.Communities.get_organizable_groups!(actor: user, query: [sort: [name: :asc]])
+    Huddlz.Communities.get_organizable_groups!(
+      actor: user,
+      load: :group_members,
+      query: [sort: [name: :asc]]
+    )
   end
 
   defp load_sidebar_owned_groups(_socket), do: []
+
+  defp subscribe_to_membership_changes(%{assigns: %{current_user: %{id: user_id}}} = socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      :ok = MembershipEvents.subscribe_user(user_id)
+    end
+
+    socket
+  end
+
+  defp subscribe_to_membership_changes(socket), do: socket
+
+  defp refresh_group_navigation(
+         {:user_group_membership_changed, user_id, _group_id},
+         %{assigns: %{current_user: %{id: user_id}}} = socket
+       ) do
+    socket = assign(socket, :sidebar_owned_groups, load_sidebar_owned_groups(socket))
+
+    if socket.view in [HuddlzWeb.MyGroupsLive, HuddlzWeb.OrganizeLive] do
+      {:cont, socket}
+    else
+      {:halt, socket}
+    end
+  end
+
+  defp refresh_group_navigation(_message, socket), do: {:cont, socket}
 end

--- a/test/huddlz_web/live/group_role_live_test.exs
+++ b/test/huddlz_web/live/group_role_live_test.exs
@@ -1,0 +1,236 @@
+defmodule HuddlzWeb.GroupRoleLiveTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  alias Huddlz.Communities
+
+  setup do
+    owner = generate(user(role: :user, display_name: "Group Owner"))
+    organizer = generate(user(role: :user, display_name: "Group Organizer"))
+    member = generate(user(role: :user, display_name: "Group Member"))
+
+    group =
+      generate(
+        group(
+          name: "Role Vocabulary Group",
+          is_public: true,
+          owner_id: owner.id,
+          actor: owner
+        )
+      )
+
+    organizer_membership =
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: organizer.id,
+          role: :organizer,
+          actor: owner
+        )
+      )
+
+    member_membership =
+      generate(
+        group_member(
+          group_id: group.id,
+          user_id: member.id,
+          role: :member,
+          actor: owner
+        )
+      )
+
+    %{
+      group: group,
+      owner: owner,
+      organizer: organizer,
+      organizer_membership: organizer_membership,
+      member: member,
+      member_membership: member_membership
+    }
+  end
+
+  describe "group page role" do
+    test "shows the actor's actual owner, organizer, or member role", %{
+      conn: conn,
+      group: group,
+      owner: owner,
+      organizer: organizer,
+      member: member
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#current-group-role", text: "Owner")
+
+      conn
+      |> login(organizer)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#current-group-role", text: "Organizer")
+
+      conn
+      |> login(member)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#current-group-role", text: "Member")
+    end
+
+    test "does not imply a membership role for non-members or admins", %{
+      conn: conn,
+      group: group
+    } do
+      non_member = generate(user(role: :user))
+      admin = generate(user(role: :admin))
+
+      conn
+      |> login(non_member)
+      |> visit(~p"/groups/#{group.slug}")
+      |> refute_has("#current-group-role")
+
+      conn
+      |> login(admin)
+      |> visit(~p"/groups/#{group.slug}")
+      |> refute_has("#current-group-role")
+    end
+  end
+
+  describe "My groups and organizer navigation roles" do
+    test "cards and organizer navigation use the same role vocabulary", %{
+      conn: conn,
+      group: group,
+      owner: owner,
+      organizer: organizer,
+      member: member
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/my-groups")
+      |> assert_has(~s(.card[href="/groups/#{group.slug}"] .card-tag), text: "Owner")
+      |> assert_has(~s(.sb-org-row[href="/organize/#{group.slug}"] .group-role), text: "Owner")
+
+      conn
+      |> login(organizer)
+      |> visit(~p"/my-groups")
+      |> assert_has(~s(.card[href="/groups/#{group.slug}"] .card-tag), text: "Organizer")
+      |> assert_has(
+        ~s(.sb-org-row[href="/organize/#{group.slug}"] .group-role),
+        text: "Organizer"
+      )
+
+      conn
+      |> login(member)
+      |> visit(~p"/my-groups")
+      |> assert_has(~s(.card[href="/groups/#{group.slug}"] .card-tag), text: "Member")
+      |> refute_has(~s(.sb-org-row[href="/organize/#{group.slug}"]))
+    end
+
+    test "organizer picker names owner and organizer roles", %{
+      conn: conn,
+      group: group,
+      owner: owner,
+      organizer: organizer
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/organize")
+      |> assert_has(~s(.row[href="/organize/#{group.slug}"] .group-role), text: "Owner")
+
+      conn
+      |> login(organizer)
+      |> visit(~p"/organize")
+      |> assert_has(~s(.row[href="/organize/#{group.slug}"] .group-role), text: "Organizer")
+    end
+  end
+
+  describe "connected role updates" do
+    test "promotion and demotion update mounted group and My groups views", %{
+      conn: conn,
+      group: group,
+      owner: owner,
+      member: member,
+      member_membership: membership
+    } do
+      group_page =
+        conn
+        |> login(member)
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has("#current-group-role", text: "Member")
+
+      my_groups =
+        conn
+        |> login(member)
+        |> visit(~p"/my-groups")
+        |> assert_has(~s(.card[href="/groups/#{group.slug}"] .card-tag), text: "Member")
+
+      Communities.change_member_role!(membership, :organizer, actor: owner)
+
+      group_page
+      |> assert_has("#current-group-role", text: "Organizer")
+
+      my_groups
+      |> assert_has(~s(.card[href="/groups/#{group.slug}"] .card-tag), text: "Organizer")
+      |> assert_has(
+        ~s(.sb-org-row[href="/organize/#{group.slug}"] .group-role),
+        text: "Organizer"
+      )
+
+      promoted_membership =
+        Communities.get_membership_in_group!(group.id, actor: member)
+
+      Communities.change_member_role!(promoted_membership, :member, actor: owner)
+
+      group_page
+      |> assert_has("#current-group-role", text: "Member")
+
+      my_groups
+      |> assert_has(~s(.card[href="/groups/#{group.slug}"] .card-tag), text: "Member")
+      |> refute_has(~s(.sb-org-row[href="/organize/#{group.slug}"]))
+    end
+
+    test "ownership transfer updates both people's mounted role labels", %{
+      conn: conn,
+      group: group,
+      owner: owner,
+      organizer: organizer
+    } do
+      owner_page =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has("#current-group-role", text: "Owner")
+
+      organizer_page =
+        conn
+        |> login(organizer)
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has("#current-group-role", text: "Organizer")
+
+      Communities.transfer_group_ownership!(group, organizer.id, actor: owner)
+
+      owner_page
+      |> assert_has("#current-group-role", text: "Organizer")
+
+      organizer_page
+      |> assert_has("#current-group-role", text: "Owner")
+    end
+
+    test "removal clears the role and rejoining restores Member", %{
+      conn: conn,
+      group: group,
+      owner: owner,
+      member: member,
+      member_membership: membership
+    } do
+      group_page =
+        conn
+        |> login(member)
+        |> visit(~p"/groups/#{group.slug}")
+        |> assert_has("#current-group-role", text: "Member")
+
+      Communities.remove_member!(membership, group.id, member.id, actor: owner)
+
+      group_page
+      |> refute_has("#current-group-role")
+      |> assert_has("button", text: "Join Group")
+      |> click_button("Join Group")
+      |> assert_has("#current-group-role", text: "Member")
+    end
+  end
+end

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -80,7 +80,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
   end
 
   describe "Hosting filter" do
-    test "shows only owned groups with Hosting tag", %{
+    test "shows only owned groups with Owner tag", %{
       conn: conn,
       member: member,
       other: other
@@ -98,7 +98,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> assert_has(".filters .chip.is-active", text: "Hosting")
       |> assert_has(".grid .card .card-title", text: "Owned One")
       |> refute_has(".grid .card .card-title", text: "Joined One")
-      |> assert_has(".grid .card .card-tag", text: "Hosting")
+      |> assert_has(".grid .card .card-tag", text: "Owner")
     end
 
     test "empty state copy", %{conn: conn, member: member} do
@@ -110,7 +110,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
   end
 
   describe "Joined filter" do
-    test "shows only joined groups with Joined tag", %{
+    test "shows only joined groups with Member tag", %{
       conn: conn,
       member: member,
       other: other
@@ -129,7 +129,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> assert_has(".filters .chip.is-active", text: "Joined")
       |> assert_has(".grid .card .card-title", text: "Joined One")
       |> refute_has(".grid .card .card-title", text: "Owned One")
-      |> assert_has(".grid .card .card-tag", text: "Joined")
+      |> assert_has(".grid .card .card-tag", text: "Member")
     end
 
     test "empty state copy", %{conn: conn, member: member} do


### PR DESCRIPTION
## Summary

- show Owner, Organizer, and Member from the persisted group relationship on group pages and My groups cards
- carry the same role vocabulary into organizer navigation without treating admin access as membership
- refresh connected role labels and organizer navigation after membership changes

## Manual verification

1. Open the same group as its owner, an organizer, a member, and an admin without membership; confirm each page shows only the actual membership role.
2. Keep the group page and My groups open while changing that person’s role; confirm the labels and organizer navigation update without a reload.
3. Check My groups and the navigation drawer at a narrow mobile width.

Closes #315