### PR TITLE
refactor(huddlz): extract duplicate huddl form panels and cover image UI

### DIFF
--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -1,16 +1,34 @@
 defmodule HuddlzWeb.Components.HuddlForm do
   @moduledoc """
   Presentation primitives shared by the huddl create and edit forms:
-  the event-type radio cards and the duration select options.
+  the event-type radio cards, the duration select options, and the
+  basics/format/when/where/capacity panels and location modal.
 
   ```
-  <.event_type_grid field={@form[:event_type]} />
-  <.field_errors field={@form[:event_type]} />
+  <.basics_panel form={@form} />
+  <.format_panel form={@form} />
+  <.when_panel form={@form} calculated_end_time={@calculated_end_time}>
+    <:recurring_controls>...</:recurring_controls>
+  </.when_panel>
+  <.where_panel form={@form} show_physical_location={@show_physical_location}
+    show_virtual_link={@show_virtual_link} group_locations={@group_locations}
+    selected_location={@selected_location} new_location_path={~p"..."} />
+  <.capacity_panel form={@form} is_public={@group.is_public} />
+  <.form_footer submit_label="Save" disable_with="Saving…" cancel_path={~p"..."} />
 
-  <.input type="select" options={duration_options()} ... />
+  <.location_modal live_action={@live_action} cancel_path={~p"..."}
+    modal_location_address={@modal_location_address}
+    modal_location_name={@modal_location_name} />
   ```
   """
   use Phoenix.Component
+
+  import HuddlzWeb.Components.Button, only: [button: 1]
+  import HuddlzWeb.Components.Icon, only: [icon: 1]
+  import HuddlzWeb.Components.Input, only: [input: 1, select: 1, textarea: 1, field_errors: 1]
+  import HuddlzWeb.Components.Modal, only: [modal: 1]
+
+  alias Phoenix.LiveView.JS
 
   @duration_options [
     {"30 minutes", "30"},
@@ -130,4 +148,251 @@ defmodule HuddlzWeb.Components.HuddlForm do
   end
 
   def duration_options, do: @duration_options
+
+  # ---------------------------------------------------------------------------
+  # Shared panels
+  # ---------------------------------------------------------------------------
+
+  attr :form, :map, required: true
+
+  def basics_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>The basics</h2>
+      </div>
+      <div class="form-grid">
+        <.input
+          field={@form[:title]}
+          label="Title"
+          placeholder="e.g. Ash Framework workshop"
+          autocomplete="off"
+        />
+        <.textarea
+          field={@form[:description]}
+          label="Description"
+          rows="4"
+          placeholder="What you'll do, what to bring, who it's for."
+        />
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+
+  def format_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Format</h2>
+      </div>
+      <.event_type_grid field={@form[:event_type]} />
+      <.field_errors field={@form[:event_type]} />
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+  attr :calculated_end_time, :string, default: nil
+  attr :date_min, :string, default: nil
+  attr :duration_prompt, :string, default: nil
+  slot :recurring_controls
+
+  def when_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>When</h2>
+      </div>
+      <div class="form-grid">
+        <div class="form-row form-row-inline">
+          <div class="form-col-md">
+            <.input field={@form[:date]} type="date" label="Date" min={@date_min} />
+          </div>
+          <div class="form-col-sm">
+            <.input field={@form[:start_time]} type="time" label="Start time" />
+          </div>
+          <div class="form-col-sm">
+            <.select
+              field={@form[:duration_minutes]}
+              label="Duration"
+              prompt={@duration_prompt}
+              options={duration_options()}
+            />
+          </div>
+        </div>
+
+        <p :if={@calculated_end_time} class="form-help">
+          Ends at: <strong>{@calculated_end_time}</strong>
+        </p>
+
+        {render_slot(@recurring_controls)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+  attr :show_physical_location, :boolean, required: true
+  attr :show_virtual_link, :boolean, required: true
+  attr :group_locations, :list, required: true
+  attr :selected_location, :map, default: nil
+  attr :new_location_path, :string, required: true
+
+  def where_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Where</h2>
+      </div>
+      <div class="form-grid">
+        <%= if @show_physical_location do %>
+          <div class="form-row">
+            <.live_component
+              module={HuddlzWeb.Live.SavedLocationPicker}
+              id="saved-location-picker"
+              group_locations={@group_locations}
+              selected_location={@selected_location}
+              new_location_path={@new_location_path}
+            />
+            <.field_errors field={@form[:physical_location]} />
+          </div>
+        <% end %>
+
+        <%= if @show_virtual_link do %>
+          <.input
+            field={@form[:virtual_link]}
+            type="url"
+            label="Online link"
+            placeholder="https://meet.example.com/..."
+            help="Only attendees see this link."
+          />
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+  attr :is_public, :boolean, required: true
+
+  def capacity_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Capacity &amp; visibility</h2>
+      </div>
+      <div class="form-grid">
+        <.input
+          field={@form[:max_attendees]}
+          type="number"
+          label="Max attendees"
+          min="1"
+          placeholder="No limit"
+          help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
+        />
+
+        <%= if @is_public do %>
+          <div class="form-row">
+            <label class="toggle">
+              <input type="hidden" name={@form[:is_private].name} value="false" />
+              <input
+                id={@form[:is_private].id}
+                type="checkbox"
+                name={@form[:is_private].name}
+                value="true"
+                checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_private].value)}
+              />
+              <span class="track"></span>
+              <span class="toggle-text">Members only</span>
+            </label>
+            <p class="form-help">
+              Only group members can RSVP. Useful for private workshops or socials.
+            </p>
+          </div>
+        <% else %>
+          <p class="form-help">
+            <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
+            This will be a private huddl (private groups can only create private huddlz).
+          </p>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  attr :submit_label, :string, required: true
+  attr :disable_with, :string, required: true
+  attr :cancel_path, :string, required: true
+
+  def form_footer(assigns) do
+    ~H"""
+    <div class="form-foot is-flush">
+      <.button variant={:primary} type="submit" phx-disable-with={@disable_with}>
+        {@submit_label}
+      </.button>
+      <.button variant={:secondary} navigate={@cancel_path}>Cancel</.button>
+    </div>
+    """
+  end
+
+  attr :live_action, :atom, required: true
+  attr :modal_location_address, :string, default: nil
+  attr :modal_location_name, :string, default: nil
+  attr :cancel_path, :string, required: true
+
+  def location_modal(assigns) do
+    ~H"""
+    <.modal
+      :if={@live_action == :new_location}
+      id="new-location-modal"
+      show
+      on_cancel={JS.patch(@cancel_path)}
+    >
+      <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
+
+      <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
+        <div class="form-row">
+          <label class="form-label" for="modal-address-autocomplete-input">
+            Search for an address
+          </label>
+          <.live_component
+            module={HuddlzWeb.Live.LocationAutocomplete}
+            id="modal-address-autocomplete"
+            variant={:form}
+            placeholder="Search for an address or venue..."
+            types={[]}
+            fetch_coordinates={true}
+            show_clear={true}
+          />
+        </div>
+
+        <div class="form-row">
+          <label class="form-label" for="location-name-input">
+            Location name (optional)
+          </label>
+          <input
+            type="text"
+            id="location-name-input"
+            name="location_name"
+            value={@modal_location_name}
+            phx-debounce="100"
+            placeholder="e.g., Community Center"
+            class="form-input"
+          />
+        </div>
+
+        <div class="form-foot is-flush">
+          <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
+            Save address
+          </.button>
+          <.button variant={:secondary} patch={@cancel_path}>
+            Cancel
+          </.button>
+        </div>
+      </form>
+    </.modal>
+    """
+  end
 end

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -1,16 +1,37 @@
 defmodule HuddlzWeb.Components.HuddlForm do
   @moduledoc """
   Presentation primitives shared by the huddl create and edit forms:
-  the huddl-format radio cards and the duration select options.
+  the event-type radio cards, the duration select options, and the
+  basics/format/when/where/capacity panels and location modal.
 
   ```
-  <.event_type_grid field={@form[:event_type]} />
-  <.field_errors field={@form[:event_type]} />
+  <.basics_panel form={@form} />
+  <.format_panel form={@form} />
+  <.when_panel form={@form} calculated_end_time={@calculated_end_time}>
+    <:recurring_controls>...</:recurring_controls>
+  </.when_panel>
+  <.where_panel form={@form} show_physical_location={@show_physical_location}
+    show_virtual_link={@show_virtual_link} group_locations={@group_locations}
+    selected_location={@selected_location} new_location_path={~p"..."} />
+  <.capacity_panel form={@form} is_public={@group.is_public} />
+  <.form_footer submit_label="Save" disable_with="Saving…" cancel_path={~p"..."} />
 
-  <.input type="select" options={duration_options()} ... />
+  <.location_modal live_action={@live_action} cancel_path={~p"..."}
+    modal_location_address={@modal_location_address}
+    modal_location_name={@modal_location_name} />
   ```
   """
   use Phoenix.Component
+
+  import HuddlzWeb.Components.Button, only: [button: 1]
+  import HuddlzWeb.Components.Icon, only: [icon: 1]
+
+  import HuddlzWeb.Components.Input,
+    only: [input: 1, select: 1, textarea: 1, field_errors: 1, toggle: 1]
+
+  import HuddlzWeb.Components.Modal, only: [modal: 1]
+
+  alias Phoenix.LiveView.JS
 
   @duration_options [
     {"30 minutes", "30"},
@@ -133,4 +154,238 @@ defmodule HuddlzWeb.Components.HuddlForm do
   end
 
   def duration_options, do: @duration_options
+
+  # ---------------------------------------------------------------------------
+  # Shared panels
+  # ---------------------------------------------------------------------------
+
+  attr :form, :map, required: true
+
+  def basics_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>The basics</h2>
+      </div>
+      <div class="form-grid">
+        <.input
+          field={@form[:title]}
+          label="Title"
+          placeholder="e.g. Ash Framework workshop"
+          autocomplete="off"
+        />
+        <.textarea
+          field={@form[:description]}
+          label="Description"
+          rows="4"
+          placeholder="What you'll do, what to bring, who it's for."
+        />
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+
+  def format_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Format</h2>
+      </div>
+      <.event_type_grid field={@form[:event_type]} />
+      <.field_errors field={@form[:event_type]} />
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+  attr :calculated_end_time, :string, default: nil
+  attr :duration_prompt, :string, default: nil
+  slot :recurring_controls
+
+  def when_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>When</h2>
+      </div>
+      <div class="form-grid">
+        <div class="form-row form-row-inline">
+          <div class="form-col-md">
+            <.input field={@form[:date]} type="date" label="Date" />
+          </div>
+          <div class="form-col-sm">
+            <.input field={@form[:start_time]} type="time" label="Start time" />
+          </div>
+          <div class="form-col-sm">
+            <.select
+              field={@form[:duration_minutes]}
+              label="Duration"
+              prompt={@duration_prompt}
+              options={duration_options()}
+            />
+          </div>
+        </div>
+
+        <p :if={@calculated_end_time} class="form-help">
+          Ends at: <strong>{@calculated_end_time}</strong>
+        </p>
+
+        {render_slot(@recurring_controls)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+  attr :show_physical_location, :boolean, required: true
+  attr :show_virtual_link, :boolean, required: true
+  attr :group_locations, :list, required: true
+  attr :selected_location, :map, default: nil
+  attr :new_location_path, :string, required: true
+
+  def where_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Where</h2>
+      </div>
+      <div class="form-grid">
+        <%= if @show_physical_location do %>
+          <.live_component
+            module={HuddlzWeb.Live.SavedLocationPicker}
+            id="saved-location-picker"
+            group_locations={@group_locations}
+            selected_location={@selected_location}
+            new_location_path={@new_location_path}
+            field={@form[:physical_location]}
+          />
+        <% end %>
+
+        <%= if @show_virtual_link do %>
+          <.input
+            field={@form[:virtual_link]}
+            type="text"
+            inputmode="url"
+            autocomplete="url"
+            label="Online link"
+            placeholder="https://meet.example.com/..."
+            help="Only attendees see this link."
+          />
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, :map, required: true
+  attr :is_public, :boolean, required: true
+
+  def capacity_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Capacity &amp; visibility</h2>
+      </div>
+      <div class="form-grid">
+        <.input
+          field={@form[:max_attendees]}
+          type="number"
+          label="Max attendees"
+          placeholder="No limit"
+          help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
+        />
+
+        <%= if @is_public do %>
+          <div class="form-row">
+            <.toggle field={@form[:is_private]} label="Members only" />
+            <p class="form-help">
+              Only group members can RSVP. Useful for private workshops or socials.
+            </p>
+          </div>
+        <% else %>
+          <p class="form-help">
+            <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
+            This will be a private huddl (private groups can only create private huddlz).
+          </p>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  attr :submit_label, :string, required: true
+  attr :disable_with, :string, required: true
+  attr :cancel_path, :string, required: true
+
+  def form_footer(assigns) do
+    ~H"""
+    <div class="form-foot is-flush">
+      <.button variant={:primary} type="submit" phx-disable-with={@disable_with}>
+        {@submit_label}
+      </.button>
+      <.button variant={:secondary} navigate={@cancel_path}>Cancel</.button>
+    </div>
+    """
+  end
+
+  attr :live_action, :atom, required: true
+  attr :modal_location_address, :string, default: nil
+  attr :modal_location_name, :string, default: nil
+  attr :cancel_path, :string, required: true
+
+  def location_modal(assigns) do
+    ~H"""
+    <.modal
+      :if={@live_action == :new_location}
+      id="new-location-modal"
+      show
+      on_cancel={JS.patch(@cancel_path)}
+    >
+      <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
+
+      <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
+        <div class="form-row">
+          <label class="form-label" for="modal-address-autocomplete-input">
+            Search for an address
+          </label>
+          <.live_component
+            module={HuddlzWeb.Live.LocationAutocomplete}
+            id="modal-address-autocomplete"
+            variant={:form}
+            placeholder="Search for an address or venue..."
+            types={[]}
+            fetch_coordinates={true}
+            show_clear={true}
+          />
+        </div>
+
+        <div class="form-row">
+          <label class="form-label" for="location-name-input">
+            Location name (optional)
+          </label>
+          <input
+            type="text"
+            id="location-name-input"
+            name="location_name"
+            value={@modal_location_name}
+            phx-debounce="100"
+            placeholder="e.g., Community Center"
+            class="form-input"
+          />
+        </div>
+
+        <div class="form-foot is-flush">
+          <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
+            Save address
+          </.button>
+          <.button variant={:secondary} patch={@cancel_path}>
+            Cancel
+          </.button>
+        </div>
+      </form>
+    </.modal>
+    """
+  end
 end

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -1,7 +1,7 @@
 defmodule HuddlzWeb.Components.HuddlForm do
   @moduledoc """
   Presentation primitives shared by the huddl create and edit forms:
-  the event-type radio cards, the duration select options, and the
+  the huddl-format radio cards, the duration select options, and the
   basics/format/when/where/capacity panels and location modal.
 
   ```
@@ -14,7 +14,6 @@ defmodule HuddlzWeb.Components.HuddlForm do
     show_virtual_link={@show_virtual_link} group_locations={@group_locations}
     selected_location={@selected_location} new_location_path={~p"..."} />
   <.capacity_panel form={@form} is_public={@group.is_public} />
-  <.form_footer submit_label="Save" disable_with="Saving…" cancel_path={~p"..."} />
 
   <.location_modal live_action={@live_action} cancel_path={~p"..."}
     modal_location_address={@modal_location_address}
@@ -311,21 +310,6 @@ defmodule HuddlzWeb.Components.HuddlForm do
           </p>
         <% end %>
       </div>
-    </div>
-    """
-  end
-
-  attr :submit_label, :string, required: true
-  attr :disable_with, :string, required: true
-  attr :cancel_path, :string, required: true
-
-  def form_footer(assigns) do
-    ~H"""
-    <div class="form-foot is-flush">
-      <.button variant={:primary} type="submit" phx-disable-with={@disable_with}>
-        {@submit_label}
-      </.button>
-      <.button variant={:secondary} navigate={@cancel_path}>Cancel</.button>
     </div>
     """
   end

--- a/lib/huddlz_web/components/upload_components.ex
+++ b/lib/huddlz_web/components/upload_components.ex
@@ -16,10 +16,14 @@ defmodule HuddlzWeb.Components.UploadComponents do
   attr :upload, :any, required: true
   attr :image_error, :string, default: nil
   attr :optional, :boolean, default: false
-  attr :show_upload_zone, :boolean, default: true
-  slot :preview
+
+  slot :preview do
+    attr :hide_upload_zone, :boolean
+  end
 
   def cover_image_panel(assigns) do
+    assigns = assign(assigns, :show_upload_zone, show_upload_zone?(assigns.preview))
+
     ~H"""
     <div class="panel">
       <div class="panel-head">
@@ -83,5 +87,9 @@ defmodule HuddlzWeb.Components.UploadComponents do
       </p>
     </div>
     """
+  end
+
+  defp show_upload_zone?(preview) do
+    Enum.all?(preview, &(not Map.get(&1, :hide_upload_zone, false)))
   end
 end

--- a/lib/huddlz_web/components/upload_components.ex
+++ b/lib/huddlz_web/components/upload_components.ex
@@ -1,0 +1,87 @@
+defmodule HuddlzWeb.Components.UploadComponents do
+  @moduledoc """
+  Shared cover-image upload panel used by the huddl create and edit forms.
+
+  ```
+  <.cover_image_panel upload={@uploads.huddl_image} image_error={@image_error}>
+    <:preview>...</:preview>
+  </.cover_image_panel>
+  ```
+  """
+  use Phoenix.Component
+
+  import HuddlzWeb.Components.Button, only: [button: 1]
+  import HuddlzWeb.Live.Helpers.UploadHelpers, only: [upload_error_to_string: 1]
+
+  attr :upload, :any, required: true
+  attr :image_error, :string, default: nil
+  attr :optional, :boolean, default: false
+  attr :show_upload_zone, :boolean, default: true
+  slot :preview
+
+  def cover_image_panel(assigns) do
+    ~H"""
+    <div class="panel">
+      <div class="panel-head">
+        <h2>Cover image</h2>
+      </div>
+
+      <label for={@upload.ref} class="sr-only">Cover image</label>
+      <.live_file_input upload={@upload} class="hidden" />
+
+      {render_slot(@preview)}
+
+      <div :if={@show_upload_zone} class="upload-zone" phx-drop-target={@upload.ref}>
+        <div class="upload-icon">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
+          </svg>
+        </div>
+        <label for={@upload.ref} class="upload-prompt">
+          Drop a 16:9 image, or <span class="upload-link">browse</span>
+        </label>
+        <div class="upload-meta muted">
+          JPG, PNG, WebP · 5 MB max{if @optional, do: " · optional", else: ""}
+        </div>
+      </div>
+
+      <%= for entry <- @upload.entries do %>
+        <div class="image-preview image-preview-progress">
+          <div class="card-cover">
+            <.live_img_preview entry={entry} class="card-cover-img" />
+          </div>
+          <div class="image-preview-foot">
+            <span>{entry.client_name} · {entry.progress}%</span>
+            <.button
+              variant={:muted}
+              type="button"
+              phx-click="cancel_image_upload"
+              phx-value-ref={entry.ref}
+            >
+              Cancel
+            </.button>
+          </div>
+        </div>
+        <p :for={err <- upload_errors(@upload, entry)} class="form-error">
+          {upload_error_to_string(err)}
+        </p>
+      <% end %>
+
+      <p :if={@image_error} class="form-error">{@image_error}</p>
+      <p :for={err <- upload_errors(@upload)} class="form-error">
+        {upload_error_to_string(err)}
+      </p>
+    </div>
+    """
+  end
+end

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -288,11 +288,14 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
         <.capacity_panel form={@form} is_public={@huddl.group.is_public} />
 
-        <.form_footer
-          submit_label="Save changes"
-          disable_with="Saving…"
-          cancel_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"}
-        />
+        <div class="form-foot is-flush">
+          <.button variant={:primary} type="submit" phx-disable-with="Saving…">
+            Save changes
+          </.button>
+          <.button variant={:secondary} navigate={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"}>
+            Cancel
+          </.button>
+        </div>
       </.form>
 
       <.location_modal

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Components.HuddlForm
+  import HuddlzWeb.Components.UploadComponents
   import HuddlzWeb.HuddlLive.FormHelpers
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
@@ -234,125 +235,22 @@ defmodule HuddlzWeb.HuddlLive.Edit do
           </div>
         <% end %>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Cover image</h2>
-          </div>
-
-          <label for={@uploads.huddl_image.ref} class="sr-only">Cover image</label>
-          <.live_file_input upload={@uploads.huddl_image} class="hidden" />
-
-          <.image_preview
-            pending_preview_url={@pending_preview_url}
-            huddl={@huddl}
-            upload_ref={@uploads.huddl_image.ref}
-          />
-
-          <div class="upload-zone" phx-drop-target={@uploads.huddl_image.ref}>
-            <div class="upload-icon">
-              <svg
-                width="22"
-                height="22"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
-              </svg>
-            </div>
-            <label for={@uploads.huddl_image.ref} class="upload-prompt">
-              Drop a 16:9 image, or <span class="upload-link">browse</span>
-            </label>
-            <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max</div>
-          </div>
-
-          <%= for entry <- @uploads.huddl_image.entries do %>
-            <div class="image-preview" style="margin-top:12px">
-              <div class="card-cover">
-                <.live_img_preview entry={entry} class="card-cover-img" />
-              </div>
-              <div class="image-preview-foot">
-                <span>{entry.client_name} · {entry.progress}%</span>
-                <.button
-                  variant={:muted}
-                  type="button"
-                  phx-click="cancel_image_upload"
-                  phx-value-ref={entry.ref}
-                >
-                  Cancel
-                </.button>
-              </div>
-            </div>
-
-            <%= for err <- upload_errors(@uploads.huddl_image, entry) do %>
-              <p class="form-error">{upload_error_to_string(err)}</p>
-            <% end %>
-          <% end %>
-
-          <p :if={@image_error} class="form-error">{@image_error}</p>
-
-          <%= for err <- upload_errors(@uploads.huddl_image) do %>
-            <p class="form-error">{upload_error_to_string(err)}</p>
-          <% end %>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>The basics</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:title]}
-              label="Title"
-              placeholder="e.g. Ash Framework workshop"
-              autocomplete="off"
+        <.cover_image_panel upload={@uploads.huddl_image} image_error={@image_error}>
+          <:preview>
+            <.image_preview
+              pending_preview_url={@pending_preview_url}
+              huddl={@huddl}
+              upload_ref={@uploads.huddl_image.ref}
             />
-            <.textarea
-              field={@form[:description]}
-              label="Description"
-              rows="4"
-              placeholder="What you'll do, what to bring, who it's for."
-            />
-          </div>
-        </div>
+          </:preview>
+        </.cover_image_panel>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Format</h2>
-          </div>
-          <.event_type_grid field={@form[:event_type]} />
-          <.field_errors field={@form[:event_type]} />
-        </div>
+        <.basics_panel form={@form} />
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>When</h2>
-          </div>
-          <div class="form-grid">
-            <div class="form-row form-row-inline">
-              <div class="form-col-md">
-                <.input field={@form[:date]} type="date" label="Date" />
-              </div>
-              <div class="form-col-sm">
-                <.input field={@form[:start_time]} type="time" label="Start time" />
-              </div>
-              <div class="form-col-sm">
-                <.select
-                  field={@form[:duration_minutes]}
-                  label="Duration"
-                  options={duration_options()}
-                />
-              </div>
-            </div>
+        <.format_panel form={@form} />
 
-            <p :if={@calculated_end_time} class="form-help">
-              Ends at: <strong>{@calculated_end_time}</strong>
-            </p>
-
+        <.when_panel form={@form} calculated_end_time={@calculated_end_time}>
+          <:recurring_controls>
             <%= if @huddl.huddl_template_id && edit_type_value(@form) == "all" do %>
               <div class="form-row form-row-inline">
                 <div class="form-col-md">
@@ -375,144 +273,33 @@ defmodule HuddlzWeb.HuddlLive.Edit do
                 </div>
               </div>
             <% end %>
-          </div>
-        </div>
+          </:recurring_controls>
+        </.when_panel>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Where</h2>
-          </div>
-          <div class="form-grid">
-            <%= if @show_physical_location do %>
-              <div class="form-row">
-                <.live_component
-                  module={HuddlzWeb.Live.SavedLocationPicker}
-                  id="saved-location-picker"
-                  group_locations={@group_locations}
-                  selected_location={@selected_location}
-                  new_location_path={
-                    ~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit/locations/new"
-                  }
-                />
-                <.field_errors field={@form[:physical_location]} />
-              </div>
-            <% end %>
+        <.where_panel
+          form={@form}
+          show_physical_location={@show_physical_location}
+          show_virtual_link={@show_virtual_link}
+          group_locations={@group_locations}
+          selected_location={@selected_location}
+          new_location_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit/locations/new"}
+        />
 
-            <%= if @show_virtual_link do %>
-              <.input
-                field={@form[:virtual_link]}
-                type="url"
-                label="Online link"
-                placeholder="https://meet.example.com/..."
-                help="Only attendees see this link."
-              />
-            <% end %>
-          </div>
-        </div>
+        <.capacity_panel form={@form} is_public={@huddl.group.is_public} />
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Capacity &amp; visibility</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:max_attendees]}
-              type="number"
-              label="Max attendees"
-              min="1"
-              placeholder="No limit"
-              help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
-            />
-
-            <%= if @huddl.group.is_public do %>
-              <div class="form-row">
-                <label class="toggle">
-                  <input type="hidden" name={@form[:is_private].name} value="false" />
-                  <input
-                    id={@form[:is_private].id}
-                    type="checkbox"
-                    name={@form[:is_private].name}
-                    value="true"
-                    checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_private].value)}
-                  />
-                  <span class="track"></span>
-                  <span class="toggle-text">Members only</span>
-                </label>
-                <p class="form-help">
-                  Only group members can RSVP. Useful for private workshops or socials.
-                </p>
-              </div>
-            <% else %>
-              <p class="form-help">
-                <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
-                This will be a private huddl (private groups can only create private huddlz).
-              </p>
-            <% end %>
-          </div>
-        </div>
-
-        <div class="form-foot is-flush">
-          <.button variant={:primary} type="submit" phx-disable-with="Saving…">
-            Save changes
-          </.button>
-          <.button variant={:secondary} navigate={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"}>
-            Cancel
-          </.button>
-        </div>
+        <.form_footer
+          submit_label="Save changes"
+          disable_with="Saving…"
+          cancel_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"}
+        />
       </.form>
 
-      <.modal
-        :if={@live_action == :new_location}
-        id="new-location-modal"
-        show
-        on_cancel={JS.patch(~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit")}
-      >
-        <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
-
-        <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
-          <div class="form-row">
-            <label class="form-label" for="modal-address-autocomplete-input">
-              Search for an address
-            </label>
-            <.live_component
-              module={HuddlzWeb.Live.LocationAutocomplete}
-              id="modal-address-autocomplete"
-              variant={:form}
-              placeholder="Search for an address or venue..."
-              types={[]}
-              fetch_coordinates={true}
-              show_clear={true}
-            />
-          </div>
-
-          <div class="form-row">
-            <label class="form-label" for="location-name-input">
-              Location name (optional)
-            </label>
-            <input
-              type="text"
-              id="location-name-input"
-              name="location_name"
-              value={@modal_location_name}
-              phx-debounce="100"
-              placeholder="e.g., Community Center"
-              class="form-input"
-            />
-          </div>
-
-          <div class="form-foot is-flush">
-            <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
-              Save address
-            </.button>
-            <.button
-              variant={:secondary}
-              patch={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit"}
-            >
-              Cancel
-            </.button>
-          </div>
-        </form>
-      </.modal>
+      <.location_modal
+        live_action={@live_action}
+        cancel_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit"}
+        modal_location_address={@modal_location_address}
+        modal_location_name={@modal_location_name}
+      />
     </Layouts.app>
     """
   end

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Components.HuddlForm
+  import HuddlzWeb.Components.UploadComponents
   import HuddlzWeb.HuddlLive.FormHelpers
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
@@ -235,125 +236,22 @@ defmodule HuddlzWeb.HuddlLive.Edit do
           </div>
         <% end %>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Cover image</h2>
-          </div>
-
-          <label for={@uploads.huddl_image.ref} class="sr-only">Cover image</label>
-          <.live_file_input upload={@uploads.huddl_image} class="hidden" />
-
-          <.image_preview
-            pending_preview_url={@pending_preview_url}
-            huddl={@huddl}
-            upload_ref={@uploads.huddl_image.ref}
-          />
-
-          <div class="upload-zone" phx-drop-target={@uploads.huddl_image.ref}>
-            <div class="upload-icon">
-              <svg
-                width="22"
-                height="22"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
-              </svg>
-            </div>
-            <label for={@uploads.huddl_image.ref} class="upload-prompt">
-              Drop a 16:9 image, or <span class="upload-link">browse</span>
-            </label>
-            <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max</div>
-          </div>
-
-          <%= for entry <- @uploads.huddl_image.entries do %>
-            <div class="image-preview" style="margin-top:12px">
-              <div class="card-cover">
-                <.live_img_preview entry={entry} class="card-cover-img" />
-              </div>
-              <div class="image-preview-foot">
-                <span>{entry.client_name} · {entry.progress}%</span>
-                <.button
-                  variant={:muted}
-                  type="button"
-                  phx-click="cancel_image_upload"
-                  phx-value-ref={entry.ref}
-                >
-                  Cancel
-                </.button>
-              </div>
-            </div>
-
-            <%= for err <- upload_errors(@uploads.huddl_image, entry) do %>
-              <p class="form-error">{upload_error_to_string(err)}</p>
-            <% end %>
-          <% end %>
-
-          <p :if={@image_error} class="form-error">{@image_error}</p>
-
-          <%= for err <- upload_errors(@uploads.huddl_image) do %>
-            <p class="form-error">{upload_error_to_string(err)}</p>
-          <% end %>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>The basics</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:title]}
-              label="Title"
-              placeholder="e.g. Ash Framework workshop"
-              autocomplete="off"
+        <.cover_image_panel upload={@uploads.huddl_image} image_error={@image_error}>
+          <:preview>
+            <.image_preview
+              pending_preview_url={@pending_preview_url}
+              huddl={@huddl}
+              upload_ref={@uploads.huddl_image.ref}
             />
-            <.textarea
-              field={@form[:description]}
-              label="Description"
-              rows="4"
-              placeholder="What you'll do, what to bring, who it's for."
-            />
-          </div>
-        </div>
+          </:preview>
+        </.cover_image_panel>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Format</h2>
-          </div>
-          <.event_type_grid field={@form[:event_type]} />
-          <.field_errors field={@form[:event_type]} />
-        </div>
+        <.basics_panel form={@form} />
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>When</h2>
-          </div>
-          <div class="form-grid">
-            <div class="form-row form-row-inline">
-              <div class="form-col-md">
-                <.input field={@form[:date]} type="date" label="Date" />
-              </div>
-              <div class="form-col-sm">
-                <.input field={@form[:start_time]} type="time" label="Start time" />
-              </div>
-              <div class="form-col-sm">
-                <.select
-                  field={@form[:duration_minutes]}
-                  label="Duration"
-                  options={duration_options()}
-                />
-              </div>
-            </div>
+        <.format_panel form={@form} />
 
-            <p :if={@calculated_end_time} class="form-help">
-              Ends at: <strong>{@calculated_end_time}</strong>
-            </p>
-
+        <.when_panel form={@form} calculated_end_time={@calculated_end_time}>
+          <:recurring_controls>
             <%= if @huddl.huddl_template_id && edit_type_value(@form) == "all" do %>
               <div class="form-row form-row-inline">
                 <div class="form-col-md">
@@ -376,130 +274,33 @@ defmodule HuddlzWeb.HuddlLive.Edit do
                 </div>
               </div>
             <% end %>
-          </div>
-        </div>
+          </:recurring_controls>
+        </.when_panel>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Where</h2>
-          </div>
-          <div class="form-grid">
-            <%= if @show_physical_location do %>
-              <.live_component
-                module={HuddlzWeb.Live.SavedLocationPicker}
-                id="saved-location-picker"
-                group_locations={@group_locations}
-                selected_location={@selected_location}
-                new_location_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit/locations/new"}
-                field={@form[:physical_location]}
-              />
-            <% end %>
+        <.where_panel
+          form={@form}
+          show_physical_location={@show_physical_location}
+          show_virtual_link={@show_virtual_link}
+          group_locations={@group_locations}
+          selected_location={@selected_location}
+          new_location_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit/locations/new"}
+        />
 
-            <%= if @show_virtual_link do %>
-              <.input
-                field={@form[:virtual_link]}
-                type="text"
-                inputmode="url"
-                autocomplete="url"
-                label="Online link"
-                placeholder="https://meet.example.com/..."
-                help="Only attendees see this link."
-              />
-            <% end %>
-          </div>
-        </div>
+        <.capacity_panel form={@form} is_public={@huddl.group.is_public} />
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Capacity &amp; visibility</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:max_attendees]}
-              type="number"
-              label="Max attendees"
-              placeholder="No limit"
-              help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
-            />
-
-            <%= if @huddl.group.is_public do %>
-              <div class="form-row">
-                <.toggle field={@form[:is_private]} label="Members only" />
-                <p class="form-help">
-                  Only group members can RSVP. Useful for private workshops or socials.
-                </p>
-              </div>
-            <% else %>
-              <p class="form-help">
-                <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
-                This will be a private huddl (private groups can only create private huddlz).
-              </p>
-            <% end %>
-          </div>
-        </div>
-
-        <div class="form-foot is-flush">
-          <.button variant={:primary} type="submit" phx-disable-with="Saving…">
-            Save changes
-          </.button>
-          <.button variant={:secondary} navigate={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"}>
-            Cancel
-          </.button>
-        </div>
+        <.form_footer
+          submit_label="Save changes"
+          disable_with="Saving…"
+          cancel_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}"}
+        />
       </.form>
 
-      <.modal
-        :if={@live_action == :new_location}
-        id="new-location-modal"
-        show
-        on_cancel={JS.patch(~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit")}
-      >
-        <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
-
-        <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
-          <div class="form-row">
-            <label class="form-label" for="modal-address-autocomplete-input">
-              Search for an address
-            </label>
-            <.live_component
-              module={HuddlzWeb.Live.LocationAutocomplete}
-              id="modal-address-autocomplete"
-              variant={:form}
-              placeholder="Search for an address or venue..."
-              types={[]}
-              fetch_coordinates={true}
-              show_clear={true}
-            />
-          </div>
-
-          <div class="form-row">
-            <label class="form-label" for="location-name-input">
-              Location name (optional)
-            </label>
-            <input
-              type="text"
-              id="location-name-input"
-              name="location_name"
-              value={@modal_location_name}
-              phx-debounce="100"
-              placeholder="e.g., Community Center"
-              class="form-input"
-            />
-          </div>
-
-          <div class="form-foot is-flush">
-            <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
-              Save address
-            </.button>
-            <.button
-              variant={:secondary}
-              patch={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit"}
-            >
-              Cancel
-            </.button>
-          </div>
-        </form>
-      </.modal>
+      <.location_modal
+        live_action={@live_action}
+        cancel_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit"}
+        modal_location_address={@modal_location_address}
+        modal_location_name={@modal_location_name}
+      />
     </Layouts.app>
     """
   end

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -168,9 +168,8 @@ defmodule HuddlzWeb.HuddlLive.New do
           upload={@uploads.huddl_image}
           image_error={@image_error}
           optional
-          show_upload_zone={is_nil(@pending_preview_url)}
         >
-          <:preview :if={@pending_preview_url}>
+          <:preview :if={@pending_preview_url} hide_upload_zone>
             <div class="image-preview" phx-drop-target={@uploads.huddl_image.ref}>
               <div class="card-cover" style={"background-image: url('#{@pending_preview_url}')"}>
               </div>

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive.New do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Components.HuddlForm
+  import HuddlzWeb.Components.UploadComponents
   import HuddlzWeb.HuddlLive.FormHelpers
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
@@ -161,65 +162,45 @@ defmodule HuddlzWeb.HuddlLive.New do
       </div>
 
       <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save">
-        <div class="panel">
-          <div class="panel-head">
-            <h2>The basics</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:title]}
-              label="Title"
-              placeholder="e.g. Ash Framework workshop"
-              autocomplete="off"
-            />
-            <.textarea
-              field={@form[:description]}
-              label="Description"
-              rows="4"
-              placeholder="What you'll do, what to bring, who it's for."
-            />
-          </div>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Format</h2>
-          </div>
-          <.event_type_grid field={@form[:event_type]} />
-          <.field_errors field={@form[:event_type]} />
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>When</h2>
-          </div>
-          <div class="form-grid">
-            <div class="form-row form-row-inline">
-              <div class="form-col-md">
-                <.input
-                  field={@form[:date]}
-                  type="date"
-                  label="Date"
-                  min={Date.utc_today() |> Date.to_iso8601()}
-                />
+        <.cover_image_panel
+          upload={@uploads.huddl_image}
+          image_error={@image_error}
+          optional
+          show_upload_zone={is_nil(@pending_preview_url)}
+        >
+          <:preview :if={@pending_preview_url}>
+            <div class="image-preview" phx-drop-target={@uploads.huddl_image.ref}>
+              <div class="card-cover" style={"background-image: url('#{@pending_preview_url}')"}>
               </div>
-              <div class="form-col-sm">
-                <.input field={@form[:start_time]} type="time" label="Start time" />
-              </div>
-              <div class="form-col-sm">
-                <.select
-                  field={@form[:duration_minutes]}
-                  label="Duration"
-                  prompt="Select duration…"
-                  options={duration_options()}
-                />
+              <div
+                class="muted"
+                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
+              >
+                <span>Image uploaded · ready to publish.</span>
+                <div style="display:flex; gap:8px">
+                  <label for={@uploads.huddl_image.ref} class="btn-secondary" style="cursor:pointer">
+                    Replace
+                  </label>
+                  <.button variant={:muted} type="button" phx-click="cancel_pending_image">
+                    Remove
+                  </.button>
+                </div>
               </div>
             </div>
+          </:preview>
+        </.cover_image_panel>
 
-            <p :if={@calculated_end_time} class="form-help">
-              Ends at: <strong>{@calculated_end_time}</strong>
-            </p>
+        <.basics_panel form={@form} />
 
+        <.format_panel form={@form} />
+
+        <.when_panel
+          form={@form}
+          calculated_end_time={@calculated_end_time}
+          date_min={Date.utc_today() |> Date.to_iso8601()}
+          duration_prompt="Select duration…"
+        >
+          <:recurring_controls>
             <div class="form-row">
               <label class="toggle">
                 <input type="hidden" name={@form[:is_recurring].name} value="false" />
@@ -258,224 +239,33 @@ defmodule HuddlzWeb.HuddlLive.New do
                 </div>
               </div>
             <% end %>
-          </div>
-        </div>
+          </:recurring_controls>
+        </.when_panel>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Where</h2>
-          </div>
-          <div class="form-grid">
-            <%= if @show_physical_location do %>
-              <div class="form-row">
-                <.live_component
-                  module={HuddlzWeb.Live.SavedLocationPicker}
-                  id="saved-location-picker"
-                  group_locations={@group_locations}
-                  selected_location={@selected_location}
-                  new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
-                />
-                <.field_errors field={@form[:physical_location]} />
-              </div>
-            <% end %>
+        <.where_panel
+          form={@form}
+          show_physical_location={@show_physical_location}
+          show_virtual_link={@show_virtual_link}
+          group_locations={@group_locations}
+          selected_location={@selected_location}
+          new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
+        />
 
-            <%= if @show_virtual_link do %>
-              <.input
-                field={@form[:virtual_link]}
-                type="url"
-                label="Online link"
-                placeholder="https://meet.example.com/..."
-                help="Only attendees see this link."
-              />
-            <% end %>
-          </div>
-        </div>
+        <.capacity_panel form={@form} is_public={@group.is_public} />
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Capacity &amp; visibility</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:max_attendees]}
-              type="number"
-              label="Max attendees"
-              min="1"
-              placeholder="No limit"
-              help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
-            />
-
-            <%= if @group.is_public do %>
-              <div class="form-row">
-                <label class="toggle">
-                  <input type="hidden" name={@form[:is_private].name} value="false" />
-                  <input
-                    id={@form[:is_private].id}
-                    type="checkbox"
-                    name={@form[:is_private].name}
-                    value="true"
-                    checked={Phoenix.HTML.Form.normalize_value("checkbox", @form[:is_private].value)}
-                  />
-                  <span class="track"></span>
-                  <span class="toggle-text">Members only</span>
-                </label>
-                <p class="form-help">
-                  Only group members can RSVP. Useful for private workshops or socials.
-                </p>
-              </div>
-            <% else %>
-              <p class="form-help">
-                <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
-                This will be a private huddl (private groups can only create private huddlz).
-              </p>
-            <% end %>
-          </div>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Cover image</h2>
-          </div>
-
-          <label for={@uploads.huddl_image.ref} class="sr-only">Cover image</label>
-          <.live_file_input upload={@uploads.huddl_image} class="hidden" />
-
-          <%= if @pending_preview_url do %>
-            <div class="image-preview" phx-drop-target={@uploads.huddl_image.ref}>
-              <div
-                class="card-cover"
-                style={"background-image: url('#{@pending_preview_url}')"}
-              >
-              </div>
-              <div
-                class="muted"
-                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-              >
-                <span>Image uploaded · ready to publish.</span>
-                <div style="display:flex; gap:8px">
-                  <label for={@uploads.huddl_image.ref} class="btn-secondary" style="cursor:pointer">
-                    Replace
-                  </label>
-                  <.button variant={:muted} type="button" phx-click="cancel_pending_image">
-                    Remove
-                  </.button>
-                </div>
-              </div>
-            </div>
-          <% else %>
-            <div class="upload-zone" phx-drop-target={@uploads.huddl_image.ref}>
-              <div class="upload-icon">
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.6"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
-                </svg>
-              </div>
-              <label for={@uploads.huddl_image.ref} class="upload-prompt">
-                Drop a 16:9 image, or <span class="upload-link">browse</span>
-              </label>
-              <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max · optional</div>
-            </div>
-
-            <%= for entry <- @uploads.huddl_image.entries do %>
-              <div class="image-preview" style="margin-top:12px">
-                <div class="card-cover">
-                  <.live_img_preview entry={entry} class="card-cover-img" />
-                </div>
-                <div
-                  class="muted"
-                  style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-                >
-                  <span>{entry.client_name} · {entry.progress}%</span>
-                  <.button
-                    variant={:muted}
-                    type="button"
-                    phx-click="cancel_image_upload"
-                    phx-value-ref={entry.ref}
-                  >
-                    Cancel
-                  </.button>
-                </div>
-              </div>
-
-              <%= for err <- upload_errors(@uploads.huddl_image, entry) do %>
-                <p class="form-error">{upload_error_to_string(err)}</p>
-              <% end %>
-            <% end %>
-          <% end %>
-
-          <p :if={@image_error} class="form-error">{@image_error}</p>
-
-          <%= for err <- upload_errors(@uploads.huddl_image) do %>
-            <p class="form-error">{upload_error_to_string(err)}</p>
-          <% end %>
-        </div>
-
-        <div class="form-foot is-flush">
-          <.button variant={:primary} type="submit" phx-disable-with="Scheduling…">
-            Schedule huddl
-          </.button>
-          <.button variant={:secondary} navigate={~p"/groups/#{@group.slug}"}>Cancel</.button>
-        </div>
+        <.form_footer
+          submit_label="Schedule huddl"
+          disable_with="Scheduling…"
+          cancel_path={~p"/groups/#{@group.slug}"}
+        />
       </.form>
 
-      <.modal
-        :if={@live_action == :new_location}
-        id="new-location-modal"
-        show
-        on_cancel={JS.patch(~p"/groups/#{@group.slug}/huddlz/new")}
-      >
-        <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
-
-        <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
-          <div class="form-row">
-            <label class="form-label" for="modal-address-autocomplete-input">
-              Search for an address
-            </label>
-            <.live_component
-              module={HuddlzWeb.Live.LocationAutocomplete}
-              id="modal-address-autocomplete"
-              variant={:form}
-              placeholder="Search for an address or venue..."
-              types={[]}
-              fetch_coordinates={true}
-              show_clear={true}
-            />
-          </div>
-
-          <div class="form-row">
-            <label class="form-label" for="location-name-input">
-              Location name (optional)
-            </label>
-            <input
-              type="text"
-              id="location-name-input"
-              name="location_name"
-              value={@modal_location_name}
-              phx-debounce="100"
-              placeholder="e.g., Community Center"
-              class="form-input"
-            />
-          </div>
-
-          <div class="form-foot is-flush">
-            <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
-              Save address
-            </.button>
-            <.button variant={:secondary} patch={~p"/groups/#{@group.slug}/huddlz/new"}>
-              Cancel
-            </.button>
-          </div>
-        </form>
-      </.modal>
+      <.location_modal
+        live_action={@live_action}
+        cancel_path={~p"/groups/#{@group.slug}/huddlz/new"}
+        modal_location_address={@modal_location_address}
+        modal_location_name={@modal_location_name}
+      />
     </Layouts.app>
     """
   end

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -5,6 +5,7 @@ defmodule HuddlzWeb.HuddlLive.New do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Components.HuddlForm
+  import HuddlzWeb.Components.UploadComponents
   import HuddlzWeb.HuddlLive.FormHelpers
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
@@ -163,64 +164,44 @@ defmodule HuddlzWeb.HuddlLive.New do
       </div>
 
       <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save">
-        <div class="panel">
-          <div class="panel-head">
-            <h2>The basics</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:title]}
-              label="Title"
-              placeholder="e.g. Ash Framework workshop"
-              autocomplete="off"
-            />
-            <.textarea
-              field={@form[:description]}
-              label="Description"
-              rows="4"
-              placeholder="What you'll do, what to bring, who it's for."
-            />
-          </div>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Format</h2>
-          </div>
-          <.event_type_grid field={@form[:event_type]} />
-          <.field_errors field={@form[:event_type]} />
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>When</h2>
-          </div>
-          <div class="form-grid">
-            <div class="form-row form-row-inline">
-              <div class="form-col-md">
-                <.input
-                  field={@form[:date]}
-                  type="date"
-                  label="Date"
-                />
+        <.cover_image_panel
+          upload={@uploads.huddl_image}
+          image_error={@image_error}
+          optional
+          show_upload_zone={is_nil(@pending_preview_url)}
+        >
+          <:preview :if={@pending_preview_url}>
+            <div class="image-preview" phx-drop-target={@uploads.huddl_image.ref}>
+              <div class="card-cover" style={"background-image: url('#{@pending_preview_url}')"}>
               </div>
-              <div class="form-col-sm">
-                <.input field={@form[:start_time]} type="time" label="Start time" />
-              </div>
-              <div class="form-col-sm">
-                <.select
-                  field={@form[:duration_minutes]}
-                  label="Duration"
-                  prompt="Select duration…"
-                  options={duration_options()}
-                />
+              <div
+                class="muted"
+                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
+              >
+                <span>Image uploaded · ready to publish.</span>
+                <div style="display:flex; gap:8px">
+                  <label for={@uploads.huddl_image.ref} class="btn-secondary" style="cursor:pointer">
+                    Replace
+                  </label>
+                  <.button variant={:muted} type="button" phx-click="cancel_pending_image">
+                    Remove
+                  </.button>
+                </div>
               </div>
             </div>
+          </:preview>
+        </.cover_image_panel>
 
-            <p :if={@calculated_end_time} class="form-help">
-              Ends at: <strong>{@calculated_end_time}</strong>
-            </p>
+        <.basics_panel form={@form} />
 
+        <.format_panel form={@form} />
+
+        <.when_panel
+          form={@form}
+          calculated_end_time={@calculated_end_time}
+          duration_prompt="Select duration…"
+        >
+          <:recurring_controls>
             <div class="form-row">
               <.toggle field={@form[:is_recurring]} label="Recurring huddl" />
               <p class="form-help">Repeats on a schedule until you stop it.</p>
@@ -248,154 +229,19 @@ defmodule HuddlzWeb.HuddlLive.New do
                 </div>
               </div>
             <% end %>
-          </div>
-        </div>
+          </:recurring_controls>
+        </.when_panel>
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Where</h2>
-          </div>
-          <div class="form-grid">
-            <%= if @show_physical_location do %>
-              <.live_component
-                module={HuddlzWeb.Live.SavedLocationPicker}
-                id="saved-location-picker"
-                group_locations={@group_locations}
-                selected_location={@selected_location}
-                new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
-                field={@form[:physical_location]}
-              />
-            <% end %>
+        <.where_panel
+          form={@form}
+          show_physical_location={@show_physical_location}
+          show_virtual_link={@show_virtual_link}
+          group_locations={@group_locations}
+          selected_location={@selected_location}
+          new_location_path={~p"/groups/#{@group.slug}/huddlz/new/locations/new"}
+        />
 
-            <%= if @show_virtual_link do %>
-              <.input
-                field={@form[:virtual_link]}
-                type="text"
-                inputmode="url"
-                autocomplete="url"
-                label="Online link"
-                placeholder="https://meet.example.com/..."
-                help="Only attendees see this link."
-              />
-            <% end %>
-          </div>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Capacity &amp; visibility</h2>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@form[:max_attendees]}
-              type="number"
-              label="Max attendees"
-              placeholder="No limit"
-              help="Leave blank for unlimited. When full, new RSVPs go to a waitlist."
-            />
-
-            <%= if @group.is_public do %>
-              <div class="form-row">
-                <.toggle field={@form[:is_private]} label="Members only" />
-                <p class="form-help">
-                  Only group members can RSVP. Useful for private workshops or socials.
-                </p>
-              </div>
-            <% else %>
-              <p class="form-help">
-                <.icon name="hero-lock-closed" class="h-4 w-4 inline" />
-                This will be a private huddl (private groups can only create private huddlz).
-              </p>
-            <% end %>
-          </div>
-        </div>
-
-        <div class="panel">
-          <div class="panel-head">
-            <h2>Cover image</h2>
-          </div>
-
-          <label for={@uploads.huddl_image.ref} class="sr-only">Cover image</label>
-          <.live_file_input upload={@uploads.huddl_image} class="hidden" />
-
-          <%= if @pending_preview_url do %>
-            <div class="image-preview" phx-drop-target={@uploads.huddl_image.ref}>
-              <div
-                class="card-cover"
-                style={"background-image: url('#{@pending_preview_url}')"}
-              >
-              </div>
-              <div
-                class="muted"
-                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-              >
-                <span>Image uploaded · ready to publish.</span>
-                <div style="display:flex; gap:8px">
-                  <label for={@uploads.huddl_image.ref} class="btn-secondary" style="cursor:pointer">
-                    Replace
-                  </label>
-                  <.button variant={:muted} type="button" phx-click="cancel_pending_image">
-                    Remove
-                  </.button>
-                </div>
-              </div>
-            </div>
-          <% else %>
-            <div class="upload-zone" phx-drop-target={@uploads.huddl_image.ref}>
-              <div class="upload-icon">
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.6"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
-                </svg>
-              </div>
-              <label for={@uploads.huddl_image.ref} class="upload-prompt">
-                Drop a 16:9 image, or <span class="upload-link">browse</span>
-              </label>
-              <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max · optional</div>
-            </div>
-
-            <%= for entry <- @uploads.huddl_image.entries do %>
-              <div class="image-preview" style="margin-top:12px">
-                <div class="card-cover">
-                  <.live_img_preview entry={entry} class="card-cover-img" />
-                </div>
-                <div
-                  class="muted"
-                  style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-                >
-                  <span>{entry.client_name} · {entry.progress}%</span>
-                  <.button
-                    variant={:muted}
-                    type="button"
-                    phx-click="cancel_image_upload"
-                    phx-value-ref={entry.ref}
-                  >
-                    Cancel
-                  </.button>
-                </div>
-              </div>
-
-              <%= for err <- upload_errors(@uploads.huddl_image, entry) do %>
-                <p class="form-error">{upload_error_to_string(err)}</p>
-              <% end %>
-            <% end %>
-          <% end %>
-
-          <p :if={@image_error} class="form-error">{@image_error}</p>
-
-          <%= for err <- upload_errors(@uploads.huddl_image) do %>
-            <p class="form-error">{upload_error_to_string(err)}</p>
-          <% end %>
-        </div>
+        <.capacity_panel form={@form} is_public={@group.is_public} />
 
         <div class="form-foot is-flush">
           <.button
@@ -422,55 +268,12 @@ defmodule HuddlzWeb.HuddlLive.New do
         </div>
       </.form>
 
-      <.modal
-        :if={@live_action == :new_location}
-        id="new-location-modal"
-        show
-        on_cancel={JS.patch(~p"/groups/#{@group.slug}/huddlz/new")}
-      >
-        <h2 class="font-display text-xl tracking-tight text-glow mb-6">Add New Address</h2>
-
-        <form phx-submit="save_location" phx-change="modal_form_changed" class="form-grid">
-          <div class="form-row">
-            <label class="form-label" for="modal-address-autocomplete-input">
-              Search for an address
-            </label>
-            <.live_component
-              module={HuddlzWeb.Live.LocationAutocomplete}
-              id="modal-address-autocomplete"
-              variant={:form}
-              placeholder="Search for an address or venue..."
-              types={[]}
-              fetch_coordinates={true}
-              show_clear={true}
-            />
-          </div>
-
-          <div class="form-row">
-            <label class="form-label" for="location-name-input">
-              Location name (optional)
-            </label>
-            <input
-              type="text"
-              id="location-name-input"
-              name="location_name"
-              value={@modal_location_name}
-              phx-debounce="100"
-              placeholder="e.g., Community Center"
-              class="form-input"
-            />
-          </div>
-
-          <div class="form-foot is-flush">
-            <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
-              Save address
-            </.button>
-            <.button variant={:secondary} patch={~p"/groups/#{@group.slug}/huddlz/new"}>
-              Cancel
-            </.button>
-          </div>
-        </form>
-      </.modal>
+      <.location_modal
+        live_action={@live_action}
+        cancel_path={~p"/groups/#{@group.slug}/huddlz/new"}
+        modal_location_address={@modal_location_address}
+        modal_location_name={@modal_location_name}
+      />
     </Layouts.app>
     """
   end

--- a/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
@@ -93,6 +93,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
       # Should show "Image uploaded" confirmation
       html = render(view)
       assert html =~ "Image uploaded"
+      refute has_element?(view, ".upload-zone")
 
       # Should have created a pending image record
       pending_count =


### PR DESCRIPTION
This change extracts common components from the huddl new/edit live views into the huddl_form component. This removes duplication that exists between the two live views. On the new view, the cover image panel is moved to the top of the page for consistency with the edit view.