### PR TITLE
fix(deploy): include legal documents in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN mix assets.setup
 
 COPY priv priv
 
+COPY docs/legal docs/legal
+
 COPY lib lib
 
 # Compile the release


### PR DESCRIPTION
## Summary

Restore Fly deploys by making the compile-time legal document sources available to the production image builder.

## Context

Huddlz.Legal embeds the policy Markdown during compilation. Image builds have failed before release creation because those source files were missing from the builder.