### PR TITLE
Fix RSVP and capacity on private huddlz

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -328,12 +328,13 @@ defmodule Huddlz.Communities.Huddl do
              )
     end
 
-    read :get_for_recurrence do
+    read :get_ignoring_visibility do
       description """
-      Internal, visibility-free fetch of a single huddl by id for the
-      recurring-series worker, which runs with no actor. Skips
-      FilterByVisibility so a private series can still be regenerated. Invoke
-      only with `authorize?: false`.
+      Internal, visibility-free fetch of a single huddl by id, for use in
+      actor-less or actor-agnostic contexts (recurring-series worker,
+      capacity-floor enforcement, RSVP locking). Skips FilterByVisibility so a
+      private huddl or series is still found. Invoke only with
+      `authorize?: false`.
       """
 
       get? true

--- a/lib/huddlz/communities/huddl/changes/enforce_capacity_floor.ex
+++ b/lib/huddlz/communities/huddl/changes/enforce_capacity_floor.ex
@@ -23,7 +23,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EnforceCapacityFloor do
   defp check_floor(cs, new_max) do
     huddl =
       Huddl
-      |> Ash.Query.for_read(:get_for_recurrence, %{id: cs.data.id})
+      |> Ash.Query.for_read(:get_ignoring_visibility, %{id: cs.data.id})
       |> Ash.Query.lock("FOR UPDATE")
       |> Ash.Query.load(:rsvp_count)
       |> Ash.read_one!(authorize?: false)

--- a/lib/huddlz/communities/huddl/changes/enforce_capacity_floor.ex
+++ b/lib/huddlz/communities/huddl/changes/enforce_capacity_floor.ex
@@ -8,8 +8,6 @@ defmodule Huddlz.Communities.Huddl.Changes.EnforceCapacityFloor do
 
   alias Huddlz.Communities.Huddl
 
-  require Ash.Query
-
   def change(changeset, _opts, _context) do
     Ash.Changeset.before_action(changeset, fn cs ->
       with true <- Ash.Changeset.changing_attribute?(cs, :max_attendees),
@@ -25,7 +23,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EnforceCapacityFloor do
   defp check_floor(cs, new_max) do
     huddl =
       Huddl
-      |> Ash.Query.filter(id == ^cs.data.id)
+      |> Ash.Query.for_read(:get_for_recurrence, %{id: cs.data.id})
       |> Ash.Query.lock("FOR UPDATE")
       |> Ash.Query.load(:rsvp_count)
       |> Ash.read_one!(authorize?: false)

--- a/lib/huddlz/communities/huddl/changes/rsvp.ex
+++ b/lib/huddlz/communities/huddl/changes/rsvp.ex
@@ -41,7 +41,7 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
 
   defp lock_huddl!(huddl_id) do
     Huddl
-    |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
+    |> Ash.Query.for_read(:get_ignoring_visibility, %{id: huddl_id})
     |> Ash.Query.lock("FOR UPDATE")
     |> Ash.Query.load(:at_capacity)
     |> Ash.read_one!(authorize?: false)

--- a/lib/huddlz/communities/huddl/changes/rsvp.ex
+++ b/lib/huddlz/communities/huddl/changes/rsvp.ex
@@ -10,8 +10,6 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
 
   alias Huddlz.Communities.{Huddl, HuddlAttendee}
 
-  require Ash.Query
-
   def change(changeset, _opts, %{actor: %{id: user_id}}) when not is_nil(user_id) do
     Ash.Changeset.before_action(changeset, &reserve_spot(&1, user_id))
   end
@@ -43,7 +41,7 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
 
   defp lock_huddl!(huddl_id) do
     Huddl
-    |> Ash.Query.filter(id == ^huddl_id)
+    |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
     |> Ash.Query.lock("FOR UPDATE")
     |> Ash.Query.load(:at_capacity)
     |> Ash.read_one!(authorize?: false)
@@ -57,7 +55,9 @@ defmodule Huddlz.Communities.Huddl.Changes.Rsvp do
 
   defp create_rsvp!(huddl_id, user_id) do
     HuddlAttendee
-    |> Ash.Changeset.for_create(:rsvp, %{huddl_id: huddl_id, user_id: user_id})
+    |> Ash.Changeset.for_create(:rsvp, %{huddl_id: huddl_id, user_id: user_id},
+      actor: %{id: user_id}
+    )
     |> Ash.create!(authorize?: false)
   end
 end

--- a/lib/huddlz/communities/workers/regenerate_recurring_series.ex
+++ b/lib/huddlz/communities/workers/regenerate_recurring_series.ex
@@ -18,7 +18,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeries do
   def perform(%Oban.Job{args: %{"huddl_id" => huddl_id}} = job) do
     huddl =
       Huddl
-      |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
+      |> Ash.Query.for_read(:get_ignoring_visibility, %{id: huddl_id})
       |> Ash.Query.load(:huddl_template)
       |> Ash.read_one!(authorize?: false)
 
@@ -71,7 +71,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeries do
 
   defp get_huddl_for_failure_notification(huddl_id) do
     Huddl
-    |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
+    |> Ash.Query.for_read(:get_ignoring_visibility, %{id: huddl_id})
     |> Ash.Query.load([:creator, :group])
     |> Ash.read_one(authorize?: false)
   end

--- a/test/huddlz/communities/huddl_rsvp_test.exs
+++ b/test/huddlz/communities/huddl_rsvp_test.exs
@@ -307,6 +307,51 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
                    end
     end
 
+    test "organizer cannot reduce capacity below current RSVPs on a private huddl", %{
+      owner: owner,
+      member: member,
+      group: group
+    } do
+      # Regression test: the capacity-floor check must not rely on the
+      # visibility-filtered primary :read action, since a private huddl (or a
+      # huddl in a private group) is invisible to that filter with no actor,
+      # which previously made the RSVP-count lookup return nil and crash
+      # instead of raising the intended validation error.
+      private_huddl =
+        Huddl
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            title: "Private Test Huddl",
+            description: "A private test huddl",
+            starts_at: DateTime.add(DateTime.utc_now(), 1, :day),
+            ends_at: DateTime.add(DateTime.utc_now(), 2, :day),
+            event_type: :virtual,
+            virtual_link: "https://zoom.us/j/000000",
+            is_private: true,
+            group_id: group.id
+          },
+          actor: owner
+        )
+        |> Ash.create!()
+
+      # Seed a second attendee directly against HuddlAttendee (bypassing the
+      # :rsvp update action) so this test stays scoped to the capacity-floor
+      # regression, not the separate visibility bug in Huddl.Changes.Rsvp.
+      HuddlAttendee
+      |> Ash.Changeset.for_create(:rsvp, %{huddl_id: private_huddl.id, user_id: member.id})
+      |> Ash.create!(actor: member, authorize?: false)
+
+      assert_raise Ash.Error.Invalid,
+                   ~r/cannot be less than the current RSVP count/,
+                   fn ->
+                     private_huddl
+                     |> Ash.reload!(actor: owner)
+                     |> Ash.Changeset.for_update(:update, %{max_attendees: 1}, actor: owner)
+                     |> Ash.update!()
+                   end
+    end
+
     test "organizer can clear max_attendees even with existing RSVPs", %{
       member: member,
       owner: owner,

--- a/test/huddlz/communities/huddl_rsvp_test.exs
+++ b/test/huddlz/communities/huddl_rsvp_test.exs
@@ -307,6 +307,46 @@ defmodule Huddlz.Communities.HuddlRsvpTest do
                    end
     end
 
+    test "member can RSVP to a private huddl", %{
+      owner: owner,
+      member: member,
+      group: group
+    } do
+      # Regression test: Huddl.Changes.Rsvp's lock_huddl!/1 must not rely on
+      # the visibility-filtered primary :read action either, for the same
+      # reason as the capacity-floor check above — a private huddl is
+      # invisible to that filter with no actor, which previously crashed the
+      # RSVP flow instead of recording the attendance.
+      private_huddl =
+        Huddl
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            title: "Private RSVP Huddl",
+            description: "A private test huddl",
+            starts_at: DateTime.add(DateTime.utc_now(), 1, :day),
+            ends_at: DateTime.add(DateTime.utc_now(), 2, :day),
+            event_type: :virtual,
+            virtual_link: "https://zoom.us/j/111111",
+            is_private: true,
+            group_id: group.id
+          },
+          actor: owner
+        )
+        |> Ash.create!()
+
+      private_huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: member)
+      |> Ash.update!()
+
+      # rsvp_count/1 reloads with no actor, which the visibility filter would
+      # reject for a private huddl, so check the aggregate with an actor here.
+      assert private_huddl
+             |> Ash.reload!(actor: owner)
+             |> Ash.load!(:rsvp_count, authorize?: false)
+             |> Map.get(:rsvp_count) == 2
+    end
+
     test "organizer cannot reduce capacity below current RSVPs on a private huddl", %{
       owner: owner,
       member: member,

--- a/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
+++ b/test/huddlz/notifications/huddl_lifecycle_notifications_test.exs
@@ -36,7 +36,7 @@ defmodule Huddlz.Notifications.HuddlLifecycleNotificationsTest do
 
   defp huddl_exists?(huddl_id) do
     Huddl
-    |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl_id})
+    |> Ash.Query.for_read(:get_ignoring_visibility, %{id: huddl_id})
     |> Ash.read_one!(authorize?: false)
     |> is_struct()
   end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -757,7 +757,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
 
       deleted =
         Huddl
-        |> Ash.Query.for_read(:get_for_recurrence, %{id: huddl.id})
+        |> Ash.Query.for_read(:get_ignoring_visibility, %{id: huddl.id})
         |> Ash.read_one!(authorize?: false)
 
       assert is_nil(deleted)
@@ -766,7 +766,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
 
   defp huddl_still_exists?(id) do
     Huddl
-    |> Ash.Query.for_read(:get_for_recurrence, %{id: id})
+    |> Ash.Query.for_read(:get_ignoring_visibility, %{id: id})
     |> Ash.read_one!(authorize?: false)
     |> is_struct(Huddl)
   end


### PR DESCRIPTION
The default query excludes private huddlz. This prevents users from RSVPing to private huddlz. It also prevents editing the capacity/max attendees. This change re-purposes the `get_for_recurrence` query which simply filters on id. The query is now renamed to `get_ignoring_visibility` to reflect it's usage.