### PR TITLE
Fix location autocomplete on Discover

### DIFF
--- a/lib/huddlz_web/live/location_autocomplete.ex
+++ b/lib/huddlz_web/live/location_autocomplete.ex
@@ -259,7 +259,7 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
       phx-hook="LocationAutocomplete"
       data-has-highlight={to_string(@suggestion_index >= 0)}
     >
-      <div class="filter-location">
+      <form class="filter-location">
         <svg
           width="14"
           height="14"
@@ -331,7 +331,7 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
             ×
           </button>
         <% end %>
-      </div>
+      </form>
 
       <%!-- Suggestion dropdown --%>
       <div

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -257,6 +257,15 @@ defmodule HuddlzWeb.HuddlSearchTest do
       |> assert_has(".filter-label", text: "Sort")
     end
 
+    test "location input is associated with its LiveView change form", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/discover")
+
+      assert has_element?(
+               view,
+               "form #location-autocomplete-input[phx-change='search_input']"
+             )
+    end
+
     test "filter bar is hidden under scope=groups", %{conn: conn} do
       conn
       |> visit("/discover?scope=groups")


### PR DESCRIPTION
## Summary

Restore browser-delivered location suggestions on Discover. Typing in the location pill now dispatches its debounced LiveView change through a valid form.

## Manual verification

1. Open `/discover`.
2. Type `sai` in the location field.
3. Confirm location suggestions appear and selecting one applies the location filter.