### PR TITLE
fix(db): match Ash feature gate to production Postgres

### DIFF
--- a/lib/huddlz/repo.ex
+++ b/lib/huddlz/repo.ex
@@ -17,6 +17,6 @@ defmodule Huddlz.Repo do
 
   @impl true
   def min_pg_version do
-    %Version{major: 17, minor: 4, patch: 0}
+    %Version{major: 16, minor: 8, patch: 0}
   end
 end


### PR DESCRIPTION
## Summary

- Match the Ash Postgres feature gate to the deployed PostgreSQL 16.8 cluster.
- Prevent PostgreSQL 17-only MERGE RETURNING token upserts from crashing password sign-in.
- Restore the signed-out RSVP path without requiring a database major-version upgrade.

## Verification

The focused password sign-in test passes and exercises token persistence through the PostgreSQL 16-compatible upsert path.

The full local precommit test phase was blocked by the shared test database retaining the calendar branch time_zone schema, which is not present on main. Compilation, formatting, dependency cleanup, and strict Credo completed successfully; CI will exercise the suite against a clean database.