### PR TITLE
fix(api): use standard discovery field sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ documentation for contributors and readers.
   verification, and access rules.
 - [Email notifications](docs/notifications.md) specifies notification
   categories, triggers, and delivery rules.
+- [Discovery API](docs/api-discovery.md) documents discovery ordering.
 - [API follow-ups](docs/api-followups.md) records deferred work for the
   JSON:API and GraphQL surfaces.
 

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -2,22 +2,34 @@
 
 Anonymous clients can discover public huddlz with `GET /api/json/huddlz`.
 
-The `sort` query parameter accepts named discovery orderings:
+The `sort` query parameter uses standard JSON:API field sorting. Fields sort
+ascending unless prefixed with `-`; comma-separated fields are applied in order.
 
-| Value | Ordering |
-| --- | --- |
-| `soonest` (default) | Start time ascending |
-| `newest` | Creation time descending |
+| UI label | API value | Ordering |
+| --- | --- | --- |
+| Soonest | `starts_at` | Start time ascending |
+| Newest | `-inserted_at` | Creation time descending |
 
-For example: `/api/json/huddlz?date_filter=upcoming&sort=soonest&page[limit]=20`.
-Omitting `sort` keeps the same soonest-first ordering. The date filter controls
-which huddlz are included; ordering only controls their sequence.
+For example: `/api/json/huddlz?date_filter=upcoming&sort=-inserted_at&page[limit]=20`.
+The creation timestamp is named `inserted_at`, not `created_at`, and is a public,
+read-only field.
 
-This discovery route uses named orderings rather than generic JSON:API field
-sorting such as `sort=starts_at` or `sort=-inserted_at`. Other collection routes
-retain their documented field sorting. See `/api/json/open_api` or
-`/api/json/swaggerui` for the generated contract.
+Omitting `sort` defaults to start time ascending. Explicit sorts replace that
+default. For example, `sort=-starts_at` puts the latest start first, and
+`sort=starts_at,-inserted_at` orders matching start times by creation time
+descending. Ordering is applied before pagination.
 
-Clients that omitted `sort` to work around issue #422 can continue doing so.
-Explicit `sort=soonest` and `sort=newest` now use the same search ordering as
-the web discovery UI; no parameter rename is needed.
+The date filter controls which huddlz are included; sorting only controls their
+sequence. See `/api/json/open_api` or `/api/json/swaggerui` for supported fields.
+
+## Migrating from the previously advertised contract
+
+The `soonest` and `newest` API values advertised before issue #422 are removed.
+Use `sort=starts_at` and `sort=-inserted_at`, respectively. Clients that omitted
+`sort` as a workaround can continue doing so without changes. The web discovery
+UI retains its Soonest/Newest labels and URLs.
+
+The shared search action also uses native field sorting in GraphQL, for example
+`searchHuddlz(sort: [{field: INSERTED_AT, order: DESC}])`; the former named sort
+argument is removed there too. Elixir callers supply `query: [sort: ...]` instead
+of the former positional ordering argument.

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -1,0 +1,23 @@
+# Discovery API
+
+Anonymous clients can discover public huddlz with `GET /api/json/huddlz`.
+
+The `sort` query parameter accepts named discovery orderings:
+
+| Value | Ordering |
+| --- | --- |
+| `soonest` (default) | Start time ascending |
+| `newest` | Creation time descending |
+
+For example: `/api/json/huddlz?date_filter=upcoming&sort=soonest&page[limit]=20`.
+Omitting `sort` keeps the same soonest-first ordering. The date filter controls
+which huddlz are included; ordering only controls their sequence.
+
+This discovery route uses named orderings rather than generic JSON:API field
+sorting such as `sort=starts_at` or `sort=-inserted_at`. Other collection routes
+retain their documented field sorting. See `/api/json/open_api` or
+`/api/json/swaggerui` for the generated contract.
+
+Clients that omitted `sort` to work around issue #422 can continue doing so.
+Explicit `sort=soonest` and `sort=newest` now use the same search ordering as
+the web discovery UI; no parameter rename is needed.

--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -20,8 +20,7 @@ defmodule Huddlz.Communities do
           {:optional, :search_latitude},
           {:optional, :search_longitude},
           {:optional, :distance_miles},
-          {:optional, :relationship},
-          {:optional, :sort}
+          {:optional, :relationship}
         ],
         get?: false
 
@@ -35,7 +34,6 @@ defmodule Huddlz.Communities do
           {:optional, :search_longitude},
           {:optional, :distance_miles},
           {:optional, :relationship},
-          {:optional, :sort},
           :search_time_zone
         ],
         get?: false

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -41,7 +41,8 @@ defmodule Huddlz.Communities.Huddl do
       base "/huddlz"
 
       get :read
-      index :search
+      # Discovery uses the action's named ordering instead of JSON:API field sorting.
+      index :search, derive_sort?: false
       index :upcoming, route: "/upcoming"
       index :past, route: "/past"
       index :by_group, route: "/by_group"
@@ -356,7 +357,7 @@ defmodule Huddlz.Communities.Huddl do
       end
 
       argument :sort, :atom do
-        description "Result ordering. :soonest sorts upcoming huddlz first; :newest sorts by recently created."
+        description "Result ordering: soonest sorts by start time ascending (default); newest sorts by creation time descending."
         allow_nil? true
         default :soonest
         constraints one_of: [:soonest, :newest]

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -41,8 +41,7 @@ defmodule Huddlz.Communities.Huddl do
       base "/huddlz"
 
       get :read
-      # Discovery uses the action's named ordering instead of JSON:API field sorting.
-      index :search, derive_sort?: false
+      index :search
       index :upcoming, route: "/upcoming"
       index :past, route: "/past"
       index :by_group, route: "/by_group"
@@ -321,6 +320,8 @@ defmodule Huddlz.Communities.Huddl do
     end
 
     read :search do
+      description "Discover huddlz matching the supplied filters. Defaults to start time ascending unless an explicit field sort is supplied."
+
       argument :query, :ci_string do
         allow_nil? true
       end
@@ -354,13 +355,6 @@ defmodule Huddlz.Communities.Huddl do
 
         allow_nil? true
         constraints one_of: [:hosting, :attending, :waitlisted]
-      end
-
-      argument :sort, :atom do
-        description "Result ordering: soonest sorts by start time ascending (default); newest sorts by creation time descending."
-        allow_nil? true
-        default :soonest
-        constraints one_of: [:soonest, :newest]
       end
 
       argument :search_time_zone, :string do
@@ -821,7 +815,7 @@ defmodule Huddlz.Communities.Huddl do
       description "Stamped when the 1-hour reminder has been sent for this huddl. Reset to nil when starts_at changes."
     end
 
-    create_timestamp :inserted_at
+    create_timestamp :inserted_at, public?: true
     update_timestamp :updated_at
   end
 

--- a/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
+++ b/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
@@ -17,7 +17,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
     |> apply_event_type_filter()
     |> apply_location_filter()
     |> apply_relationship_filter(context)
-    |> apply_sort()
+    |> Ash.Query.default_sort(starts_at: :asc)
   end
 
   defp apply_lifecycle_filter(query) do
@@ -167,13 +167,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
 
       _ ->
         query
-    end
-  end
-
-  defp apply_sort(query) do
-    case Ash.Query.get_argument(query, :sort) do
-      :newest -> Ash.Query.sort(query, inserted_at: :desc)
-      _ -> Ash.Query.sort(query, starts_at: :asc)
     end
   end
 end

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -126,7 +126,6 @@ defmodule HuddlzWeb.CalendarLive do
            nil,
            nil,
            role,
-           :soonest,
            actor: user,
            page: false,
            load: @card_loads

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -431,13 +431,16 @@ defmodule HuddlzWeb.HuddlLive do
       args.search_longitude,
       args.distance_miles,
       Keyword.get(opts, :relationship),
-      args.sort,
       args.search_time_zone,
       actor: actor,
+      query: [sort: sort_fields(args.sort)],
       page: Keyword.get(opts, :page, []),
       load: @huddl_card_loads
     )
   end
+
+  defp sort_fields(:newest), do: [inserted_at: :desc]
+  defp sort_fields(:soonest), do: [starts_at: :asc]
 
   defp list_groups(query, page, actor) do
     case Communities.search_groups(query,

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -114,9 +114,9 @@ defmodule HuddlzWeb.MyHuddlzLive do
     end
   end
 
-  defp filter_query(:upcoming), do: {:attending, :upcoming, :soonest}
-  defp filter_query(:waitlisted), do: {:waitlisted, :upcoming, :soonest}
-  defp filter_query(:past), do: {:attending, :past, :newest}
+  defp filter_query(:upcoming), do: {:attending, :upcoming, [starts_at: :asc]}
+  defp filter_query(:waitlisted), do: {:waitlisted, :upcoming, [starts_at: :asc]}
+  defp filter_query(:past), do: {:attending, :past, [inserted_at: :desc]}
 
   defp run_search(user, relationship, date_filter, opts) do
     Communities.search_huddlz(
@@ -127,8 +127,8 @@ defmodule HuddlzWeb.MyHuddlzLive do
       nil,
       nil,
       relationship,
-      Keyword.get(opts, :sort, :soonest),
       actor: user,
+      query: [sort: Keyword.get(opts, :sort, [])],
       page: Keyword.get(opts, :page, []),
       load: @card_loads
     )

--- a/test/features/api_discovery_ordering.feature
+++ b/test/features/api_discovery_ordering.feature
@@ -20,9 +20,9 @@ Feature: Discovery ordering for API callers
       | <third>  |
 
     Examples:
-      | ordering | first          | second         | third        |
-      | soonest  | Morning Coffee | Board Games    | Weekend Walk |
-      | newest   | Board Games    | Morning Coffee | Weekend Walk |
+      | ordering     | first          | second         | third        |
+      | starts_at    | Morning Coffee | Board Games    | Weekend Walk |
+      | -inserted_at | Board Games    | Morning Coffee | Weekend Walk |
 
   Scenario: Discovery defaults to huddlz starting soonest
     When I discover upcoming huddlz through the API without choosing an ordering or signing in

--- a/test/features/api_discovery_ordering.feature
+++ b/test/features/api_discovery_ordering.feature
@@ -1,0 +1,33 @@
+@async @database @conn @api_discovery_ordering
+Feature: Discovery ordering for API callers
+  As a visitor using the discovery API without signing in
+  I want to choose between huddlz starting soonest and newly created huddlz
+  So that I can find my next huddl
+
+  Background:
+    Given these public upcoming huddlz are available for API discovery:
+      | title          | starts in days | created days ago |
+      | Weekend Walk   | 7              | 3                |
+      | Morning Coffee | 1              | 2                |
+      | Board Games    | 4              | 1                |
+
+  Scenario Outline: A visitor chooses discovery ordering
+    When I discover upcoming huddlz through the API ordered by "<ordering>" without signing in
+    Then the discovery API should return huddlz in this order:
+      | title    |
+      | <first>  |
+      | <second> |
+      | <third>  |
+
+    Examples:
+      | ordering | first          | second         | third        |
+      | soonest  | Morning Coffee | Board Games    | Weekend Walk |
+      | newest   | Board Games    | Morning Coffee | Weekend Walk |
+
+  Scenario: Discovery defaults to huddlz starting soonest
+    When I discover upcoming huddlz through the API without choosing an ordering or signing in
+    Then the discovery API should return huddlz in this order:
+      | title          |
+      | Morning Coffee |
+      | Board Games    |
+      | Weekend Walk   |

--- a/test/features/group_image.feature
+++ b/test/features/group_image.feature
@@ -6,22 +6,22 @@ Feature: Group Image Management
 
   Background:
     Given the following users exist:
-      | email                | role     | display_name    |
-      | owner@example.com    | user     | Group Owner     |
-      | member@example.com   | user     | Group Member    |
-      | other@example.com    | user     | Other User      |
+      | email                          | role | display_name |
+      | group-image-owner@example.com  | user | Group Owner  |
+      | group-image-member@example.com | user | Group Member |
+      | group-image-other@example.com  | user | Other User   |
 
   # ===== Group Creation with Image =====
 
   Scenario: Owner can see image upload area when creating a group
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     Then I should see "Cover image"
     And I should see "Drop a 16:9 image"
     And I should see "JPG, PNG, WebP · 5 MB max"
 
   Scenario: Creating a group without an image
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I fill in "Group name" with "No Image Group"
     And I fill in "Description" with "A group without an image"
@@ -32,7 +32,7 @@ Feature: Group Image Management
     And I should see "No Image Group"
 
   Scenario: Creating a group with an image upload
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I fill in "Group name" with "Image Test Group"
     And I fill in "Description" with "A group with an image"
@@ -45,7 +45,7 @@ Feature: Group Image Management
     And the group "Image Test Group" should have an image
 
   Scenario: Canceling a pending image before saving group
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I fill in "Group name" with "Cancel Image Group"
     And I select "Saint Augustine, FL, USA" as the group city in "America/New_York"
@@ -58,7 +58,7 @@ Feature: Group Image Management
     And the group "Cancel Image Group" should not have an image
 
   Scenario: Re-uploading replaces the pending image
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I fill in "Group name" with "Replace Image Group"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
@@ -70,14 +70,14 @@ Feature: Group Image Management
   # ===== Group Editing with Image =====
 
   Scenario: Owner can see image upload area when editing a group
-    Given a public group "Edit Test Group" exists with owner "owner@example.com"
-    And I am signed in as "owner@example.com"
+    Given a public group "Edit Test Group" exists with owner "group-image-owner@example.com"
+    And I am signed in as "group-image-owner@example.com"
     When I visit the edit page for group "Edit Test Group"
     Then I should see "Cover image"
 
   Scenario: Owner can upload a new image for existing group
-    Given a public group "Add Image Group" exists with owner "owner@example.com"
-    And I am signed in as "owner@example.com"
+    Given a public group "Add Image Group" exists with owner "group-image-owner@example.com"
+    And I am signed in as "group-image-owner@example.com"
     When I visit the edit page for group "Add Image Group"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "New image uploaded. Save to apply."
@@ -86,9 +86,9 @@ Feature: Group Image Management
     And the group "Add Image Group" should have an image
 
   Scenario: Owner can replace existing group image
-    Given a public group "Replace Image Group" exists with owner "owner@example.com"
+    Given a public group "Replace Image Group" exists with owner "group-image-owner@example.com"
     And the group "Replace Image Group" has an image
-    And I am signed in as "owner@example.com"
+    And I am signed in as "group-image-owner@example.com"
     When I visit the edit page for group "Replace Image Group"
     Then I should see "Current image"
     When I upload "test/fixtures/test_image.jpg" to "Cover image"
@@ -98,10 +98,10 @@ Feature: Group Image Management
     And the group "Replace Image Group" should have an image
 
   Scenario: Owner can remove existing group image
-    Given a public group "Remove Image Group" exists with owner "owner@example.com"
+    Given a public group "Remove Image Group" exists with owner "group-image-owner@example.com"
     And the group "Remove Image Group" has an image
-    And a huddl "Group Image Huddl" exists in "Remove Image Group" created by "owner@example.com"
-    And I am signed in as "owner@example.com"
+    And a huddl "Group Image Huddl" exists in "Remove Image Group" created by "group-image-owner@example.com"
+    And I am signed in as "group-image-owner@example.com"
     When I visit the edit page for group "Remove Image Group"
     Then I should see "Current image"
     When I click the "Remove" button
@@ -121,9 +121,9 @@ Feature: Group Image Management
     Then I should see "Drop a 16:9 image"
 
   Scenario: Canceling group image removal preserves the image
-    Given a public group "Keep Image Group" exists with owner "owner@example.com"
+    Given a public group "Keep Image Group" exists with owner "group-image-owner@example.com"
     And the group "Keep Image Group" has an image
-    And I am signed in as "owner@example.com"
+    And I am signed in as "group-image-owner@example.com"
     When I visit the edit page for group "Keep Image Group"
     And I click the "Remove" button
     Then I should see "Remove this group cover image?"
@@ -132,9 +132,9 @@ Feature: Group Image Management
     And the group "Keep Image Group" should have an image
 
   Scenario: Canceling a pending image shows current image again
-    Given a public group "Cancel Replace Group" exists with owner "owner@example.com"
+    Given a public group "Cancel Replace Group" exists with owner "group-image-owner@example.com"
     And the group "Cancel Replace Group" has an image
-    And I am signed in as "owner@example.com"
+    And I am signed in as "group-image-owner@example.com"
     When I visit the edit page for group "Cancel Replace Group"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "New image uploaded. Save to apply."
@@ -145,13 +145,13 @@ Feature: Group Image Management
   # ===== Group Image Display =====
 
   Scenario: Group image is displayed on group page
-    Given a public group "Display Image Group" exists with owner "owner@example.com"
+    Given a public group "Display Image Group" exists with owner "group-image-owner@example.com"
     And the group "Display Image Group" has an image
     When I visit the group page for "Display Image Group"
     Then I should see the group image
 
   Scenario: Group without image shows placeholder with group name
-    Given a public group "No Image Display Group" exists with owner "owner@example.com"
+    Given a public group "No Image Display Group" exists with owner "group-image-owner@example.com"
     When I visit the group page for "No Image Display Group"
     Then I should not see the group image
     And I should see the group name "No Image Display Group" in the placeholder
@@ -159,22 +159,22 @@ Feature: Group Image Management
   # ===== Permissions =====
 
   Scenario: Non-owner cannot upload images for group
-    Given a public group "Other Owner Group" exists with owner "owner@example.com"
-    And I am signed in as "other@example.com"
+    Given a public group "Other Owner Group" exists with owner "group-image-owner@example.com"
+    And I am signed in as "group-image-other@example.com"
     When I visit the edit page for group "Other Owner Group"
     Then I should be redirected to the group page
 
   Scenario: Member cannot upload images for group
-    Given a public group "Member Test Group" exists with owner "owner@example.com"
-    And "member@example.com" is a member of "Member Test Group"
-    And I am signed in as "member@example.com"
+    Given a public group "Member Test Group" exists with owner "group-image-owner@example.com"
+    And "group-image-member@example.com" is a member of "Member Test Group"
+    And I am signed in as "group-image-member@example.com"
     When I visit the edit page for group "Member Test Group"
     Then I should be redirected to the group page
 
   # ===== Edge Cases =====
 
   Scenario: Form validation errors preserve pending image
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
@@ -183,7 +183,7 @@ Feature: Group Image Management
     And I should see "Image uploaded"
 
   Scenario: Navigating away leaves orphaned pending image for cleanup
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"

--- a/test/features/step_definitions/api_discovery_ordering_steps.exs
+++ b/test/features/step_definitions/api_discovery_ordering_steps.exs
@@ -1,0 +1,59 @@
+defmodule ApiDiscoveryOrderingSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+
+  step "these public upcoming huddlz are available for API discovery:", context do
+    owner = generate(user())
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    now = DateTime.utc_now()
+
+    for row <- context.datatable.maps do
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            actor: owner,
+            title: row["title"],
+            date: Date.add(DateTime.to_date(now), String.to_integer(row["starts in days"])),
+            is_private: false
+          )
+        )
+
+      Ash.Seed.update!(huddl, %{
+        inserted_at: DateTime.add(now, -String.to_integer(row["created days ago"]), :day)
+      })
+    end
+
+    context
+  end
+
+  step "I discover upcoming huddlz through the API ordered by {string} without signing in",
+       %{args: [ordering]} = context do
+    discover(context, %{"date_filter" => "upcoming", "sort" => ordering})
+  end
+
+  step "I discover upcoming huddlz through the API without choosing an ordering or signing in",
+       context do
+    discover(context, %{"date_filter" => "upcoming"})
+  end
+
+  step "the discovery API should return huddlz in this order:", context do
+    response = Phoenix.ConnTest.json_response(context.discovery_response, 200)
+
+    assert Enum.map(response["data"], & &1["attributes"]["title"]) ==
+             Enum.map(context.datatable.maps, & &1["title"])
+
+    context
+  end
+
+  defp discover(context, params) do
+    conn =
+      context.conn
+      |> Plug.Conn.put_req_header("accept", "application/vnd.api+json")
+      |> Phoenix.ConnTest.dispatch(HuddlzWeb.Endpoint, :get, "/api/json/huddlz", params)
+
+    Map.put(context, :discovery_response, conn)
+  end
+end

--- a/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
+++ b/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
@@ -80,7 +80,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           -97.7431,
           50,
           nil,
-          :soonest,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -103,7 +102,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           -97.7431,
           10,
           nil,
-          :soonest,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -125,7 +123,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           -97.7431,
           100,
           nil,
-          :soonest,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -150,7 +147,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           nil,
           nil,
           nil,
-          :soonest,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -172,7 +168,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           -97.7431,
           10,
           nil,
-          :soonest,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -186,7 +181,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           -97.7431,
           100,
           nil,
-          :soonest,
           actor: owner,
           page: [limit: 20, offset: 0, count: true]
         )
@@ -307,10 +301,10 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
     end
   end
 
-  describe "sort argument" do
+  describe "query sorting" do
     setup %{owner: owner, group: group} do
       # Three huddlz with distinct (starts_at, inserted_at) orderings so
-      # :soonest and :newest must produce different sequences.
+      # start time and creation time sorting must produce different sequences.
       now = DateTime.utc_now()
 
       first_inserted =
@@ -359,7 +353,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
       }
     end
 
-    test "defaults to :soonest (starts_at ascending)", %{
+    test "defaults to starts_at ascending", %{
       owner: owner,
       first_inserted: latest_start,
       middle_inserted: earliest_start
@@ -368,7 +362,6 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
         Huddlz.Communities.search_huddlz(
           nil,
           :all,
-          nil,
           nil,
           nil,
           nil,
@@ -384,7 +377,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
                Enum.find_index(ids, &(&1 == latest_start.id))
     end
 
-    test ":newest sorts by inserted_at descending", %{
+    test "explicit inserted_at descending overrides the default", %{
       owner: owner,
       first_inserted: oldest_insert,
       last_inserted: newest_insert
@@ -398,7 +391,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           nil,
           nil,
           nil,
-          :newest,
+          query: [sort: [inserted_at: :desc]],
           actor: owner,
           page: [limit: 50, count: true]
         )
@@ -409,7 +402,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
                Enum.find_index(ids, &(&1 == oldest_insert.id))
     end
 
-    test ":soonest sorts by starts_at ascending", %{
+    test "explicit starts_at ascending sorts chronologically", %{
       owner: owner,
       first_inserted: latest_start,
       middle_inserted: earliest_start,
@@ -424,8 +417,8 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
           nil,
           nil,
           nil,
-          :soonest,
           actor: owner,
+          query: [sort: [starts_at: :asc]],
           page: [limit: 50, count: true]
         )
 

--- a/test/huddlz/communities/huddl_lifecycle_test.exs
+++ b/test/huddlz/communities/huddl_lifecycle_test.exs
@@ -47,7 +47,6 @@ defmodule Huddlz.Communities.HuddlLifecycleTest do
                nil,
                nil,
                nil,
-               :soonest,
                actor: context.owner,
                page: false
              )

--- a/test/huddlz_web/api/graphql/huddl_test.exs
+++ b/test/huddlz_web/api/graphql/huddl_test.exs
@@ -1,6 +1,30 @@
 defmodule HuddlzWeb.Api.Graphql.HuddlTest do
   use HuddlzWeb.ApiCase, async: true
 
+  test "anonymous search accepts native creation-time sorting", %{conn: conn} do
+    owner = generate(user())
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    older = generate(huddl(group_id: group.id, actor: owner, date: Date.add(Date.utc_today(), 1)))
+    newer = generate(huddl(group_id: group.id, actor: owner, date: Date.add(Date.utc_today(), 7)))
+    Ash.Seed.update!(older, %{inserted_at: DateTime.add(DateTime.utc_now(), -1, :day)})
+
+    response =
+      conn
+      |> gql_post("""
+      { searchHuddlz(dateFilter: "upcoming", sort: [{field: INSERTED_AT, order: DESC}]) {
+        results { id }
+      } }
+      """)
+      |> json_response(200)
+
+    refute Map.has_key?(response, "errors")
+
+    assert Enum.map(response["data"]["searchHuddlz"]["results"], & &1["id"]) == [
+             newer.id,
+             older.id
+           ]
+  end
+
   describe "me query" do
     test "returns the current actor when authenticated", %{conn: conn} do
       target = generate(user(display_name: "Me"))

--- a/test/huddlz_web/api/json/huddl_test.exs
+++ b/test/huddlz_web/api/json/huddl_test.exs
@@ -23,7 +23,7 @@ defmodule HuddlzWeb.Api.Json.HuddlTest do
       %{later: later, sooner: sooner, middle: middle}
     end
 
-    test "anonymous discovery accepts soonest ordering", %{
+    test "anonymous discovery accepts start-time field sorting", %{
       conn: conn,
       later: later,
       sooner: sooner,
@@ -31,13 +31,13 @@ defmodule HuddlzWeb.Api.Json.HuddlTest do
     } do
       response =
         conn
-        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "soonest"})
+        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "starts_at"})
         |> json_response(200)
 
       assert Enum.map(response["data"], & &1["id"]) == [sooner.id, middle.id, later.id]
     end
 
-    test "anonymous discovery accepts newest ordering", %{
+    test "anonymous discovery accepts creation-time field sorting", %{
       conn: conn,
       later: later,
       sooner: sooner,
@@ -45,10 +45,54 @@ defmodule HuddlzWeb.Api.Json.HuddlTest do
     } do
       response =
         conn
-        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "newest"})
+        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "-inserted_at"})
         |> json_response(200)
 
       assert Enum.map(response["data"], & &1["id"]) == [middle.id, sooner.id, later.id]
+    end
+
+    test "explicit descending start time overrides the default", %{
+      conn: conn,
+      later: later,
+      sooner: sooner,
+      middle: middle
+    } do
+      response =
+        conn
+        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "-starts_at"})
+        |> json_response(200)
+
+      assert Enum.map(response["data"], & &1["id"]) == [later.id, middle.id, sooner.id]
+    end
+
+    test "multiple sort fields break start-time ties before pagination", %{
+      conn: conn,
+      sooner: sooner,
+      middle: middle
+    } do
+      Ash.Seed.update!(middle, %{starts_at: sooner.starts_at, ends_at: sooner.ends_at})
+
+      response =
+        conn
+        |> get("/api/json/huddlz", %{
+          "date_filter" => "upcoming",
+          "sort" => "starts_at,-inserted_at",
+          "page" => %{"limit" => "1"}
+        })
+        |> json_response(200)
+
+      assert Enum.map(response["data"], & &1["id"]) == [middle.id]
+    end
+
+    test "UI ordering names are rejected as unknown API fields", %{conn: conn} do
+      for sort <- ["soonest", "newest"] do
+        response =
+          conn
+          |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => sort})
+          |> json_response(400)
+
+        assert Enum.any?(response["errors"], &(&1["code"] == "invalid_sort"))
+      end
     end
 
     test "anonymous discovery defaults to soonest", %{
@@ -64,7 +108,9 @@ defmodule HuddlzWeb.Api.Json.HuddlTest do
     end
   end
 
-  test "OpenAPI documents one named discovery sort and no duplicate parameters", %{conn: conn} do
+  test "OpenAPI documents one field-based discovery sort and no duplicate parameters", %{
+    conn: conn
+  } do
     schema = conn |> get("/api/json/open_api") |> response(200) |> Jason.decode!()
 
     for {_path, item} <- schema["paths"],
@@ -76,8 +122,12 @@ defmodule HuddlzWeb.Api.Json.HuddlTest do
 
     parameters = get_in(schema, ["paths", "/api/json/huddlz", "get", "parameters"])
     assert [sort] = Enum.filter(parameters, &(&1["name"] == "sort" and &1["in"] == "query"))
-    assert Enum.sort(sort["schema"]["enum"]) == ["newest", "soonest"]
-    assert sort["description"] =~ "soonest sorts by start time ascending (default)"
+    refute Map.has_key?(sort["schema"], "enum")
+    pattern = Regex.compile!(sort["schema"]["pattern"])
+    assert Regex.match?(pattern, "starts_at")
+    assert Regex.match?(pattern, "-inserted_at")
+    refute Regex.match?(pattern, "soonest")
+    refute Regex.match?(pattern, "newest")
   end
 
   describe "DELETE /api/json/huddlz/:id" do

--- a/test/huddlz_web/api/json/huddl_test.exs
+++ b/test/huddlz_web/api/json/huddl_test.exs
@@ -1,6 +1,85 @@
 defmodule HuddlzWeb.Api.Json.HuddlTest do
   use HuddlzWeb.ApiCase, async: true
 
+  describe "GET /api/json/huddlz discovery ordering" do
+    setup do
+      owner = generate(user())
+      group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+
+      later =
+        generate(huddl(group_id: group.id, actor: owner, date: Date.add(Date.utc_today(), 7)))
+
+      sooner =
+        generate(huddl(group_id: group.id, actor: owner, date: Date.add(Date.utc_today(), 1)))
+
+      middle =
+        generate(huddl(group_id: group.id, actor: owner, date: Date.add(Date.utc_today(), 4)))
+
+      now = DateTime.utc_now()
+      Ash.Seed.update!(later, %{inserted_at: DateTime.add(now, -3, :day)})
+      Ash.Seed.update!(sooner, %{inserted_at: DateTime.add(now, -2, :day)})
+      Ash.Seed.update!(middle, %{inserted_at: DateTime.add(now, -1, :day)})
+
+      %{later: later, sooner: sooner, middle: middle}
+    end
+
+    test "anonymous discovery accepts soonest ordering", %{
+      conn: conn,
+      later: later,
+      sooner: sooner,
+      middle: middle
+    } do
+      response =
+        conn
+        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "soonest"})
+        |> json_response(200)
+
+      assert Enum.map(response["data"], & &1["id"]) == [sooner.id, middle.id, later.id]
+    end
+
+    test "anonymous discovery accepts newest ordering", %{
+      conn: conn,
+      later: later,
+      sooner: sooner,
+      middle: middle
+    } do
+      response =
+        conn
+        |> get("/api/json/huddlz", %{"date_filter" => "upcoming", "sort" => "newest"})
+        |> json_response(200)
+
+      assert Enum.map(response["data"], & &1["id"]) == [middle.id, sooner.id, later.id]
+    end
+
+    test "anonymous discovery defaults to soonest", %{
+      conn: conn,
+      later: later,
+      sooner: sooner,
+      middle: middle
+    } do
+      response =
+        conn |> get("/api/json/huddlz", %{"date_filter" => "upcoming"}) |> json_response(200)
+
+      assert Enum.map(response["data"], & &1["id"]) == [sooner.id, middle.id, later.id]
+    end
+  end
+
+  test "OpenAPI documents one named discovery sort and no duplicate parameters", %{conn: conn} do
+    schema = conn |> get("/api/json/open_api") |> response(200) |> Jason.decode!()
+
+    for {_path, item} <- schema["paths"],
+        {method, operation} <- item,
+        method in ~w(get post patch put delete options head) do
+      parameters = Enum.map(operation["parameters"] || [], &{&1["name"], &1["in"]})
+      assert parameters == Enum.uniq(parameters)
+    end
+
+    parameters = get_in(schema, ["paths", "/api/json/huddlz", "get", "parameters"])
+    assert [sort] = Enum.filter(parameters, &(&1["name"] == "sort" and &1["in"] == "query"))
+    assert Enum.sort(sort["schema"]["enum"]) == ["newest", "soonest"]
+    assert sort["description"] =~ "soonest sorts by start time ascending (default)"
+  end
+
   describe "DELETE /api/json/huddlz/:id" do
     test "owner can delete a draft huddl", %{conn: conn} do
       owner = generate(user())

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -79,6 +79,36 @@ defmodule HuddlzWeb.HuddlSearchTest do
   end
 
   describe "search functionality" do
+    test "Soonest and Newest controls reorder huddlz", %{
+      conn: conn,
+      huddl1: first,
+      huddl2: second,
+      huddl3: third
+    } do
+      now = DateTime.utc_now()
+      Ash.Seed.update!(first, %{inserted_at: DateTime.add(now, -3, :day)})
+
+      Ash.Seed.update!(second, %{
+        starts_at: DateTime.add(now, 5, :day),
+        ends_at: DateTime.add(now, 5, :day) |> DateTime.add(1, :hour),
+        inserted_at: DateTime.add(now, -2, :day)
+      })
+
+      Ash.Seed.update!(third, %{inserted_at: DateTime.add(now, -1, :day)})
+
+      {:ok, view, html} = live(conn, "/discover")
+
+      titles = fn html ->
+        html |> Floki.parse_document!() |> Floki.find("h3.card-title") |> Enum.map(&Floki.text/1)
+      end
+
+      assert titles.(html) == [first.title, second.title, third.title]
+      html = view |> element(".chip-group a.chip", "Newest") |> render_click()
+      assert titles.(html) == [third.title, second.title, first.title]
+      html = view |> element(".chip-group a.chip", "Soonest") |> render_click()
+      assert titles.(html) == [first.title, second.title, third.title]
+    end
+
     test "displays all upcoming huddlz by default", %{conn: conn} do
       conn
       |> visit("/discover")

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -161,7 +161,10 @@ defmodule Huddlz.Generator do
       Group,
       :create_group,
       defaults: [
-        name: StreamData.repeatedly(fn -> Faker.Company.name() end),
+        name:
+          StreamData.repeatedly(fn ->
+            "#{Faker.Company.name()} #{System.unique_integer([:positive])}"
+          end),
         description: StreamData.repeatedly(fn -> Faker.Lorem.paragraph(2..3) end),
         location: "Test Location",
         time_zone: "America/New_York",


### PR DESCRIPTION
Discovery uses standard JSON:API field sorting: `sort=starts_at` for Soonest and `sort=-inserted_at` for Newest. Omitting `sort` still defaults to start time ascending. Explicit sorts take precedence over the default, including multiple fields, and OpenAPI exposes one sorting parameter.

The web UI retains its Soonest/Newest labels and URLs. API clients must replace the previously advertised `soonest`/`newest` values with field sorts; clients omitting `sort` need no changes. The creation timestamp `inserted_at` is now public and read-only to support sorting. GraphQL uses native field sorting as well. Consumer migration details are in `docs/api-discovery.md`.

Cucumber covers anonymous API ordering. Integration coverage checks sort precedence and pagination, OpenAPI uniqueness, GraphQL sorting, and the UI controls.

Fixes #422.
