### PR TITLE
fix(ui): add stable id to Discover distance form

### DIFF
--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -597,6 +597,7 @@ defmodule HuddlzWeb.HuddlLive do
                 it doesn't perturb the .filter-distance flex layout. --%>
           <form
             :if={@location_active}
+            id="distance-filter-form"
             class="filter-distance"
             phx-change="distance_change"
             style="display:contents"

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -297,7 +297,8 @@ defmodule HuddlzWeb.HuddlLiveTest do
       session
       |> assert_has("h1", text: "Results for")
       |> assert_has("input[name='q'][value='elixir']")
-      |> assert_has(".filter-distance input[type='range'][value='25']")
+      |> assert_has("form#distance-filter-form[phx-change='distance_change']", count: 1)
+      |> assert_has("#distance-filter-form input[type='range'][value='25']")
       |> assert_has(".filter-distance-value", text: "25 mi")
     end
   end


### PR DESCRIPTION
Give the Discover distance filter a stable form ID so LiveView can recover it after reconnecting and no longer warns about its missing ID. Extend the existing location-search test to require exactly one identified distance form.

Verified in an isolated local browser: changing Austin's radius from 25 to 5 miles excluded seeded huddlz 15.2 miles away while retaining those 2.1 miles away. After stopping the server, changing the slider to 25, and restarting, the slider, displayed distance, URL, and results recovered consistently. This verifies recovery with the fix; it does not establish state loss on the original version. The dev console also logged a MutationObserver error, without preventing these checks.

Closes #411
