### PR TITLE
fix(email): refresh calendar entries in recurring series updates

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -51,7 +51,7 @@ Each trigger has an ID (e.g. C3) used throughout the doc and the GitHub issues.
 | C1 | New huddl created in a group | All group members | Activity | Default ON. Body links to settings page. |
 | C2 | Huddl details meaningfully changed | All current RSVPs | Activity | "Meaningful" = `starts_at`, `ends_at`, `time_zone`, `physical_location`, `virtual_link`, `title`, `capacity`, or `privacy`. Includes an updated `.ics` attachment. Skip cosmetic and no-op edits. |
 | C3 | Huddl cancelled / deleted | All current RSVPs | Transactional | Highest priority. People may have travel plans. |
-| C4 | Recurring series modified | Deduplicated RSVPs across retained upcoming instances | Activity | One summary per person, linked to their next retained RSVP. Subsequent instances are covered by their own reminders (D1/D2). |
+| C4 | Recurring series modified | Deduplicated RSVPs across retained upcoming instances | Activity | One summary per person, linked to their next retained RSVP. One calendar attachment per active RSVP on a published future huddl, preserving each instance UID; waitlisted and cancelled huddlz get no attachment. |
 
 ### D. Huddl reminders (time-based, Oban cron)
 
@@ -106,7 +106,7 @@ Locked for v1, no re-litigation:
 
 1. C1 audience = every group member. Mitigated by the settings page.
 2. E1/E2 volume = per-RSVP, no cap. Daily digest is a v2 idea.
-3. C4 = one email per affected person about their next retained RSVP. Later instances rely on D1/D2.
+3. C4 = one email per affected person about their next retained RSVP, with a separate calendar attachment for every active RSVP on a published future huddl. This retains one summary email instead of sending one update email per instance. Reminders (D1/D2) remain unchanged.
 4. `.ics` attachments ship in v1 on C2, E3, D1, D2.
 5. Defaults: Activity ON, Digest OFF, Transactional always on.
 
@@ -134,7 +134,7 @@ Unsubscribe links in email footers deep-link to a confirmation page, then a POST
 
 - **`User.notification_preferences`** — JSONB map keyed by trigger code. Defaults applied at read time, so adding a new key doesn't need a backfill.
 - **Sender modules** — one per email under `lib/huddlz/notifications/senders/` (or colocated under `lib/huddlz/accounts/user/senders/` to match AshAuthentication). Each sender: build email, check preferences, deliver.
-- **Huddl schedule payloads** — payloads that include `starts_at_iso` also include the huddl's canonical `time_zone`, so email and in-app summaries render in the huddl's local time. C2 additionally requires `ends_at_iso` and `changed_fields` to build the updated calendar attachment and change summary.
+- **Huddl schedule payloads** — payloads that include `starts_at_iso` also include the huddl's canonical `time_zone`, so email and in-app summaries render in the huddl's local time. C2 additionally requires `ends_at_iso` and `changed_fields` to build the updated calendar attachment and change summary. C4 carries recipient-scoped `calendar_huddlz` with these schedule payloads. Attachments use the existing iCalendar export format and stable per-instance UIDs, with UTC start/end times and a generation timestamp. They are files to open/import, not iTIP meeting requests or a subscribed calendar feed; automatic replacement depends on the calendar client.
 - **Ash notifiers** — most action-driven emails (B1, B3, C1, C3, E1, E2, E3) attach as `Ash.Notifier` modules on the resource. Avoids scattering side-effects across LiveViews.
 - **Reminder scheduling (D1, D2)** — when a huddl is created, schedule two Oban jobs (`scheduled_at: starts_at - 24h` and `starts_at - 1h`). On huddl update, cancel + reschedule. On RSVP create/destroy, do *not* touch the huddl-level job — the job resolves recipients at run time.
 - **Unsubscribe** — `Phoenix.Token` signed payload `{user_id, category}`, route at `/unsubscribe/:token`. GET shows confirmation; POST flips the preference and redirects to the settings page.

--- a/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
+++ b/lib/huddlz/communities/huddl/changes/edit_recurring_huddlz.ex
@@ -11,6 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
 
   alias Huddlz.Communities.Huddl.Changes.NotifyMeaningfulUpdate
   alias Huddlz.Communities.Huddl.Changes.RecipientHelpers
+  alias Huddlz.Communities.Huddl.Changes.SeriesRsvpTarget
   alias Huddlz.Communities.Huddl.RecurrenceHelper
   alias Huddlz.Communities.HuddlTemplate
 
@@ -128,8 +129,19 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz do
 
     huddl
     |> RecipientHelpers.series_rsvp_targets(exclude: actor_id)
-    |> Enum.each(fn {user_id, target} ->
-      payload = NotifyMeaningfulUpdate.payload(target, huddl.group, changed_fields)
+    |> Enum.each(fn %SeriesRsvpTarget{
+                      user_id: user_id,
+                      next_huddl: target,
+                      calendar_huddlz: targets
+                    } ->
+      calendar_huddlz =
+        targets
+        |> Enum.map(&NotifyMeaningfulUpdate.payload(&1, huddl.group, changed_fields))
+
+      payload =
+        target
+        |> NotifyMeaningfulUpdate.payload(huddl.group, changed_fields)
+        |> Map.put("calendar_huddlz", calendar_huddlz)
 
       RecipientHelpers.deliver_each([user_id], :huddl_series_updated, payload)
     end)

--- a/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
+++ b/lib/huddlz/communities/huddl/changes/recipient_helpers.ex
@@ -11,6 +11,7 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   alias Huddlz.Communities
   alias Huddlz.Communities.GroupMember
   alias Huddlz.Communities.Huddl
+  alias Huddlz.Communities.Huddl.Changes.SeriesRsvpTarget
   alias Huddlz.Communities.Huddl.RecurrenceHelper
   alias Huddlz.Notifications
 
@@ -32,14 +33,15 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
   end
 
   @doc """
-  Returns one next-upcoming huddl per person who has an RSVP on the source
+  Returns the next summary target and upcoming calendar huddlz for each person
+  with an RSVP or waitlist entry on the source
   occurrence or any later occurrence in its recurring series.
 
-  Choosing a target per recipient keeps a whole-series summary useful for
+  Choosing targets per recipient keeps a whole-series summary useful for
   people who attend different dates and ensures the link points to a huddl
   they can still access after reconciliation.
   """
-  @spec series_rsvp_targets(Huddl.t(), keyword()) :: [{Ecto.UUID.t(), Huddl.t()}]
+  @spec series_rsvp_targets(Huddl.t(), keyword()) :: [SeriesRsvpTarget.t()]
   def series_rsvp_targets(%Huddl{} = source, opts \\ []) do
     actor_id = Keyword.get(opts, :exclude)
     huddlz = [source | RecurrenceHelper.future_instances(source)]
@@ -51,12 +53,27 @@ defmodule Huddlz.Communities.Huddl.Changes.RecipientHelpers do
     |> Enum.reject(&(&1.user_id == actor_id))
     |> Enum.group_by(& &1.user_id)
     |> Enum.map(fn {user_id, attendances} ->
-      next_huddl =
+      targets =
         attendances
         |> Enum.map(&Map.fetch!(huddlz_by_id, &1.huddl_id))
-        |> Enum.min_by(& &1.starts_at, DateTime)
+        |> Enum.sort_by(& &1.starts_at, DateTime)
 
-      {user_id, next_huddl}
+      now = DateTime.utc_now()
+
+      calendar_huddlz =
+        attendances
+        |> Enum.filter(&is_nil(&1.waitlisted_at))
+        |> Enum.map(&Map.fetch!(huddlz_by_id, &1.huddl_id))
+        |> Enum.filter(
+          &(&1.lifecycle_state == :published and DateTime.compare(&1.starts_at, now) == :gt)
+        )
+        |> Enum.sort_by(& &1.starts_at, DateTime)
+
+      %SeriesRsvpTarget{
+        user_id: user_id,
+        next_huddl: hd(targets),
+        calendar_huddlz: calendar_huddlz
+      }
     end)
   end
 

--- a/lib/huddlz/communities/huddl/changes/series_rsvp_target.ex
+++ b/lib/huddlz/communities/huddl/changes/series_rsvp_target.ex
@@ -1,0 +1,16 @@
+defmodule Huddlz.Communities.Huddl.Changes.SeriesRsvpTarget do
+  @moduledoc """
+  A recipient's series-summary destination and eligible calendar huddlz.
+  """
+
+  alias Huddlz.Communities.Huddl
+
+  @enforce_keys [:user_id, :next_huddl, :calendar_huddlz]
+  defstruct [:user_id, :next_huddl, :calendar_huddlz]
+
+  @type t :: %__MODULE__{
+          user_id: Ecto.UUID.t(),
+          next_huddl: Huddl.t(),
+          calendar_huddlz: [Huddl.t()]
+        }
+end

--- a/lib/huddlz/notifications/senders/huddl_series_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_series_updated.ex
@@ -11,7 +11,10 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
   Required payload keys are the same as C2 (`huddl_id`,
   `huddl_title`, `starts_at_iso`, `group_name`, `group_slug`,
   `changed_fields`), but the values describe the next-instance row
-  rather than the row that triggered the edit.
+  rather than the row that triggered the edit. `calendar_huddlz` contains
+  schedule payloads for that recipient's active, future RSVPs. Each gets its
+  own attachment with the same UID as its confirmation; waitlisted and cancelled
+  huddlz are excluded. Older queued payloads without this key remain valid.
   """
 
   @behaviour Huddlz.Notifications.Sender
@@ -21,6 +24,7 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
   alias Huddlz.Mailer
   alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.ICS
   alias Huddlz.Notifications.Senders.ChangedFields
   alias Huddlz.Notifications.Senders.HeaderSafe
   alias Huddlz.Notifications.Senders.HtmlEscape
@@ -41,6 +45,13 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
 
     safe_when = HtmlEscape.escape(when_text)
     safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
+
+    calendar_note =
+      if Map.get(payload, "calendar_huddlz", []) == [],
+        do: "",
+        else:
+          "Updated calendar entries for your upcoming RSVPs are attached. Open each attachment to update that date in your calendar."
+
     huddl_url = Urls.huddl_url(payload)
 
     {footer_html, footer_text} = Footer.build(user, :huddl_series_updated)
@@ -61,6 +72,8 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
     is now scheduled for #{safe_when}. See it at
     <a href="#{huddl_url}">#{huddl_url}</a>.</p>
 
+    <p>#{calendar_note}</p>
+
     <p>You will still receive the usual reminders for each huddl you are attending.</p>
     #{footer_html}
     """)
@@ -74,9 +87,26 @@ defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
     Your next upcoming instance, "#{huddl_title(payload)}", is now scheduled for
     #{when_text}. See it at #{huddl_url}.
 
+    #{calendar_note}
+
     You will still receive the usual reminders for each huddl you are attending.
     #{footer_text}
     """)
+    |> attach_calendars(payload)
+  end
+
+  defp attach_calendars(email, payload) do
+    Enum.reduce(Map.get(payload, "calendar_huddlz", []), email, fn huddl, email ->
+      {_filename, content} = ICS.updated_huddl(huddl)
+
+      attachment(
+        email,
+        Swoosh.Attachment.new({:data, content},
+          filename: "huddl-#{huddl["huddl_id"]}.ics",
+          content_type: "text/calendar"
+        )
+      )
+    end)
   end
 
   defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title

--- a/test/features/series_calendar_updates.feature
+++ b/test/features/series_calendar_updates.feature
@@ -1,0 +1,28 @@
+@database @conn @series_calendar_updates
+Feature: Calendar entries after a recurring series update
+  As an attendee of recurring huddlz
+  I want refreshed calendar entries for the dates I have RSVPed to
+  So that my calendar reflects the organizer's schedule changes
+
+  Scenario: A weekly series moves one hour across daylight saving time
+    Given attendees hold different dates of a weekly series across daylight saving time
+    When the organizer moves the whole series one hour later
+    Then each attendee receives one series email with calendar entries for only their RSVPs
+    And each calendar entry keeps its original identity and the new local schedule
+
+  Scenario: Series calendar delivery respects participation and preferences
+    Given attendees hold different dates of a weekly series across daylight saving time
+    And other people have waitlisted, cancelled, or disabled series emails
+    When the organizer moves the whole series one hour later
+    Then each attendee receives one series email with calendar entries for only their RSVPs
+    And waitlisted people receive only a summary and opted-out people receive no email
+
+  Scenario: Shortening a series does not re-add cancelled dates to calendars
+    Given attendees hold different dates of a weekly series across daylight saving time
+    When the organizer shortens the series to its first two dates
+    Then series attachments contain only retained dates and dropped dates have cancellation emails
+
+  Scenario: An attendee cannot trigger series calendar updates
+    Given attendees hold different dates of a weekly series across daylight saving time
+    When an attendee tries to edit the whole series
+    Then the edit is forbidden and no update email is sent

--- a/test/features/step_definitions/series_calendar_updates_steps.exs
+++ b/test/features/step_definitions/series_calendar_updates_steps.exs
@@ -1,0 +1,264 @@
+defmodule SeriesCalendarUpdatesSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Huddlz.Test.Helpers.Authentication, only: [login: 2]
+  import PhoenixTest
+
+  alias Huddlz.Communities
+  alias Huddlz.Communities.Huddl.RecurrenceHelper
+
+  step "attendees hold different dates of a weekly series across daylight saving time", context do
+    owner = generate(user(role: :user))
+
+    group =
+      generate(
+        group(is_public: true, time_zone: "America/New_York", owner_id: owner.id, actor: owner)
+      )
+
+    source =
+      generate(
+        huddl(
+          title: "Weekly calendar series",
+          group_id: group.id,
+          actor: owner,
+          event_type: :virtual,
+          virtual_link: "https://example.com/private-room",
+          date: ~D[2030-10-27],
+          start_time: ~T[18:00:00],
+          duration_minutes: 60,
+          is_recurring: true,
+          frequency: "weekly",
+          repeat_until: ~D[2030-11-18]
+        )
+      )
+
+    Oban.drain_queue(queue: :default)
+
+    [first, second, third] =
+      source |> RecurrenceHelper.future_instances() |> Enum.sort_by(& &1.starts_at, DateTime)
+
+    alice = generate(user())
+    bob = generate(user())
+    holdings = [{alice, [source, first, second]}, {bob, [second]}]
+
+    for {attendee, huddlz} <- holdings, huddl <- huddlz do
+      Communities.rsvp_huddl!(huddl, actor: attendee)
+    end
+
+    Oban.drain_queue(queue: :notifications)
+    confirmations = emails()
+
+    Map.merge(context, %{
+      owner: owner,
+      group: group,
+      source: source,
+      holdings: holdings,
+      confirmations: confirmations,
+      unheld: third
+    })
+  end
+
+  step "other people have waitlisted, cancelled, or disabled series emails", context do
+    [alice_holding | _] = context.holdings
+    {alice, _} = alice_holding
+    [cancelled_huddl | _] = RecurrenceHelper.future_instances(context.source)
+    cancelled = generate(user())
+    opted_out = generate(user(notification_preferences: %{"huddl_series_updated" => false}))
+    waitlisted = generate(user())
+
+    Communities.rsvp_huddl!(cancelled_huddl, actor: cancelled)
+    Communities.cancel_rsvp_huddl!(cancelled_huddl, actor: cancelled)
+    Communities.rsvp_huddl!(context.source, actor: opted_out)
+    source = Communities.update_huddl!(context.source, %{max_attendees: 3}, actor: context.owner)
+
+    another_opted_out =
+      generate(user(notification_preferences: %{"huddl_series_updated" => false}))
+
+    Communities.rsvp_huddl!(context.unheld, actor: opted_out)
+    Communities.rsvp_huddl!(context.unheld, actor: another_opted_out)
+    full = Communities.update_huddl!(context.unheld, %{max_attendees: 3}, actor: context.owner)
+    Communities.join_waitlist_huddl!(full, actor: waitlisted)
+    Communities.join_waitlist_huddl!(full, actor: alice)
+    Oban.drain_queue(queue: :notifications)
+    emails()
+
+    Map.merge(context, %{
+      source: source,
+      waitlisted: waitlisted,
+      opted_out: opted_out,
+      cancelled: cancelled
+    })
+  end
+
+  step "waitlisted people receive only a summary and opted-out people receive no email",
+       context do
+    assert email_for(context.updated_emails, context.waitlisted).attachments == []
+
+    for attendee <- [context.opted_out, context.cancelled, context.owner] do
+      refute Enum.any?(context.updated_emails, &(&1.to == [{"", to_string(attendee.email)}]))
+    end
+
+    context
+  end
+
+  step "the organizer moves the whole series one hour later", context do
+    session =
+      context.conn
+      |> login(context.owner)
+      |> visit("/groups/#{context.group.slug}/huddlz/#{context.source.id}/edit")
+      |> click_button("Whole series")
+      |> fill_in("Start time", with: "19:00", exact: false)
+      |> click_button("Save changes")
+      |> assert_has("#flash-info", text: "Huddl updated successfully!")
+
+    Oban.drain_queue(queue: :notifications)
+    Map.merge(context, %{session: session, updated_emails: emails()})
+  end
+
+  step "each attendee receives one series email with calendar entries for only their RSVPs",
+       context do
+    assert length(context.updated_emails) ==
+             length(context.holdings) + if(context[:waitlisted], do: 1, else: 0)
+
+    for {attendee, huddlz} <- context.holdings do
+      email = email_for(context.updated_emails, attendee)
+      assert email.subject == "Recurring series updated: Weekly calendar series"
+      assert email.cc == []
+      assert email.bcc == []
+      assert length(email.attachments) == length(huddlz)
+      assert length(Enum.uniq_by(email.attachments, & &1.filename)) == length(huddlz)
+
+      entries =
+        Enum.map(email.attachments, fn attachment ->
+          assert attachment.content_type == "text/calendar"
+          assert attachment.type == :attachment
+          assert String.ends_with?(attachment.filename, ".ics")
+          assert [entry] = ICal.from_ics(attachment.data).events
+          refute attachment.data =~ "private-room"
+          entry
+        end)
+
+      assert Enum.sort(Enum.map(entries, & &1.uid)) ==
+               Enum.sort(Enum.map(huddlz, &"huddl-#{&1.id}@huddlz.com"))
+    end
+
+    context
+  end
+
+  step "each calendar entry keeps its original identity and the new local schedule", context do
+    expected = %{
+      ~D[2030-10-27] => ~U[2030-10-27 23:00:00Z],
+      ~D[2030-11-03] => ~U[2030-11-04 00:00:00Z],
+      ~D[2030-11-10] => ~U[2030-11-11 00:00:00Z]
+    }
+
+    for {attendee, _huddlz} <- context.holdings do
+      original_entries =
+        context.confirmations
+        |> Enum.filter(&(&1.to == [{"", to_string(attendee.email)}]))
+        |> Enum.flat_map(& &1.attachments)
+        |> Enum.flat_map(&ICal.from_ics(&1.data).events)
+        |> Map.new(&{&1.uid, &1})
+
+      for attachment <- email_for(context.updated_emails, attendee).attachments do
+        [entry] = ICal.from_ics(attachment.data).events
+        original = Map.fetch!(original_entries, entry.uid)
+
+        original_date =
+          original.dtstart |> DateTime.shift_zone!("America/New_York") |> DateTime.to_date()
+
+        assert entry.dtstart == Map.fetch!(expected, original_date)
+        assert DateTime.diff(entry.dtend, entry.dtstart) == 3600
+
+        assert DateTime.to_time(DateTime.shift_zone!(entry.dtstart, "America/New_York")) ==
+                 ~T[19:00:00]
+
+        assert DateTime.diff(DateTime.utc_now(), entry.dtstamp) in 0..30
+      end
+    end
+
+    context
+  end
+
+  step "the organizer shortens the series to its first two dates", context do
+    context.conn
+    |> login(context.owner)
+    |> visit("/groups/#{context.group.slug}/huddlz/#{context.source.id}/edit")
+    |> click_button("Whole series")
+    |> fill_in("Repeat until", with: "2030-11-04", exact: false)
+    |> click_button("Save changes")
+    |> assert_has("#flash-info", text: "Huddl updated successfully!")
+
+    Oban.drain_queue(queue: :notifications)
+    Map.put(context, :updated_emails, emails())
+  end
+
+  step "series attachments contain only retained dates and dropped dates have cancellation emails",
+       context do
+    for {attendee, held} <- context.holdings do
+      series_emails =
+        Enum.filter(
+          context.updated_emails,
+          &String.starts_with?(&1.subject, "Recurring series updated:")
+        )
+
+      entries =
+        email_for(series_emails, attendee).attachments
+        |> Enum.flat_map(&ICal.from_ics(&1.data).events)
+
+      retained =
+        Enum.filter(held, &(DateTime.compare(&1.starts_at, ~U[2030-11-05 00:00:00Z]) == :lt))
+
+      assert Enum.sort(Enum.map(entries, & &1.uid)) ==
+               Enum.sort(Enum.map(retained, &"huddl-#{&1.id}@huddlz.com"))
+
+      assert Enum.any?(
+               context.updated_emails,
+               &(&1.to == [{"", to_string(attendee.email)}] and
+                   String.starts_with?(&1.subject, "Cancelled:"))
+             )
+    end
+
+    context
+  end
+
+  step "an attendee tries to edit the whole series", context do
+    [{attendee, _} | _] = context.holdings
+
+    result =
+      Communities.update_huddl(
+        context.source,
+        %{
+          start_time: ~T[19:00:00],
+          edit_type: "all",
+          frequency: "weekly",
+          repeat_until: ~D[2030-11-18]
+        },
+        actor: attendee
+      )
+
+    Oban.drain_queue(queue: :notifications)
+    Map.merge(context, %{edit_result: result, updated_emails: emails()})
+  end
+
+  step "the edit is forbidden and no update email is sent", context do
+    assert {:error, %Ash.Error.Forbidden{}} = context.edit_result
+    assert context.updated_emails == []
+    context
+  end
+
+  defp email_for(emails, attendee) do
+    assert [email] = Enum.filter(emails, &(&1.to == [{"", to_string(attendee.email)}]))
+    email
+  end
+
+  defp emails(acc \\ []) do
+    receive do
+      {:email, email} -> emails([email | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end


### PR DESCRIPTION
Whole-series edits now include one calendar attachment for each attendee's active RSVP on a published future huddl. Each attachment preserves the instance's calendar identity and updated schedule. Waitlisted and cancelled dates are excluded, and existing email preferences still apply.

Verified the organizer's whole-series edit in a local browser and inspected captured emails and attachment identities, dates, recipients, and timestamps. This reuses the existing `.ics` import format; automatic replacement in external calendar clients was not exercised.

Closes #418
