### PR TITLE
fix(groups): keep membership visibility, roles, and actions current

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,21 @@ This is a web application written using the Phoenix web framework.
 - Keep agent-authored PR descriptions concise and factual; do not invent
   verification claims or paste routine command output.
 
+### Outside-in BDD
+
+- Drive development from the outside in: end-to-end behavior → integration →
+  unit. This is the order of investigation, not a requirement to test every
+  behavior at every layer.
+- Cucumber scenarios are the default, pre-agreed test seams for this project.
+  Each scenario exercises a full vertical slice through a public user interface
+  and asserts observable outcomes in domain language. Treat this guidance as
+  seam agreement when applying TDD skills; proceed without reconfirming it.
+- Work one scenario at a time: demonstrate the expected behavior failing,
+  implement enough to make it pass, then move to the next scenario.
+- Add integration or unit tests when they clarify complex rules or cover cases
+  that are difficult to exercise through the outer scenario. Keep the outer
+  scenario as the acceptance check and verify behavior through public interfaces.
+
 ### Naming Conventions
 
 **IMPORTANT: ALWAYS follow these naming conventions precisely**

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -399,6 +399,11 @@ defmodule Huddlz.Communities.Group do
   end
 
   aggregates do
+    first :viewer_role, :group_members, :role do
+      description "The current actor's persisted membership role in this group"
+      filter expr(user_id == ^actor(:id))
+    end
+
     first :current_image_url, :group_images, :thumbnail_path do
       description "Returns the thumbnail path of the group's current image"
       sort inserted_at: :desc

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -8,6 +8,7 @@ defmodule Huddlz.Communities.GroupMember do
     domain: Huddlz.Communities,
     data_layer: AshPostgres.DataLayer,
     authorizers: [Ash.Policy.Authorizer],
+    notifiers: [Huddlz.Communities.MembershipEvents],
     extensions: [AshJsonApi.Resource, AshGraphql.Resource]
 
   graphql do

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -8,6 +8,19 @@ defmodule Huddlz.Communities.MembershipEvents do
 
   @pubsub Huddlz.PubSub
 
+  @behaviour Ash.Notifier
+
+  @impl true
+  def requires_original_data?(_resource, _action), do: false
+
+  @impl true
+  def notify(%Ash.Notifier.Notification{action: %{name: name}, data: member})
+      when name in [:join_group, :leave_group, :add_member] do
+    broadcast(member.group_id, member.user_id)
+  end
+
+  def notify(_notification), do: :ok
+
   def subscribe(group_id) when is_binary(group_id) do
     Phoenix.PubSub.subscribe(@pubsub, topic(group_id))
   end

--- a/lib/huddlz/communities/membership_events.ex
+++ b/lib/huddlz/communities/membership_events.ex
@@ -15,7 +15,7 @@ defmodule Huddlz.Communities.MembershipEvents do
 
   @impl true
   def notify(%Ash.Notifier.Notification{action: %{name: name}, data: member})
-      when name in [:join_group, :leave_group, :add_member] do
+      when name in [:join_group, :leave_group, :add_member, :accept_invitation, :set_role] do
     broadcast(member.group_id, member.user_id)
   end
 

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -128,7 +128,15 @@ defmodule HuddlzWeb.Layouts do
                 <div class={["group-mark", group_mark_variant(idx)]}>
                   {group_initials(group.name)}
                 </div>
-                <span class="name">{group.name}</span>
+                <span class="name">
+                  <span class="block truncate">{group.name}</span>
+                  <span
+                    :if={role = HuddlzWeb.GroupRole.label(group.viewer_role)}
+                    class="block text-xs font-normal text-base-content/70"
+                  >
+                    {role}
+                  </span>
+                </span>
               </a>
               <div :if={@active_group_slug == group.slug} class="sb-sub">
                 <a

--- a/lib/huddlz_web/group_role.ex
+++ b/lib/huddlz_web/group_role.ex
@@ -1,0 +1,8 @@
+defmodule HuddlzWeb.GroupRole do
+  @moduledoc "Shared display names for persisted group membership roles."
+
+  def label(:owner), do: "Owner"
+  def label(:organizer), do: "Organizer"
+  def label(:member), do: "Member"
+  def label(_), do: nil
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -27,7 +27,8 @@ defmodule HuddlzWeb.GroupLive.Show do
      |> assign(:subscribed_group_id, nil)
      |> assign(:members_visible?, false)
      |> assign(:member_grid_extras, 0)
-     |> stream(:member_grid, [])}
+     |> stream(:member_grid, [])
+     |> stream(:huddlz, [])}
   end
 
   @impl true
@@ -51,8 +52,7 @@ defmodule HuddlzWeb.GroupLive.Show do
          |> assign(:is_member, !is_nil(membership))
          |> assign_action_permissions(group, user, membership)
          |> assign(:active_tab, "upcoming")
-         |> assign(:upcoming_huddlz, upcoming_huddlz)
-         |> assign(:past_huddlz, [])
+         |> stream_huddlz(upcoming_huddlz)
          |> assign(:past_page, 1)
          |> assign(:past_total_pages, 0)}
 
@@ -87,19 +87,13 @@ defmodule HuddlzWeb.GroupLive.Show do
       {:ok, group} ->
         membership = current_user_membership(group, user)
 
-        {past_huddlz, past_total_pages} =
-          get_past_group_huddlz_paginated(group, user, page: 1, per_page: 10)
-
         socket
         |> assign(:group, group)
         |> assign_member_grid(get_members(group, user, !is_nil(membership)))
         |> assign(:member_count, group.member_count)
         |> assign(:is_member, !is_nil(membership))
         |> assign_action_permissions(group, user, membership)
-        |> assign(:upcoming_huddlz, get_upcoming_group_huddlz(group, user, limit: 10))
-        |> assign(:past_huddlz, past_huddlz)
-        |> assign(:past_page, 1)
-        |> assign(:past_total_pages, past_total_pages)
+        |> refresh_huddlz()
         |> assign(:leave_dialog_open, false)
 
       {:error, _reason} ->
@@ -367,17 +361,20 @@ defmodule HuddlzWeb.GroupLive.Show do
             </button>
           </div>
 
-          <%= if @active_tab == "upcoming" do %>
-            <.huddl_grid huddlz={@upcoming_huddlz} empty_message="No upcoming huddlz scheduled." />
-          <% else %>
-            <.huddl_grid huddlz={@past_huddlz} empty_message="No past huddlz found." />
-            <.pagination
-              :if={@past_total_pages > 1}
-              current_page={@past_page}
-              total_pages={@past_total_pages}
-              event_name="change_past_page"
-            />
-          <% end %>
+          <.huddl_grid
+            huddlz={@streams.huddlz}
+            empty_message={
+              if @active_tab == "upcoming",
+                do: "No upcoming huddlz scheduled.",
+                else: "No past huddlz found."
+            }
+          />
+          <.pagination
+            :if={@active_tab == "past" && @past_total_pages > 1}
+            current_page={@past_page}
+            total_pages={@past_total_pages}
+            event_name="change_past_page"
+          />
         </div>
       </div>
 
@@ -440,76 +437,87 @@ defmodule HuddlzWeb.GroupLive.Show do
     """
   end
 
-  attr :huddlz, :list, required: true
+  attr :huddlz, Phoenix.LiveView.LiveStream, required: true
   attr :empty_message, :string, required: true
 
   defp huddl_grid(assigns) do
     ~H"""
-    <%= if @huddlz == [] do %>
-      <p class="empty-state muted">
+    <div id="group-huddl-grid" class="grid two" phx-update="stream">
+      <p id="group-huddl-grid-empty" class="empty-state muted hidden only:block col-span-full">
         {@empty_message}
       </p>
-    <% else %>
-      <div class="grid two">
-        <.card
-          :for={{huddl, idx} <- Enum.with_index(@huddlz)}
-          navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}
-          gradient={Integer.mod(idx, 6) + 1}
-        >
-          <:cover>
-            <.cover_image
-              :if={huddl.display_image_url}
-              id={"group-huddl-card-cover-#{huddl.id}"}
-              class="card-cover-img"
-              image_url={huddl.display_image_url}
-            />
-            <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
-            <.card_tag variant={tag_variant(huddl.event_type)}>
-              {tag_label(huddl.event_type)}
-            </.card_tag>
-          </:cover>
-          <:body>
-            <span class="card-group">{huddl_kind_label(huddl)}</span>
-            <h3 class="card-title">{huddl.title}</h3>
-            <div class="card-meta">
-              <span>{format_meta_when(huddl)}</span>
-              <%= if huddl.rsvp_count > 0 || huddl.max_attendees do %>
-                <span class="dot"></span>
-                <span>{rsvp_label(huddl)}</span>
-              <% end %>
-            </div>
-          </:body>
-        </.card>
-      </div>
-    <% end %>
+      <.card
+        :for={{id, %{huddl: huddl, gradient: gradient}} <- @huddlz}
+        id={id}
+        navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}
+        gradient={gradient}
+      >
+        <:cover>
+          <.cover_image
+            :if={huddl.display_image_url}
+            id={"group-huddl-card-cover-#{huddl.id}"}
+            class="card-cover-img"
+            image_url={huddl.display_image_url}
+          />
+          <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
+          <.card_tag variant={tag_variant(huddl.event_type)}>
+            {tag_label(huddl.event_type)}
+          </.card_tag>
+        </:cover>
+        <:body>
+          <span class="card-group">{huddl_kind_label(huddl)}</span>
+          <h3 class="card-title">{huddl.title}</h3>
+          <div class="card-meta">
+            <span>{format_meta_when(huddl)}</span>
+            <%= if huddl.rsvp_count > 0 || huddl.max_attendees do %>
+              <span class="dot"></span>
+              <span>{rsvp_label(huddl)}</span>
+            <% end %>
+          </div>
+        </:body>
+      </.card>
+    </div>
     """
+  end
+
+  defp stream_huddlz(socket, huddlz) do
+    entries =
+      huddlz
+      |> Enum.with_index()
+      |> Enum.map(fn {huddl, index} ->
+        %{id: huddl.id, huddl: huddl, gradient: Integer.mod(index, 6) + 1}
+      end)
+
+    stream(socket, :huddlz, entries, reset: true)
+  end
+
+  defp refresh_huddlz(%{assigns: %{active_tab: "past"}} = socket) do
+    {huddlz, total_pages} =
+      get_past_group_huddlz_paginated(socket.assigns.group, socket.assigns.current_user,
+        page: 1,
+        per_page: 10
+      )
+
+    socket
+    |> stream_huddlz(huddlz)
+    |> assign(:past_page, 1)
+    |> assign(:past_total_pages, total_pages)
+  end
+
+  defp refresh_huddlz(socket) do
+    stream_huddlz(
+      socket,
+      get_upcoming_group_huddlz(socket.assigns.group, socket.assigns.current_user, limit: 10)
+    )
   end
 
   @impl true
   def handle_event("switch_tab", %{"tab" => tab}, socket) do
     socket =
-      case tab do
-        "upcoming" ->
-          socket
-          |> assign(:active_tab, "upcoming")
-
-        "past" ->
-          {past_huddlz, total_pages} =
-            get_past_group_huddlz_paginated(
-              socket.assigns.group,
-              socket.assigns.current_user,
-              page: 1,
-              per_page: 10
-            )
-
-          socket
-          |> assign(:active_tab, "past")
-          |> assign(:past_huddlz, past_huddlz)
-          |> assign(:past_page, 1)
-          |> assign(:past_total_pages, total_pages)
-
-        _ ->
-          socket
+      if tab in ["upcoming", "past"] do
+        socket |> assign(:active_tab, tab) |> refresh_huddlz()
+      else
+        socket
       end
 
     {:noreply, socket}
@@ -528,7 +536,7 @@ defmodule HuddlzWeb.GroupLive.Show do
 
     socket =
       socket
-      |> assign(:past_huddlz, past_huddlz)
+      |> stream_huddlz(past_huddlz)
       |> assign(:past_page, page)
       |> assign(:past_total_pages, total_pages)
 

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -87,12 +87,20 @@ defmodule HuddlzWeb.GroupLive.Show do
       {:ok, group} ->
         membership = current_user_membership(group, user)
 
+        {past_huddlz, past_total_pages} =
+          get_past_group_huddlz_paginated(group, user, page: 1, per_page: 10)
+
         socket
         |> assign(:group, group)
         |> assign_member_grid(get_members(group, user, !is_nil(membership)))
         |> assign(:member_count, group.member_count)
         |> assign(:is_member, !is_nil(membership))
         |> assign_action_permissions(group, user, membership)
+        |> assign(:upcoming_huddlz, get_upcoming_group_huddlz(group, user, limit: 10))
+        |> assign(:past_huddlz, past_huddlz)
+        |> assign(:past_page, 1)
+        |> assign(:past_total_pages, past_total_pages)
+        |> assign(:leave_dialog_open, false)
 
       {:error, _reason} ->
         handle_error(socket, :not_found,
@@ -411,6 +419,7 @@ defmodule HuddlzWeb.GroupLive.Show do
         </ul>
 
         <p class="mt-4 text-sm text-base-content/60">
+          Leaving does not cancel your existing RSVPs.
           You can rejoin later if the group is public or you receive another invitation.
         </p>
 
@@ -531,18 +540,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
     case join_group(socket.assigns.group, user) do
       {:ok, _} ->
-        group = reload_group(socket.assigns.group, user)
-        membership = current_user_membership(group, user)
-        members = get_members(group, user, true)
-
         {:noreply,
          socket
          |> put_flash(:info, "Successfully joined the group!")
-         |> assign(:group, group)
-         |> assign(:is_member, true)
-         |> assign_member_grid(members)
-         |> assign(:member_count, group.member_count)
-         |> assign_action_permissions(group, user, membership)}
+         |> refresh_membership_state()}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to join group")}
@@ -564,17 +565,10 @@ defmodule HuddlzWeb.GroupLive.Show do
 
     case leave_group(socket.assigns.group, user) do
       :ok ->
-        group = reload_group(socket.assigns.group, user)
-
         {:noreply,
          socket
          |> put_flash(:info, "Successfully left the group")
-         |> assign(:leave_dialog_open, false)
-         |> assign(:group, group)
-         |> assign(:is_member, false)
-         |> assign_member_grid(nil)
-         |> assign(:member_count, group.member_count)
-         |> assign_action_permissions(group, user, nil)}
+         |> refresh_membership_state()}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Failed to leave group")}
@@ -583,7 +577,12 @@ defmodule HuddlzWeb.GroupLive.Show do
 
   def handle_event("leave_group", _, socket), do: {:noreply, socket}
 
-  @group_loads [:current_image_url, :member_count, owner: [:current_profile_picture_url]]
+  @group_loads [
+    :current_image_url,
+    :member_count,
+    :viewer_role,
+    owner: [:current_profile_picture_url]
+  ]
 
   defp get_group_by_slug(slug, actor) do
     case Communities.get_by_slug(slug, actor: actor, load: @group_loads) do
@@ -592,10 +591,6 @@ defmodule HuddlzWeb.GroupLive.Show do
       {:error, %Ash.Error.Query.NotFound{}} -> {:error, :not_found}
       {:error, _} -> {:error, :not_found}
     end
-  end
-
-  defp reload_group(%{slug: slug}, actor) do
-    Communities.get_by_slug!(slug, actor: actor, load: @group_loads)
   end
 
   defp group_meta(group) do
@@ -692,9 +687,7 @@ defmodule HuddlzWeb.GroupLive.Show do
   defp parse_page(val) when is_integer(val) and val >= 1, do: val
   defp parse_page(_), do: 1
 
-  defp role_pill(%{can_edit_group: true}), do: "Owner"
-  defp role_pill(%{is_member: true}), do: "Joined"
-  defp role_pill(_assigns), do: nil
+  defp role_pill(%{group: group}), do: HuddlzWeb.GroupRole.label(group.viewer_role)
 
   defp assign_member_grid(socket, nil) do
     socket

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -16,7 +16,7 @@ defmodule HuddlzWeb.MyGroupsLive do
   alias HuddlzWeb.Layouts
   require Logger
 
-  @group_loads [:current_image_url, :member_count]
+  @group_loads [:current_image_url, :member_count, :viewer_role]
   @page_size 20
   @valid_filters ~w(all hosting joined)
 
@@ -52,6 +52,21 @@ defmodule HuddlzWeb.MyGroupsLive do
     else
       {:noreply, socket}
     end
+  end
+
+  @impl true
+  def handle_info(
+        {:organizer_access_changed, user_id},
+        %{assigns: %{current_user: %{id: user_id}}} = socket
+      ) do
+    user = socket.assigns.current_user
+    filter = socket.assigns.filter
+
+    {:noreply,
+     socket
+     |> assign(:counts, load_counts(user))
+     |> load_results(filter, 1, user)
+     |> push_patch(to: filter_path(filter, 1))}
   end
 
   @impl true
@@ -117,10 +132,6 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   defp filter_path(filter, _page), do: ~p"/my-groups?#{[filter: filter]}"
 
-  defp role_for(group, user) do
-    if group.owner_id == user.id, do: :hosting, else: :joined
-  end
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -160,7 +171,7 @@ defmodule HuddlzWeb.MyGroupsLive do
           <%= for {group, idx} <- Enum.with_index(@groups) do %>
             <.my_group_card
               group={group}
-              role={role_for(group, @current_user)}
+              role={group.viewer_role}
               gradient={Integer.mod(idx, 6) + 1}
             />
           <% end %>
@@ -189,7 +200,7 @@ defmodule HuddlzWeb.MyGroupsLive do
           group={@group}
           gradient={@gradient}
         />
-        <span class={["card-tag", role_class(@role)]}>{role_label(@role)}</span>
+        <span class={["card-tag", role_class(@role)]}>{HuddlzWeb.GroupRole.label(@role)}</span>
       </:cover>
       <:body>
         <span :if={@group.location} class="card-group">{@group.location}</span>
@@ -212,11 +223,9 @@ defmodule HuddlzWeb.MyGroupsLive do
   defp empty_message(:hosting), do: "You haven't created a group yet."
   defp empty_message(:joined), do: "You haven't joined any groups yet."
 
-  defp role_class(:hosting), do: "hybrid"
-  defp role_class(:joined), do: "in-person"
-
-  defp role_label(:hosting), do: "Hosting"
-  defp role_label(:joined), do: "Joined"
+  defp role_class(:owner), do: "hybrid"
+  defp role_class(:organizer), do: "virtual"
+  defp role_class(_), do: "in-person"
 
   defp member_count_label(group) do
     case Map.get(group, :member_count) do

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -80,6 +80,7 @@ defmodule HuddlzWeb.OrganizeLive do
         socket
         |> subscribe_to_membership_changes(group)
         |> assign(:group, group)
+        |> assign(:can_edit_group, Ash.can?({group, :update_details}, user))
         |> assign(:page_title, "#{group.name} · Organizer")
         |> load_section(action, group, user)
 
@@ -242,6 +243,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <% :overview -> %>
           <.overview_view
             group={@group}
+            can_edit_group={@can_edit_group}
             upcoming_huddlz={@upcoming_huddlz}
             open_rsvps={@open_rsvps}
           />
@@ -250,6 +252,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <% :members -> %>
           <.members_view
             group={@group}
+            can_edit_group={@can_edit_group}
             owner_members={@streams.owner_members}
             organizer_members={@streams.organizer_members}
             regular_members={@streams.regular_members}
@@ -347,6 +350,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :upcoming_huddlz, :list, required: true
   attr :open_rsvps, :integer, required: true
 
+  attr :can_edit_group, :boolean, required: true
+
   defp overview_view(assigns) do
     assigns =
       assigns
@@ -360,7 +365,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <p>A scannable summary of this group's huddlz and members.</p>
       </div>
       <div class="actions">
-        <a class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
+        <a :if={@can_edit_group} class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
         <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>
           + Create huddl
         </a>
@@ -553,6 +558,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :transfer_target_form, Phoenix.HTML.Form, required: true
   attr :current_user, :map, required: true
 
+  attr :can_edit_group, :boolean, required: true
+
   defp members_view(assigns) do
     grouped = [
       {:owner, assigns.owner_members, assigns.role_counts.owner},
@@ -579,7 +586,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <p>Who's part of {@group.name}.</p>
       </div>
       <div class="actions">
-        <a class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
+        <a :if={@can_edit_group} class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
       </div>
     </div>
 
@@ -721,7 +728,7 @@ defmodule HuddlzWeb.OrganizeLive do
               </div>
             </div>
             <button
-              :if={invitation.status == :pending}
+              :if={invitation.status == :pending && Ash.can?({invitation, :revoke}, @current_user)}
               id={"revoke-invitation-#{invitation.id}"}
               type="button"
               class="pill"
@@ -1038,6 +1045,7 @@ defmodule HuddlzWeb.OrganizeLive do
       {:ok, reloaded_group} ->
         socket
         |> assign(:group, reloaded_group)
+        |> assign(:can_edit_group, Ash.can?({reloaded_group, :update_details}, user))
         |> refresh_members_if_visible(reloaded_group, user)
 
       :error ->

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -1057,7 +1057,7 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp refresh_members_if_visible(%{assigns: %{live_action: :members}} = socket, group, user) do
-    assign_members(socket, list_group_members(group, user))
+    load_section(socket, :members, group, user)
   end
 
   defp refresh_members_if_visible(socket, _group, _user), do: socket

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -1047,6 +1047,7 @@ defmodule HuddlzWeb.OrganizeLive do
         |> assign(:group, reloaded_group)
         |> assign(:can_edit_group, Ash.can?({reloaded_group, :update_details}, user))
         |> refresh_members_if_visible(reloaded_group, user)
+        |> refresh_pending_member_action()
 
       :error ->
         socket
@@ -1060,6 +1061,27 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp refresh_members_if_visible(socket, _group, _user), do: socket
+
+  defp refresh_pending_member_action(%{assigns: %{pending_member_action: nil}} = socket),
+    do: socket
+
+  defp refresh_pending_member_action(socket) do
+    action = socket.assigns.pending_member_action
+    member = Map.get(socket.assigns.member_lookup, action.member.id)
+
+    if member_action_allowed?(
+         action.type,
+         member,
+         socket.assigns.group,
+         socket.assigns.current_user
+       ) do
+      assign(socket, :pending_member_action, %{action | member: member})
+    else
+      socket
+      |> assign(:pending_member_action, nil)
+      |> assign(:member_action_form, member_action_form())
+    end
+  end
 
   defp assign_members(socket, members) do
     by_role = Enum.group_by(members, & &1.role)

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -126,7 +126,7 @@ defmodule HuddlzWeb.LiveUserAuth do
   defp load_sidebar_owned_groups(%{assigns: %{current_user: user}}) when not is_nil(user) do
     Huddlz.Communities.get_organizable_groups!(
       actor: user,
-      load: [:member_count],
+      load: [:member_count, :viewer_role],
       query: [sort: [name: :asc]]
     )
   end
@@ -196,10 +196,13 @@ defmodule HuddlzWeb.LiveUserAuth do
       |> assign(:sidebar_owned_groups, groups)
       |> maybe_assign_picker_groups(groups)
 
-    {:halt, socket}
+    organizer_access_result(socket)
   end
 
   defp refresh_organizer_access(_message, socket), do: {:cont, socket}
+
+  defp organizer_access_result(%{view: HuddlzWeb.MyGroupsLive} = socket), do: {:cont, socket}
+  defp organizer_access_result(socket), do: {:halt, socket}
 
   defp maybe_assign_picker_groups(%{assigns: %{owned_groups: _}} = socket, groups) do
     groups = Ash.load!(groups, :current_image_url, actor: socket.assigns.current_user)

--- a/test/features/group_membership_visibility.feature
+++ b/test/features/group_membership_visibility.feature
@@ -1,0 +1,76 @@
+@async @database @conn @membership_visibility
+Feature: Group membership visibility
+  Members see private huddlz while they belong to a group.
+
+  Background:
+    Given the following users exist:
+      | email                 | role | display_name |
+      | owner311@example.com  | user | Owner Olive  |
+      | member311@example.com | user | Member Maya  |
+    And a public group "Membership Visibility" exists with owner "owner311@example.com"
+    And a members-only huddl "Private planning" exists in "Membership Visibility"
+
+  Scenario: Leaving immediately hides private huddlz
+    Given "member311@example.com" is a member of "Membership Visibility"
+    And I am signed in as "member311@example.com"
+    When I visit the group page for "Membership Visibility"
+    Then I should see the huddl card "Private planning"
+    When I click the "Leave Group" button
+    Then the leave confirmation should explain that RSVPs are preserved
+    When I click the "Yes, leave group" button
+    Then I should not see the huddl card "Private planning"
+    And the group member count should be 1
+    And the "Join Group" button should be visible
+
+  Scenario: Joining and rejoining reveal private huddlz and member identities
+    Given I am signed in as "member311@example.com"
+    When I visit the group page for "Membership Visibility"
+    Then I should not see the huddl card "Private planning"
+    And group member identities should be hidden
+    When I click the "Join Group" button
+    Then I should see the huddl card "Private planning"
+    And I should see the group member "Owner Olive"
+    And the group member count should be 2
+    When I click the "Leave Group" button
+    And I click the "Yes, leave group" button
+    Then I should not see the huddl card "Private planning"
+    And group member identities should be hidden
+    When I click the "Join Group" button
+    Then I should see the huddl card "Private planning"
+    And I should see the group member "Owner Olive"
+    And the group member count should be 2
+
+  Scenario: Removal clears a mounted past tab and a pending leave dialog
+    Given "member311@example.com" is a member of "Membership Visibility"
+    And a past members-only huddl "Private retrospective" exists in "Membership Visibility"
+    And I am signed in as "member311@example.com"
+    When I visit the group page for "Membership Visibility"
+    And I click the "Past" button
+    Then I should see the huddl card "Private retrospective"
+    When I click the "Leave Group" button
+    And the owner removes me from "Membership Visibility" in another session
+    Then I should not see the huddl card "Private retrospective"
+    And group member identities should be hidden
+    And the leave confirmation should be closed
+    When I submit stale group interactions
+    Then I should not see the huddl card "Private planning"
+    And I should not see the huddl card "Private retrospective"
+    And the "Join Group" button should be visible
+
+  Scenario: Organizer demotion removes privileged group actions
+    Given "member311@example.com" is an organizer of "Membership Visibility"
+    And I am signed in as "member311@example.com"
+    When I visit the group page for "Membership Visibility"
+    Then the huddl creation action should be visible
+    When the owner demotes me in "Membership Visibility" in another session
+    Then the huddl creation action should be hidden
+    And I should see the huddl card "Private planning"
+
+  Scenario: Former members cannot navigate directly to a private huddl
+    Given "member311@example.com" is a member of "Membership Visibility"
+    And I am signed in as "member311@example.com"
+    When I visit the group page for "Membership Visibility"
+    And I click the "Leave Group" button
+    And I click the "Yes, leave group" button
+    And I try to open the private huddl directly
+    Then I should see the branded not found recovery page

--- a/test/features/group_role_labels.feature
+++ b/test/features/group_role_labels.feature
@@ -1,0 +1,74 @@
+@async @database @conn @group_roles
+Feature: Actual group role labels
+  Role labels describe membership independently of administrative access.
+
+  Background:
+    Given the following users exist:
+      | email                  | role  | display_name    |
+      | owner315@example.com   | user  | Owner Olive     |
+      | helper315@example.com  | user  | Organizer Oscar |
+      | member315@example.com  | user  | Member Maya     |
+      | admin315@example.com   | admin | Admin Alex      |
+      | visitor315@example.com | user  | Visitor Vera    |
+    And a public group "Role Labels" exists with owner "owner315@example.com"
+    And "helper315@example.com" is an organizer of "Role Labels"
+    And "member315@example.com" is a member of "Role Labels"
+
+  Scenario: An organizer sees their actual role across group surfaces
+    Given I am signed in as "helper315@example.com"
+    When I visit the group page for "Role Labels"
+    Then my group role should be "Organizer"
+    And my navigation role for "Role Labels" should be "Organizer"
+    When I visit "/my-groups"
+    Then my card role for "Role Labels" should be "Organizer"
+
+  Scenario: A mounted My groups card follows promotion and demotion
+    Given I am signed in as "member315@example.com"
+    When I visit "/my-groups"
+    Then my card role for "Role Labels" should be "Member"
+    When the owner promotes me in "Role Labels" in another session
+    Then my card role for "Role Labels" should be "Organizer"
+    And my navigation role for "Role Labels" should be "Organizer"
+    When the owner demotes me in "Role Labels" in another session
+    Then my card role for "Role Labels" should be "Member"
+
+  Scenario Outline: Membership labels match the persisted role
+    Given I am signed in as "<email>"
+    When I visit the group page for "Role Labels"
+    Then my group role should be "<role>"
+    When I visit "/my-groups"
+    Then my card role for "Role Labels" should be "<role>"
+
+    Examples:
+      | email                 | role   |
+      | owner315@example.com  | Owner  |
+      | member315@example.com | Member |
+
+  Scenario Outline: Access without membership does not imply a group role
+    Given I am signed in as "<email>"
+    When I visit the group page for "Role Labels"
+    Then I should have no group role label
+    When I click the "Join Group" button
+    Then my group role should be "Member"
+    When I click the "Leave Group" button
+    And I click the "Yes, leave group" button
+    Then I should have no group role label
+    When I click the "Join Group" button
+    Then my group role should be "Member"
+
+    Examples:
+      | email                  |
+      | admin315@example.com   |
+      | visitor315@example.com |
+
+  Scenario: Ownership transfer updates the former owner's mounted role
+    Given I am signed in as "owner315@example.com"
+    When I visit the group page for "Role Labels"
+    Then my group role should be "Owner"
+    When I transfer "Role Labels" to "helper315@example.com" in another session
+    Then my group role should be "Organizer"
+    And my navigation role for "Role Labels" should be "Organizer"
+    When I open the organizer roster for "Role Labels"
+    Then the group edit action should be hidden
+    When I visit the edit page for "Role Labels"
+    Then I should see "You don't have permission to edit this group"

--- a/test/features/group_role_labels.feature
+++ b/test/features/group_role_labels.feature
@@ -65,7 +65,7 @@ Feature: Actual group role labels
     Given I am signed in as "owner315@example.com"
     When I visit the group page for "Role Labels"
     Then my group role should be "Owner"
-    When I transfer "Role Labels" to "helper315@example.com" in another session
+    When the owner transfers "Role Labels" to "helper315@example.com" in another session
     Then my group role should be "Organizer"
     And my navigation role for "Role Labels" should be "Organizer"
     When I open the organizer roster for "Role Labels"

--- a/test/features/group_role_labels.feature
+++ b/test/features/group_role_labels.feature
@@ -72,3 +72,24 @@ Feature: Actual group role labels
     Then the group edit action should be hidden
     When I visit the edit page for "Role Labels"
     Then I should see "You don't have permission to edit this group"
+
+  Scenario: Accepting an invitation adds a mounted My groups card
+    Given a private group "Invitation Roles" exists with owner "owner315@example.com"
+    And "visitor315@example.com" has an organizer invitation to "Invitation Roles"
+    And I am signed in as "visitor315@example.com"
+    When I visit "/my-groups"
+    Then I should not see "Invitation Roles"
+    When I accept my invitation to "Invitation Roles" in another session
+    Then my card role for "Invitation Roles" should be "Organizer"
+    And my navigation role for "Invitation Roles" should be "Organizer"
+
+  Scenario: An invitation promotion updates a mounted group page
+    Given a private group "Invitation Roles" exists with owner "owner315@example.com"
+    And "member315@example.com" has an organizer invitation to "Invitation Roles"
+    And "member315@example.com" is a member of "Invitation Roles"
+    And I am signed in as "member315@example.com"
+    When I visit the group page for "Invitation Roles"
+    Then my group role should be "Member"
+    When I accept my invitation to "Invitation Roles" in another session
+    Then my group role should be "Organizer"
+    And my navigation role for "Invitation Roles" should be "Organizer"

--- a/test/features/organizer_action_permissions.feature
+++ b/test/features/organizer_action_permissions.feature
@@ -1,0 +1,62 @@
+@async @database @conn @organizer_permissions
+Feature: Organizer action permissions
+  The organizer workspace offers actions permitted for the current person.
+
+  Background:
+    Given the following users exist:
+      | email                 | role | display_name    |
+      | owner314@example.com  | user | Owner Olive     |
+      | helper314@example.com | user | Organizer Oscar |
+      | admin314@example.com  | admin | Admin Alex     |
+      | member314@example.com | user | Member Maya    |
+    And a public group "Organizer Permissions" exists with owner "owner314@example.com"
+    And "helper314@example.com" is an organizer of "Organizer Permissions"
+
+  Scenario: An organizer is not offered owner-only group editing
+    Given I am signed in as "helper314@example.com"
+    When I open the organizer roster for "Organizer Permissions"
+    Then the group edit action should be hidden
+
+  Scenario Outline: Authorized people can open the group editor
+    Given I am signed in as "<email>"
+    When I open the organizer roster for "Organizer Permissions"
+    And I click link "Edit group"
+    Then I should see "Edit Group"
+    And the "Save Changes" button should be visible
+
+    Examples:
+      | email                |
+      | owner314@example.com |
+      | admin314@example.com |
+
+  Scenario: A member cannot open the workspace directly
+    Given "member314@example.com" is a member of "Organizer Permissions"
+    And I am signed in as "member314@example.com"
+    When I open the organizer roster for "Organizer Permissions"
+    Then I should see "That group doesn't exist, or you don't organize it."
+    And the group edit action should be hidden
+
+  Scenario: A signed-out visitor must sign in to open the workspace
+    When I open the organizer roster for "Organizer Permissions"
+    Then the "Sign in" button should be visible
+
+  Scenario: Demotion removes a mounted organizer workspace
+    Given I am signed in as "helper314@example.com"
+    When I open the organizer roster for "Organizer Permissions"
+    And the owner demotes me in "Organizer Permissions" in another session
+    Then the organizer roster should be inaccessible
+
+  Scenario: Leaving in another session removes a mounted organizer workspace
+    Given I am signed in as "helper314@example.com"
+    When I open the organizer roster for "Organizer Permissions"
+    And I leave "Organizer Permissions" in another session
+    Then the organizer roster should be inaccessible
+
+  Scenario: An organizer cannot revoke an owner-issued organizer invitation
+    Given a private group "Private Permissions" exists with owner "owner314@example.com"
+    And "helper314@example.com" is an organizer of "Private Permissions"
+    And "member314@example.com" has an organizer invitation to "Private Permissions"
+    And I am signed in as "helper314@example.com"
+    When I open the organizer roster for "Private Permissions"
+    Then I should see "Awaiting response"
+    And the "Revoke" button should not be visible

--- a/test/features/organizer_action_permissions.feature
+++ b/test/features/organizer_action_permissions.feature
@@ -60,3 +60,12 @@ Feature: Organizer action permissions
     When I open the organizer roster for "Private Permissions"
     Then I should see "Awaiting response"
     And the "Revoke" button should not be visible
+
+  Scenario: Ownership loss closes an unauthorized pending confirmation
+    Given "member314@example.com" is a member of "Organizer Permissions"
+    And I am signed in as "owner314@example.com"
+    When I open the organizer roster for "Organizer Permissions"
+    And I open the promotion confirmation for "Member Maya"
+    And I transfer "Organizer Permissions" to "helper314@example.com" in another session
+    Then the membership action confirmation should be closed
+    And the group edit action should be hidden

--- a/test/features/organizer_action_permissions.feature
+++ b/test/features/organizer_action_permissions.feature
@@ -66,6 +66,26 @@ Feature: Organizer action permissions
     And I am signed in as "owner314@example.com"
     When I open the organizer roster for "Organizer Permissions"
     And I open the promotion confirmation for "Member Maya"
-    And I transfer "Organizer Permissions" to "helper314@example.com" in another session
+    And the owner transfers "Organizer Permissions" to "helper314@example.com" in another session
     Then the membership action confirmation should be closed
     And the group edit action should be hidden
+
+  Scenario: Ownership loss removes organizer invitation controls from an open roster
+    Given a private group "Invitation Transfer" exists with owner "owner314@example.com"
+    And "helper314@example.com" is an organizer of "Invitation Transfer"
+    And "member314@example.com" has an organizer invitation to "Invitation Transfer"
+    And I am signed in as "owner314@example.com"
+    When I open the organizer roster for "Invitation Transfer"
+    Then the "Revoke" button should be visible
+    When the owner transfers "Invitation Transfer" to "helper314@example.com" in another session
+    Then the "Revoke" button should not be visible
+
+  Scenario: Ownership gain reveals organizer invitation controls in an open roster
+    Given a private group "Invitation Transfer" exists with owner "owner314@example.com"
+    And "helper314@example.com" is an organizer of "Invitation Transfer"
+    And "member314@example.com" has an organizer invitation to "Invitation Transfer"
+    And I am signed in as "helper314@example.com"
+    When I open the organizer roster for "Invitation Transfer"
+    Then the "Revoke" button should not be visible
+    When the owner transfers "Invitation Transfer" to "helper314@example.com" in another session
+    Then the "Revoke" button should be visible

--- a/test/features/step_definitions/group_membership_visibility_steps.exs
+++ b/test/features/step_definitions/group_membership_visibility_steps.exs
@@ -43,12 +43,14 @@ defmodule GroupMembershipVisibilitySteps do
     context
   end
 
-  step "I transfer {string} to {string} in another session", %{args: [name, email]} = context do
+  step "the owner transfers {string} to {string} in another session",
+       %{args: [name, email]} = context do
     group = Enum.find(context.groups, &(to_string(&1.name) == name))
+    owner = Enum.find(context.users, &(&1.id == group.owner_id))
     target = Enum.find(context.users, &(to_string(&1.email) == email))
 
     Phoenix.ConnTest.build_conn()
-    |> login(context.current_user)
+    |> login(owner)
     |> visit("/organize/#{group.slug}/members")
     |> select("New owner", option: target.display_name)
     |> click_button("Transfer group ownership")

--- a/test/features/step_definitions/group_membership_visibility_steps.exs
+++ b/test/features/step_definitions/group_membership_visibility_steps.exs
@@ -1,0 +1,211 @@
+defmodule GroupMembershipVisibilitySteps do
+  use Cucumber.StepDefinition
+  import Huddlz.Generator
+  import PhoenixTest
+  import Huddlz.Test.Helpers.Authentication
+
+  step "the leave confirmation should explain that RSVPs are preserved", context do
+    assert_has(context.session, "#leave-group-dialog",
+      text: "Leaving does not cancel your existing RSVPs."
+    )
+
+    context
+  end
+
+  step "I transfer {string} to {string} in another session", %{args: [name, email]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == name))
+    target = Enum.find(context.users, &(to_string(&1.email) == email))
+
+    Phoenix.ConnTest.build_conn()
+    |> login(context.current_user)
+    |> visit("/organize/#{group.slug}/members")
+    |> select("New owner", option: target.display_name)
+    |> click_button("Transfer group ownership")
+    |> fill_in("Type #{name} to confirm", with: name)
+    |> click_button("Transfer ownership")
+
+    context
+  end
+
+  step "I try to open the private huddl directly", context do
+    huddl = context.private_huddl
+    group = Enum.find(context.groups, &(&1.id == huddl.group_id))
+
+    {404, _headers, body} =
+      Phoenix.ConnTest.assert_error_sent(404, fn ->
+        context.session.conn
+        |> Phoenix.ConnTest.dispatch(
+          HuddlzWeb.Endpoint,
+          :get,
+          "/groups/#{group.slug}/huddlz/#{huddl.id}"
+        )
+      end)
+
+    Map.put(context, :error_body, body)
+  end
+
+  step "{string} has an organizer invitation to {string}", %{args: [email, name]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == name))
+    owner = Enum.find(context.users, &(&1.id == group.owner_id))
+    invitee = Enum.find(context.users, &(to_string(&1.email) == email))
+    Huddlz.Communities.invite_to_group!(group.id, invitee.id, :organizer, actor: owner)
+    context
+  end
+
+  step "I should have no group role label", context do
+    refute_has(context.session, ".role-pill")
+    context
+  end
+
+  step "the owner promotes me in {string} in another session", %{args: [group_name]} = context do
+    manage_current_member(context, group_name, "Promote", "Promote to organizer")
+  end
+
+  step "my group role should be {string}", %{args: [role]} = context do
+    assert_has(context.session, ".role-pill", text: role)
+    context
+  end
+
+  step "my card role for {string} should be {string}", %{args: [name, role]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == name))
+    assert_has(context.session, "a[href='/groups/#{group.slug}'] .card-tag", text: role)
+    context
+  end
+
+  step "my navigation role for {string} should be {string}", %{args: [name, role]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == name))
+    assert_has(context.session, ".sb-org-row[href='/organize/#{group.slug}']", text: role)
+    context
+  end
+
+  step "I leave {string} in another session", %{args: [group_name]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == group_name))
+
+    Phoenix.ConnTest.build_conn()
+    |> login(context.current_user)
+    |> visit("/groups/#{group.slug}")
+    |> click_button("Leave Group")
+    |> click_button("Yes, leave group")
+
+    context
+  end
+
+  step "the organizer roster should be inaccessible", context do
+    unwrap(context.session, fn view ->
+      Phoenix.LiveViewTest.assert_redirect(view, "/organize")
+      ""
+    end)
+
+    context
+  end
+
+  step "a past members-only huddl {string} exists in {string}",
+       %{args: [title, group_name]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == group_name))
+
+    generate(
+      past_huddl(title: title, group_id: group.id, creator_id: group.owner_id, is_private: true)
+    )
+
+    context
+  end
+
+  step "the owner removes me from {string} in another session", %{args: [group_name]} = context do
+    manage_current_member(context, group_name, "Remove", "Remove from group")
+  end
+
+  step "the owner demotes me in {string} in another session", %{args: [group_name]} = context do
+    manage_current_member(context, group_name, "Demote", "Demote to member")
+  end
+
+  step "the leave confirmation should be closed", context do
+    refute_has(context.session, "#leave-group-dialog")
+    context
+  end
+
+  step "the huddl creation action should be visible", context do
+    assert_has(context.session, "a[href$='/huddlz/new']")
+    context
+  end
+
+  step "the huddl creation action should be hidden", context do
+    refute_has(context.session, "a[href$='/huddlz/new']")
+    context
+  end
+
+  step "I submit stale group interactions", context do
+    session =
+      unwrap(context.session, fn view ->
+        Phoenix.LiveViewTest.render_click(view, "leave_group", %{})
+        Phoenix.LiveViewTest.render_click(view, "change_past_page", %{"page" => "1"})
+        Phoenix.LiveViewTest.render_click(view, "switch_tab", %{"tab" => "upcoming"})
+      end)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  defp manage_current_member(context, group_name, action, confirmation) do
+    group = Enum.find(context.groups, &(to_string(&1.name) == group_name))
+    owner = Enum.find(context.users, &(&1.id == group.owner_id))
+
+    Phoenix.ConnTest.build_conn()
+    |> login(owner)
+    |> visit("/organize/#{group.slug}/members")
+    |> within("[aria-label='Manage #{context.current_user.display_name}']", fn session ->
+      click_button(session, action)
+    end)
+    |> click_button(confirmation)
+
+    context
+  end
+
+  step "I open the organizer roster for {string}", %{args: [group_name]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == group_name))
+    session = visit(context[:session] || context.conn, "/organize/#{group.slug}/members")
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "the group edit action should be hidden", context do
+    refute_has(context.session, "a", text: "Edit group")
+    context
+  end
+
+  step "I should see the huddl card {string}", %{args: [title]} = context do
+    assert_has(context.session, ".card-title", text: title)
+    context
+  end
+
+  step "I should not see the huddl card {string}", %{args: [title]} = context do
+    refute_has(context.session, ".card-title", text: title)
+    context
+  end
+
+  step "group member identities should be hidden", context do
+    refute_has(context.session, "#member-grid .member-mark")
+    context
+  end
+
+  step "I should see the group member {string}", %{args: [name]} = context do
+    assert_has(context.session, "#member-grid .member-mark[title='#{name}']")
+    context
+  end
+
+  step "a members-only huddl {string} exists in {string}",
+       %{args: [title, group_name]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == group_name))
+    owner = Enum.find(context.users, &(&1.id == group.owner_id))
+
+    private_huddl =
+      generate(
+        huddl(
+          title: title,
+          group_id: group.id,
+          creator_id: owner.id,
+          is_private: true,
+          actor: owner
+        )
+      )
+
+    Map.put(context, :private_huddl, private_huddl)
+  end
+end

--- a/test/features/step_definitions/group_membership_visibility_steps.exs
+++ b/test/features/step_definitions/group_membership_visibility_steps.exs
@@ -4,6 +4,37 @@ defmodule GroupMembershipVisibilitySteps do
   import PhoenixTest
   import Huddlz.Test.Helpers.Authentication
 
+  step "I accept my invitation to {string} in another session", %{args: [name]} = context do
+    group = Enum.find(context.groups, &(to_string(&1.name) == name))
+
+    invitation =
+      Huddlz.Communities.list_my_group_invitations!(actor: context.current_user)
+      |> Enum.find(&(&1.group_id == group.id))
+
+    Phoenix.ConnTest.build_conn()
+    |> login(context.current_user)
+    |> visit("/invitations/#{invitation.id}")
+    |> click_button("Accept invitation")
+    |> assert_has("main", text: "You accepted this invitation.")
+
+    context
+  end
+
+  step "I open the promotion confirmation for {string}", %{args: [name]} = context do
+    session =
+      within(context.session, "[aria-label='Manage #{name}']", fn session ->
+        click_button(session, "Promote")
+      end)
+
+    assert_has(session, "#member-action-dialog")
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "the membership action confirmation should be closed", context do
+    refute_has(context.session, "#member-action-dialog")
+    context
+  end
+
   step "the leave confirmation should explain that RSVPs are preserved", context do
     assert_has(context.session, "#leave-group-dialog",
       text: "Leaving does not cancel your existing RSVPs."

--- a/test/huddlz_web/live/group_slug_auto_update_test.exs
+++ b/test/huddlz_web/live/group_slug_auto_update_test.exs
@@ -18,16 +18,32 @@ defmodule HuddlzWeb.GroupSlugAutoUpdateTest do
 
       # Type "A" - too short, slug not generated yet
       render_change(view, "validate", %{"form" => %{"name" => "A"}})
-      assert has_element?(view, "#group-slug-preview", "URL: http://localhost:4002/groups/...")
+
+      assert has_element?(
+               view,
+               "#group-slug-preview",
+               "URL: #{HuddlzWeb.Endpoint.url()}/groups/..."
+             )
+
       assert has_element?(view, "#form_name-error-0", "Must be between 3 and 100 characters")
 
       # Type "As" - still too short
       render_change(view, "validate", %{"form" => %{"name" => "As"}})
-      assert has_element?(view, "#group-slug-preview", "URL: http://localhost:4002/groups/...")
+
+      assert has_element?(
+               view,
+               "#group-slug-preview",
+               "URL: #{HuddlzWeb.Endpoint.url()}/groups/..."
+             )
 
       # Type "Ash" - now valid, slug should be generated
       render_change(view, "validate", %{"form" => %{"name" => "Ash"}})
-      assert has_element?(view, "#group-slug-preview", "URL: http://localhost:4002/groups/ash")
+
+      assert has_element?(
+               view,
+               "#group-slug-preview",
+               "URL: #{HuddlzWeb.Endpoint.url()}/groups/ash"
+             )
 
       # Add space and more text
       render_change(view, "validate", %{"form" => %{"name" => "Ash Framework"}})
@@ -35,7 +51,7 @@ defmodule HuddlzWeb.GroupSlugAutoUpdateTest do
       assert has_element?(
                view,
                "#group-slug-preview",
-               "URL: http://localhost:4002/groups/ash-framework"
+               "URL: #{HuddlzWeb.Endpoint.url()}/groups/ash-framework"
              )
     end
 

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -80,7 +80,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
   end
 
   describe "Hosting filter" do
-    test "shows only owned groups with Hosting tag", %{
+    test "shows only owned groups with Owner tag", %{
       conn: conn,
       member: member,
       other: other
@@ -98,7 +98,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> assert_has(".filters .chip.is-active", text: "Hosting")
       |> assert_has(".grid .card .card-title", text: "Owned One")
       |> refute_has(".grid .card .card-title", text: "Joined One")
-      |> assert_has(".grid .card .card-tag", text: "Hosting")
+      |> assert_has(".grid .card .card-tag", text: "Owner")
     end
 
     test "empty state copy", %{conn: conn, member: member} do
@@ -110,7 +110,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
   end
 
   describe "Joined filter" do
-    test "shows only joined groups with Joined tag", %{
+    test "shows only joined groups with Member tag", %{
       conn: conn,
       member: member,
       other: other
@@ -129,7 +129,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> assert_has(".filters .chip.is-active", text: "Joined")
       |> assert_has(".grid .card .card-title", text: "Joined One")
       |> refute_has(".grid .card .card-title", text: "Owned One")
-      |> assert_has(".grid .card .card-tag", text: "Joined")
+      |> assert_has(".grid .card .card-tag", text: "Member")
     end
 
     test "empty state copy", %{conn: conn, member: member} do

--- a/test/huddlz_web/live/organize_live_members_test.exs
+++ b/test/huddlz_web/live/organize_live_members_test.exs
@@ -171,11 +171,8 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     assert {:ok, _membership} =
              Communities.change_member_role(member_membership, :organizer, actor: owner)
 
-    assert has_element?(view, "#member-action-dialog")
-
-    view
-    |> element("#member-action-form")
-    |> render_submit()
+    refute has_element?(view, "#member-action-dialog")
+    render_submit(view, "confirm_member_action", %{})
 
     assert Ash.get!(GroupMember, member_membership.id, authorize?: false).role == :organizer
   end


### PR DESCRIPTION
Membership changes now refresh mounted group pages, My groups, and navigation: private huddlz and member identities disappear on membership loss, role labels reflect Owner/Organizer/Member, and organizer actions and pending confirmations follow current permissions. Invitation acceptance, promotion, demotion, removal, and ownership transfer follow the same refresh behavior.

Existing RSVP records remain preserved, with matching leave confirmation copy. AGENTS.md documents Cucumber vertical slices and outside-in BDD loops.

For manual review, keep the affected person's group page or organizer roster open while changing their membership in another session; verify private content, role labels, and available actions update without a reload. These workflows were exercised in an isolated browser database, including mobile navigation.

Closes #311
Closes #314
Closes #315
