### PR TITLE
fix(accounts): validate notification preference updates

### DIFF
--- a/lib/huddlz/accounts/user.ex
+++ b/lib/huddlz/accounts/user.ex
@@ -257,18 +257,21 @@ defmodule Huddlz.Accounts.User do
 
       argument :preferences, :map, allow_nil?: false
 
-      validate present(:preferences)
+      validate Huddlz.Accounts.User.Validations.NotificationPreferences do
+        only_when_valid? true
+      end
 
       change fn changeset, _ctx ->
-        existing = changeset.data.notification_preferences || %{}
-        incoming = Ash.Changeset.get_argument(changeset, :preferences)
+               existing = changeset.data.notification_preferences || %{}
+               incoming = Ash.Changeset.get_argument(changeset, :preferences)
 
-        Ash.Changeset.change_attribute(
-          changeset,
-          :notification_preferences,
-          Map.merge(existing, incoming)
-        )
-      end
+               Ash.Changeset.change_attribute(
+                 changeset,
+                 :notification_preferences,
+                 Map.merge(existing, incoming)
+               )
+             end,
+             only_when_valid?: true
     end
 
     update :change_email do

--- a/lib/huddlz/accounts/user/validations/notification_preferences.ex
+++ b/lib/huddlz/accounts/user/validations/notification_preferences.ex
@@ -1,0 +1,20 @@
+defmodule Huddlz.Accounts.User.Validations.NotificationPreferences do
+  @moduledoc false
+  use Ash.Resource.Validation
+
+  alias Huddlz.Notifications.Triggers
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    known_keys = Enum.map(Map.keys(Triggers.all()), &Triggers.preference_key/1)
+    preferences = Ash.Changeset.get_argument(changeset, :preferences)
+
+    if Enum.all?(preferences, fn {key, value} -> key in known_keys and is_boolean(value) end) do
+      :ok
+    else
+      {:error,
+       field: :preferences,
+       message: "must contain only known notification preference keys with boolean values"}
+    end
+  end
+end

--- a/test/features/notification_preference_validation.feature
+++ b/test/features/notification_preference_validation.feature
@@ -1,0 +1,19 @@
+@async @database @conn
+Feature: Valid notification preference updates
+  As a user updating my notification preferences through the API
+  I want invalid changes to be rejected together
+  So that my saved email choices are preserved
+
+  Scenario Outline: Invalid preferences leave all saved choices unchanged
+    Given I have opted out of RSVP confirmations through the API
+    When I request these notification preferences through the API:
+      | preference        | value   |
+      | rsvp_confirmation | true    |
+      | <preference>      | <value> |
+    Then the notification preference update should be rejected
+    And my saved notification preferences should be unchanged
+
+    Examples:
+      | preference    | value   |
+      | unknown       | true    |
+      | rsvp_received | "false" |

--- a/test/features/step_definitions/notification_preference_validation_steps.exs
+++ b/test/features/step_definitions/notification_preference_validation_steps.exs
@@ -1,0 +1,63 @@
+defmodule NotificationPreferenceValidationSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import HuddlzWeb.ApiCase, only: [authenticated_conn: 2, gql_post: 3]
+  import Phoenix.ConnTest, only: [json_response: 2]
+
+  step "I have opted out of RSVP confirmations through the API", context do
+    user = generate(user())
+    preferences = %{"rsvp_confirmation" => false}
+    response = update_preferences(context.conn, user, preferences)
+    assert %{"errors" => []} = response["data"]["updateNotificationPreferences"]
+
+    Map.merge(context, %{preference_user: user, saved_preferences: preferences})
+  end
+
+  step "I request these notification preferences through the API:", context do
+    preferences =
+      Map.new(context.datatable.maps, fn row ->
+        {row["preference"], Jason.decode!(row["value"])}
+      end)
+
+    response = update_preferences(context.conn, context.preference_user, preferences)
+    Map.put(context, :preference_response, response)
+  end
+
+  step "the notification preference update should be rejected", context do
+    assert %{"result" => nil, "errors" => [%{"fields" => ["preferences"]}]} =
+             context.preference_response["data"]["updateNotificationPreferences"]
+
+    context
+  end
+
+  step "my saved notification preferences should be unchanged", context do
+    response =
+      context.conn
+      |> authenticated_conn(context.preference_user)
+      |> gql_post("query { me { notificationPreferences } }", %{})
+      |> json_response(200)
+
+    assert Jason.decode!(response["data"]["me"]["notificationPreferences"]) ==
+             context.saved_preferences
+
+    context
+  end
+
+  defp update_preferences(conn, user, preferences) do
+    query = """
+    mutation UpdatePreferences($id: ID!, $preferences: JsonString!) {
+      updateNotificationPreferences(id: $id, input: {preferences: $preferences}) {
+        result { id }
+        errors { fields }
+      }
+    }
+    """
+
+    conn
+    |> authenticated_conn(user)
+    |> gql_post(query, %{"id" => user.id, "preferences" => Jason.encode!(preferences)})
+    |> json_response(200)
+  end
+end

--- a/test/huddlz/accounts/user/notification_preferences_test.exs
+++ b/test/huddlz/accounts/user/notification_preferences_test.exs
@@ -9,6 +9,51 @@ defmodule Huddlz.Accounts.User.NotificationPreferencesTest do
   end
 
   describe "update_notification_preferences action" do
+    test "rejects unknown keys without saving any of the partial update" do
+      user = generate(user())
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               user
+               |> Ash.Changeset.for_update(
+                 :update_notification_preferences,
+                 %{preferences: %{"rsvp_received" => false, "unknown" => true}},
+                 actor: user
+               )
+               |> Ash.update()
+
+      assert Ash.get!(Huddlz.Accounts.User, user.id, actor: user).notification_preferences == %{}
+    end
+
+    test "rejects non-boolean values instead of silently falling back to defaults" do
+      user = generate(user())
+
+      for value <- ["false", "true", 0, 1, nil, [], %{}] do
+        assert {:error, %Ash.Error.Invalid{}} =
+                 user
+                 |> Ash.Changeset.for_update(
+                   :update_notification_preferences,
+                   %{preferences: %{"rsvp_received" => value}},
+                   actor: user
+                 )
+                 |> Ash.update()
+      end
+    end
+
+    test "accepts an empty partial update and rejects missing or invalid maps" do
+      user = generate(user())
+
+      changeset = fn params ->
+        Ash.Changeset.for_update(user, :update_notification_preferences, params, actor: user)
+      end
+
+      assert {:ok, unchanged} = changeset.(%{preferences: %{}}) |> Ash.update()
+      assert unchanged.notification_preferences == %{}
+
+      for params <- [%{}, %{preferences: nil}, %{preferences: "invalid"}] do
+        assert {:error, %Ash.Error.Invalid{}} = changeset.(params) |> Ash.update()
+      end
+    end
+
     test "self can merge a partial map onto existing preferences" do
       user = generate(user())
 

--- a/test/huddlz/notifications_test.exs
+++ b/test/huddlz/notifications_test.exs
@@ -78,9 +78,9 @@ defmodule Huddlz.NotificationsTest do
     end
 
     test "transactional ignores the user's preferences" do
-      user = generate_user_with_prefs(%{"anything" => false})
+      user = generate_user_with_prefs(%{"password_changed" => false})
       entry = transactional()
-      assert Notifications.should_deliver?(user, :anything, entry)
+      assert Notifications.should_deliver?(user, :password_changed, entry)
     end
 
     test "activity with default true and no preference sends" do
@@ -114,7 +114,8 @@ defmodule Huddlz.NotificationsTest do
     end
 
     test "garbage value in the preferences map falls back to the default" do
-      user = generate_user_with_prefs(%{"rsvp_received" => "yes"})
+      # Model legacy data directly: the update action now rejects this value.
+      user = %{generate(user()) | notification_preferences: %{"rsvp_received" => "yes"}}
       entry = activity(default: true)
       assert Notifications.should_deliver?(user, :rsvp_received, entry)
     end
@@ -153,7 +154,8 @@ defmodule Huddlz.NotificationsTest do
     end
 
     test "falls back to the default when the stored value is non-boolean" do
-      user = generate_user_with_prefs(%{"rsvp_received" => "yes"})
+      # Model legacy data directly: the update action now rejects this value.
+      user = %{generate(user()) | notification_preferences: %{"rsvp_received" => "yes"}}
       assert Notifications.preference_for(user, :rsvp_received) == true
     end
   end

--- a/test/huddlz_web/api/graphql/notification_preferences_test.exs
+++ b/test/huddlz_web/api/graphql/notification_preferences_test.exs
@@ -80,6 +80,38 @@ defmodule HuddlzWeb.Api.Graphql.NotificationPreferencesTest do
       assert reloaded.notification_preferences["rsvp_received"] == false
     end
 
+    test "rejects unknown keys and non-boolean values without saving", %{conn: conn} do
+      target = generate(user())
+
+      query = """
+      mutation Toggle($prefs: JsonString!) {
+        updateNotificationPreferences(id: "#{target.id}", input: {preferences: $prefs}) {
+          result { id }
+          errors { message fields }
+        }
+      }
+      """
+
+      for preferences <- [%{"unknown" => true}, %{"rsvp_received" => "false"}] do
+        response =
+          conn
+          |> authenticated_conn(target)
+          |> gql_post(query, %{"prefs" => Jason.encode!(preferences)})
+          |> json_response(200)
+
+        assert %{"result" => nil, "errors" => [%{"fields" => ["preferences"]}]} =
+                 response["data"]["updateNotificationPreferences"]
+      end
+
+      response =
+        conn
+        |> authenticated_conn(target)
+        |> gql_post("query { me { notificationPreferences } }", %{})
+        |> json_response(200)
+
+      assert Jason.decode!(response["data"]["me"]["notificationPreferences"]) == %{}
+    end
+
     test "rejects unauthenticated callers", %{conn: conn} do
       target = generate(user())
 

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -48,11 +48,19 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       |> login(user)
       |> visit("/profile/notifications")
       |> uncheck("Confirmation when I RSVP to a huddl")
+      |> check("Weekly digest of upcoming huddlz")
       |> click_button("Save preferences")
       |> assert_has("*", text: "Notification preferences saved")
 
       reloaded = Ash.get!(Huddlz.Accounts.User, user.id, actor: user)
       assert reloaded.notification_preferences["rsvp_confirmation"] == false
+      assert reloaded.notification_preferences["weekly_digest"] == true
+
+      conn
+      |> login(user)
+      |> visit("/profile/notifications")
+      |> assert_has("#prefs-rsvp_confirmation:not([checked])")
+      |> assert_has("#prefs-weekly_digest[checked]")
     end
   end
 end


### PR DESCRIPTION
Reject unknown notification preference keys and non-boolean values at the domain action boundary, including GraphQL updates. Valid partial updates and checkbox form submissions retain their existing behavior; malformed legacy values still fall back safely when read.

Related to #125 (partial scope):
- Completed: preference validation, with domain, GraphQL, and settings form coverage.
- Already resolved: unsubscribe uses a styled HEEx template and auth shell. Browser verification confirmed the confirmation and opt-out flow.
- Deferred: Swoosh Sandbox migration. The installed version supports it, but notification delivery already runs through Oban and the reported LiveView email handlers are gone; no launch defect justified this maintenance change.

Manually verified settings save/reload and unsubscribe confirmation using a disposable local account and isolated database on port 4125, with the local mail adapter. No real messages were sent. Full precommit passed with reduced BEAM scheduler concurrency to fit the local database pool. Existing tests require the default test URL port; no test HTTP listener was started.
