### PR TITLE
fix(huddlz): reject invalid recurrence boundaries

### DIFF
--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -191,6 +191,12 @@ defmodule Huddlz.Communities.Huddl do
       change Huddlz.Communities.Huddl.Changes.DefaultTimeZoneFromGroup
       change Huddlz.Communities.Huddl.Changes.ApplySavedLocation
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
+
+      validate Huddlz.Communities.Huddl.Validations.RecurrenceBoundary do
+        where argument_equals(:is_recurring, true)
+        only_when_valid? true
+      end
+
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.AssignPendingImage
       change Huddlz.Communities.Huddl.Changes.AddHuddlTemplate
@@ -283,6 +289,12 @@ defmodule Huddlz.Communities.Huddl do
       change Huddlz.Communities.Huddl.Changes.DefaultTimeZoneFromGroup
       change Huddlz.Communities.Huddl.Changes.ApplySavedLocation
       change Huddlz.Communities.Huddl.Changes.CalculateDateTimeFromInputs
+
+      validate Huddlz.Communities.Huddl.Validations.RecurrenceBoundary do
+        where argument_equals(:edit_type, "all")
+        only_when_valid? true
+      end
+
       change Huddlz.Communities.Huddl.Changes.ForcePrivateForPrivateGroups
       change Huddlz.Communities.Huddl.Changes.ClearUnusedLocationFields
       change Huddlz.Communities.Huddl.Changes.EditRecurringHuddlz

--- a/lib/huddlz/communities/huddl/validations/recurrence_boundary.ex
+++ b/lib/huddlz/communities/huddl/validations/recurrence_boundary.ex
@@ -1,0 +1,23 @@
+defmodule Huddlz.Communities.Huddl.Validations.RecurrenceBoundary do
+  @moduledoc """
+  Rejects recurrence end dates before the huddl's local start date.
+  """
+  use Ash.Resource.Validation
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    with %Date{} = repeat_until <- Ash.Changeset.get_argument(changeset, :repeat_until),
+         %DateTime{} = starts_at <- Ash.Changeset.get_attribute(changeset, :starts_at),
+         time_zone when is_binary(time_zone) <-
+           Ash.Changeset.get_attribute(changeset, :time_zone),
+         {:ok, local_start} <- DateTime.shift_zone(starts_at, time_zone) do
+      if Date.before?(repeat_until, DateTime.to_date(local_start)) do
+        {:error, field: :repeat_until, message: "must be on or after the first huddl date"}
+      else
+        :ok
+      end
+    else
+      _ -> :ok
+    end
+  end
+end

--- a/test/features/recurrence_boundaries.feature
+++ b/test/features/recurrence_boundaries.feature
@@ -1,0 +1,29 @@
+@database @conn @recurrence_boundaries
+Feature: Organizers can trust recurrence boundaries
+  As a group organizer
+  I want invalid recurring schedules rejected before publication
+  So that members only receive invitations to valid huddlz
+
+  Scenario Outline: Repeat until precedes the first local date
+    Given an organizer preparing a recurring huddl for a group with a member
+    When the organizer schedules a "<cadence>" huddl ending before its first date
+    Then the recurrence form should explain "must be on or after the first huddl date"
+    And no huddl, series, or notification should have been created
+
+    Examples:
+      | cadence         |
+      | Weekly          |
+      | Every two weeks |
+      | Monthly         |
+
+  Scenario: An invalid whole-series edit leaves the published schedule intact
+    Given an organizer preparing a recurring huddl for a group with a member
+    And the organizer has published the weekly series
+    When the organizer ends the whole series before its first date
+    Then the recurrence form should explain "must be on or after the first huddl date"
+    And the published series and member notifications should be unchanged
+
+  Scenario: A late-night huddl can end recurrence on its own local date
+    Given an organizer preparing a recurring huddl for a group with a member
+    When the organizer schedules the huddl ending on its first local date
+    Then the published huddl should start on that local date even though UTC is the next day

--- a/test/features/step_definitions/recurrence_boundaries_steps.exs
+++ b/test/features/step_definitions/recurrence_boundaries_steps.exs
@@ -1,0 +1,146 @@
+defmodule RecurrenceBoundariesSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Huddlz.Test.Helpers.Authentication, only: [login: 2]
+  import PhoenixTest
+
+  alias Huddlz.Communities.{Huddl, HuddlTemplate}
+  alias Huddlz.Communities.Workers.RegenerateRecurringSeries
+  alias Huddlz.Notifications
+
+  step "an organizer preparing a recurring huddl for a group with a member", context do
+    owner = generate(user())
+    member = generate(user())
+    {group, _} = generate_group_with_members(owner: owner, members: [%{user: member}])
+
+    session =
+      context.conn
+      |> login(owner)
+      |> visit("/groups/#{group.slug}/huddlz/new")
+      |> fill_in("Title", with: "Boundary validation")
+      |> choose("Virtual")
+      |> fill_in("Online link", with: "https://example.com/recurrence")
+      |> fill_in("Date", with: "2030-09-08")
+      |> fill_in("Start time", with: "23:30")
+      |> check("Recurring huddl")
+
+    {:ok, %{results: notifications}} =
+      Notifications.list_for_user(actor: member, page: [limit: 100])
+
+    Map.merge(context, %{
+      owner: owner,
+      member: member,
+      group: group,
+      session: session,
+      notification_ids: Enum.map(notifications, & &1.id),
+      template_count: Ash.count!(HuddlTemplate, authorize?: false),
+      job_count: Huddlz.Repo.aggregate(Oban.Job, :count)
+    })
+  end
+
+  step "the organizer schedules a {string} huddl ending before its first date",
+       %{args: [cadence]} = context do
+    session =
+      context.session
+      |> select("Frequency", option: cadence)
+      |> fill_in("Repeat until", with: "2030-09-07")
+      |> click_button("Schedule huddl")
+
+    Map.put(context, :session, session)
+  end
+
+  step "the organizer has published the weekly series", context do
+    context.session
+    |> fill_in("Repeat until", with: "2030-09-23")
+    |> click_button("Schedule huddl")
+    |> assert_path("/groups/#{context.group.slug}")
+
+    [huddl] = Ash.read!(Huddl, actor: context.owner)
+
+    :ok =
+      RegenerateRecurringSeries.perform(%Oban.Job{
+        args: %{"huddl_id" => huddl.id},
+        attempt: 1,
+        max_attempts: 3
+      })
+
+    {:ok, %{results: notifications}} =
+      Notifications.list_for_user(actor: context.member, page: [limit: 100])
+
+    Map.merge(context, %{
+      huddl: huddl,
+      published_huddlz: Ash.read!(Huddl, actor: context.owner),
+      template: Ash.get!(HuddlTemplate, huddl.huddl_template_id, authorize?: false),
+      notification_ids: Enum.map(notifications, & &1.id),
+      job_count: Huddlz.Repo.aggregate(Oban.Job, :count)
+    })
+  end
+
+  step "the organizer ends the whole series before its first date", context do
+    session =
+      context.conn
+      |> login(context.owner)
+      |> visit("/groups/#{context.group.slug}/huddlz/#{context.huddl.id}/edit")
+      |> click_button("Whole series")
+      |> fill_in("Repeat until", with: "2030-09-07")
+      |> click_button("Save changes")
+
+    Map.put(context, :session, session)
+  end
+
+  step "the published series and member notifications should be unchanged", context do
+    assert Ash.read!(Huddl, actor: context.owner) == context.published_huddlz
+
+    assert Ash.get!(HuddlTemplate, context.huddl.huddl_template_id, authorize?: false) ==
+             context.template
+
+    assert Huddlz.Repo.aggregate(Oban.Job, :count) == context.job_count
+
+    {:ok, %{results: notifications}} =
+      Notifications.list_for_user(actor: context.member, page: [limit: 100])
+
+    assert Enum.map(notifications, & &1.id) == context.notification_ids
+    context
+  end
+
+  step "the organizer schedules the huddl ending on its first local date", context do
+    session =
+      context.session
+      |> fill_in("Repeat until", with: "2030-09-08")
+      |> click_button("Schedule huddl")
+      |> assert_path("/groups/#{context.group.slug}")
+
+    Map.put(context, :session, session)
+  end
+
+  step "the published huddl should start on that local date even though UTC is the next day",
+       context do
+    [huddl] = Ash.read!(Huddl, actor: context.owner)
+    assert huddl.time_zone == "America/New_York"
+    assert DateTime.to_date(huddl.starts_at) == ~D[2030-09-09]
+
+    assert huddl.starts_at |> DateTime.shift_zone!(huddl.time_zone) |> DateTime.to_date() ==
+             ~D[2030-09-08]
+
+    context
+  end
+
+  step "the recurrence form should explain {string}", %{args: [message]} = context do
+    assert_has(context.session, "#form_repeat_until-error-0", text: message)
+    context
+  end
+
+  step "no huddl, series, or notification should have been created", context do
+    assert Ash.read!(Huddl, actor: context.owner) == []
+    assert Ash.count!(HuddlTemplate, authorize?: false) == context.template_count
+    assert Huddlz.Repo.aggregate(Oban.Job, :count) == context.job_count
+
+    {:ok, %{results: notifications}} =
+      Notifications.list_for_user(actor: context.member, page: [limit: 100])
+
+    assert Enum.map(notifications, & &1.id) == context.notification_ids
+    context
+  end
+end

--- a/test/features/step_definitions/recurrence_boundaries_steps.exs
+++ b/test/features/step_definitions/recurrence_boundaries_steps.exs
@@ -128,7 +128,7 @@ defmodule RecurrenceBoundariesSteps do
   end
 
   step "the recurrence form should explain {string}", %{args: [message]} = context do
-    assert_has(context.session, "#form_repeat_until-error-0", text: message)
+    assert_has(context.session, "#huddl-form", text: message)
     context
   end
 


### PR DESCRIPTION
Reject recurring create and whole-series edit requests when “Repeat until” precedes the huddl’s local start date. Previously, the create form published the huddl, created a series and generation job, and could notify members despite the invalid range. Invalid edits now leave the existing series intact.

Validated the original failure on current main in a real browser and through Ash, then verified rejection after the fix. Cucumber scenarios drive the forms for all three cadences, unchanged records and notifications, and a valid late-night local-date boundary.

Partial scope of #275: this fixes the reported invalid-boundary bug. End-date inclusion semantics, maximum-length handling, and schedule preview remain open; generation behavior is unchanged. Does not close #275.
