### PR TITLE
fix(api): expose usable huddl artwork URLs

### DIFF
--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -22,6 +22,34 @@ descending. Ordering is applied before pagination.
 The date filter controls which huddlz are included; sorting only controls their
 sequence. See `/api/json/open_api` or `/api/json/swaggerui` for supported fields.
 
+## Artwork
+
+Discovery and detail responses (`GET /api/json/huddlz/:id`) include the read-only
+`attributes.image_url` field by default. It is an absolute URL for the current
+huddl thumbnail, falling back to the current group thumbnail, or `null` when
+neither has artwork. Soft-deleted images are excluded. This uses the same
+artwork selection as the website; clients do not need to fetch the group or
+reimplement the fallback.
+
+For sparse responses, include `image_url` explicitly:
+
+```text
+/api/json/huddlz?date_filter=upcoming&sort=starts_at&fields[huddl]=title,image_url
+/api/json/huddlz/:id?fields[huddl]=title,image_url
+```
+
+`thumbnail_url` remains a separate legacy stored value and is not the uploaded
+artwork source. The internal `display_image_url` and `current_image_url` paths
+remain unavailable as public API fields.
+
+iOS clients should decode `image_url` as optional and use it in both discovery
+and details, retaining their placeholder when it is null or fails to download.
+Resource visibility rules still apply to requests for artwork. Production URLs
+use the configured storage host; local URLs use the configured application
+origin. A physical device needs an origin it can reach instead of `localhost`.
+After deployment, verify both response types and download their returned URLs
+before checking live imagery in the iOS app (huddlz-hq/huddlz-ios#7).
+
 ## Migrating from the previously advertised contract
 
 The `soonest` and `newest` API values advertised before issue #422 are removed.

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -37,6 +37,27 @@ defmodule Huddlz.Communities.Huddl do
   json_api do
     type "huddl"
 
+    default_fields [
+      :id,
+      :title,
+      :description,
+      :starts_at,
+      :ends_at,
+      :time_zone,
+      :event_type,
+      :physical_location,
+      :is_private,
+      :thumbnail_url,
+      :max_attendees,
+      :lifecycle_state,
+      :published_at,
+      :cancelled_at,
+      :completed_at,
+      :cancellation_reason,
+      :inserted_at,
+      :image_url
+    ]
+
     routes do
       base "/huddlz"
 
@@ -933,6 +954,14 @@ defmodule Huddlz.Communities.Huddl do
     calculate :display_image_url, :string do
       description "Returns huddl's image, falling back to group image if none"
       calculation Huddlz.Communities.Huddl.Calculations.DisplayImageUrl
+    end
+
+    calculate :image_url, :string do
+      public? true
+
+      description "Absolute artwork URL using the huddl image, then group image; null without artwork"
+
+      calculation Huddlz.Communities.Huddl.Calculations.ImageUrl
     end
   end
 

--- a/lib/huddlz/communities/huddl/calculations/image_url.ex
+++ b/lib/huddlz/communities/huddl/calculations/image_url.ex
@@ -1,0 +1,22 @@
+defmodule Huddlz.Communities.Huddl.Calculations.ImageUrl do
+  @moduledoc """
+  Resolves the shared display artwork path to a URL API clients can fetch.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context), do: [:display_image_url]
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    Enum.map(records, &image_url(&1.display_image_url))
+  end
+
+  defp image_url(nil), do: nil
+
+  defp image_url(path) do
+    HuddlzWeb.Endpoint.url()
+    |> URI.merge(Huddlz.Storage.url(path))
+    |> URI.to_string()
+  end
+end

--- a/test/features/api_artwork.feature
+++ b/test/features/api_artwork.feature
@@ -1,0 +1,11 @@
+@async @database @conn @api_artwork
+Feature: Artwork for API clients
+  As a visitor using the public API
+  I want the same artwork in discovery and huddl details
+  So that I can recognize huddlz without signing in
+
+  Scenario: Available artwork and missing artwork are usable
+    Given public upcoming huddlz with their own artwork, group artwork, and no artwork
+    When I discover those huddlz and open their details through the API without signing in
+    Then both API responses provide the available artwork or no artwork
+    And the available artwork can be downloaded

--- a/test/features/step_definitions/api_artwork_steps.exs
+++ b/test/features/step_definitions/api_artwork_steps.exs
@@ -1,0 +1,80 @@
+defmodule ApiArtworkSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+
+  step "public upcoming huddlz with their own artwork, group artwork, and no artwork", context do
+    owner = generate(user())
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    empty_group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    direct = generate(huddl(group_id: group.id, actor: owner, thumbnail_url: nil))
+    fallback = generate(huddl(group_id: group.id, actor: owner, thumbnail_url: nil))
+    empty = generate(huddl(group_id: empty_group.id, actor: owner, thumbnail_url: nil))
+
+    group_image = upload(Huddlz.Communities.GroupImage, :group_id, group.id, owner)
+    huddl_image = upload(Huddlz.Communities.HuddlImage, :huddl_id, direct.id, owner)
+
+    Map.put(context, :artwork, %{
+      direct.id => HuddlzWeb.Endpoint.url() <> huddl_image.thumbnail_path,
+      fallback.id => HuddlzWeb.Endpoint.url() <> group_image.thumbnail_path,
+      empty.id => nil
+    })
+  end
+
+  step "I discover those huddlz and open their details through the API without signing in",
+       context do
+    discovery = get(context.conn, "/api/json/huddlz?date_filter=upcoming")
+    details = for id <- Map.keys(context.artwork), do: get(context.conn, "/api/json/huddlz/#{id}")
+    Map.merge(context, %{artwork_discovery: discovery, artwork_details: details})
+  end
+
+  step "both API responses provide the available artwork or no artwork", context do
+    discovery = Phoenix.ConnTest.json_response(context.artwork_discovery, 200)["data"]
+
+    details =
+      Enum.map(context.artwork_details, &Phoenix.ConnTest.json_response(&1, 200)["data"])
+
+    for records <- [discovery, details] do
+      actual = Map.new(records, &{&1["id"], Map.fetch!(&1["attributes"], "image_url")})
+      assert actual == context.artwork
+    end
+
+    context
+  end
+
+  step "the available artwork can be downloaded", context do
+    for url <- Map.values(context.artwork), url do
+      conn = get(context.conn, URI.parse(url).path)
+      assert byte_size(Phoenix.ConnTest.response(conn, 200)) > 0
+      assert Plug.Conn.get_resp_header(conn, "content-type") == ["image/jpeg"]
+    end
+
+    context
+  end
+
+  defp get(conn, path) do
+    Phoenix.ConnTest.dispatch(conn, HuddlzWeb.Endpoint, :get, path, nil)
+  end
+
+  defp upload(resource, parent_key, parent_id, owner) do
+    file = %Plug.Upload{
+      path: "test/fixtures/test_image.jpg",
+      filename: "cover.jpg",
+      content_type: "image/jpeg"
+    }
+
+    image =
+      resource
+      |> Ash.Changeset.for_create(:upload, %{parent_key => parent_id, :file => file},
+        actor: owner
+      )
+      |> Ash.create!()
+
+    ExUnit.Callbacks.on_exit(fn ->
+      for path <- [image.storage_path, image.thumbnail_path], do: Huddlz.Storage.delete(path)
+    end)
+
+    image
+  end
+end

--- a/test/huddlz_web/api/json/huddl_artwork_test.exs
+++ b/test/huddlz_web/api/json/huddl_artwork_test.exs
@@ -1,0 +1,138 @@
+defmodule HuddlzWeb.Api.Json.HuddlArtworkTest do
+  use HuddlzWeb.ApiCase, async: true
+
+  test "artwork uses the current huddl image, then group fallback, then null", %{conn: conn} do
+    owner = generate(user())
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    huddl = generate(huddl(group_id: group.id, actor: owner, thumbnail_url: nil))
+    group_image = create_image(Huddlz.Communities.GroupImage, :group_id, group.id, owner)
+
+    assert_artwork(conn, huddl, group_image.thumbnail_path)
+
+    huddl_image = create_image(Huddlz.Communities.HuddlImage, :huddl_id, huddl.id, owner)
+    assert_artwork(conn, huddl, huddl_image.thumbnail_path)
+
+    huddl_image |> Ash.Changeset.for_update(:soft_delete, %{}, actor: owner) |> Ash.update!()
+    assert_artwork(conn, huddl, group_image.thumbnail_path)
+
+    group_image |> Ash.Changeset.for_update(:soft_delete, %{}, actor: owner) |> Ash.update!()
+    assert_artwork(conn, huddl, nil)
+  end
+
+  test "field selection includes artwork only when requested", %{conn: conn} do
+    owner = generate(user())
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    huddl = generate(huddl(group_id: group.id, actor: owner, thumbnail_url: nil))
+    image = create_image(Huddlz.Communities.GroupImage, :group_id, group.id, owner)
+
+    for path <- ["/api/json/huddlz", "/api/json/huddlz/#{huddl.id}"] do
+      params = %{"date_filter" => "upcoming", "fields" => %{"huddl" => "title,image_url"}}
+      body = conn |> get(path, params) |> json_response(200)
+      assert [data] = List.wrap(body["data"])
+
+      assert data["attributes"] == %{
+               "title" => huddl.title,
+               "image_url" => HuddlzWeb.Endpoint.url() <> image.thumbnail_path
+             }
+
+      body = conn |> get(path, put_in(params, ["fields", "huddl"], "title")) |> json_response(200)
+      assert [data] = List.wrap(body["data"])
+      assert data["attributes"] == %{"title" => huddl.title}
+
+      for field <- ["display_image_url", "current_image_url"] do
+        body =
+          conn |> get(path, put_in(params, ["fields", "huddl"], field)) |> json_response(400)
+
+        assert Enum.any?(body["errors"], &(&1["code"] == "invalid_field"))
+      end
+    end
+  end
+
+  test "anonymous and unrelated clients cannot discover unauthorized artwork", %{conn: conn} do
+    owner = generate(user())
+    stranger = generate(user())
+    public_group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    private_group = generate(group(owner_id: owner.id, is_public: false, actor: owner))
+
+    for opts <- [
+          [group_id: public_group.id, is_private: true],
+          [group_id: private_group.id],
+          [group_id: public_group.id, lifecycle_state: :draft],
+          [group_id: public_group.id, lifecycle_state: :cancelled]
+        ] do
+      huddl =
+        generate(
+          huddl(Keyword.delete(opts, :lifecycle_state) ++ [actor: owner, thumbnail_url: nil])
+        )
+
+      huddl = Ash.Seed.update!(huddl, %{lifecycle_state: opts[:lifecycle_state] || :published})
+
+      Ash.Seed.seed!(Huddlz.Communities.HuddlImage, %{
+        huddl_id: huddl.id,
+        filename: "private.jpg",
+        content_type: "image/jpeg",
+        size_bytes: 100,
+        storage_path: "/uploads/430/#{huddl.id}.jpg",
+        thumbnail_path: "/uploads/430/#{huddl.id}_thumb.jpg"
+      })
+
+      for client <- [conn, authenticated_conn(conn, stranger)] do
+        body =
+          client
+          |> get("/api/json/huddlz", %{
+            "date_filter" => "upcoming",
+            "fields" => %{"huddl" => "title,image_url"}
+          })
+          |> json_response(200)
+
+        assert body["data"] == []
+
+        client
+        |> get("/api/json/huddlz/#{huddl.id}", %{"fields" => %{"huddl" => "image_url"}})
+        |> json_response(404)
+      end
+    end
+  end
+
+  test "OpenAPI documents the public artwork URL", %{conn: conn} do
+    schema = conn |> get("/api/json/open_api") |> response(200) |> Jason.decode!()
+
+    properties =
+      get_in(schema, ["components", "schemas", "huddl", "properties", "attributes", "properties"])
+
+    assert %{"type" => "string", "nullable" => true} in properties["image_url"]["anyOf"]
+    assert %{"type" => "null"} in properties["image_url"]["anyOf"]
+    refute Map.has_key?(properties, "display_image_url")
+    refute Map.has_key?(properties, "current_image_url")
+  end
+
+  defp assert_artwork(conn, huddl, path) do
+    expected = if path, do: HuddlzWeb.Endpoint.url() <> path
+
+    for route <- ["/api/json/huddlz?date_filter=upcoming", "/api/json/huddlz/#{huddl.id}"] do
+      body = conn |> get(route) |> json_response(200)
+      assert [data] = List.wrap(body["data"])
+      assert data["id"] == huddl.id
+      assert Map.fetch!(data["attributes"], "image_url") == expected
+    end
+  end
+
+  defp create_image(resource, parent_key, parent_id, owner) do
+    path = "/uploads/430/#{Ash.UUID.generate()}.jpg"
+
+    resource
+    |> Ash.Changeset.for_create(
+      :create,
+      %{
+        parent_key => parent_id,
+        :filename => "cover.jpg",
+        :content_type => "image/jpeg",
+        :size_bytes => 100,
+        :storage_path => path,
+        :thumbnail_path => path <> "_thumb.jpg"
+      },
+      actor: owner
+    )
+    |> Ash.create!()
+  end
+end


### PR DESCRIPTION
Public API clients could not retrieve the uploaded artwork shown on the website. Discovery and huddl details now include read-only `attributes.image_url`: an absolute storage URL using the existing huddl-image → group-image fallback, or `null` without artwork. Sparse requests can select `image_url`; existing visibility rules remain in effect.

Closes #430. Unblocks the API contract needed by huddlz-hq/huddlz-ios#7. iOS should decode the optional `image_url` for discovery and details and retain its placeholder for missing or failed images.

Verified anonymous discovery/detail responses and image downloads over local HTTP, including direct artwork, group fallback, no artwork, sparse fields, and unauthorized records. After deployment, repeat these requests against production and check imagery in iOS; local URLs require a device-reachable app origin. No deployment or live iOS verification was performed.
