### PR TITLE
fix(ui): make public huddl listings and archives crawlable

### DIFF
--- a/docs/canonical-urls.md
+++ b/docs/canonical-urls.md
@@ -3,9 +3,12 @@
 Public group pages use `/groups/:slug`; anonymously visible huddl pages use
 `/groups/:group_slug/huddlz/:id`. Their canonical links and Open Graph URLs use
 Phoenix's configured endpoint URL (`PHX_SCHEME`, `PHX_HOST`, and the configured
-URL port), never the request host. Query parameters do not affect these detail
-handlers, so their canonical URLs omit them. Group Upcoming/Past tabs are local
-LiveView state, with no separate URL.
+URL port), never the request host. Huddl detail parameters do not affect content and are omitted from canonicals.
+Group Upcoming is the base URL. The public group archive uses `?tab=past`,
+with `&page=N` for pages after the first. These archive URLs have matching
+self-referencing canonical and Open Graph URLs; unrelated parameters are
+omitted. Invalid page values use page one, and out-of-range pages redirect to
+the last page. Archive navigation is available in initial anonymous HTML.
 
 Discovery uses a self-referencing `/discover` URL retaining every query
 parameter, including scope, search, location, date, sort, and pagination. This
@@ -29,9 +32,9 @@ serves the launch SEO requirement while preserving live navigation. See the
 There are no legacy HTML detail aliases or slug-history redirects in the
 current router. An incorrect group slug does not resolve a huddl. Future slug
 migrations and redirects belong with the actual URL migration, not speculative
-routes. There is currently no sitemap; #258 should use the same verified detail
-paths and endpoint configuration. Crawlable-link and structured-data work stay
-in #260 and #162.
+routes. Sitemaps use the same verified detail paths and endpoint configuration; see
+[sitemaps.md](sitemaps.md). Listing and archive pages provide on-site discovery
+and do not need sitemap entries. Structured data remains separate in #162.
 
 Deployment configuration is unchanged: runtime defaults are `https` and
 `huddlz.com`, while the checked-in `fly.toml` sets `PHX_HOST=huddlz.fly.dev`.

--- a/docs/crawlable-links.md
+++ b/docs/crawlable-links.md
@@ -1,0 +1,71 @@
+# Crawlable public links
+
+Audit baseline: `a13ef31f` on main (2026-09-07), including canonical URLs
+(PR #431) and sitemaps (PR #433). This work addresses #260 independently of
+structured data (#162).
+
+## Findings
+
+- Home already renders an ordinary `/discover` link for anonymous visitors.
+- Discovery renders huddl cards as anchors to
+  `/groups/:group_slug/huddlz/:id`. Its Groups link exposes the public group
+  listing; group cards link to `/groups/:slug`. These agree with the existing
+  canonical and sitemap detail paths.
+- Discovery queries run during the initial HTTP request, before any socket
+  connection. Its previous pagination controls were buttons without hrefs:
+  pages after the first were inaccessible through those controls without
+  JavaScript. Pagination now renders patch links with ordinary hrefs for
+  previous, next and numbered pages, retaining active filters and group scope.
+  First-page links omit `page=1`; disabled boundary controls have no href.
+- Group detail pages render up to ten upcoming huddl links. Discovery provides
+  the complete paginated path to upcoming and in-progress public huddlz, so this
+  group preview does not need to become a second upcoming pagination system.
+- Past/completed public detail pages are indexable and included in sitemaps.
+  `/discover?date_filter=past` serves a paginated archive through anonymous
+  HTTP, but currently has no public navigation link. Group Past tabs and their
+  pagination remain socket-only state; query parameters do not select them.
+  Exposing public archive navigation is pending the product decision for #260.
+  **The issue is therefore only partially addressed by discovery pagination.**
+- A huddl detail page has no group backlink. This does not orphan either page:
+  public groups have their own discovery listing, and huddlz have discovery
+  links. No additional backlink is required to meet this issue.
+
+## Intentional exclusions and crawl boundaries
+
+Anonymous resource policies exclude private groups, members-only huddlz,
+public-looking huddlz inside private groups, drafts and cancellations. Deleted
+records cannot resolve. Anonymous detail requests return 404 for these records;
+public listings do not link to them. Cancelled huddlz remain available only to
+organizers and people with RSVP history, consistent with canonical and sitemap
+eligibility. This change does not broaden those permissions.
+
+Personal dashboards, calendars, notifications, profile pages, management routes,
+and discovery `yours=hosting|attending` require authentication and are not public
+indexable listing paths. Sign-in/registration links are navigation, not public
+huddl content. There is no new robots/noindex policy in this change.
+
+Existing filter links remain usable; pagination retains their search, format,
+date, sort and location context. No arbitrary search terms, locations or new
+filter combinations are generated to expand the crawl surface. A sitemap is an
+additional discovery mechanism and does not fix the missing on-site archive
+path described above.
+
+## Verification
+
+The Cucumber scenario starts with anonymous home HTML, follows the actual
+Browse href, follows pagination hrefs, and requests every linked huddl detail
+with 21 public fixtures. Additional HTTP tests cover paginated group listings,
+past-filter pagination, filter context and exclusion of restricted/deleted
+records. These checks use initial responses, not a DOM after JavaScript runs.
+
+An isolated local browser server with 21 upcoming huddlz verifies next-page
+navigation, detail navigation and browser Back retaining page two. Local tests
+prove response contents and navigation, not search-engine indexing. Production
+host configuration, deployment and search-engine acceptance remain rollout
+checks; no deployment or Search Console operation is included here.
+
+References:
+
+- [Google crawlable link guidance](https://developers.google.com/search/docs/crawling-indexing/links-crawlable)
+- [Canonical URL policy](canonical-urls.md)
+- [Sitemap visibility contract](sitemaps.md)

--- a/docs/crawlable-links.md
+++ b/docs/crawlable-links.md
@@ -21,11 +21,14 @@ structured data (#162).
   the complete paginated path to upcoming and in-progress public huddlz, so this
   group preview does not need to become a second upcoming pagination system.
 - Past/completed public detail pages are indexable and included in sitemaps.
-  `/discover?date_filter=past` serves a paginated archive through anonymous
-  HTTP, but currently has no public navigation link. Group Past tabs and their
-  pagination remain socket-only state; query parameters do not select them.
-  Exposing public archive navigation is pending the product decision for #260.
-  **The issue is therefore only partially addressed by discovery pagination.**
+  Previously the group Past tab and its pagination were socket-only state.
+  They now expose `/groups/:slug?tab=past` and `&page=N` through ordinary
+  links. Upcoming stays the default, and switching back omits archive params.
+  Archive pages have distinct canonical and Open Graph URLs, while huddl
+  detail URLs remain unchanged. Past huddlz sort newest first, with an ID
+  tie-breaker for matching dates. Out-of-range pages redirect to the last page.
+  The complete on-site archive path runs through public group discovery;
+  no extra combinations of discovery filters need to be generated.
 - A huddl detail page has no group backlink. This does not orphan either page:
   public groups have their own discovery listing, and huddlz have discovery
   links. No additional backlink is required to meet this issue.
@@ -47,19 +50,22 @@ huddl content. There is no new robots/noindex policy in this change.
 Existing filter links remain usable; pagination retains their search, format,
 date, sort and location context. No arbitrary search terms, locations or new
 filter combinations are generated to expand the crawl surface. A sitemap is an
-additional discovery mechanism and does not fix the missing on-site archive
-path described above.
+additional discovery mechanism; the archive is also reachable entirely through
+on-site anchors, starting at home.
 
 ## Verification
 
 The Cucumber scenario starts with anonymous home HTML, follows the actual
 Browse href, follows pagination hrefs, and requests every linked huddl detail
-with 21 public fixtures. Additional HTTP tests cover paginated group listings,
-past-filter pagination, filter context and exclusion of restricted/deleted
+with 21 public fixtures. A second scenario follows group discovery and the Past
+link through multiple archive pages and published/completed detail pages.
+Additional HTTP tests cover paginated group listings,
+past-filter pagination, filter context, invalid archive parameters and exclusion of restricted/deleted
 records. These checks use initial responses, not a DOM after JavaScript runs.
 
 An isolated local browser server with 21 upcoming huddlz verifies next-page
-navigation, detail navigation and browser Back retaining page two. Local tests
+navigation, detail navigation and browser Back retaining page two. Archive
+browser checks cover Past, next/previous, direct reload and returning to Upcoming. Local tests
 prove response contents and navigation, not search-engine indexing. Production
 host configuration, deployment and search-engine acceptance remain rollout
 checks; no deployment or Search Console operation is included here.

--- a/lib/huddlz_web/components/pagination.ex
+++ b/lib/huddlz_web/components/pagination.ex
@@ -4,8 +4,8 @@ defmodule HuddlzWeb.Components.Pagination do
   flanking an `<ol class="page-numbers">`. Page-number entries collapse to an
   ellipsis when the total exceeds 7.
 
-  Pages are emitted as `<button>` elements that fire a `phx-click` event with
-  `phx-value-page=N`; the host LiveView pushes the corresponding patch URL.
+  Supply `page_path` for crawlable LiveView patch links, or `event_name` for
+  pagination managed entirely by the host LiveView.
   """
   use Phoenix.Component
 
@@ -13,21 +13,25 @@ defmodule HuddlzWeb.Components.Pagination do
   attr :total_pages, :integer, required: true
 
   attr :event_name, :string,
-    required: true,
+    default: nil,
     doc: "phx-click event name dispatched to the LiveView"
 
+  attr :page_path, :any, default: nil, doc: "Function mapping a page number to a URL"
+
+  attr :id, :string, default: "pagination"
   attr :class, :any, default: nil
 
   def pagination(assigns) do
     ~H"""
-    <nav class={["pagination", @class]} aria-label="Pagination">
-      <button
-        type="button"
+    <nav id={@id} class={["pagination", @class]} aria-label="Pagination">
+      <.page_control
         class="page-nav"
         disabled={@current_page <= 1}
+        id={@id <> "-previous"}
         aria-label="Previous page"
-        phx-click={@event_name}
-        phx-value-page={@current_page - 1}
+        event_name={@event_name}
+        page_path={@page_path}
+        page={@current_page - 1}
       >
         <svg
           width="14"
@@ -42,33 +46,35 @@ defmodule HuddlzWeb.Components.Pagination do
           <path d="m15 18-6-6 6-6" />
         </svg>
         <span>Prev</span>
-      </button>
+      </.page_control>
       <ol class="page-numbers">
         <%= for entry <- pagination_range(@current_page, @total_pages) do %>
           <%= if entry == :ellipsis do %>
             <li class="page-ellipsis" aria-hidden="true">…</li>
           <% else %>
             <li>
-              <button
-                type="button"
+              <.page_control
                 class={["page-num", entry == @current_page && "is-active"]}
+                id={@id <> "-page-#{entry}"}
                 aria-current={entry == @current_page && "page"}
-                phx-click={@event_name}
-                phx-value-page={entry}
+                event_name={@event_name}
+                page_path={@page_path}
+                page={entry}
               >
                 {entry}
-              </button>
+              </.page_control>
             </li>
           <% end %>
         <% end %>
       </ol>
-      <button
-        type="button"
+      <.page_control
         class="page-nav"
         disabled={@current_page >= @total_pages}
+        id={@id <> "-next"}
         aria-label="Next page"
-        phx-click={@event_name}
-        phx-value-page={@current_page + 1}
+        event_name={@event_name}
+        page_path={@page_path}
+        page={@current_page + 1}
       >
         <span>Next</span>
         <svg
@@ -83,8 +89,33 @@ defmodule HuddlzWeb.Components.Pagination do
         >
           <path d="m9 6 6 6-6 6" />
         </svg>
-      </button>
+      </.page_control>
     </nav>
+    """
+  end
+
+  attr :page_path, :any, default: nil
+  attr :event_name, :string, default: nil
+  attr :page, :integer, required: true
+  attr :disabled, :boolean, default: false
+  attr :rest, :global, include: ~w(aria-label aria-current)
+  slot :inner_block, required: true
+
+  defp page_control(assigns) do
+    ~H"""
+    <%= if @page_path && !@disabled do %>
+      <.link patch={@page_path.(@page)} {@rest}>{render_slot(@inner_block)}</.link>
+    <% else %>
+      <button
+        type="button"
+        disabled={@disabled}
+        phx-click={@event_name}
+        phx-value-page={@page}
+        {@rest}
+      >
+        {render_slot(@inner_block)}
+      </button>
+    <% end %>
     """
   end
 

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -32,31 +32,46 @@ defmodule HuddlzWeb.GroupLive.Show do
   end
 
   @impl true
-  def handle_params(%{"slug" => slug}, _, socket) do
+  def handle_params(%{"slug" => slug} = params, _, socket) do
     user = socket.assigns.current_user
 
     case get_group_by_slug(slug, user) do
       {:ok, group} ->
-        meta = group_meta(group)
+        tab = if params["tab"] == "past", do: "past", else: "upcoming"
+        page = if tab == "past", do: parse_page(params["page"]), else: 1
+
+        meta =
+          Map.put(
+            group_meta(group),
+            :url,
+            unverified_url(HuddlzWeb.Endpoint, group_page_path(group, tab, page))
+          )
+
         membership = current_user_membership(group, user)
         members = get_members(group, user, !is_nil(membership))
-        upcoming_huddlz = get_upcoming_group_huddlz(group, user, limit: 10)
 
-        {:noreply,
-         socket
-         |> subscribe_to_membership_changes(group)
-         |> assign(:page_title, group.name)
-         |> assign(:meta, meta)
-         |> assign(:canonical_url, if(group.is_public, do: meta.url))
-         |> assign(:group, group)
-         |> assign_member_grid(members)
-         |> assign(:member_count, group.member_count)
-         |> assign(:is_member, !is_nil(membership))
-         |> assign_action_permissions(group, user, membership)
-         |> assign(:active_tab, "upcoming")
-         |> stream_huddlz(upcoming_huddlz)
-         |> assign(:past_page, 1)
-         |> assign(:past_total_pages, 0)}
+        socket =
+          socket
+          |> subscribe_to_membership_changes(group)
+          |> assign(:page_title, group.name)
+          |> assign(:meta, meta)
+          |> assign(:canonical_url, if(group.is_public, do: meta.url))
+          |> assign(:group, group)
+          |> assign_member_grid(members)
+          |> assign(:member_count, group.member_count)
+          |> assign(:is_member, !is_nil(membership))
+          |> assign_action_permissions(group, user, membership)
+          |> assign(:active_tab, tab)
+          |> assign(:past_page, page)
+          |> assign(:past_total_pages, 1)
+          |> refresh_huddlz()
+
+        if tab == "past" and page > socket.assigns.past_total_pages do
+          {:noreply,
+           push_patch(socket, to: group_page_path(group, tab, socket.assigns.past_total_pages))}
+        else
+          {:noreply, socket}
+        end
 
       {:error, _reason} ->
         not_found!()
@@ -340,28 +355,24 @@ defmodule HuddlzWeb.GroupLive.Show do
             <h2>Huddlz</h2>
           </div>
 
-          <div class="filters" role="tablist" aria-label="Huddl timeframe">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={@active_tab == "upcoming"}
+          <nav class="filters" aria-label="Huddl timeframe">
+            <.link
+              id="group-huddlz-upcoming"
+              patch={group_page_path(@group, "upcoming", 1)}
+              aria-current={@active_tab == "upcoming" && "page"}
               class={["chip", @active_tab == "upcoming" && "is-active"]}
-              phx-click="switch_tab"
-              phx-value-tab="upcoming"
             >
               Upcoming
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={@active_tab == "past"}
+            </.link>
+            <.link
+              id="group-huddlz-past"
+              patch={group_page_path(@group, "past", 1)}
+              aria-current={@active_tab == "past" && "page"}
               class={["chip", @active_tab == "past" && "is-active"]}
-              phx-click="switch_tab"
-              phx-value-tab="past"
             >
               Past
-            </button>
-          </div>
+            </.link>
+          </nav>
 
           <.huddl_grid
             huddlz={@streams.huddlz}
@@ -375,7 +386,8 @@ defmodule HuddlzWeb.GroupLive.Show do
             :if={@active_tab == "past" && @past_total_pages > 1}
             current_page={@past_page}
             total_pages={@past_total_pages}
-            event_name="change_past_page"
+            id="group-archive-pagination"
+            page_path={&group_page_path(@group, "past", &1)}
           />
         </div>
       </div>
@@ -496,13 +508,12 @@ defmodule HuddlzWeb.GroupLive.Show do
   defp refresh_huddlz(%{assigns: %{active_tab: "past"}} = socket) do
     {huddlz, total_pages} =
       get_past_group_huddlz_paginated(socket.assigns.group, socket.assigns.current_user,
-        page: 1,
+        page: socket.assigns.past_page,
         per_page: 10
       )
 
     socket
     |> stream_huddlz(huddlz)
-    |> assign(:past_page, 1)
     |> assign(:past_total_pages, total_pages)
   end
 
@@ -513,36 +524,22 @@ defmodule HuddlzWeb.GroupLive.Show do
     )
   end
 
+  defp group_page_path(group, "past", page) when page > 1,
+    do: ~p"/groups/#{group.slug}?#{[tab: "past", page: page]}"
+
+  defp group_page_path(group, "past", _page), do: ~p"/groups/#{group.slug}?#{[tab: "past"]}"
+  defp group_page_path(group, _tab, _page), do: ~p"/groups/#{group.slug}"
+
   @impl true
   def handle_event("switch_tab", %{"tab" => tab}, socket) do
-    socket =
-      if tab in ["upcoming", "past"] do
-        socket |> assign(:active_tab, tab) |> refresh_huddlz()
-      else
-        socket
-      end
-
-    {:noreply, socket}
+    {:noreply, push_patch(socket, to: group_page_path(socket.assigns.group, tab, 1))}
   end
 
   def handle_event("change_past_page", %{"page" => page_str}, socket) do
-    page = parse_page(page_str)
-
-    {past_huddlz, total_pages} =
-      get_past_group_huddlz_paginated(
-        socket.assigns.group,
-        socket.assigns.current_user,
-        page: page,
-        per_page: 10
-      )
-
-    socket =
-      socket
-      |> stream_huddlz(past_huddlz)
-      |> assign(:past_page, page)
-      |> assign(:past_total_pages, total_pages)
-
-    {:noreply, socket}
+    {:noreply,
+     push_patch(socket,
+       to: group_page_path(socket.assigns.group, "past", parse_page(page_str))
+     )}
   end
 
   def handle_event("join_group", _, socket) do
@@ -668,6 +665,7 @@ defmodule HuddlzWeb.GroupLive.Show do
     page_result =
       Communities.get_past_group_huddlz!(group.id,
         actor: user,
+        query: [sort: [starts_at: :desc, id: :desc]],
         page: [limit: per_page, offset: offset, count: true],
         load: [:status, :rsvp_count, :visible_virtual_link, :display_image_url, :group]
       )

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -211,19 +211,6 @@ defmodule HuddlzWeb.HuddlLive do
      )}
   end
 
-  def handle_event("change_page", %{"page" => page_str}, socket) do
-    page = parse_page(page_str)
-    cleared? = location_explicitly_cleared?(socket.assigns)
-
-    path =
-      scoped_path(socket.assigns.scope, socket.assigns.yours, form_params_from_assigns(socket),
-        override_location_with_cleared: cleared?,
-        page: page
-      )
-
-    {:noreply, push_patch(socket, to: path)}
-  end
-
   def handle_event("distance_change", %{"distance_miles" => raw}, socket) do
     new_distance = parse_distance(raw)
 
@@ -520,6 +507,13 @@ defmodule HuddlzWeb.HuddlLive do
     }
   end
 
+  defp pagination_path(page, assigns) do
+    scoped_path(assigns.scope, assigns.yours, form_params_from_assigns(assigns),
+      override_location_with_cleared: location_explicitly_cleared?(assigns),
+      page: page
+    )
+  end
+
   defp filter_url(overrides, assigns) do
     params = Map.merge(form_params_from_assigns(assigns), overrides)
     scoped_path(assigns.scope, assigns.yours, params)
@@ -701,9 +695,10 @@ defmodule HuddlzWeb.HuddlLive do
           </div>
           <.pagination
             :if={@page_info.total_pages > 1}
+            id="discovery-pagination"
             current_page={@page_info.current_page}
             total_pages={@page_info.total_pages}
-            event_name="change_page"
+            page_path={&pagination_path(&1, assigns)}
           />
         <% end %>
       <% else %>
@@ -717,9 +712,10 @@ defmodule HuddlzWeb.HuddlLive do
           </div>
           <.pagination
             :if={@page_info.total_pages > 1}
+            id="discovery-pagination"
             current_page={@page_info.current_page}
             total_pages={@page_info.total_pages}
-            event_name="change_page"
+            page_path={&pagination_path(&1, assigns)}
           />
         <% end %>
       <% end %>

--- a/test/features/crawlable_links.feature
+++ b/test/features/crawlable_links.feature
@@ -4,3 +4,8 @@ Feature: Discover public huddlz through ordinary links
     Given more than one page of public huddlz for crawling
     When a crawler follows Browse huddlz from the home page
     Then the crawler can follow discovery pages to every public huddl
+
+  Scenario: An anonymous visitor discovers a group's public archive without JavaScript
+    Given a public group with more than one page of past huddlz
+    When a crawler follows group discovery to the group's Past link
+    Then the crawler can follow archive pages to every past public huddl

--- a/test/features/crawlable_links.feature
+++ b/test/features/crawlable_links.feature
@@ -1,0 +1,6 @@
+@database @conn @crawlable_links
+Feature: Discover public huddlz through ordinary links
+  Scenario: An anonymous visitor follows discovery pagination without JavaScript
+    Given more than one page of public huddlz for crawling
+    When a crawler follows Browse huddlz from the home page
+    Then the crawler can follow discovery pages to every public huddl

--- a/test/features/group_membership_visibility.feature
+++ b/test/features/group_membership_visibility.feature
@@ -45,7 +45,7 @@ Feature: Group membership visibility
     And a past members-only huddl "Private retrospective" exists in "Membership Visibility"
     And I am signed in as "member311@example.com"
     When I visit the group page for "Membership Visibility"
-    And I click the "Past" button
+    And I click link "Past"
     Then I should see the huddl card "Private retrospective"
     When I click the "Leave Group" button
     And the owner removes me from "Membership Visibility" in another session

--- a/test/features/step_definitions/crawlable_links_steps.exs
+++ b/test/features/step_definitions/crawlable_links_steps.exs
@@ -1,0 +1,57 @@
+defmodule CrawlableLinksSteps do
+  use Cucumber.StepDefinition
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Phoenix.ConnTest
+  @endpoint HuddlzWeb.Endpoint
+
+  step "more than one page of public huddlz for crawling", context do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+
+    huddlz =
+      for day <- 1..21 do
+        generate(
+          huddl(
+            group_id: group.id,
+            actor: owner,
+            title: "Crawl huddl #{day}",
+            date: Date.add(Date.utc_today(), day),
+            event_type: :virtual,
+            virtual_link: "https://example.test/join"
+          )
+        )
+      end
+
+    {:ok, Map.merge(context, %{crawl_group: group, crawl_huddlz: huddlz})}
+  end
+
+  step "a crawler follows Browse huddlz from the home page", context do
+    home = document("/")
+    [href] = Floki.attribute(home, "a[href='/discover']", "href")
+    {:ok, Map.put(context, :crawl_document, document(href))}
+  end
+
+  step "the crawler can follow discovery pages to every public huddl", context do
+    first = context.crawl_document
+    [next] = Floki.attribute(first, "a[aria-label='Next page']", "href")
+    second = document(next)
+    [previous] = Floki.attribute(second, "a[aria-label='Previous page']", "href")
+    assert previous == "/discover"
+    assert huddl_links(document(previous)) == huddl_links(first)
+    links = huddl_links(first) ++ huddl_links(second)
+
+    for huddl <- context.crawl_huddlz do
+      path = "/groups/#{context.crawl_group.slug}/huddlz/#{huddl.id}"
+      assert path in links
+      assert Floki.text(document(path)) =~ huddl.title
+    end
+
+    :ok
+  end
+
+  defp document(path),
+    do: build_conn() |> get(path) |> html_response(200) |> Floki.parse_document!()
+
+  defp huddl_links(doc), do: Floki.attribute(doc, "a[href*='/huddlz/']", "href")
+end

--- a/test/features/step_definitions/crawlable_links_steps.exs
+++ b/test/features/step_definitions/crawlable_links_steps.exs
@@ -50,6 +50,68 @@ defmodule CrawlableLinksSteps do
     :ok
   end
 
+  step "a public group with more than one page of past huddlz", context do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+
+    huddlz =
+      for day <- 1..12 do
+        generate(
+          past_huddl(
+            group_id: group.id,
+            creator_id: owner.id,
+            title: "Public archive huddl #{day}",
+            lifecycle_state: if(day == 12, do: :completed, else: :published),
+            starts_at: DateTime.add(DateTime.utc_now(), -day, :day),
+            ends_at: DateTime.add(DateTime.utc_now(), -day, :day) |> DateTime.add(3600)
+          )
+        )
+      end
+
+    {:ok, Map.merge(context, %{crawl_group: group, crawl_huddlz: huddlz})}
+  end
+
+  step "a crawler follows group discovery to the group's Past link", context do
+    [discover] = Floki.attribute(document("/"), "a[href='/discover']", "href")
+    [groups] = Floki.attribute(document(discover), "a[href='/discover?scope=groups']", "href")
+    [group] = Floki.attribute(document(groups), "a.card", "href")
+    [past] = Floki.attribute(document(group), "a#group-huddlz-past", "href")
+    assert past == group <> "?tab=past"
+    {:ok, Map.put(context, :crawl_document, document(past))}
+  end
+
+  step "the crawler can follow archive pages to every past public huddl", context do
+    first = context.crawl_document
+    [next] = Floki.attribute(first, "a[aria-label='Next page']", "href")
+    assert URI.decode_query(URI.parse(next).query) == %{"tab" => "past", "page" => "2"}
+    second = document(next)
+    [previous] = Floki.attribute(second, "a[aria-label='Previous page']", "href")
+    assert huddl_links(document(previous)) == huddl_links(first)
+    assert length(huddl_links(first)) == 10
+    assert length(huddl_links(second)) == 2
+    assert Floki.attribute(second, "a[aria-label='Next page']", "href") == []
+
+    for doc <- [first, second] do
+      [canonical] = Floki.attribute(doc, "head link[rel=canonical]", "href")
+      assert Floki.attribute(doc, "head meta[property='og:url']", "content") == [canonical]
+    end
+
+    assert Floki.attribute(second, "head link[rel=canonical]", "href") == [
+             HuddlzWeb.Endpoint.url() <> next
+           ]
+
+    for huddl <- context.crawl_huddlz do
+      path = "/groups/#{context.crawl_group.slug}/huddlz/#{huddl.id}"
+      assert path in (huddl_links(first) ++ huddl_links(second))
+      assert Floki.text(document(path)) =~ huddl.title
+    end
+
+    [upcoming] = Floki.attribute(second, "a#group-huddlz-upcoming", "href")
+    assert upcoming == "/groups/#{context.crawl_group.slug}"
+    assert Floki.text(document(upcoming)) =~ "No upcoming huddlz scheduled."
+    :ok
+  end
+
   defp document(path),
     do: build_conn() |> get(path) |> html_response(200) |> Floki.parse_document!()
 

--- a/test/features/step_definitions/view_past_huddlz_steps.exs
+++ b/test/features/step_definitions/view_past_huddlz_steps.exs
@@ -190,8 +190,8 @@ defmodule ViewPastHuddlzSteps do
 
   # Click on the Past Events tab
   step "I click on the {string} tab", %{args: [tab_name], conn: conn} do
-    # Click the tab button
-    conn = conn |> click_button(tab_name)
+    # Follow the timeframe link
+    conn = conn |> click_link(tab_name)
     {:ok, %{conn: conn}}
   end
 
@@ -286,7 +286,7 @@ defmodule ViewPastHuddlzSteps do
 
   step "I should see pagination controls", %{conn: conn} do
     # Check for pagination controls
-    assert_has(conn, "button[phx-click=change_past_page]")
+    assert_has(conn, "#group-archive-pagination a.page-num")
     :ok
   end
 

--- a/test/huddlz_web/crawlable_links_test.exs
+++ b/test/huddlz_web/crawlable_links_test.exs
@@ -109,6 +109,48 @@ defmodule HuddlzWeb.CrawlableLinksTest do
            )
   end
 
+  test "the public group archive excludes restricted past huddlz", %{conn: conn} do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+    public = generate(past_huddl(group_id: group.id, creator_id: owner.id))
+
+    hidden =
+      for attrs <- [[is_private: true], [lifecycle_state: :draft], [lifecycle_state: :cancelled]] do
+        generate(past_huddl([group_id: group.id, creator_id: owner.id] ++ attrs))
+      end
+
+    archive = document(conn, "/groups/#{group.slug}?tab=past")
+    links = Floki.attribute(archive, "a[href*='/huddlz/']", "href")
+    assert links == ["/groups/#{group.slug}/huddlz/#{public.id}"]
+
+    for huddl <- hidden do
+      refute Floki.text(archive) =~ huddl.title
+    end
+  end
+
+  test "archive page parameters normalize safely and cannot create endless pagination", %{
+    conn: conn
+  } do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+    generate(past_huddl(group_id: group.id, creator_id: owner.id, title: "Archived huddl"))
+    path = "/groups/#{group.slug}?tab=past"
+
+    for page <- ["0", "-1", "abc", "1"] do
+      doc = document(conn, path <> "&page=" <> page)
+      assert Floki.text(doc) =~ "Archived huddl"
+
+      assert Floki.attribute(doc, "head link[rel=canonical]", "href") == [
+               HuddlzWeb.Endpoint.url() <> path
+             ]
+    end
+
+    response = get(conn, path <> "&page=999")
+    assert redirected_to(response) == path
+    assert Floki.text(document(conn, redirected_to(response))) =~ "Archived huddl"
+    assert Floki.attribute(document(conn, path), "a[aria-label='Next page']", "href") == []
+  end
+
   defp document(conn, path),
     do: conn |> get(path) |> html_response(200) |> Floki.parse_document!()
 end

--- a/test/huddlz_web/crawlable_links_test.exs
+++ b/test/huddlz_web/crawlable_links_test.exs
@@ -1,0 +1,114 @@
+defmodule HuddlzWeb.CrawlableLinksTest do
+  use HuddlzWeb.ConnCase, async: true
+  @moduletag :crawlable_links
+
+  test "anonymous discovery pagination preserves search, date, format and sort", %{conn: conn} do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+
+    for n <- 1..21 do
+      generate(
+        past_huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          title: "Archive crawl #{n}",
+          event_type: :virtual,
+          latitude: 40.0,
+          longitude: -74.0
+        )
+      )
+    end
+
+    params = %{
+      "q" => "Archive crawl",
+      "date_filter" => "past",
+      "event_type" => "virtual",
+      "sort" => "newest",
+      "lat" => "40.0",
+      "lng" => "-74.0",
+      "location" => "Test location",
+      "time_zone" => "America/New_York",
+      "distance" => "25"
+    }
+
+    first = document(conn, "/discover?" <> URI.encode_query(params))
+    [next] = Floki.attribute(first, "a[aria-label='Next page']", "href")
+    assert URI.decode_query(URI.parse(next).query) == Map.put(params, "page", "2")
+    second = document(conn, next)
+    assert length(Floki.find(first, ".card-title")) == 20
+    assert length(Floki.find(second, ".card-title")) == 1
+    [previous] = Floki.attribute(second, "a[aria-label='Previous page']", "href")
+    assert URI.decode_query(URI.parse(previous).query) == params
+    assert Floki.text(document(conn, previous)) =~ "Archive crawl"
+    assert Floki.attribute(second, "a[aria-label='Next page']", "href") == []
+  end
+
+  test "group discovery links and pagination work without a socket", %{conn: conn} do
+    owner = generate(user())
+    groups = for n <- 1..21, do: generate(group(actor: owner, name: "Crawl community #{n}"))
+    first = document(conn, "/discover?scope=groups&q=Crawl")
+    [next] = Floki.attribute(first, "a[aria-label='Next page']", "href")
+
+    assert URI.decode_query(URI.parse(next).query) == %{
+             "scope" => "groups",
+             "q" => "Crawl",
+             "page" => "2"
+           }
+
+    second = document(conn, next)
+    paths = Floki.attribute(first, "a.card", "href") ++ Floki.attribute(second, "a.card", "href")
+
+    for group <- groups do
+      path = "/groups/#{group.slug}"
+      assert path in paths
+      assert Floki.text(document(conn, path)) =~ to_string(group.name)
+    end
+  end
+
+  test "public listings exclude private, draft, cancelled and deleted huddlz", %{conn: conn} do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+    private_group = generate(group(actor: owner, is_public: false))
+    visible = generate(huddl(group_id: group.id, actor: owner))
+
+    hidden =
+      for {target, attrs} <- [
+            {group, [is_private: true]},
+            {private_group, []},
+            {group, [lifecycle_state: :draft]}
+          ] do
+        generate(huddl([group_id: target.id, actor: owner] ++ attrs))
+      end
+
+    cancelled = generate(huddl(group_id: group.id, actor: owner))
+    cancelled = cancelled |> Ash.Changeset.for_update(:cancel, %{}, actor: owner) |> Ash.update!()
+    deleted = generate(huddl(group_id: group.id, actor: owner))
+    deleted = deleted |> Ash.Changeset.for_update(:cancel, %{}, actor: owner) |> Ash.update!()
+    Ash.destroy!(deleted, actor: generate(user(role: :admin)))
+
+    for path <- ["/discover", "/discover?date_filter=all", "/groups/#{group.slug}"] do
+      links = Floki.attribute(document(conn, path), "a", "href")
+      assert "/groups/#{group.slug}/huddlz/#{visible.id}" in links
+
+      for huddl <- [cancelled, deleted | hidden] do
+        refute Enum.any?(links, &String.ends_with?(&1, "/huddlz/#{huddl.id}"))
+      end
+    end
+
+    for huddl <- [cancelled, deleted | hidden] do
+      slug = if huddl.group_id == group.id, do: group.slug, else: private_group.slug
+
+      assert {404, _, _} =
+               assert_error_sent(404, fn -> get(conn, "/groups/#{slug}/huddlz/#{huddl.id}") end)
+    end
+
+    refute "/groups/#{private_group.slug}" in Floki.attribute(
+             document(conn, "/discover?scope=groups"),
+             "a",
+             "href"
+           )
+  end
+
+  defp document(conn, path),
+    do: conn |> get(path) |> html_response(200) |> Floki.parse_document!()
+end

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -74,7 +74,7 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Check that upcoming tab is active by default
-      assert has_element?(view, "button.chip.is-active", "Upcoming")
+      assert has_element?(view, "a.chip.is-active", "Upcoming")
 
       # Check that upcoming events are displayed (limited to 10)
       upcoming_titles = upcoming_huddls |> Enum.take(10) |> Enum.map(& &1.title)
@@ -148,10 +148,10 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Click on the Past tab
-      view |> element("button", "Past") |> render_click()
+      view |> element("#group-huddlz-past") |> render_click()
 
       # Check that past tab is now active
-      assert has_element?(view, "button.chip.is-active", "Past")
+      assert has_element?(view, "a.chip.is-active", "Past")
 
       # Check that past events are displayed
       assert has_element?(view, "h3", "Past Event 1")
@@ -162,10 +162,10 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Switch to past events tab
-      view |> element("button", "Past") |> render_click()
+      view |> element("#group-huddlz-past") |> render_click()
 
       # Check that pagination controls are present
-      assert has_element?(view, "button[phx-click=change_past_page]")
+      assert has_element?(view, "#group-archive-pagination a.page-num")
 
       # Check that only 10 events are displayed on first page
       assert has_element?(view, "h3", "Past Event 1")
@@ -177,13 +177,13 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Switch to past events tab
-      view |> element("button", "Past") |> render_click()
+      view |> element("#group-huddlz-past") |> render_click()
 
       # Click next page (page 2 button)
-      view |> element("button", "2") |> render_click()
+      view |> element("#group-archive-pagination-page-2") |> render_click()
 
       # Check that we're on page 2
-      assert has_element?(view, "button.page-num.is-active", "2")
+      assert has_element?(view, "a.page-num.is-active", "2")
 
       # Check that events 11-20 are displayed
       assert has_element?(view, "h3", "Past Event 11")
@@ -196,13 +196,13 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Switch to past events tab
-      view |> element("button", "Past") |> render_click()
+      view |> element("#group-huddlz-past") |> render_click()
 
       # Click on page 3
-      view |> element("button", "3") |> render_click()
+      view |> element("#group-archive-pagination-page-3") |> render_click()
 
       # Check that we're on page 3
-      assert has_element?(view, "button.page-num.is-active", "3")
+      assert has_element?(view, "a.page-num.is-active", "3")
 
       # Check that events 21-25 are displayed (last page)
       assert has_element?(view, "h3", "Past Event 21")
@@ -214,9 +214,9 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Switch to past events tab and move off page 1 so the fallback is observable.
-      view |> element("button", "Past") |> render_click()
-      view |> element("button", "2") |> render_click()
-      assert has_element?(view, "button.page-num.is-active", "2")
+      view |> element("#group-huddlz-past") |> render_click()
+      view |> element("#group-archive-pagination-page-2") |> render_click()
+      assert has_element?(view, "a.page-num.is-active", "2")
 
       # A crafted socket event with a non-numeric page must not crash the
       # LiveView; it falls back to page 1. String.to_integer/1 would have
@@ -224,7 +224,7 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       html = render_hook(view, "change_past_page", %{"page" => "not-a-number"})
 
       assert html =~ "Past Event 1"
-      assert has_element?(view, "button.page-num.is-active", "1")
+      assert has_element?(view, "a.page-num.is-active", "1")
     end
 
     test "shows no past events message when group has no past events", %{conn: conn, user: user} do
@@ -234,7 +234,7 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{new_group.slug}")
 
       # Switch to past events tab
-      view |> element("button", "Past") |> render_click()
+      view |> element("#group-huddlz-past") |> render_click()
 
       # Check that no past events message is displayed
       assert has_element?(view, "p", "No past huddlz found.")
@@ -257,15 +257,15 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{group.slug}")
 
       # Start on upcoming tab
-      assert has_element?(view, "button.chip.is-active", "Upcoming")
+      assert has_element?(view, "a.chip.is-active", "Upcoming")
 
       # Switch to past events tab
-      view |> element("button", "Past") |> render_click()
-      assert has_element?(view, "button.chip.is-active", "Past")
+      view |> element("#group-huddlz-past") |> render_click()
+      assert has_element?(view, "a.chip.is-active", "Past")
 
       # Switch back to upcoming events tab
-      view |> element("button", "Upcoming") |> render_click()
-      assert has_element?(view, "button.chip.is-active", "Upcoming")
+      view |> element("#group-huddlz-upcoming") |> render_click()
+      assert has_element?(view, "a.chip.is-active", "Upcoming")
     end
   end
 
@@ -310,8 +310,8 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       {:ok, view, _html} = live(conn, ~p"/groups/#{private_group.slug}")
 
       # Check that tabs are present
-      assert has_element?(view, "button", "Upcoming")
-      assert has_element?(view, "button", "Past")
+      assert has_element?(view, "#group-huddlz-upcoming")
+      assert has_element?(view, "#group-huddlz-past")
     end
   end
 end

--- a/test/huddlz_web/live/huddl_search_pagination_test.exs
+++ b/test/huddlz_web/live/huddl_search_pagination_test.exs
@@ -85,7 +85,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> visit("/discover")
       |> assert_has(".page-num", text: "1")
       |> assert_has(".page-num", text: "2")
-      |> assert_has("button[phx-click=change_page]")
+      |> assert_has("a.page-num")
     end
 
     test "shows 20 results on first page", %{conn: conn} do
@@ -103,7 +103,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "navigates to page 2", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_button(".page-num", "2")
+      |> click_link(".page-num", "2")
       |> assert_has(".discover-meta", text: "22 huddlz")
       # Should see huddl 21-22
       |> assert_has("h3", text: "Test Huddl 21")
@@ -116,15 +116,15 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
     test "shows previous button on page 2", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_button(".page-num", "2")
-      |> assert_has("button[phx-click=change_page][phx-value-page='1']")
+      |> click_link(".page-num", "2")
+      |> assert_has("a[aria-label='Previous page']")
     end
 
     test "navigates back to page 1", %{conn: conn} do
       conn
       |> visit("/discover")
-      |> click_button(".page-num", "2")
-      |> click_button(".page-num", "1")
+      |> click_link(".page-num", "2")
+      |> click_link(".page-num", "1")
       |> assert_has(".discover-meta", text: "22 huddlz")
       |> assert_has("h3", text: "Test Huddl 1")
     end
@@ -135,7 +135,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       # Filter to reduce results
       |> click_link(".chip-group a.chip", "Virtual")
       # Should have fewer than 20 results
-      |> refute_has("button[phx-click=change_page]")
+      |> refute_has("a.page-num")
     end
 
     test "pagination persists with filters", %{conn: conn} do
@@ -165,7 +165,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> click_link(".chip-group a.chip", "Virtual")
       # Should still have pagination
       |> assert_has(".page-num", text: "2")
-      |> click_button(".page-num", "2")
+      |> click_link(".page-num", "2")
       # Filter chip should persist as active on page 2
       |> assert_has(".chip-group a.chip.is-active", text: "Virtual")
     end
@@ -183,7 +183,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       conn
       |> visit("/discover")
       |> assert_has(".discover-meta", text: "22 huddlz")
-      |> click_button(".page-num", "2")
+      |> click_link(".page-num", "2")
       |> assert_has(".discover-meta", text: "22 huddlz")
     end
   end
@@ -195,7 +195,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> assert_has("p", text: "No huddlz match this search")
       # No pagination should be shown
       |> refute_has(".page-num")
-      |> refute_has("button[phx-click=change_page]")
+      |> refute_has("a.page-num")
     end
 
     test "handles exactly 20 results", %{conn: conn} do
@@ -226,7 +226,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> assert_has(".discover-meta", text: "20 huddlz")
       # No pagination should be shown for exactly 20 results
       |> refute_has(".page-num", text: "2")
-      |> refute_has("button[phx-click=change_page]")
+      |> refute_has("a.page-num")
     end
   end
 
@@ -240,11 +240,11 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       |> refute_has("h3", text: "Test Huddl 20")
     end
 
-    test "clicking a page button updates the URL via push_patch", %{conn: conn} do
+    test "clicking a page link updates the URL via push_patch", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/discover")
 
       view
-      |> element("button.page-num[phx-value-page='2']")
+      |> element("#discovery-pagination-page-2")
       |> render_click()
 
       assert_patch(view, "/discover?page=2")
@@ -254,7 +254,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       {:ok, view, _html} = live(conn, "/discover?page=2")
 
       view
-      |> element("button.page-num[phx-value-page='1']")
+      |> element("#discovery-pagination-page-1")
       |> render_click()
 
       assert_patch(view, "/discover")
@@ -296,7 +296,7 @@ defmodule HuddlzWeb.HuddlSearchPaginationTest do
       {:ok, view, _html} = live(conn, "/discover?q=Test")
 
       view
-      |> element("button.page-num[phx-value-page='2']")
+      |> element("#discovery-pagination-page-2")
       |> render_click()
 
       assert_patch(view, "/discover?q=Test&page=2")


### PR DESCRIPTION
Public huddlz are now reachable through ordinary links in anonymous server HTML. Discovery exposes pagination links that preserve filters and group scope. Group Past navigation opens a paginated public archive, with upcoming huddlz remaining the default and each archive page using its own canonical URL.

Private, draft, cancelled and deleted content remain excluded. The audit in `docs/crawlable-links.md` records the on-site paths, intentional exclusions and alignment with existing canonical URLs and sitemaps. Structured data is separate.

To verify manually, use a catalog with more than 20 public huddlz or groups and a group with more than 10 past huddlz. Follow pagination and Past links, reload an archive page, and use Back. Initial HTML should expose the same hrefs without JavaScript. Local verification does not establish production search-engine indexing; no deployment is included.

Closes #260.
