### PR TITLE
feat(seo): add structured data to public detail pages

### DIFF
--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -1,0 +1,78 @@
+# Public structured data
+
+Issue: [#162](https://github.com/huddlz-hq/huddlz/issues/162). Audit date: 2026-09-07.
+
+## Verified gap
+
+Main at `a13ef31f` had no JSON-LD implementation. Anonymous production HTTP
+responses for [Jax.Ex](https://huddlz.com/groups/jax-ex) and its
+[public huddl](https://huddlz.com/groups/jax-ex/huddlz/1bff1410-6d4e-45f9-90fc-55b66063961e)
+contained visible titles, descriptions, canonical links and Open Graph metadata,
+but zero `application/ld+json` blocks. The canonical and sitemap work was already
+merged in #431 and #433. This change uses those existing detail-page URLs.
+
+## Mapping and privacy
+
+Public huddl detail pages emit one schema.org `Event` object. Dates use the
+huddl's time zone and the applicable UTC offset. Each generated recurring
+occurrence uses its own detail URL and dates. Images follow the same uploaded
+artwork and group fallback as the visible page; missing artwork is omitted.
+The organizing group supplies the organizer name and public URL.
+
+Physical locations use the publicly displayed address as `PostalAddress.name`,
+without guessing address components or publishing an address-book name that the
+page does not show. Virtual locations identify the visible online attendance
+option; they never contain the restricted join URL, including when the viewer
+is an organizer or attendee. Hybrid huddlz include both location types.
+[Google's address examples](https://developers.google.com/search/docs/appearance/structured-data/event#structured-data-type-definitions)
+and [schema.org VirtualLocation](https://schema.org/VirtualLocation) support these
+vocabularies; their presence alone does not establish rich-result eligibility.
+
+Public group pages emit `Organization` with the group's visible name,
+description, home location and available artwork. A home city is not asserted
+to be a headquarters or mailing address, and a cover image is not called a logo.
+Private membership details and owner contact information are excluded.
+[Google's Organization guidance](https://developers.google.com/search/docs/appearance/structured-data/organization)
+has no required properties and recommends supplying relevant, available facts.
+
+## Lifecycle limits
+
+The existing public canonical URL gate permits only published/completed public
+huddlz in public groups. Drafts, private pages and cancelled huddlz omit JSON-LD
+even for authorized viewers; anonymous requests remain 404. Publishing cancelled
+metadata would require a separate decision to change that visibility policy.
+
+Schedule edits replace the current dates. There is no persisted prior start date
+or public rescheduled state, so the markup does not invent `previousStartDate`
+or `EventRescheduled`. `EventScheduled` also covers a huddl that has already
+taken place as scheduled. See [schema.org's status definition](https://schema.org/EventScheduled).
+Consequently, #162's original cancellation/rescheduling acceptance wording is
+not fully implemented; these are deliberate limits of the current domain model.
+
+## Rendering and verification
+
+The shared component renders inert JSON-LD inside the LiveView body. It is in
+the initial response and is replaced with the view during navigation, without
+adding head synchronization code. JSON serialization escapes HTML delimiters
+before marking the encoded string safe. The [HTML standard](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element)
+distinguishes data blocks from executable JavaScript; the template contains no
+executable inline script. Google accepts JSON-LD in the
+[head or body](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data).
+
+HTTP acceptance scenarios and integration checks parse JSON and cover attendance
+modes, date offsets, recurrence identities, current schedule updates, artwork,
+host/query-independent URLs, hostile strings, and privacy exclusions. Connected
+LiveView checks cover updated dates and navigation. Synthetic fixtures on a
+dedicated local server were checked in a real browser, including group-to-huddl
+navigation and private-link absence. A separate HTTP fetch and JSON parser
+verified the initial hybrid HTML, independent of the browser DOM.
+
+## Rollout limitations
+
+Production Rich Results Test and Search Console checks were not performed.
+No private data was submitted to an external validator. After deployment, test
+representative public physical/hybrid URLs and verify artwork accessibility and
+quality. Purely virtual huddlz are outside Google's current specialized
+experience, and membership/invitation requirements can also make a gathering
+ineligible. Structured data cannot guarantee indexing or enhanced presentation.
+See [Google's eligibility guidance](https://developers.google.com/search/docs/appearance/structured-data/event#guidelines).

--- a/lib/huddlz_web/components/structured_data.ex
+++ b/lib/huddlz_web/components/structured_data.ex
@@ -1,0 +1,120 @@
+defmodule HuddlzWeb.StructuredData do
+  @moduledoc """
+  Public page JSON-LD, rendered inside the LiveView so navigation replaces it.
+  A public canonical URL gates output, including for authenticated viewers.
+  """
+  use HuddlzWeb, :html
+
+  alias Huddlz.Storage.{GroupImages, HuddlImages}
+  alias HuddlzWeb.MetaHelpers
+
+  attr :huddl, :any, required: true
+  attr :url, :string, required: true
+
+  def huddl(assigns) do
+    assigns = assign(assigns, :data, huddl_data(assigns.huddl, assigns.url))
+
+    ~H"""
+    <.json_ld data={@data} />
+    """
+  end
+
+  attr :group, :any, required: true
+  attr :url, :string, required: true
+
+  def group(assigns) do
+    assigns = assign(assigns, :data, group_data(assigns.group, assigns.url))
+
+    ~H"""
+    <.json_ld data={@data} />
+    """
+  end
+
+  defp group_data(_group, nil), do: nil
+
+  defp group_data(group, public_url) do
+    %{
+      "@context" => "https://schema.org",
+      "@type" => "Organization",
+      "@id" => public_url,
+      "url" => public_url,
+      "name" => group.name,
+      "description" => group.description,
+      "location" => if(group.location, do: %{"@type" => "Place", "name" => group.location}),
+      "image" => MetaHelpers.image_url(group.current_image_url, GroupImages)
+    }
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp huddl_data(_huddl, nil), do: nil
+
+  defp huddl_data(huddl, public_url) do
+    %{
+      "@context" => "https://schema.org",
+      "@type" => "Event",
+      "@id" => public_url,
+      "url" => public_url,
+      "name" => huddl.title,
+      "description" => huddl.description,
+      "startDate" => local_date(huddl.starts_at, huddl.time_zone),
+      "endDate" => local_date(huddl.ends_at, huddl.time_zone),
+      "eventStatus" => "https://schema.org/EventScheduled",
+      "eventAttendanceMode" => attendance_mode(huddl.event_type),
+      "location" => location(huddl),
+      "organizer" => %{
+        "@type" => "Organization",
+        "@id" => url(~p"/groups/#{huddl.group.slug}"),
+        "url" => url(~p"/groups/#{huddl.group.slug}"),
+        "name" => huddl.group.name
+      },
+      "image" => MetaHelpers.image_url(huddl.display_image_url, HuddlImages)
+    }
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp local_date(datetime, time_zone) do
+    datetime |> DateTime.shift_zone!(time_zone) |> DateTime.to_iso8601()
+  end
+
+  defp attendance_mode(:in_person), do: "https://schema.org/OfflineEventAttendanceMode"
+  defp attendance_mode(:virtual), do: "https://schema.org/OnlineEventAttendanceMode"
+  defp attendance_mode(:hybrid), do: "https://schema.org/MixedEventAttendanceMode"
+
+  defp location(%{event_type: :virtual}), do: virtual_location()
+  defp location(%{event_type: :in_person} = huddl), do: physical_location(huddl)
+
+  defp location(%{event_type: :hybrid} = huddl),
+    do: [physical_location(huddl), virtual_location()]
+
+  # Join links require an RSVP and must never enter public metadata, even when
+  # the current viewer can see them. The public page only identifies "Online".
+  defp virtual_location, do: %{"@type" => "VirtualLocation", "name" => "Online"}
+
+  defp physical_location(huddl) do
+    %{
+      "@type" => "Place",
+      "address" => %{"@type" => "PostalAddress", "name" => huddl.physical_location}
+    }
+  end
+
+  attr :data, :map, default: nil
+
+  defp json_ld(assigns) do
+    ~H"""
+    <%!-- Inert JSON-LD data, not executable inline JavaScript. --%>
+    <script :if={@data} id="public-structured-data" type="application/ld+json">
+      <%= raw(encode(@data)) %>
+    </script>
+    """
+  end
+
+  # Escape HTML delimiters as well as JSON strings: even <!-- and <script>
+  # inside a description must not change the HTML parser's script-data state.
+  defp encode(data) do
+    data
+    |> Jason.encode!(escape: :html_safe)
+    |> String.replace("<", "\\u003C")
+    |> String.replace(">", "\\u003E")
+    |> String.replace("&", "\\u0026")
+  end
+end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -138,6 +138,7 @@ defmodule HuddlzWeb.GroupLive.Show do
       sidebar_owned_groups={@sidebar_owned_groups}
       active="discover"
     >
+      <HuddlzWeb.StructuredData.group group={@group} url={@canonical_url} />
       <div id="group-detail-hero" class="hero group-hero">
         <.group_cover
           id={"group-detail-cover-#{@group.id}"}

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -59,6 +59,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
       sidebar_owned_groups={@sidebar_owned_groups}
       active="discover"
     >
+      <HuddlzWeb.StructuredData.huddl huddl={@huddl} url={@canonical_url} />
       <section
         :if={@huddl.status == :cancelled && @huddl.cancellation_reason}
         id="cancellation-reason"

--- a/test/features/step_definitions/structured_data_steps.exs
+++ b/test/features/step_definitions/structured_data_steps.exs
@@ -1,0 +1,77 @@
+defmodule StructuredDataSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Phoenix.ConnTest
+
+  @endpoint HuddlzWeb.Endpoint
+
+  step "a public in-person huddl with a known schedule and address", context do
+    owner = generate(user())
+
+    group =
+      generate(
+        group(
+          actor: owner,
+          name: "Structured data community",
+          description: "A community for sharing lunch."
+        )
+      )
+
+    huddl =
+      generate(
+        huddl(
+          actor: owner,
+          group_id: group.id,
+          title: "Community lunch",
+          description: "Bring your lunch and meet the community.",
+          date: ~D[2030-07-20],
+          start_time: ~T[12:00:00],
+          duration_minutes: 60
+        )
+      )
+
+    {:ok, Map.merge(context, %{structured_group: group, structured_huddl: huddl})}
+  end
+
+  step "a crawler requests the huddl page without signing in", context do
+    path = "/groups/#{context.structured_group.slug}/huddlz/#{context.structured_huddl.id}"
+    html = build_conn() |> get(path) |> html_response(200)
+    {:ok, Map.put(context, :structured_html, html)}
+  end
+
+  step "the initial HTML describes that huddl once as structured data", context do
+    document = Floki.parse_document!(context.structured_html)
+    assert [block] = Floki.find(document, "script[type='application/ld+json']")
+    data = block |> Floki.text(js: true) |> Jason.decode!()
+    assert data["@type"] == "Event"
+    assert data["name"] == "Community lunch"
+    assert data["description"] == "Bring your lunch and meet the community."
+    assert data["startDate"] == "2030-07-20T12:00:00-04:00"
+    assert data["endDate"] == "2030-07-20T13:00:00-04:00"
+    assert data["eventAttendanceMode"] == "https://schema.org/OfflineEventAttendanceMode"
+    assert data["location"]["address"]["name"] == "123 Main St, Anytown, USA"
+    assert data["organizer"]["name"] == "Structured data community"
+    assert [data["url"]] == Floki.attribute(document, "link[rel=canonical]", "href")
+    :ok
+  end
+
+  step "a crawler requests the group page without signing in", context do
+    html = build_conn() |> get("/groups/#{context.structured_group.slug}") |> html_response(200)
+    {:ok, Map.put(context, :structured_html, html)}
+  end
+
+  step "the initial HTML describes the public group once as an organization", context do
+    document = Floki.parse_document!(context.structured_html)
+    assert [block] = Floki.find(document, "script[type='application/ld+json']")
+    data = block |> Floki.text(js: true) |> Jason.decode!()
+    assert data["@type"] == "Organization"
+    assert data["name"] == "Structured data community"
+    assert data["description"] == "A community for sharing lunch."
+    assert data["location"] == %{"@type" => "Place", "name" => "Test Location"}
+    assert [data["url"]] == Floki.attribute(document, "link[rel=canonical]", "href")
+    refute Map.has_key?(data, "member")
+    :ok
+  end
+end

--- a/test/features/structured_data.feature
+++ b/test/features/structured_data.feature
@@ -1,0 +1,11 @@
+@database @conn @structured_data
+Feature: Public structured data
+  Scenario: An anonymous crawler reads a public huddl's schedule and organizer
+    Given a public in-person huddl with a known schedule and address
+    When a crawler requests the huddl page without signing in
+    Then the initial HTML describes that huddl once as structured data
+
+  Scenario: An anonymous crawler identifies a public group
+    Given a public in-person huddl with a known schedule and address
+    When a crawler requests the group page without signing in
+    Then the initial HTML describes the public group once as an organization

--- a/test/huddlz_web/structured_data_test.exs
+++ b/test/huddlz_web/structured_data_test.exs
@@ -1,0 +1,332 @@
+defmodule HuddlzWeb.StructuredDataTest do
+  use HuddlzWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest, only: [live: 2]
+
+  alias Huddlz.Communities.Workers.RegenerateRecurringSeries
+
+  @moduletag :structured_data
+
+  setup do
+    owner = generate(user())
+    group = generate(group(actor: owner))
+    %{owner: owner, group: group}
+  end
+
+  test "attendance modes describe public locations without disclosing join links",
+       %{conn: conn, owner: owner, group: group} do
+    for {mode, attendance, locations} <- [
+          {:in_person, "OfflineEventAttendanceMode", ["Place"]},
+          {:virtual, "OnlineEventAttendanceMode", ["VirtualLocation"]},
+          {:hybrid, "MixedEventAttendanceMode", ["Place", "VirtualLocation"]}
+        ] do
+      huddl =
+        generate(
+          huddl(
+            actor: owner,
+            group_id: group.id,
+            event_type: mode,
+            virtual_link: "https://example.test/private-join-secret",
+            date: ~D[2030-01-20],
+            start_time: ~T[12:00:00],
+            duration_minutes: 90,
+            thumbnail_url: "https://example.test/public-cover.jpg"
+          )
+        )
+
+      path = ~p"/groups/#{group.slug}/huddlz/#{huddl.id}"
+
+      for viewer <- [conn, login(conn, owner)] do
+        document =
+          %{viewer | host: "untrusted.example"}
+          |> get(path <> "?utm_source=share")
+          |> html_response(200)
+          |> Floki.parse_document!()
+
+        data = structured_data(document)
+        assert data["@context"] == "https://schema.org"
+        assert data["@type"] == "Event"
+        assert data["eventAttendanceMode"] == "https://schema.org/#{attendance}"
+        assert data["eventStatus"] == "https://schema.org/EventScheduled"
+        assert data["startDate"] == "2030-01-20T12:00:00-05:00"
+        assert data["endDate"] == "2030-01-20T13:30:00-05:00"
+        assert Enum.map(List.wrap(data["location"]), & &1["@type"]) == locations
+        assert data["url"] == HuddlzWeb.Endpoint.url() <> path
+        assert data["@id"] == data["url"]
+        assert [data["url"]] == Floki.attribute(document, "link[rel=canonical]", "href")
+        assert [data["url"]] == Floki.attribute(document, "meta[property='og:url']", "content")
+        assert data["organizer"]["url"] == url(~p"/groups/#{group.slug}")
+        refute Map.has_key?(data, "image")
+        refute Jason.encode!(data) =~ "private-join-secret"
+
+        for location <- List.wrap(data["location"]) do
+          case location["@type"] do
+            "Place" ->
+              assert location["address"] == %{
+                       "@type" => "PostalAddress",
+                       "name" => "123 Main St, Anytown, USA"
+                     }
+
+            "VirtualLocation" ->
+              assert location == %{"@type" => "VirtualLocation", "name" => "Online"}
+          end
+        end
+      end
+    end
+  end
+
+  test "JSON strings round-trip without introducing HTML or executable script",
+       %{conn: conn, owner: owner, group: group} do
+    unsafe = "Quotes \" & café 雪 </script><script>alert(1)</script><!--<script>\u2028\u2029 end"
+
+    huddl =
+      generate(huddl(actor: owner, group_id: group.id, title: unsafe, description: unsafe))
+
+    document =
+      conn
+      |> get(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> html_response(200)
+      |> Floki.parse_document!()
+
+    data = structured_data(document)
+    assert data["name"] == unsafe
+    assert data["description"] == unsafe
+    assert Floki.find(document, "h1") |> Floki.text() == unsafe
+    assert Floki.find(document, "script:not([type='application/ld+json']):not([src])") == []
+    assert Floki.find(document, "#huddl-cover-#{huddl.id}") == []
+
+    group =
+      group
+      |> Ash.Changeset.for_update(:update_details, %{description: unsafe}, actor: owner)
+      |> Ash.update!()
+
+    group_document =
+      conn |> get(~p"/groups/#{group.slug}") |> html_response(200) |> Floki.parse_document!()
+
+    assert structured_data(group_document)["description"] == unsafe
+  end
+
+  test "artwork follows visible group fallback and huddl artwork with absolute URLs",
+       %{conn: conn, owner: owner, group: group} do
+    huddl = generate(huddl(actor: owner, group_id: group.id))
+    group_path = "/uploads/group_images/#{group.id}/cover_thumb.jpg"
+    huddl_path = "/uploads/huddl_images/#{huddl.id}/cover_thumb.jpg"
+
+    Huddlz.Communities.GroupImage
+    |> Ash.Changeset.for_create(:create, %{
+      filename: "cover.jpg",
+      content_type: "image/jpeg",
+      size_bytes: 123,
+      storage_path: group_path,
+      thumbnail_path: group_path,
+      group_id: group.id
+    })
+    |> Ash.create!(authorize?: false)
+
+    for path <- [~p"/groups/#{group.slug}", ~p"/groups/#{group.slug}/huddlz/#{huddl.id}"] do
+      document = conn |> get(path) |> html_response(200) |> Floki.parse_document!()
+      assert structured_data(document)["image"] == HuddlzWeb.Endpoint.url() <> group_path
+
+      assert [structured_data(document)["image"]] ==
+               Floki.attribute(document, "meta[property='og:image']", "content")
+    end
+
+    Huddlz.Communities.HuddlImage
+    |> Ash.Changeset.for_create(:create, %{
+      filename: "cover.jpg",
+      content_type: "image/jpeg",
+      size_bytes: 123,
+      storage_path: huddl_path,
+      thumbnail_path: huddl_path,
+      huddl_id: huddl.id
+    })
+    |> Ash.create!(authorize?: false)
+
+    document =
+      conn
+      |> get(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> html_response(200)
+      |> Floki.parse_document!()
+
+    assert structured_data(document)["image"] == HuddlzWeb.Endpoint.url() <> huddl_path
+  end
+
+  test "restricted pages omit structured data even for organizers",
+       %{conn: conn, owner: owner, group: group} do
+    private_group = generate(group(actor: owner, is_public: false))
+    cancelled = generate(huddl(actor: owner, group_id: group.id))
+    Huddlz.Communities.cancel_huddl!(cancelled, "Private cancellation reason", actor: owner)
+
+    paths =
+      for {target_group, opts} <- [
+            {group, [is_private: true]},
+            {private_group, []},
+            {group, [lifecycle_state: :draft]}
+          ] do
+        huddl = generate(huddl([actor: owner, group_id: target_group.id] ++ opts))
+        ~p"/groups/#{target_group.slug}/huddlz/#{huddl.id}"
+      end
+
+    for path <- [
+          ~p"/groups/#{private_group.slug}",
+          ~p"/groups/#{group.slug}/huddlz/#{cancelled.id}" | paths
+        ] do
+      html = conn |> login(owner) |> get(path) |> html_response(200)
+      assert Floki.find(Floki.parse_document!(html), "script[type='application/ld+json']") == []
+      assert {404, _, body} = assert_error_sent(404, fn -> get(conn, path) end)
+      assert Floki.find(Floki.parse_document!(body), "script[type='application/ld+json']") == []
+      refute body =~ "Private cancellation reason"
+    end
+  end
+
+  test "schedule edits replace current dates in HTTP and connected metadata without inventing history",
+       %{conn: conn, owner: owner, group: group} do
+    huddl =
+      generate(
+        huddl(
+          actor: owner,
+          group_id: group.id,
+          date: ~D[2030-07-20],
+          start_time: ~T[12:00:00],
+          duration_minutes: 60
+        )
+      )
+
+    path = ~p"/groups/#{group.slug}/huddlz/#{huddl.id}"
+    {:ok, view, _html} = Phoenix.LiveViewTest.live(conn, path)
+
+    Huddlz.Communities.update_huddl!(
+      huddl,
+      %{
+        date: ~D[2030-11-20],
+        start_time: ~T[15:00:00],
+        duration_minutes: 90,
+        title: "New schedule"
+      },
+      actor: owner
+    )
+
+    for html <- [Phoenix.LiveViewTest.render(view), conn |> get(path) |> html_response(200)] do
+      data = html |> Floki.parse_document!() |> structured_data()
+      assert data["name"] == "New schedule"
+      assert data["startDate"] == "2030-11-20T15:00:00-05:00"
+      assert data["endDate"] == "2030-11-20T16:30:00-05:00"
+      assert data["eventStatus"] == "https://schema.org/EventScheduled"
+      refute Map.has_key?(data, "previousStartDate")
+      assert data["@id"] == HuddlzWeb.Endpoint.url() <> path
+    end
+  end
+
+  test "live navigation replaces detail metadata and removes it when leaving detail pages",
+       %{conn: conn, owner: owner, group: group} do
+    huddl = generate(huddl(actor: owner, group_id: group.id))
+    {:ok, view, _html} = Phoenix.LiveViewTest.live(conn, ~p"/groups/#{group.slug}")
+
+    assert Phoenix.LiveViewTest.render(view)
+           |> Floki.parse_document!()
+           |> structured_data()
+           |> Map.fetch!("@type") == "Organization"
+
+    {:ok, huddl_view, html} =
+      view
+      |> Phoenix.LiveViewTest.element("#huddlz-#{huddl.id}")
+      |> Phoenix.LiveViewTest.render_click()
+      |> Phoenix.LiveViewTest.follow_redirect(conn)
+
+    assert html |> Floki.parse_document!() |> structured_data() |> Map.fetch!("@id") ==
+             url(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+
+    {:ok, home_conn} =
+      huddl_view
+      |> Phoenix.LiveViewTest.element("a[aria-label='huddlz home']")
+      |> Phoenix.LiveViewTest.render_click()
+      |> Phoenix.LiveViewTest.follow_redirect(conn)
+
+    assert Floki.find(
+             Floki.parse_document!(html_response(home_conn, 200)),
+             "script[type='application/ld+json']"
+           ) == []
+  end
+
+  test "recurring occurrences have separate identities and local dates across daylight saving",
+       %{conn: conn, owner: owner, group: group} do
+    huddl =
+      generate(
+        huddl(
+          actor: owner,
+          creator_id: owner.id,
+          group_id: group.id,
+          date: ~D[2030-03-03],
+          start_time: ~T[12:00:00],
+          duration_minutes: 60,
+          is_recurring: true,
+          frequency: "weekly",
+          repeat_until: ~D[2030-03-18]
+        )
+      )
+
+    assert :ok =
+             RegenerateRecurringSeries.perform(%Oban.Job{
+               args: %{"huddl_id" => huddl.id},
+               attempt: 1,
+               max_attempts: 3
+             })
+
+    paths =
+      conn
+      |> get(~p"/groups/#{group.slug}")
+      |> html_response(200)
+      |> Floki.parse_document!()
+      |> Floki.attribute("#group-huddl-grid a[id^='huddlz-']", "href")
+
+    assert length(paths) == 3
+
+    data =
+      Enum.map(paths, fn path ->
+        document = conn |> get(path) |> html_response(200) |> Floki.parse_document!()
+        data = structured_data(document)
+        assert [data["@id"]] == Floki.attribute(document, "link[rel=canonical]", "href")
+        data
+      end)
+
+    assert Enum.map(data, & &1["startDate"]) == [
+             "2030-03-03T12:00:00-05:00",
+             "2030-03-10T12:00:00-04:00",
+             "2030-03-17T12:00:00-04:00"
+           ]
+
+    assert data |> Enum.map(& &1["@id"]) |> Enum.uniq() |> length() == 3
+  end
+
+  test "completed public huddlz retain their actual schedule", %{
+    conn: conn,
+    owner: owner,
+    group: group
+  } do
+    huddl =
+      generate(
+        past_huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          lifecycle_state: :completed,
+          starts_at: ~U[2025-07-20 16:00:00Z],
+          ends_at: ~U[2025-07-20 17:00:00Z]
+        )
+      )
+
+    data =
+      conn
+      |> get(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> html_response(200)
+      |> Floki.parse_document!()
+      |> structured_data()
+
+    assert data["startDate"] == "2025-07-20T12:00:00-04:00"
+    assert data["endDate"] == "2025-07-20T13:00:00-04:00"
+    refute Map.has_key?(data, "previousStartDate")
+  end
+
+  defp structured_data(document) do
+    assert [block] = Floki.find(document, "script[type='application/ld+json']")
+    block |> Floki.text(js: true) |> Jason.decode!()
+  end
+end


### PR DESCRIPTION
Public huddl and group detail pages now emit one server-rendered JSON-LD object describing their visible content. Huddl metadata follows attendance mode, local schedule, occurrence identity, public address, organizer, and displayed artwork; URLs match the existing canonical URLs. LiveView navigation replaces the metadata, and JSON serialization safely handles HTML-like input.

Existing visibility rules remain in force: private/draft/cancelled pages and restricted join links do not enter public structured data. Schedule edits publish current dates without inventing rescheduling history. These limits against the original acceptance wording, the production audit, and source guidance are recorded in `docs/structured-data.md`.

After deployment, validate representative public physical/hybrid pages with Google's Rich Results Test and check artwork accessibility. Production validator checks have not been performed; this does not guarantee rich-result eligibility or indexing, particularly for virtual-only huddlz.

Refs #162.
