### PR TITLE
test(ui): exercise search forms and rendered huddl order

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -248,7 +248,13 @@ defmodule HuddlzWeb.Layouts do
         <% end %>
         <form class="topbar-search" action="/discover" method="get" role="search">
           <span class="lead-key" aria-hidden="true">/</span>
-          <input type="search" name="q" placeholder="Search huddlz" value={@query} />
+          <input
+            type="search"
+            name="q"
+            aria-label="Search huddlz"
+            placeholder="Search huddlz"
+            value={@query}
+          />
         </form>
         <div class="content-actions">
           <%= if @signed_in do %>

--- a/test/features/step_definitions/huddl_listing_steps.exs
+++ b/test/features/step_definitions/huddl_listing_steps.exs
@@ -63,17 +63,24 @@ defmodule HuddlListingSteps do
     Map.put(context, :conn, conn)
   end
 
-  # Search for a term — discovery search now lives in the global chrome.
-  # Driving via URL keeps the test focused on the search → results contract
-  # without coupling to whichever chrome form (desktop/mobile) is matched.
   step "I search for {string}", %{args: [term]} = context do
-    conn = context.conn |> visit("/discover?q=" <> URI.encode_www_form(term))
+    conn =
+      context.conn
+      |> within(".content-topbar", fn session ->
+        session |> fill_in("Search huddlz", with: term) |> submit()
+      end)
+
     Map.merge(context, %{conn: conn, search_term: term})
   end
 
   # Clear search
   step "I clear the search form", context do
-    conn = context.conn |> visit("/discover")
+    conn =
+      context.conn
+      |> within(".content-topbar", fn session ->
+        session |> fill_in("Search huddlz", with: "") |> submit()
+      end)
+
     Map.put(context, :conn, conn)
   end
 
@@ -141,12 +148,10 @@ defmodule HuddlListingSteps do
   end
 
   step "I should see all upcoming huddlz again", context do
-    # In the real implementation, we'd see all original huddlz again
-    # For the test, we'll verify we're still on a page with the chrome search.
     conn =
-      context.conn
-      |> assert_has("input[placeholder='Search huddlz']")
-      |> refute_has("p", text: "No huddlz found")
+      Enum.reduce(context.huddlz, context.conn, fn huddl, session ->
+        assert_has(session, "h3", text: huddl.title, exact: true)
+      end)
 
     Map.put(context, :conn, conn)
   end

--- a/test/features/step_definitions/view_past_huddlz_steps.exs
+++ b/test/features/step_definitions/view_past_huddlz_steps.exs
@@ -209,19 +209,15 @@ defmodule ViewPastHuddlzSteps do
     {:ok, %{conn: conn}}
   end
 
-  step "the past huddlz should be sorted newest first", %{
-    conn: conn,
-    past_huddlz: past_huddlz
-  } do
-    # Verify all past huddlz are visible
-    # While we can't easily check DOM ordering with PhoenixTest,
-    # we can ensure all events are present (backend handles sorting)
-    Enum.each(past_huddlz, fn huddl ->
-      assert_has(conn, "h3", text: huddl.title)
+  step "the past huddlz should be sorted newest first", %{conn: conn} do
+    assert_has(conn, "#group-huddl-grid h3", count: 3)
+
+    ["Yesterday's Workshop", "Last Week's Meetup", "Monthly Retrospective"]
+    |> Enum.with_index(1)
+    |> Enum.each(fn {title, position} ->
+      assert_has(conn, "#group-huddl-grid h3", text: title, exact: true, at: position)
     end)
 
-    # The actual sorting order is tested at the query level
-    # This step ensures the data is displayed correctly
     :ok
   end
 


### PR DESCRIPTION
Make the Cucumber search and clear steps submit the topbar form, and verify that clearing restores every fixture. Give the search field an accessible name so those interactions use its label.

Assert past huddl titles in rendered newest-first order instead of only checking their presence. Temporary mutations to the submitted search parameter and displayed order both caused the strengthened scenarios to fail; both mutations were restored.

These checks remain on PhoenixTest. Browser infrastructure is still outside this change; this follows the coverage assessment in #420.
