### PR TITLE
feat(ui): restyle shared components against the design sheets

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -191,39 +191,37 @@ html {
 /* Sharp-edged checkbox. */
 @utility checkbox-cyber {
   appearance: none;
-  width: 1rem;
-  height: 1rem;
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
-  border: 1px solid var(--color-base-300);
-  background-color: transparent;
+  border: 1px solid var(--line-strong);
+  background-color: var(--bg);
   cursor: pointer;
   position: relative;
-  border-radius: var(--radius-hz-tight);
+  border-radius: 5px;
   transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 
   &:hover {
-    border-color: var(--color-primary);
+    border-color: var(--accent);
   }
 
   &:focus-visible {
     outline: none;
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 1px var(--color-primary);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
   }
 
   &:checked {
-    background-color: var(--color-primary);
-    border-color: var(--color-primary);
+    background-color: var(--accent);
+    border-color: var(--accent);
   }
 
   &:checked::after {
     content: '';
     position: absolute;
     inset: 0;
-    background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3.5,8.5 6.5,11.5 12.5,5'/%3E%3C/svg%3E");
-    background-size: 0.85rem 0.85rem;
-    background-position: center;
-    background-repeat: no-repeat;
+    background-color: var(--on-accent);
+    mask: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3.5,8.5 6.5,11.5 12.5,5'/%3E%3C/svg%3E") center / 0.8rem 0.8rem no-repeat;
   }
 
   &:disabled {
@@ -786,7 +784,7 @@ body .sidebar {
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--line);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--panel-2) 90%, transparent) 0%, color-mix(in srgb, var(--panel) 92%, transparent) 100%);
+  background: var(--panel);
   height: 100vh;
   position: sticky;
   top: 0;
@@ -796,46 +794,47 @@ body .sidebar-brand {
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 72px;
-  padding: 0 22px;
+  height: 64px;
+  padding: 0 20px;
   border-bottom: 1px solid var(--line);
 }
 
 body .brand-glyph {
   width: 28px;
   height: 28px;
-  border: 1px solid var(--cyan);
-  border-radius: 6px;
+  border-radius: 8px;
+  background: var(--accent);
   display: grid;
   place-items: center;
-  color: var(--cyan);
-  font-family: var(--mono);
+  color: var(--on-accent);
+  font-size: 15px;
   font-weight: 700;
-  font-size: 14px;
 }
 
 body .brand-text {
   color: var(--text);
-  font-family: var(--mono);
-  font-size: 18px;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 body .sb-nav {
   flex: 1 1 auto;
   overflow-y: auto;
-  padding: 14px 12px 12px;
+  padding: 12px 8px;
 }
 
 body .sb-item {
   display: flex;
   align-items: center;
   gap: 12px;
-  height: 36px;
+  height: 40px;
   padding: 0 12px;
   border-radius: var(--radius-sm);
   color: var(--soft);
-  font-size: 13.5px;
-  font-weight: 580;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 120ms ease, color 120ms ease;
 }
 
 body .sb-item svg {
@@ -846,19 +845,19 @@ body .sb-item svg {
 }
 
 body .sb-item:hover {
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  background: var(--panel-2);
   color: var(--text);
 }
 
 body .sb-item:hover svg { color: var(--soft); }
 
 body .sb-item.active {
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: var(--accent-soft);
   color: var(--text);
-  font-weight: 700;
+  font-weight: 600;
 }
 
-body .sb-item.active svg { color: var(--cyan); }
+body .sb-item.active svg { color: var(--accent-ink); }
 
 body .sb-item .badge {
   margin-left: auto;
@@ -868,34 +867,34 @@ body .sb-item .badge {
   display: grid;
   place-items: center;
   border-radius: var(--radius-pill);
-  background: var(--cyan);
+  background: var(--accent);
   color: var(--on-accent);
-  font-family: var(--mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
 }
 
 body .group-mark {
-  width: 22px;
-  height: 22px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-deep));
-  color: var(--on-accent);
-  font-family: var(--mono);
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--accent-ink);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   display: grid;
   place-items: center;
   flex: 0 0 auto;
 }
 
 body .group-mark.mark-magenta {
-  background: linear-gradient(135deg, var(--pink), #2a0a2a);
-  color: #1a0610;
+  background: var(--pink-soft);
+  color: var(--pink);
 }
 
 body .group-mark.mark-warm {
-  background: linear-gradient(135deg, var(--warn), #4a1f0a);
-  color: #1a0c00;
+  background: var(--warn-soft);
+  color: var(--warn);
 }
 
 body .sb-orgs {
@@ -914,13 +913,13 @@ body .sb-org-row {
   display: flex;
   align-items: center;
   gap: 12px;
-  height: 36px;
+  height: 40px;
   margin: 1px 0;
   padding: 0 12px;
   border-radius: var(--radius-sm);
   color: var(--soft);
-  font-size: 13.5px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 500;
 }
 
 body .sb-org-row .name {
@@ -931,14 +930,14 @@ body .sb-org-row .name {
 }
 
 body .sb-org-row:hover {
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  background: var(--panel-2);
   color: var(--text);
 }
 
 body .sb-org-row.active {
   color: var(--text);
-  font-weight: 700;
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  font-weight: 600;
+  background: var(--accent-soft);
 }
 
 body .sb-sub {
@@ -951,30 +950,31 @@ body .sb-sub-item {
   display: flex;
   align-items: center;
   gap: 8px;
-  height: 30px;
+  height: 32px;
   padding: 0 10px;
   margin: 1px 0;
-  border-radius: var(--radius-sm);
+  border-radius: 6px;
   color: var(--muted);
-  font-size: 12.5px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+body .sb-sub-item:hover { color: var(--text); background: var(--panel-2); }
+
+body .sb-sub-item.active {
+  color: var(--accent-ink);
   font-weight: 600;
 }
 
-body .sb-sub-item:hover { color: var(--text); background: color-mix(in srgb, var(--accent) 5%, transparent); }
-
-body .sb-sub-item.active {
-  color: var(--cyan);
-  font-weight: 700;
-}
-
 body .sb-org-row.create { color: var(--muted); }
-body .sb-org-row.create:hover { color: var(--cyan); }
+body .sb-org-row.create:hover { color: var(--accent-ink); }
 
 body .plus-mark {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   flex: 0 0 auto;
   border: 1px dashed var(--line-strong);
+  border-radius: 6px;
   display: grid;
   place-items: center;
   color: var(--muted);
@@ -984,35 +984,34 @@ body .plus-mark {
 }
 
 body .sb-org-row.create:hover .plus-mark {
-  border-color: var(--cyan);
+  border-color: var(--accent);
   border-style: solid;
-  color: var(--cyan);
+  color: var(--accent-ink);
 }
 
 body .sb-user {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 16px;
+  padding: 16px 20px;
   border-top: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
   color: inherit;
   transition: background 120ms ease;
 }
 
-body a.sb-user:hover { background: color-mix(in srgb, var(--accent) 6%, transparent); }
+body a.sb-user:hover { background: var(--panel-2); }
 
 body .sb-user .avatar {
   flex: 0 0 auto;
   width: 36px;
   height: 36px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  background: linear-gradient(135deg, var(--warn), var(--pink));
+  background: linear-gradient(135deg, #f6c177, #e84fb4);
   color: #200817;
   display: grid;
   place-items: center;
-  font-family: var(--mono);
-  font-weight: 800;
+  font-weight: 700;
   font-size: 13px;
   object-fit: cover;
 }
@@ -1020,8 +1019,8 @@ body .sb-user .avatar {
 body .sb-user .who { display: flex; flex-direction: column; min-width: 0; }
 
 body .sb-user .name {
-  font-size: 13.5px;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
@@ -1030,8 +1029,7 @@ body .sb-user .name {
 
 body .sb-user .role {
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 11px;
+  font-size: 12px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1047,14 +1045,14 @@ body .main {
 body .content-topbar {
   display: flex;
   align-items: center;
-  gap: 16px;
-  height: 72px;
-  padding: 0 32px;
+  gap: 12px;
+  height: 64px;
+  padding: 0 40px;
   border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg) 65%, transparent);
-  backdrop-filter: blur(8px);
+  background: var(--panel);
   position: sticky;
   top: 0;
+  z-index: 30;
 }
 
 body .topbar-brand {
@@ -1069,22 +1067,22 @@ body .topbar-brand {
 body .topbar-search {
   flex: 1 1 auto;
   min-width: 0;
-  max-width: 560px;
+  max-width: 480px;
   margin: 0;
   display: flex;
   align-items: center;
-  gap: 12px;
-  height: 40px;
-  padding: 0 14px;
+  gap: 10px;
+  height: 36px;
+  padding: 0 12px;
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
   color: var(--muted);
-  font-size: 13.5px;
-  font-weight: 580;
+  font-size: 14px;
+  font-weight: 500;
 }
 
-body .topbar-search:focus-within { border-color: var(--cyan); box-shadow: 0 0 0 3px var(--cyan-soft); }
+body .topbar-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 body .topbar-search input {
   flex: 1 1 auto;
   min-width: 0;
@@ -1100,13 +1098,15 @@ body .topbar-search input::-webkit-search-cancel-button { display: none; }
 
 body .topbar-search .lead-key {
   flex: 0 0 auto;
-  width: 22px;
+  height: 20px;
+  padding: 0 6px;
   display: grid;
   place-items: center;
-  color: var(--cyan);
-  font-family: var(--mono);
-  font-size: 18px;
-  font-weight: 700;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
   line-height: 1;
   user-select: none;
 }
@@ -1124,10 +1124,19 @@ body .icon-pill {
   height: 36px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
-  background: transparent;
+  background: var(--panel);
   color: var(--soft);
   display: grid;
   place-items: center;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+body .icon-pill:hover { border-color: var(--accent); color: var(--accent-ink); }
+
+body .icon-pill.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
 }
 
 body .icon-pill .dot {
@@ -1137,8 +1146,9 @@ body .icon-pill .dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--magenta);
-  box-shadow: 0 0 8px var(--magenta);
+  background: var(--pink);
+  border: 2px solid var(--panel);
+  box-sizing: content-box;
 }
 
 body .icon-pill .notification-badge {
@@ -1148,17 +1158,15 @@ body .icon-pill .notification-badge {
   min-width: 19px;
   height: 19px;
   padding: 0 5px;
-  border: 2px solid var(--bg);
+  border: 2px solid var(--panel);
   border-radius: 999px;
-  background: var(--magenta);
+  background: var(--pink);
   color: white;
   display: grid;
   place-items: center;
-  font-family: var(--mono);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: 700;
   line-height: 1;
-  box-shadow: 0 0 10px color-mix(in srgb, var(--magenta) 55%, transparent);
 }
 
 body .btn-primary {
@@ -1166,53 +1174,145 @@ body .btn-primary {
   padding: 0 16px;
   border: 0;
   border-radius: var(--radius-sm);
-  background: var(--cyan);
+  background: var(--accent);
   color: var(--on-accent);
   font-size: 13px;
-  font-weight: 800;
-  letter-spacing: 0.02em;
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  cursor: pointer;
+  transition: filter 120ms ease, opacity 120ms ease;
 }
+
+body .btn-primary:hover { filter: brightness(1.06); }
+
+body .btn-primary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--panel), 0 0 0 4px var(--accent);
+}
+
+body .btn-primary:disabled,
+body .btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: none;
+}
+
+body .btn-primary.phx-click-loading,
+body .btn-secondary.phx-click-loading,
+body .phx-submit-loading .btn-primary[type="submit"],
+body .phx-submit-loading .btn-secondary[type="submit"] {
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+body .btn-primary.phx-click-loading::before,
+body .btn-secondary.phx-click-loading::before,
+body .phx-submit-loading .btn-primary[type="submit"]::before,
+body .phx-submit-loading .btn-secondary[type="submit"]::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  animation: hz-spin 0.8s linear infinite;
+}
+
+@keyframes hz-spin { to { transform: rotate(360deg); } }
 
 body .btn-secondary {
   height: 36px;
-  padding: 0 16px;
+  padding: 0 14px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
 }
 
-body .btn-secondary:hover { border-color: var(--cyan); color: var(--cyan); }
+body .btn-secondary:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+body .btn-secondary:hover { border-color: var(--accent); color: var(--accent-ink); }
 
 /* ─────────────────────────────────────────────  CONTENT  ────── */
 body .content-body {
   flex: 1 1 auto;
-  padding: 32px 32px 64px;
+  padding: 40px 40px 64px;
   overflow-y: auto;
 }
+
+/* Flash toasts: top right, one column, above the sticky topbar. */
+body .flash-group {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(380px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+body .flash {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+body .flash-icon { width: 20px; height: 20px; display: grid; place-items: center; margin-top: 1px; }
+body .flash-info .flash-icon { color: var(--accent-ink); }
+body .flash-error .flash-icon { color: var(--danger); }
+body .flash-body { min-width: 0; font-size: 13px; line-height: 1.45; color: var(--soft); }
+body .flash-title { margin: 0 0 2px; font-size: 14px; font-weight: 600; color: var(--text); }
+body .flash-close {
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+body .flash-close:hover { color: var(--text); background: var(--panel-2); }
 
 body .page-head {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
   gap: 24px;
-  margin-bottom: 32px;
+  margin-bottom: 24px;
 }
 
 body .page-head h1 {
   margin: 0 0 8px;
-  font-family: var(--mono);
-  font-size: 34px;
-  letter-spacing: -0.005em;
-  line-height: 1.05;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
 }
 
 body .page-head p {
@@ -1223,51 +1323,57 @@ body .page-head p {
   line-height: 1.5;
 }
 
-body .page-head .actions { display: flex; gap: 10px; flex: 0 0 auto; }
+body .page-head .actions { display: flex; gap: 8px; flex: 0 0 auto; }
 
 body .eyebrow {
-  color: var(--cyan);
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
+  color: var(--accent-ink);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 /* Scope tabs (Huddlz / Groups on explore) */
 body .scope-tabs {
   display: inline-flex;
-  border: 1px solid var(--line-strong);
+  gap: 4px;
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg) 40%, transparent);
+  background: var(--panel-2);
   padding: 4px;
   margin-bottom: 16px;
 }
 
 body .scope-tab {
-  padding: 7px 16px;
+  height: 32px;
+  padding: 0 16px;
   border: 0;
-  border-radius: 4px;
+  border-radius: 6px;
   background: transparent;
   color: var(--soft);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
 }
 
 body .scope-tab.is-active {
-  background: var(--cyan-soft);
-  color: var(--cyan);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
 /* Filter bar (explore) */
 body .filter-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: 18px 24px;
-  padding: 16px 18px;
+  gap: 16px 32px;
+  padding: 16px 20px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--panel-2);
+  background: var(--panel);
   margin-bottom: 16px;
 }
 
@@ -1279,10 +1385,9 @@ body .filter-group {
 }
 
 body .filter-label {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -1436,10 +1541,9 @@ body .filter-distance input[type="range"]::-moz-range-thumb {
 }
 
 body .filter-distance-value {
-  font-family: var(--mono);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
-  color: var(--cyan);
+  color: var(--accent-ink);
   min-width: 40px;
 }
 
@@ -1449,7 +1553,7 @@ body .chip-group {
   gap: 6px;
 }
 
-body .chip-group .chip { height: 28px; padding: 0 12px; font-size: 12px; }
+body .chip-group .chip { height: 32px; padding: 0 14px; font-size: 13px; }
 
 /* Filters / chips */
 body .filters {
@@ -1469,14 +1573,19 @@ body .chip {
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--soft);
-  font-size: 12.5px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
 }
 
+body .chip:hover { border-color: var(--accent); color: var(--accent-ink); }
+
 body .chip.is-active {
-  border-color: var(--cyan);
-  color: var(--cyan);
-  background: var(--cyan-soft);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+  font-weight: 600;
 }
 
 /* Grid + cards */
@@ -1500,12 +1609,12 @@ body .card {
   flex-direction: column;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--panel-2);
+  background: var(--panel);
   overflow: hidden;
   transition: border-color 120ms ease, transform 120ms ease;
 }
 
-body .card:hover { border-color: var(--line-strong); transform: translateY(-1px); }
+body .card:hover { border-color: var(--line-strong); transform: translateY(-2px); }
 
 body .card-cover {
   position: relative;
@@ -1602,20 +1711,20 @@ body .date-stamp {
   top: 12px;
   left: 12px;
   z-index: 2;
-  width: 50px;
-  height: 50px;
-  border: 1px solid var(--cyan);
+  width: 48px;
+  height: 48px;
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg) 78%, transparent);
-  color: var(--cyan);
-  font-family: var(--mono);
-  display: grid;
-  grid-template-rows: auto auto;
-  place-items: center;
-  padding: 4px 0;
+  background: var(--panel);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
 }
 
-body .date-stamp .m { font-size: 9.5px; letter-spacing: 0.18em; }
+body .date-stamp .m { color: var(--accent-ink); font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
 body .date-stamp .d { font-size: 18px; font-weight: 700; line-height: 1; }
 
 body .card-tag {
@@ -1623,37 +1732,34 @@ body .card-tag {
   top: 12px;
   right: 12px;
   z-index: 2;
-  padding: 3px 8px;
-  border: 1px solid color-mix(in srgb, var(--text) 16%, transparent);
+  height: 24px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
   border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  background: var(--panel);
   color: var(--soft);
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 11px;
+  font-weight: 600;
 }
 
-body .card-tag.hybrid { color: var(--cyan); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
-body .card-tag.online { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 40%, transparent); }
-body .card-tag.in-person { color: var(--magenta); border-color: color-mix(in srgb, var(--pink) 35%, transparent); }
 
-body .card-body { padding: 14px 16px 16px; display: flex; flex-direction: column; gap: 8px; }
+body .card-body { padding: 16px; display: flex; flex-direction: column; gap: 6px; }
 
 body .card-group {
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 body .card-title {
   margin: 0;
   overflow-wrap: anywhere;
   font-size: 16px;
-  font-weight: 700;
-  line-height: 1.25;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 
@@ -1662,13 +1768,14 @@ body .card-group { overflow-wrap: anywhere; }
 body .card-meta {
   display: flex;
   align-items: center;
-  gap: 14px;
+  flex-wrap: wrap;
+  gap: 8px;
   margin-top: 4px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 13px;
 }
 
-body .card-meta .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--muted); }
+body .card-meta .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--line-strong); }
 
 body .card-foot {
   display: flex;
@@ -1766,8 +1873,8 @@ body .kpi .spark {
 body .panel {
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--panel-2);
-  padding: 18px 20px;
+  background: var(--panel);
+  padding: 20px 24px;
   margin-bottom: 24px;
 }
 
@@ -1775,17 +1882,21 @@ body .panel-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  gap: 16px;
+  margin: -20px -24px 20px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--line);
 }
 
 body .panel-head h2 {
   margin: 0;
-  font-family: var(--mono);
   font-size: 16px;
-  letter-spacing: -0.005em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
 }
 
-body .panel-sub { margin-top: 4px; color: var(--muted); font-size: 12px; }
+body .panel-sub { margin-top: 4px; color: var(--muted); font-size: 13px; line-height: 1.5; }
 
 body .panel.split {
   display: grid;
@@ -1804,12 +1915,9 @@ body .row {
   display: grid;
   align-items: center;
   gap: 16px;
-  /* padding-top is 1px short of padding-bottom to compensate for the 1px
-     border-top eating into the box (box-sizing: border-box) — without this
-     the grid track lands 1px below the row's geometric center. */
   padding: 13px 0 14px;
   border-top: 1px solid var(--line);
-  font-size: 13.5px;
+  font-size: 14px;
 }
 
 body .row:first-child {
@@ -1820,11 +1928,10 @@ body .row:first-child {
 body .row .meta { color: var(--muted); font-size: 12px; }
 body .row .row-title .title-tag {
   margin-left: 8px;
-  color: var(--cyan);
-  font-family: var(--mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  color: var(--accent-ink);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   vertical-align: middle;
 }
@@ -1911,27 +2018,36 @@ body .locations-back a { color: var(--muted); }
 body .locations-back a:hover { color: var(--cyan); }
 
 
-body .row .row-title { font-weight: 700; color: var(--text); }
+body .row .row-title { font-weight: 600; color: var(--text); }
 body .pill {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   vertical-align: middle;
-  height: 22px;
+  height: 24px;
   padding: 0 10px;
-  border: 1px solid var(--line-strong);
   border-radius: var(--radius-pill);
+  background: var(--panel-2);
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
   white-space: nowrap;
 }
 
-body .pill.cyan { color: var(--cyan); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
-body .pill.warn { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 35%, transparent); }
-body .pill.magenta { color: var(--magenta); border-color: color-mix(in srgb, var(--pink) 35%, transparent); }
-body .pill.muted { color: var(--muted); }
+body .pill.cyan::before,
+body .pill.warn::before,
+body .pill.magenta::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+body .pill.cyan { color: var(--accent-ink); background: var(--accent-soft); }
+body .pill.warn { color: var(--warn); background: var(--warn-soft); }
+body .pill.magenta { color: var(--pink); background: var(--pink-soft); }
+body .pill.muted { color: var(--muted); background: var(--panel-2); }
 
 /* Capacity bar */
 body .bar {
@@ -1958,11 +2074,11 @@ body .rsvp-banner {
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg) 50%, transparent);
+  background: var(--panel-2);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 body .rsvp-banner.cyan { color: var(--cyan); border-color: color-mix(in srgb, var(--accent) 40%, transparent); background: var(--cyan-soft); }
@@ -2001,39 +2117,40 @@ body .facts .value .virtual-link-text:hover { text-decoration: underline; }
 body .facts .value .muted { color: var(--muted); font-weight: 500; font-size: 12px; }
 
 /* Magenta-warn destructive button (delete huddl) */
-body .btn-secondary.destructive-btn { color: var(--magenta); border-color: color-mix(in srgb, var(--pink) 40%, transparent); }
-body .btn-secondary.destructive-btn:hover { color: var(--magenta); border-color: var(--magenta); }
+body .btn-secondary.destructive-btn {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
+  background: var(--danger-soft);
+}
+body .btn-secondary.destructive-btn:hover { color: var(--danger); border-color: var(--danger); }
 
 /* Huddl deletion confirmation — one focused warning moment, not a browser alert. */
 body .delete-confirm {
   display: grid;
-  grid-template-columns: 48px minmax(0, 1fr);
+  grid-template-columns: 40px minmax(0, 1fr);
   gap: 16px;
-  padding: 2px 0 22px;
+  padding: 2px 0 20px;
   border-bottom: 1px solid var(--line);
 }
 
 body .delete-confirm-icon {
   display: grid;
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--pink) 42%, transparent);
   border-radius: var(--radius-sm);
-  color: var(--magenta);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--pink) 16%, transparent), color-mix(in srgb, var(--pink) 4%, transparent));
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--pink) 72%, transparent);
+  color: var(--warn);
+  background: var(--warn-soft);
 }
 
 body .delete-confirm-copy h2,
 body .share-modal-copy h2 {
-  margin: 5px 0 9px;
+  margin: 6px 0 8px;
   color: var(--text);
-  font-family: var(--font-display);
-  font-size: clamp(21px, 3vw, 27px);
-  line-height: 1.1;
-  letter-spacing: -0.02em;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
 }
 
 body .delete-confirm-copy p {
@@ -2056,20 +2173,17 @@ body .delete-confirm-series-note {
 body .delete-confirm-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 10px;
-  padding-top: 18px;
+  gap: 8px;
+  padding-top: 16px;
 }
 
 body .delete-confirm-submit {
-  color: #fff !important;
-  border-color: var(--magenta) !important;
-  background: color-mix(in srgb, var(--pink) 86%, transparent) !important;
+  color: #ffffff !important;
+  border-color: var(--danger) !important;
+  background: var(--danger) !important;
 }
 
-body .delete-confirm-submit:hover {
-  background: var(--magenta) !important;
-  box-shadow: 0 0 22px color-mix(in srgb, var(--pink) 18%, transparent);
-}
+body .delete-confirm-submit:hover { filter: brightness(1.06); }
 
 @media (max-width: 520px) {
   body .delete-confirm {
@@ -2698,9 +2812,9 @@ body .huddl-side-section {
 
 body .huddl-side-section h3 {
   margin: 0 0 12px;
-  font-size: 14px;
-  font-family: var(--mono);
-  letter-spacing: 0.04em;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -2758,9 +2872,9 @@ body .notif-mark {
   margin-top: 6px;
 }
 
-body .notif-mark.cyan { background: var(--cyan); box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 50%, transparent); }
-body .notif-mark.warn { background: var(--warn); box-shadow: 0 0 8px color-mix(in srgb, var(--warn) 50%, transparent); }
-body .notif-mark.muted { background: var(--line-strong); box-shadow: none; }
+body .notif-mark.cyan { background: var(--accent); }
+body .notif-mark.warn { background: var(--warn); }
+body .notif-mark.muted { background: var(--line-strong); }
 
 body .invitation-back-link {
   display: inline-flex;
@@ -2922,11 +3036,11 @@ body .group-hero-location {
 }
 
 body .hero-content h1 {
-  margin: 0 0 6px;
-  font-family: var(--mono);
-  font-size: 38px;
-  letter-spacing: -0.01em;
-  line-height: 1.05;
+  margin: 0 0 8px;
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
   overflow-wrap: anywhere;
 }
 
@@ -2949,42 +3063,37 @@ body .organizer-update {
   align-items: center;
   gap: 16px;
   margin-bottom: 16px;
-  padding: 18px 20px;
-  border: 1px solid color-mix(in srgb, var(--pink) 62%, transparent);
+  padding: 16px 20px;
+  border: 1px solid color-mix(in srgb, var(--pink) 40%, transparent);
   border-radius: var(--radius);
-  background:
-    linear-gradient(105deg, color-mix(in srgb, var(--pink) 20%, transparent), color-mix(in srgb, var(--pink) 10%, transparent) 62%, color-mix(in srgb, var(--pink) 5%, transparent)),
-    var(--panel-2);
-  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--pink) 82%, transparent), 0 10px 32px color-mix(in srgb, var(--pink) 7%, transparent);
+  background: var(--panel);
 }
 
 body .organizer-update-icon {
   display: grid;
   place-items: center;
-  width: 42px;
-  height: 42px;
-  border: 1px solid color-mix(in srgb, var(--pink) 30%, transparent);
+  width: 40px;
+  height: 40px;
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--pink) 10%, transparent);
-  color: var(--magenta);
+  background: var(--pink-soft);
+  color: var(--pink);
 }
 
 body .organizer-update-copy { min-width: 0; }
 
 body .organizer-update h2 {
-  margin: 0 0 4px;
-  color: var(--pink);
-  font-size: 16px;
-  font-weight: 800;
+  margin: 0 0 2px;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
   line-height: 1.3;
-  letter-spacing: -0.01em;
 }
 
 body .organizer-update p {
   margin: 0;
-  color: var(--text);
-  font-size: 14px;
-  line-height: 1.45;
+  color: var(--soft);
+  font-size: 13px;
+  line-height: 1.5;
   overflow-wrap: anywhere;
 }
 
@@ -3013,18 +3122,19 @@ body .huddl-rest { grid-area: rest; display: flex; flex-direction: column; gap: 
 
 body .huddl-side {
   position: sticky;
-  top: 96px;
+  top: 88px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--panel-2);
+  background: var(--panel);
+  box-shadow: var(--shadow);
   padding: 24px;
 }
 
 body .huddl-side h3 {
-  margin: 0 0 16px;
-  font-size: 14px;
-  font-family: var(--mono);
-  letter-spacing: 0.04em;
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -3045,18 +3155,18 @@ body .facts li {
   font-size: 13px;
 }
 
-body .facts svg { width: 16px; height: 16px; flex: 0 0 auto; color: var(--cyan); margin-top: 2px; }
+body .facts svg { width: 18px; height: 18px; flex: 0 0 auto; color: var(--accent-ink); margin-top: 1px; }
 
-body .facts .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
-body .facts .value { color: var(--text); font-weight: 600; overflow-wrap: anywhere; }
+body .facts .label { color: var(--muted); font-size: 12px; font-weight: 500; margin-bottom: 2px; }
+body .facts .value { color: var(--text); font-size: 14px; font-weight: 600; overflow-wrap: anywhere; }
 
 body .prose { color: var(--soft); font-size: 15px; line-height: 1.65; }
 body .prose p { margin: 0 0 16px; }
 body .prose h2 {
   margin: 32px 0 12px;
-  font-family: var(--mono);
-  font-size: 20px;
-  letter-spacing: -0.005em;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 
@@ -3334,14 +3444,15 @@ body .profile-head {
 }
 
 body .big-avatar {
-  width: 88px;
-  height: 88px;
-  background: linear-gradient(135deg, var(--warn), var(--pink));
+  width: 96px;
+  height: 96px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #f6c177, #e84fb4);
   color: #200817;
   display: grid;
   place-items: center;
-  font-family: var(--mono);
-  font-weight: 800;
+  font-weight: 700;
   font-size: 28px;
   flex: 0 0 auto;
   object-fit: cover;
@@ -3590,72 +3701,94 @@ body .legal-acceptance .form-error { margin: 9px 0 0 28px; }
 body .form-grid {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
   max-width: 560px;
 }
 
 body .form-row { display: flex; flex-direction: column; gap: 6px; }
 
 body .form-label {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
 }
 
 body .form-input, body .form-textarea, body .form-select {
   width: 100%;
-  padding: 10px 12px;
+  padding: 9px 12px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
+  background: var(--bg);
   color: var(--text);
   font: inherit;
   font-size: 14px;
+  line-height: 20px;
   outline: 0;
   transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+body .form-input::placeholder, body .form-textarea::placeholder { color: var(--muted); }
+
+body .form-input[aria-invalid="true"], body .form-textarea[aria-invalid="true"], body .form-select[aria-invalid="true"] {
+  border-color: var(--danger);
+}
+
+body .form-input[aria-invalid="true"]:focus, body .form-textarea[aria-invalid="true"]:focus, body .form-select[aria-invalid="true"]:focus {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 3px var(--danger-soft);
+}
+
+body .form-input:disabled, body .form-textarea:disabled, body .form-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 body .form-select {
   appearance: none;
   -webkit-appearance: none;
   padding-right: 32px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23b7c1c3' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%237f8c8f' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
   background-size: 12px;
 }
 
 body .form-input:focus, body .form-textarea:focus, body .form-select:focus {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 3px var(--cyan-soft);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-body .form-textarea { min-height: 120px; resize: vertical; line-height: 1.5; }
+body .form-textarea { min-height: 96px; resize: vertical; line-height: 1.5; padding: 10px 12px; }
 
-body .form-help { color: var(--muted); font-size: 12px; }
-body .form-error { color: var(--warn); font-size: 12px; }
+body .form-help { color: var(--muted); font-size: 12px; line-height: 1.5; }
+body .form-error { color: var(--danger); font-size: 12px; font-weight: 500; }
 
 body .form-control.read-only {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 12px;
+  padding: 9px 12px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg) 40%, transparent);
-  color: var(--soft);
+  background: var(--panel-2);
+  color: var(--text);
   font-size: 14px;
+  line-height: 20px;
 }
 
 body .form-foot {
-  margin-top: 18px;
-  padding-top: 18px;
+  margin-top: 20px;
+  padding-top: 16px;
   border-top: 1px solid var(--line);
   display: flex;
-  gap: 10px;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+body .panel > .form-foot {
+  margin: 20px -24px -20px;
+  padding: 16px 24px;
 }
 
 /* No top border or gap — for foots stacked under their own panel/form. */
@@ -3729,8 +3862,11 @@ body .form-clear {
 
 body .form-clear:hover { color: var(--text); }
 
-body .btn-secondary.muted-btn { color: var(--muted); }
-body .btn-secondary.muted-btn:hover { color: var(--warn); border-color: var(--warn); }
+body .btn-secondary.muted-btn {
+  color: var(--muted);
+  border-color: transparent;
+}
+body .btn-secondary.muted-btn:hover { color: var(--text); border-color: transparent; background: var(--panel-2); }
 
 body .profile-photo-row {
   display: flex;
@@ -3986,59 +4122,55 @@ body .toggle {
 
 body .toggle .track {
   position: relative;
-  width: 36px;
-  height: 20px;
-  flex: 0 0 36px;
+  width: 40px;
+  height: 22px;
+  flex: 0 0 40px;
   border-radius: 999px;
   background: var(--line-strong);
-  border: 1px solid var(--soft);
+  border: 0;
   padding: 0;
   opacity: 1;
   rotate: 0deg;
-  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+  transition: background 120ms ease, box-shadow 120ms ease;
 }
 
-body .toggle input:checked + .track { border-color: var(--cyan); }
+body .toggle input:checked + .track { border-color: transparent; }
 
 body .toggle .track::after {
   content: "";
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 14px;
-  height: 14px;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
-  background: var(--text);
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
   transition: transform 120ms ease;
 }
 
 body .toggle input:checked + .track {
-  background: var(--cyan);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 40%, transparent);
+  background: var(--accent);
 }
 
 body .toggle input:focus-visible + .track {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 3px var(--cyan-soft);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-body .toggle input:checked + .track::after { transform: translateX(14px); }
+body .toggle input:checked + .track::after { transform: translateX(18px); }
 
 body .toggle input:disabled + .track {
-  opacity: 0.5;
-  background: var(--cyan-dim);
+  opacity: 0.6;
 }
 
 body .toggle .toggle-text {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--muted);
-  min-width: 28px;
+  min-width: 24px;
 }
 
-body .toggle input:checked ~ .toggle-text { color: var(--cyan); }
+body .toggle input:checked ~ .toggle-text { color: var(--accent-ink); }
 body .toggle input:disabled ~ .toggle-text { color: var(--muted); opacity: 0.7; }
 
 /* Group visibility editor — makes saved vs selected state explicit. */
@@ -4142,12 +4274,12 @@ body .cyan { color: var(--cyan); }
    sit alongside muted prose. Strips the default `<button>` chrome and adopts
    the surrounding font. */
 body .button-link {
-  background: transparent;
-  border: 0;
   padding: 0;
-  margin: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-ink);
   font: inherit;
-  color: var(--cyan);
+  font-weight: 600;
   cursor: pointer;
 }
 
@@ -4282,39 +4414,37 @@ body .page-numbers {
   padding: 0;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
 }
 
 body .page-num {
   display: inline-grid;
   place-items: center;
-  min-width: 32px;
-  height: 32px;
+  min-width: 36px;
+  height: 36px;
   padding: 0 8px;
-  border: 1px solid transparent;
+  border: 1px solid var(--line-strong);
   background: transparent;
   color: var(--soft);
   border-radius: var(--radius-sm);
-  font-family: var(--mono);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
 }
 
 body .page-num:hover {
-  border-color: var(--line-strong);
-  color: var(--text);
+  border-color: var(--accent);
+  color: var(--accent-ink);
 }
 
 body .page-num.is-active {
-  background: var(--cyan-soft);
-  border-color: var(--cyan-dim);
-  color: var(--cyan);
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-ink);
 }
 
 body .page-ellipsis {
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 12px;
+  font-size: 13px;
   padding: 0 4px;
 }
 
@@ -4322,22 +4452,19 @@ body .page-nav {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 32px;
+  height: 36px;
   padding: 0 12px;
   border: 1px solid var(--line-strong);
   background: transparent;
   color: var(--soft);
   border-radius: var(--radius-sm);
-  font-family: var(--mono);
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 body .page-nav:not(:disabled):hover {
-  color: var(--text);
-  border-color: var(--cyan-dim);
+  color: var(--accent-ink);
+  border-color: var(--accent);
 }
 
 body .page-nav:disabled {

--- a/lib/huddlz_web/components/flash.ex
+++ b/lib/huddlz_web/components/flash.ex
@@ -1,8 +1,8 @@
 defmodule HuddlzWeb.Components.Flash do
   @moduledoc """
-  Flash notice rendering plus the `show/2` / `hide/2` JS animation helpers
-  it shares with the layout's client-error banner. Slides in from the top,
-  fades out on dismiss.
+  Flash toast rendering plus the `show/2` / `hide/2` JS animation helpers
+  it shares with the layout's client-error banner. Toasts stack top-right
+  (see `.flash-group` in app.css), slide in, and fade out on dismiss.
   """
   use Phoenix.Component
   use Gettext, backend: HuddlzWeb.Gettext
@@ -27,36 +27,20 @@ defmodule HuddlzWeb.Components.Flash do
       id={@id}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
-      class="w-full cursor-pointer mb-4"
+      class={["flash", "flash-#{@kind}"]}
       {@rest}
     >
-      <div class={[
-        "flex items-center gap-3 border rounded-hz-surface px-4 py-3 text-sm",
-        @kind == :info && "border-primary/30 bg-primary/5 text-primary",
-        @kind == :error && "border-error/30 bg-error/5 text-error"
-      ]}>
-        <div class={[
-          "w-1 self-stretch",
-          @kind == :info && "bg-primary",
-          @kind == :error && "bg-error"
-        ]} />
-        <Icon.icon :if={@kind == :info} name="hero-information-circle-mini" class="size-5 shrink-0" />
-        <Icon.icon
-          :if={@kind == :error}
-          name="hero-exclamation-circle-mini"
-          class="size-5 shrink-0"
-        />
-        <span class="flex-1">
-          <span :if={@title} class="font-semibold">{@title}: </span>{msg}
-        </span>
-        <button
-          type="button"
-          class="opacity-50 hover:opacity-100 transition-opacity"
-          aria-label={gettext("close")}
-        >
-          <Icon.icon name="hero-x-mark-solid" class="size-4" />
-        </button>
+      <span class="flash-icon" aria-hidden="true">
+        <Icon.icon :if={@kind == :info} name="hero-check-circle" class="size-5" />
+        <Icon.icon :if={@kind == :error} name="hero-exclamation-circle" class="size-5" />
+      </span>
+      <div class="flash-body">
+        <p :if={@title} class="flash-title">{@title}</p>
+        <span>{msg}</span>
       </div>
+      <button type="button" class="flash-close" aria-label={gettext("close")}>
+        <Icon.icon name="hero-x-mark" class="size-4" />
+      </button>
     </div>
     """
   end

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -550,7 +550,7 @@ defmodule HuddlzWeb.Layouts do
 
   def flash_group(assigns) do
     ~H"""
-    <div id={@id} aria-live="polite">
+    <div id={@id} class="flash-group" aria-live="polite">
       <.flash kind={:info} flash={@flash} />
       <.flash kind={:error} flash={@flash} />
 


### PR DESCRIPTION
Second step of the UI refresh. The shared components now match the Controls, Forms and Feedback sheets on the design canvas, so every page picks up the new look without markup changes.

## What changes for users

- One typeface. Headings, labels, pills and the wordmark switch from Space Mono to Inter, with a tighter type scale.
- Panels, cards, chips, tabs, buttons and inputs share the 8px/12px radii and the accent-soft active state. Buttons show hover, focus, disabled and loading states.
- Flash messages are toasts in the top-right corner with an icon and a close button instead of a full-width bar.
- Toggles, checkboxes, the organizer update banner and the confirm dialog lose their glows and gradients.
- The sidebar and topbar tighten to a 64px header row and 40px nav items.

Both themes were checked on Discover, the huddl page, My huddlz, Profile and Settings.

## Worth knowing

Class names are unchanged, so this is CSS plus the flash component. Page-specific layouts (calendar, organize, forms) still carry some old spacing and will be rebuilt one page at a time next.