### PR TITLE
feat(ui): rebuild the discover page on the design tokens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1341,7 +1341,7 @@ body .scope-tabs {
   border-radius: var(--radius-sm);
   background: var(--panel-2);
   padding: 4px;
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }
 
 body .scope-tab {
@@ -1374,7 +1374,7 @@ body .filter-bar {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--panel);
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }
 
 body .filter-group {
@@ -1550,7 +1550,7 @@ body .filter-distance-value {
 body .chip-group {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
 }
 
 body .chip-group .chip { height: 32px; padding: 0 14px; font-size: 13px; }
@@ -1591,14 +1591,14 @@ body .chip.is-active {
 /* Grid + cards */
 body .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
 }
 
-body .grid.two { grid-template-columns: repeat(2, 1fr); }
+body .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 
 @media (max-width: 1280px) {
- body .grid { grid-template-columns: repeat(2, 1fr); } }
+ body .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 
 @media (max-width: 720px) {
  body .grid, body .grid.two { grid-template-columns: 1fr; } }
@@ -1619,9 +1619,29 @@ body .card:hover { border-color: var(--line-strong); transform: translateY(-2px)
 body .card-cover {
   position: relative;
   aspect-ratio: 16 / 9;
-  background-size: cover;
-  background-position: center;
+  background: var(--panel-2);
   overflow: hidden;
+}
+
+body .card-cover-fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+body .card-cover-fallback span {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line-strong);
+  background: var(--panel);
+  color: var(--accent-ink);
+  display: grid;
+  place-items: center;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
 }
 
 body .card-cover-img {
@@ -1696,15 +1716,6 @@ body .group-cover-image {
   width: 100%;
   height: 100%;
 }
-
-body .card-cover.gradient-1 { background: linear-gradient(135deg, #06424a 0%, #0c1c20 50%, #1a0c30 100%); }
-body .card-cover.gradient-2 { background: linear-gradient(160deg, #2c0a36 0%, #050810 60%, #0a3a44 100%); }
-body .card-cover.gradient-3 { background: linear-gradient(135deg, #1a3633 0%, #050810 60%, #2a1010 100%); }
-body .card-cover.gradient-4 { background: linear-gradient(135deg, #14232a 0%, #060a14 60%, #2a0e2a 100%); }
-body .card-cover.gradient-5 { background: linear-gradient(120deg, #082a2a 0%, #050a14 70%, #1a0c2a 100%); }
-body .card-cover.gradient-6 { background: linear-gradient(160deg, #181818 0%, #051820 50%, #1a3340 100%); }
-
-
 
 body .date-stamp {
   position: absolute;
@@ -2801,8 +2812,44 @@ body .eyebrow .eyebrow-warn { color: var(--warn); }
 /* Empty-state placeholder inside .member-grid */
 body .member-grid-empty { font-size: 13px; }
 
-/* Empty-state placeholder for grid-driven lists (huddlz, etc) */
-body .empty-state { padding: 24px 0; font-size: 14px; }
+/* Empty state: dashed, centered placeholder for lists with nothing to show */
+body .empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 40px 24px;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius);
+  text-align: center;
+}
+
+body .empty-state-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  color: var(--muted);
+  display: grid;
+  place-items: center;
+}
+
+body .empty-state h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+body .empty-state p {
+  margin: 0;
+  max-width: 360px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+body .empty-state-action { margin-top: 4px; }
 
 /* Sub-section inside huddl-side */
 body .huddl-side-section {
@@ -4340,14 +4387,18 @@ body .button-link:hover { text-decoration: underline; }
 
 /* Discover-page meta line (result count + inline reset link). */
 body .discover-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 24px;
   color: var(--muted);
-  font-size: 12px;
-  margin-bottom: 14px;
+  font-size: 13px;
 }
 
 /* "All huddlz" backlink wrapper used when ?yours= is active. */
 body .discover-back {
-  margin-bottom: 16px;
+  margin-bottom: 24px;
   font-size: 13px;
 }
 
@@ -4591,6 +4642,28 @@ body .page-nav:disabled {
   body .visibility-selection { grid-template-columns: 1fr; }
   body .visibility-toggle { margin-top: 4px; }
   body .filters { gap: 6px; }
+  body .scope-tabs { display: flex; margin-bottom: 16px; }
+  body .scope-tabs .scope-tab { flex: 1 1 0; justify-content: center; }
+  body .filter-bar {
+    flex-wrap: nowrap;
+    gap: 8px;
+    margin: 0 -12px 16px;
+    padding: 0 12px 4px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  body .filter-bar::-webkit-scrollbar { display: none; }
+  body .filter-group { flex: 0 0 auto; flex-wrap: nowrap; gap: 8px; }
+  body .filter-group > * { flex: 0 0 auto; }
+  body .filter-location-wrap { min-width: 160px; }
+  body .filter-label { display: none; }
+  body .chip-group { flex-wrap: nowrap; }
+  body .chip-group .chip { white-space: nowrap; }
+  body .discover-meta { margin-bottom: 16px; }
+  body .grid { gap: 16px; }
   body .insight-strip { gap: 8px; }
   /* Listings on org pages: collapse multi-column rows */
   body .row.huddlz-row, body .row.members-row { grid-template-columns: 56px 1fr; row-gap: 8px; }

--- a/lib/huddlz_web/components/card.ex
+++ b/lib/huddlz_web/components/card.ex
@@ -85,6 +85,23 @@ defmodule HuddlzWeb.Components.Card do
   end
 
   @doc """
+  Renders the neutral cover shown when a huddl has no image: a 16:9 tile in
+  `panel-2` carrying the group's initials (used inside a `<:cover>` slot of
+  `card`).
+  """
+  attr :name, :string, required: true, doc: "group name the initials are taken from"
+
+  def cover_fallback(assigns) do
+    assigns = assign(assigns, :initials, group_initials(assigns.name))
+
+    ~H"""
+    <div class="card-cover-fallback" aria-hidden="true">
+      <span>{@initials}</span>
+    </div>
+    """
+  end
+
+  @doc """
   Renders a date stamp (used inside a `<:cover>` slot of `card`).
   """
   attr :month, :string, required: true, doc: "3-letter month abbreviation, uppercase"

--- a/lib/huddlz_web/components/components.ex
+++ b/lib/huddlz_web/components/components.ex
@@ -3,7 +3,7 @@ defmodule HuddlzWeb.Components do
   Design components facade.
 
   Each function component (`<.avatar>`, `<.button>`, `<.card>`, `<.chip>`,
-  `<.flash>`, `<.icon>`, `<.input>`, `<.list_row>`, `<.modal>`,
+  `<.empty_state>`, `<.flash>`, `<.icon>`, `<.input>`, `<.list_row>`, `<.modal>`,
   `<.pagination>`, `<.panel>`, `<.pill>`) lives in its own module under this
   namespace. Styles live in `assets/css/app.css`.
 
@@ -20,6 +20,7 @@ defmodule HuddlzWeb.Components do
       import HuddlzWeb.Components.Chip
       import HuddlzWeb.Components.Flash
       import HuddlzWeb.Components.CoverImage
+      import HuddlzWeb.Components.EmptyState
       import HuddlzWeb.Components.Icon
       import HuddlzWeb.Components.Input
       import HuddlzWeb.Components.ListRow

--- a/lib/huddlz_web/components/empty_state.ex
+++ b/lib/huddlz_web/components/empty_state.ex
@@ -1,0 +1,31 @@
+defmodule HuddlzWeb.Components.EmptyState do
+  @moduledoc """
+  Empty state — a dashed, centered placeholder shown where a list has
+  nothing to render. Pairs a hero icon with a short title, one line of
+  guidance, and an optional action.
+  """
+  use Phoenix.Component
+
+  import HuddlzWeb.Components.Icon
+
+  attr :title, :string, required: true
+  attr :icon, :string, default: nil, doc: ~s(hero icon name, e.g. "hero-magnifying-glass")
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  slot :inner_block, doc: "one line of guidance, rendered as a paragraph"
+  slot :action, doc: "an optional button or link"
+
+  def empty_state(assigns) do
+    ~H"""
+    <div class={["empty-state", @class]} {@rest}>
+      <span :if={@icon} class="empty-state-icon" aria-hidden="true">
+        <.icon name={@icon} class="size-5" />
+      </span>
+      <h3>{@title}</h3>
+      <p :if={@inner_block != []}>{render_slot(@inner_block)}</p>
+      <div :if={@action != []} class="empty-state-action">{render_slot(@action)}</div>
+    </div>
+    """
+  end
+end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -675,18 +675,18 @@ defmodule HuddlzWeb.HuddlLive do
       </div>
 
       <div class="discover-meta">
-        {result_count_label(@page_info.total_count, @scope)}
-        <span :if={any_filter_active?(assigns)}>
-          ·
+        <span>{result_count_label(@page_info.total_count, @scope)}</span>
+        <%= if any_filter_active?(assigns) and not results_empty?(assigns) do %>
+          <span aria-hidden="true">·</span>
           <button type="button" phx-click="clear_filters" class="button-link">
             Clear filters
           </button>
-        </span>
+        <% end %>
       </div>
 
       <%= if @scope == :huddlz do %>
         <%= if Enum.empty?(@huddls) do %>
-          <p class="muted">{empty_message(assigns)}</p>
+          <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
         <% else %>
           <div class="grid">
             <%= for {{huddl, distance}, idx} <- Enum.with_index(@huddls) do %>
@@ -703,7 +703,7 @@ defmodule HuddlzWeb.HuddlLive do
         <% end %>
       <% else %>
         <%= if @groups == [] do %>
-          <p class="muted">{empty_message(assigns)}</p>
+          <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
         <% else %>
           <div class="grid">
             <%= for {group, idx} <- Enum.with_index(@groups) do %>
@@ -734,12 +734,15 @@ defmodule HuddlzWeb.HuddlLive do
       gradient={@gradient}
     >
       <:cover>
-        <.cover_image
-          :if={@huddl.display_image_url}
-          id={"huddl-card-cover-#{@huddl.id}"}
-          class="card-cover-img"
-          image_url={@huddl.display_image_url}
-        />
+        <%= if @huddl.display_image_url do %>
+          <.cover_image
+            id={"huddl-card-cover-#{@huddl.id}"}
+            class="card-cover-img"
+            image_url={@huddl.display_image_url}
+          />
+        <% else %>
+          <.cover_fallback name={@huddl.group.name} />
+        <% end %>
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>
           {tag_label(@huddl.event_type)}
@@ -787,6 +790,24 @@ defmodule HuddlzWeb.HuddlLive do
         </div>
       </:body>
     </.card>
+    """
+  end
+
+  attr :icon, :string, required: true
+  attr :title, :string, required: true
+  attr :body, :string, required: true
+  attr :clearable, :boolean, required: true
+
+  defp discover_empty(assigns) do
+    ~H"""
+    <.empty_state icon={@icon} title={@title}>
+      {@body}
+      <:action :if={@clearable}>
+        <.button variant={:secondary} type="button" phx-click="clear_filters">
+          Clear filters
+        </.button>
+      </:action>
+    </.empty_state>
     """
   end
 
@@ -909,17 +930,48 @@ defmodule HuddlzWeb.HuddlLive do
       assigns.date_filter != "upcoming" or assigns.location_active or assigns.sort != :soonest
   end
 
-  defp empty_message(%{scope: :groups}),
-    do: "No groups match this search. Try Huddlz or change your filters."
+  # The empty state carries its own "Clear filters" action, so the meta line
+  # drops its link whenever there is nothing to list.
+  defp results_empty?(%{huddls: [], groups: []}), do: true
+  defp results_empty?(_), do: false
 
-  defp empty_message(%{yours: :hosting}), do: "You aren't hosting any huddlz that match."
-  defp empty_message(%{yours: :attending}), do: "You aren't attending any huddlz that match."
+  defp empty_state_copy(%{scope: :groups}) do
+    %{
+      icon: "hero-user-group",
+      title: "No groups found",
+      body: "No groups match this search. Try Huddlz or change your filters."
+    }
+  end
 
-  defp empty_message(%{scope: :huddlz} = assigns) do
+  defp empty_state_copy(%{yours: :hosting}) do
+    %{
+      icon: "hero-calendar",
+      title: "Nothing you're hosting",
+      body: "You aren't hosting any huddlz that match."
+    }
+  end
+
+  defp empty_state_copy(%{yours: :attending}) do
+    %{
+      icon: "hero-calendar",
+      title: "Nothing you're attending",
+      body: "You aren't attending any huddlz that match."
+    }
+  end
+
+  defp empty_state_copy(%{scope: :huddlz} = assigns) do
     if any_filter_active?(assigns) do
-      "No huddlz match this search. Try Groups or change your filters."
+      %{
+        icon: "hero-magnifying-glass",
+        title: "Nothing matches those filters",
+        body: "No huddlz match this search. Try Groups or change your filters."
+      }
     else
-      "No upcoming huddlz right now."
+      %{
+        icon: "hero-calendar",
+        title: "Nothing coming up",
+        body: "No upcoming huddlz right now."
+      }
     end
   end
 

--- a/test/huddlz_web/components/components_test.exs
+++ b/test/huddlz_web/components/components_test.exs
@@ -193,6 +193,51 @@ defmodule HuddlzWeb.ComponentsTest do
     end
   end
 
+  describe "cover_fallback/1" do
+    test "renders the group's initials inside the neutral cover tile" do
+      assigns = %{}
+
+      html = rendered_to_string(~H|<.cover_fallback name="Phoenix Elixir Meetup" />|)
+
+      assert html =~ ~s(class="card-cover-fallback")
+      assert html =~ ~s(aria-hidden="true")
+      assert html =~ "<span>PE</span>"
+    end
+  end
+
+  describe "empty_state/1" do
+    test "renders icon, title, guidance and action" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.empty_state icon="hero-magnifying-glass" title="Nothing matches those filters">
+          Try a wider distance or clear the type and date filters.
+          <:action><.button>Clear filters</.button></:action>
+        </.empty_state>
+        """)
+
+      assert html =~ ~s(class="empty-state )
+      assert html =~ ~s(class="empty-state-icon")
+      assert html =~ "hero-magnifying-glass"
+      assert html =~ "<h3>Nothing matches those filters</h3>"
+      assert html =~ "Try a wider distance"
+      assert html =~ ~s(class="empty-state-action")
+      assert html =~ "Clear filters"
+    end
+
+    test "omits the icon, paragraph and action when not given" do
+      assigns = %{}
+
+      html = rendered_to_string(~H|<.empty_state title="No notifications yet" />|)
+
+      assert html =~ "<h3>No notifications yet</h3>"
+      refute html =~ "empty-state-icon"
+      refute html =~ "<p"
+      refute html =~ "empty-state-action"
+    end
+  end
+
   describe "list_row/1" do
     test "renders a row with passed content and class" do
       assigns = %{}


### PR DESCRIPTION
## Summary

Third step-3 page after the huddl page (#450), built on the tokens (#448) and shared components (#449).

- **Empty-state component** (`<.empty_state>`): dashed tile with a hero icon, title, one line of guidance and an optional action. Discover is its first consumer; the other list pages pick it up in their own PRs.
- **Card cover fallback** (`<.cover_fallback>`): huddlz without a cover get a neutral `panel-2` tile with the group's initials, matching the huddl page hero. The six hardcoded dark cover gradients are gone from huddl cards, so they render correctly in light mode. Group covers keep theirs until the My groups PR.
- **Discover layout**: 24px grid gap and even 24px section spacing, 13px meta line, chip groups at 8px. The meta line hides its "Clear filters" link when the empty state already offers one, so there is a single button to click.
- **Phone layout**: scope tabs fill the width, the filter bar becomes a horizontal scrolling chip strip with labels hidden, cards stack with a 16px gap.

## Testing

`mix precommit` is clean. New component tests cover `empty_state` and `cover_fallback`; existing Discover tests pass unchanged since the empty-state copy still lives in a `<p>`.