### PR TITLE
feat(ui): rebuild the my huddlz page on the design tokens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1588,6 +1588,9 @@ body .chip.is-active {
   font-weight: 600;
 }
 
+body .chip-count { color: var(--muted); font-weight: 600; }
+body .chip.is-active .chip-count { color: var(--accent-ink); }
+
 /* Grid + cards */
 body .grid {
   display: grid;
@@ -1792,9 +1795,13 @@ body .card-foot {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 12px 16px;
   border-top: 1px solid var(--line);
 }
+
+body .card-foot-note { color: var(--muted); font-size: 12px; }
+body .card-foot .pill.cyan::before { background: var(--success); }
 
 body .stack { display: flex; align-items: center; }
 
@@ -4641,7 +4648,7 @@ body .page-nav:disabled {
   body .visibility-panel-head { flex-direction: column; align-items: flex-start; gap: 10px; }
   body .visibility-selection { grid-template-columns: 1fr; }
   body .visibility-toggle { margin-top: 4px; }
-  body .filters { gap: 6px; }
+  body .filters { gap: 8px; margin-bottom: 16px; }
   body .scope-tabs { display: flex; margin-bottom: 16px; }
   body .scope-tabs .scope-tab { flex: 1 1 0; justify-content: center; }
   body .filter-bar {

--- a/lib/huddlz_web/components/chip.ex
+++ b/lib/huddlz_web/components/chip.ex
@@ -8,6 +8,7 @@ defmodule HuddlzWeb.Components.Chip do
   use Phoenix.Component
 
   attr :active, :boolean, default: false
+  attr :count, :integer, default: nil, doc: "optional result count shown after the label"
   attr :class, :any, default: nil
 
   attr :rest, :global,
@@ -24,6 +25,7 @@ defmodule HuddlzWeb.Components.Chip do
         {@rest}
       >
         {render_slot(@inner_block)}
+        <span :if={@count} class="chip-count">{" "}{@count}</span>
       </.link>
       """
     else
@@ -32,6 +34,7 @@ defmodule HuddlzWeb.Components.Chip do
       ~H"""
       <button type={@type} class={["chip", @active && "is-active", @class]} {@rest}>
         {render_slot(@inner_block)}
+        <span :if={@count} class="chip-count">{" "}{@count}</span>
       </button>
       """
     end

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -2,7 +2,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
   @moduledoc """
   LiveView at `/my-huddlz`. Personal feed of huddlz the signed-in user is
   attending, waitlisted on, or has already attended. Filter chips
-  (Upcoming · N / Waitlisted · N / Past) drive a `?filter=` URL param;
+  (Upcoming N / Waitlisted N / Past N) drive a `?filter=` URL param;
   `?page=N` paginates the active filter.
 
   Hosting moves to the organizer workspace — by design this view is
@@ -157,30 +157,41 @@ defmodule HuddlzWeb.MyHuddlzLive do
           <h1>My huddlz</h1>
           <p>{filter_blurb(@filter)}</p>
         </div>
-        <.link navigate={~p"/discover"} class="btn-primary">
-          Find another huddl
-        </.link>
+        <.button variant={:primary} navigate={~p"/discover"}>
+          <.icon name="hero-magnifying-glass" class="size-4" /> Find another huddl
+        </.button>
       </div>
 
       <div class="filters">
-        <.chip patch={filter_path(:upcoming, 1)} active={@filter == :upcoming}>
-          Upcoming · {@counts.upcoming}
+        <.chip
+          patch={filter_path(:upcoming, 1)}
+          active={@filter == :upcoming}
+          count={@counts.upcoming}
+        >
+          Upcoming
         </.chip>
-        <.chip patch={filter_path(:waitlisted, 1)} active={@filter == :waitlisted}>
-          Waitlisted · {@counts.waitlisted}
+        <.chip
+          patch={filter_path(:waitlisted, 1)}
+          active={@filter == :waitlisted}
+          count={@counts.waitlisted}
+        >
+          Waitlisted
         </.chip>
-        <.chip patch={filter_path(:past, 1)} active={@filter == :past}>
-          Past · {@counts.past}
+        <.chip patch={filter_path(:past, 1)} active={@filter == :past} count={@counts.past}>
+          Past
         </.chip>
       </div>
 
       <%= if Enum.empty?(@huddls) do %>
-        <p class="muted">{empty_message(@filter)}</p>
+        <.empty_state icon={empty_icon(@filter)} title={empty_title(@filter)}>
+          {empty_message(@filter)}
+          <:action :if={@filter == :upcoming}>
+            <.button variant={:secondary} navigate={~p"/discover"}>Browse huddlz</.button>
+          </:action>
+        </.empty_state>
       <% else %>
         <div class="grid">
-          <%= for {huddl, idx} <- Enum.with_index(@huddls) do %>
-            <.my_huddl_card huddl={huddl} filter={@filter} gradient={Integer.mod(idx, 6) + 1} />
-          <% end %>
+          <.my_huddl_card :for={huddl <- @huddls} huddl={huddl} filter={@filter} />
         </div>
         <.pagination
           :if={@page_info.total_pages > 1}
@@ -195,21 +206,20 @@ defmodule HuddlzWeb.MyHuddlzLive do
 
   attr :huddl, :map, required: true
   attr :filter, :atom, required: true
-  attr :gradient, :integer, required: true
 
   defp my_huddl_card(assigns) do
     ~H"""
-    <.card
-      navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}
-      gradient={@gradient}
-    >
+    <.card navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}>
       <:cover>
-        <.cover_image
-          :if={@huddl.display_image_url}
-          id={"my-huddl-card-cover-#{@huddl.id}"}
-          class="card-cover-img"
-          image_url={@huddl.display_image_url}
-        />
+        <%= if @huddl.display_image_url do %>
+          <.cover_image
+            id={"my-huddl-card-cover-#{@huddl.id}"}
+            class="card-cover-img"
+            image_url={@huddl.display_image_url}
+          />
+        <% else %>
+          <.cover_fallback name={@huddl.group.name} />
+        <% end %>
         <.date_stamp month={huddl_month(@huddl)} day={huddl_day(@huddl)} />
         <.card_tag variant={tag_variant(@huddl.event_type)}>
           {tag_label(@huddl.event_type)}
@@ -230,7 +240,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
         <.pill variant={pill_variant(@huddl, @filter)}>
           {pill_label(@huddl, @filter)}
         </.pill>
-        <span class="muted" style="font-size:12px">{relative_time(@huddl.starts_at)}</span>
+        <span class="card-foot-note">{relative_time(@huddl.starts_at)}</span>
       </:foot>
     </.card>
     """
@@ -244,6 +254,14 @@ defmodule HuddlzWeb.MyHuddlzLive do
 
   defp filter_blurb(:past),
     do: "Huddlz you've attended. Most recent first."
+
+  defp empty_icon(:upcoming), do: "hero-calendar"
+  defp empty_icon(:waitlisted), do: "hero-clock"
+  defp empty_icon(:past), do: "hero-check-circle"
+
+  defp empty_title(:upcoming), do: "Nothing coming up"
+  defp empty_title(:waitlisted), do: "No waitlists"
+  defp empty_title(:past), do: "Nothing attended yet"
 
   defp empty_message(:upcoming),
     do: "No upcoming RSVPs yet. Find one to attend."
@@ -261,7 +279,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
     end
   end
 
-  defp filter_pill_variant(:upcoming), do: :default
+  defp filter_pill_variant(:upcoming), do: :cyan
   defp filter_pill_variant(:waitlisted), do: :warn
   defp filter_pill_variant(:past), do: :muted
 

--- a/test/huddlz_web/components/components_test.exs
+++ b/test/huddlz_web/components/components_test.exs
@@ -47,6 +47,16 @@ defmodule HuddlzWeb.ComponentsTest do
       refute inactive =~ "is-active"
     end
 
+    test "renders an optional count after the label" do
+      assigns = %{}
+
+      counted = rendered_to_string(~H"<.chip count={3}>Upcoming</.chip>")
+      plain = rendered_to_string(~H"<.chip>Upcoming</.chip>")
+
+      assert counted =~ ~s(<span class="chip-count"> 3</span>)
+      refute plain =~ "chip-count"
+    end
+
     test "renders a link when href is given" do
       assigns = %{}
       active = rendered_to_string(~H|<.chip href="/discover" active>Discover</.chip>|)

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -53,6 +53,40 @@ defmodule HuddlzWeb.HuddlLiveTest do
       |> assert_has(".grid .card .card-cover")
     end
 
+    test "shows the group's initials when a huddl has no image, and the image when it does", %{
+      conn: conn,
+      host: host
+    } do
+      group = generate(group(name: "Phoenix Elixir Meetup", owner_id: host.id, actor: host))
+
+      bare =
+        generate(huddl(group_id: group.id, creator_id: host.id, is_private: false, actor: host))
+
+      pictured =
+        generate(huddl(group_id: group.id, creator_id: host.id, is_private: false, actor: host))
+
+      Huddlz.Communities.HuddlCoverImage
+      |> Ash.Changeset.for_create(:create, %{
+        filename: "cover.jpg",
+        content_type: "image/jpeg",
+        size_bytes: 123,
+        storage_path: "/uploads/huddl_cover_images/#{pictured.id}/cover.jpg",
+        thumbnail_path: "/uploads/huddl_cover_images/#{pictured.id}/cover_thumb.jpg",
+        huddl_id: pictured.id
+      })
+      |> Ash.create!(authorize?: false)
+
+      bare_card = ~s(.card[href="/groups/#{group.slug}/huddlz/#{bare.id}"])
+      pictured_card = ~s(.card[href="/groups/#{group.slug}/huddlz/#{pictured.id}"])
+
+      conn
+      |> visit("/discover")
+      |> assert_has("#{bare_card} .card-cover-fallback", text: "PE", exact: true)
+      |> refute_has("#{bare_card} .cover-image")
+      |> assert_has("#{pictured_card} #huddl-card-cover-#{pictured.id}.cover-image")
+      |> refute_has("#{pictured_card} .card-cover-fallback")
+    end
+
     test "searches huddlz by title", %{conn: conn, host: host, public_group: public_group} do
       _elixir_huddl =
         generate(

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -135,7 +135,9 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       conn
       |> login(attendee)
       |> visit("/my-huddlz")
-      |> assert_has("p", text: "No upcoming RSVPs yet. Find one to attend.")
+      |> assert_has(".empty-state h3", text: "Nothing coming up")
+      |> assert_has(".empty-state p", text: "No upcoming RSVPs yet. Find one to attend.")
+      |> assert_has(".empty-state a[href=\"/discover\"]", text: "Browse huddlz")
     end
 
     test "Upcoming count reflects attended huddlz", %{
@@ -150,7 +152,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       conn
       |> login(attendee)
       |> visit("/my-huddlz")
-      |> assert_has(".filters .chip", text: "Upcoming · 1")
+      |> assert_has(".filters .chip", text: "Upcoming 1")
     end
 
     test "shows a creator's huddl automatically and removes it after cancellation", %{
@@ -164,7 +166,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(host)
       |> visit("/my-huddlz")
       |> assert_has("h3.card-title", text: "Creator RSVP")
-      |> assert_has(".filters .chip", text: "Upcoming · 1")
+      |> assert_has(".filters .chip", text: "Upcoming 1")
 
       rsvp!(Ash.reload!(huddl), host, :cancel_rsvp)
 
@@ -172,7 +174,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(host)
       |> visit("/my-huddlz")
       |> refute_has("h3.card-title", text: "Creator RSVP")
-      |> assert_has(".filters .chip", text: "Upcoming · 0")
+      |> assert_has(".filters .chip", text: "Upcoming 0")
     end
   end
 
@@ -213,7 +215,8 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       conn
       |> login(attendee)
       |> visit("/my-huddlz?filter=waitlisted")
-      |> assert_has("p", text: "You're not on a waitlist right now.")
+      |> assert_has(".empty-state p", text: "You're not on a waitlist right now.")
+      |> refute_has(".empty-state a")
     end
   end
 
@@ -239,7 +242,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       conn
       |> login(attendee)
       |> visit("/my-huddlz?filter=past")
-      |> assert_has("p", text: "No past attendance yet.")
+      |> assert_has(".empty-state p", text: "No past attendance yet.")
     end
 
     test "places a creator's RSVP in Past after the huddl ends", %{
@@ -254,7 +257,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(host)
       |> visit("/my-huddlz?filter=past")
       |> assert_has("h3.card-title", text: "Creator Attended")
-      |> assert_has(".filters .chip", text: "Past · 1")
+      |> assert_has(".filters .chip", text: "Past 1")
       |> assert_has(".pill", text: "Attended")
     end
   end
@@ -288,7 +291,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> visit("/my-huddlz")
       |> assert_has("h3.card-title", text: "I Am Going")
       |> refute_has("h3.card-title", text: "They Are Going")
-      |> assert_has(".filters .chip", text: "Upcoming · 1")
+      |> assert_has(".filters .chip", text: "Upcoming 1")
     end
   end
 
@@ -373,7 +376,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       conn
       |> login(attendee)
       |> visit("/my-huddlz")
-      |> assert_has(".filters .chip", text: "Upcoming · 22")
+      |> assert_has(".filters .chip", text: "Upcoming 22")
       |> assert_has(".pagination .page-num", text: "2")
     end
 

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -2,6 +2,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
   alias Huddlz.Communities
+  alias Huddlz.Communities.HuddlCoverImage
 
   setup do
     host = generate(user(role: :user))
@@ -31,6 +32,19 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
         )
       )
     )
+  end
+
+  defp attach_cover_image!(huddl) do
+    HuddlCoverImage
+    |> Ash.Changeset.for_create(:create, %{
+      filename: "cover.jpg",
+      content_type: "image/jpeg",
+      size_bytes: 123,
+      storage_path: "/uploads/huddl_cover_images/#{huddl.id}/cover.jpg",
+      thumbnail_path: "/uploads/huddl_cover_images/#{huddl.id}/cover_thumb.jpg",
+      huddl_id: huddl.id
+    })
+    |> Ash.create!(authorize?: false)
   end
 
   defp create_past_huddl(host, group, opts) do
@@ -309,6 +323,35 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> login(attendee)
       |> visit("/my-huddlz")
       |> assert_has(~s(.grid .card[href="/groups/#{public_group.slug}/huddlz/#{huddl.id}"]))
+    end
+  end
+
+  describe "card covers" do
+    test "shows the group's initials when a huddl has no image, and the image when it does", %{
+      conn: conn,
+      attendee: attendee,
+      host: host
+    } do
+      group =
+        generate(group(name: "Phoenix Elixir Meetup", owner_id: host.id, actor: host))
+
+      bare = create_huddl(host, group, title: "Bare Show")
+      pictured = create_huddl(host, group, title: "Pictured Show")
+      attach_cover_image!(pictured)
+
+      rsvp!(bare, attendee, :rsvp)
+      rsvp!(pictured, attendee, :rsvp)
+
+      bare_card = ~s(.card[href="/groups/#{group.slug}/huddlz/#{bare.id}"])
+      pictured_card = ~s(.card[href="/groups/#{group.slug}/huddlz/#{pictured.id}"])
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has("#{bare_card} .card-cover-fallback", text: "PE", exact: true)
+      |> refute_has("#{bare_card} .cover-image")
+      |> assert_has("#{pictured_card} #my-huddl-card-cover-#{pictured.id}.cover-image")
+      |> refute_has("#{pictured_card} .card-cover-fallback")
     end
   end
 


### PR DESCRIPTION
## Summary

- `<.chip>` gains an optional `count` attribute, rendered as a muted figure after the label (accent when the chip is active); My huddlz uses it for Upcoming / Waitlisted / Past
- Huddl cards on My huddlz drop the gradient covers and use `<.cover_fallback>` with the group's initials when there is no image
- The Going pill moves to the accent tint with a success dot; the relative-time note in the card foot is a `card-foot-note`
- The three empty states use `<.empty_state>` with an icon and title; Upcoming adds a Browse huddlz link to Discover
- Page-head button is `<.button variant={:primary}>` with a search icon; mobile filters use an 8px gap

## Testing

`mix precommit` clean. My huddlz LiveView tests updated for the new chip and empty-state markup; component test added for the chip count.