### PR TITLE
feat(ui): rebuild the my groups page on the design tokens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1661,46 +1661,30 @@ body .group-cover {
   inset: 0;
   isolation: isolate;
   overflow: hidden;
-  background: linear-gradient(135deg, #06424a 0%, #0c1c20 50%, #1a0c30 100%);
+  background: var(--panel-2);
 }
-
-body .group-cover.gradient-1 { background: linear-gradient(135deg, #06424a 0%, #0c1c20 50%, #1a0c30 100%); }
-body .group-cover.gradient-2 { background: linear-gradient(160deg, #2c0a36 0%, #050810 60%, #0a3a44 100%); }
-body .group-cover.gradient-3 { background: linear-gradient(135deg, #1a3633 0%, #050810 60%, #2a1010 100%); }
-body .group-cover.gradient-4 { background: linear-gradient(135deg, #14232a 0%, #060a14 60%, #2a0e2a 100%); }
-body .group-cover.gradient-5 { background: linear-gradient(120deg, #082a2a 0%, #050a14 70%, #1a0c2a 100%); }
-body .group-cover.gradient-6 { background: linear-gradient(160deg, #181818 0%, #051820 50%, #1a3340 100%); }
 
 body .group-cover-fallback {
   position: absolute;
   inset: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  gap: 6px;
+  display: grid;
+  place-items: center;
   padding: 16px;
-  background-image:
-    linear-gradient(color-mix(in srgb, var(--accent) 6%, transparent) 1px, transparent 1px),
-    linear-gradient(90deg, color-mix(in srgb, var(--accent) 6%, transparent) 1px, transparent 1px);
-  background-size: 28px 28px;
 }
 
 body .group-cover-signal {
-  color: rgba(244, 251, 251, 0.84);
-  font-family: var(--mono);
-  font-size: clamp(30px, 5vw, 54px);
-  font-weight: 800;
-  letter-spacing: -0.08em;
-  line-height: 0.9;
-}
-
-body .group-cover-label {
-  color: rgba(244, 251, 251, 0.58);
-  font-family: var(--mono);
-  font-size: 9px;
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--line-strong);
+  border-radius: 16px;
+  background: var(--panel);
+  color: var(--accent-ink);
+  display: grid;
+  place-items: center;
+  font-size: 22px;
   font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  line-height: 1;
 }
 
 body .cover-image {
@@ -1756,6 +1740,18 @@ body .card-tag {
   color: var(--soft);
   font-size: 11px;
   font-weight: 600;
+}
+
+body .card-tag.owner {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+}
+
+body .card-tag.organizer {
+  border-color: color-mix(in srgb, var(--warn) 50%, transparent);
+  background: var(--warn-soft);
+  color: var(--warn);
 }
 
 
@@ -1993,16 +1989,15 @@ body .organizer-group-row .group-cover--thumb {
   border-radius: var(--radius-sm);
 }
 
-body .group-cover--thumb .group-cover-fallback {
-  align-items: center;
-  justify-content: center;
-  padding: 4px;
-  background-size: 12px 12px;
-}
+body .group-cover--thumb .group-cover-fallback { padding: 0; }
 
 body .group-cover--thumb .group-cover-signal {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   font-size: 13px;
-  letter-spacing: -0.04em;
 }
 
 body .organizer-group-copy { min-width: 0; }
@@ -3094,14 +3089,13 @@ body .group-cover--hero::after {
   pointer-events: none;
 }
 
-body .group-cover--hero .group-cover-fallback {
-  justify-content: center;
-  padding: 32px;
-}
+body .group-cover--hero .group-cover-fallback { place-items: start center; padding: 32px; }
 
 body .group-cover--hero .group-cover-signal {
-  font-size: clamp(64px, 12vw, 132px);
-  opacity: 0.42;
+  width: 96px;
+  height: 96px;
+  border-radius: 24px;
+  font-size: 32px;
 }
 
 body .hero-content {

--- a/lib/huddlz_web/components/card.ex
+++ b/lib/huddlz_web/components/card.ex
@@ -3,8 +3,7 @@ defmodule HuddlzWeb.Components.Card do
   V3 card — anchor card used for huddlz, groups, and saved items in grid views.
 
   Slot-driven so callers can compose cover image, date stamp, tag, body, and
-  foot independently. The default `gradient` cycles through 1–6 to vary cover
-  fallbacks across a list.
+  foot independently.
   """
   use Phoenix.Component
 
@@ -13,12 +12,6 @@ defmodule HuddlzWeb.Components.Card do
   attr :href, :string, default: nil
   attr :navigate, :string, default: nil
   attr :patch, :string, default: nil
-
-  attr :gradient, :integer,
-    values: [1, 2, 3, 4, 5, 6],
-    default: 1,
-    doc: "1–6 selects the cover fallback gradient"
-
   attr :class, :any, default: nil
   attr :rest, :global
 
@@ -35,7 +28,7 @@ defmodule HuddlzWeb.Components.Card do
       class={["card", @class]}
       {@rest}
     >
-      <div :if={@cover != []} class={"card-cover gradient-#{@gradient}"}>
+      <div :if={@cover != []} class="card-cover">
         {render_slot(@cover)}
       </div>
       <div class="card-body">
@@ -49,30 +42,21 @@ defmodule HuddlzWeb.Components.Card do
   end
 
   @doc """
-  Renders group cover media with a branded fallback that remains visible when
-  the image is absent or cannot be loaded.
+  Renders group cover media over a neutral fallback, a `panel-2` field with
+  the group's initials in a tile, that stays visible when the image is absent
+  or cannot be loaded.
   """
   attr :group, :map, required: true
   attr :id, :string, required: true
   attr :variant, :atom, values: [:card, :hero, :thumb], default: :card
 
-  attr :gradient, :integer,
-    values: [1, 2, 3, 4, 5, 6],
-    default: 1,
-    doc: "1–6 selects the fallback gradient"
-
   def group_cover(assigns) do
     assigns = assign(assigns, :initials, group_initials(assigns.group.name))
 
     ~H"""
-    <div
-      id={@id}
-      class={["group-cover", "group-cover--#{@variant}", "gradient-#{@gradient}"]}
-      data-testid="group-cover"
-    >
+    <div id={@id} class={["group-cover", "group-cover--#{@variant}"]} data-testid="group-cover">
       <div class="group-cover-fallback" aria-hidden="true">
         <span class="group-cover-signal">{@initials}</span>
-        <span :if={@variant != :thumb} class="group-cover-label">huddlz group</span>
       </div>
       <.cover_image
         :if={@group.current_image_url}

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -462,10 +462,9 @@ defmodule HuddlzWeb.GroupLive.Show do
         {@empty_message}
       </p>
       <.card
-        :for={{id, %{huddl: huddl, gradient: gradient}} <- @huddlz}
+        :for={{id, %{huddl: huddl}} <- @huddlz}
         id={id}
         navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}
-        gradient={gradient}
       >
         <:cover>
           <.cover_image
@@ -496,12 +495,7 @@ defmodule HuddlzWeb.GroupLive.Show do
   end
 
   defp stream_huddlz(socket, huddlz) do
-    entries =
-      huddlz
-      |> Enum.with_index()
-      |> Enum.map(fn {huddl, index} ->
-        %{id: huddl.id, huddl: huddl, gradient: Integer.mod(index, 6) + 1}
-      end)
+    entries = Enum.map(huddlz, &%{id: &1.id, huddl: &1})
 
     stream(socket, :huddlz, entries, reset: true)
   end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -689,9 +689,7 @@ defmodule HuddlzWeb.HuddlLive do
           <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
         <% else %>
           <div class="grid">
-            <%= for {{huddl, distance}, idx} <- Enum.with_index(@huddls) do %>
-              <.huddl_card huddl={huddl} distance={distance} gradient={Integer.mod(idx, 6) + 1} />
-            <% end %>
+            <.huddl_card :for={{huddl, distance} <- @huddls} huddl={huddl} distance={distance} />
           </div>
           <.pagination
             :if={@page_info.total_pages > 1}
@@ -706,9 +704,7 @@ defmodule HuddlzWeb.HuddlLive do
           <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
         <% else %>
           <div class="grid">
-            <%= for {group, idx} <- Enum.with_index(@groups) do %>
-              <.group_card group={group} gradient={Integer.mod(idx, 6) + 1} />
-            <% end %>
+            <.group_card :for={group <- @groups} group={group} />
           </div>
           <.pagination
             :if={@page_info.total_pages > 1}
@@ -725,14 +721,10 @@ defmodule HuddlzWeb.HuddlLive do
 
   attr :huddl, :map, required: true
   attr :distance, :float, default: nil
-  attr :gradient, :integer, default: 1
 
   defp huddl_card(assigns) do
     ~H"""
-    <.card
-      navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}
-      gradient={@gradient}
-    >
+    <.card navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}>
       <:cover>
         <%= if @huddl.display_image_url do %>
           <.cover_image
@@ -770,17 +762,12 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   attr :group, :map, required: true
-  attr :gradient, :integer, default: 1
 
   defp group_card(assigns) do
     ~H"""
-    <.card navigate={~p"/groups/#{@group.slug}"} gradient={@gradient}>
+    <.card navigate={~p"/groups/#{@group.slug}"}>
       <:cover>
-        <.group_cover
-          id={"discover-group-cover-#{@group.id}"}
-          group={@group}
-          gradient={@gradient}
-        />
+        <.group_cover id={"discover-group-cover-#{@group.id}"} group={@group} />
       </:cover>
       <:body>
         <span :if={@group.location} class="card-group">{@group.location}</span>

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -147,34 +147,39 @@ defmodule HuddlzWeb.MyGroupsLive do
           <h1>My groups</h1>
           <p>{filter_blurb(@filter)}</p>
         </div>
-        <.link navigate={~p"/groups/new"} class="btn-primary">
-          Start a group
-        </.link>
+        <.button variant={:primary} navigate={~p"/groups/new"}>
+          <.icon name="hero-plus" class="size-4" /> Start a group
+        </.button>
       </div>
 
       <div class="filters">
-        <.chip patch={filter_path(:all, 1)} active={@filter == :all}>
-          All · {@counts.all}
+        <.chip patch={filter_path(:all, 1)} active={@filter == :all} count={@counts.all}>
+          All
         </.chip>
-        <.chip patch={filter_path(:hosting, 1)} active={@filter == :hosting}>
-          Hosting · {@counts.hosting}
+        <.chip
+          patch={filter_path(:hosting, 1)}
+          active={@filter == :hosting}
+          count={@counts.hosting}
+        >
+          Hosting
         </.chip>
-        <.chip patch={filter_path(:joined, 1)} active={@filter == :joined}>
-          Joined · {@counts.joined}
+        <.chip patch={filter_path(:joined, 1)} active={@filter == :joined} count={@counts.joined}>
+          Joined
         </.chip>
       </div>
 
       <%= if Enum.empty?(@groups) do %>
-        <p class="muted">{empty_message(@filter)}</p>
+        <.empty_state icon={empty_icon(@filter)} title={empty_title(@filter)}>
+          {empty_message(@filter)}
+          <:action :if={@filter != :hosting}>
+            <.button variant={:secondary} navigate={~p"/discover?scope=groups"}>
+              Browse groups
+            </.button>
+          </:action>
+        </.empty_state>
       <% else %>
         <div class="grid">
-          <%= for {group, idx} <- Enum.with_index(@groups) do %>
-            <.my_group_card
-              group={group}
-              role={group.viewer_role}
-              gradient={Integer.mod(idx, 6) + 1}
-            />
-          <% end %>
+          <.my_group_card :for={group <- @groups} group={group} role={group.viewer_role} />
         </div>
         <.pagination
           :if={@page_info.total_pages > 1}
@@ -189,17 +194,12 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   attr :group, :map, required: true
   attr :role, :atom, required: true
-  attr :gradient, :integer, required: true
 
   defp my_group_card(assigns) do
     ~H"""
-    <.card navigate={~p"/groups/#{@group.slug}"} gradient={@gradient}>
+    <.card navigate={~p"/groups/#{@group.slug}"}>
       <:cover>
-        <.group_cover
-          id={"my-group-cover-#{@group.id}"}
-          group={@group}
-          gradient={@gradient}
-        />
+        <.group_cover id={"my-group-cover-#{@group.id}"} group={@group} />
         <span class={["card-tag", role_class(@role)]}>{HuddlzWeb.GroupRole.label(@role)}</span>
       </:cover>
       <:body>
@@ -217,15 +217,23 @@ defmodule HuddlzWeb.MyGroupsLive do
   defp filter_blurb(:hosting), do: "Groups you organize."
   defp filter_blurb(:joined), do: "Groups you've joined."
 
+  defp empty_icon(:all), do: "hero-user-group"
+  defp empty_icon(:hosting), do: "hero-megaphone"
+  defp empty_icon(:joined), do: "hero-user-plus"
+
+  defp empty_title(:all), do: "No groups yet"
+  defp empty_title(:hosting), do: "You're not hosting a group"
+  defp empty_title(:joined), do: "No groups joined"
+
   defp empty_message(:all),
     do: "You haven't organized or joined any groups yet. Start one or browse Discover."
 
   defp empty_message(:hosting), do: "You haven't created a group yet."
   defp empty_message(:joined), do: "You haven't joined any groups yet."
 
-  defp role_class(:owner), do: "hybrid"
-  defp role_class(:organizer), do: "virtual"
-  defp role_class(_), do: "in-person"
+  defp role_class(:owner), do: "owner"
+  defp role_class(:organizer), do: "organizer"
+  defp role_class(_), do: nil
 
   defp member_count_label(group) do
     case Map.get(group, :member_count) do

--- a/test/browser/steps/group_cover_steps.exs
+++ b/test/browser/steps/group_cover_steps.exs
@@ -145,13 +145,13 @@ defmodule BrowserCoverSteps do
 
   defp assert_fallback(conn) do
     conn
-    |> assert_has("#group-detail-hero .group-cover-label", text: "huddlz group")
+    |> assert_has("#group-detail-hero .group-cover-signal")
     |> assert_browser("""
     (() => {
       const cover = document.querySelector('#group-detail-hero .group-cover');
       const fallback = cover.querySelector('.group-cover-fallback');
       const image = cover.querySelector('.cover-image');
-      return getComputedStyle(cover).backgroundImage.includes('gradient') &&
+      return getComputedStyle(cover).backgroundColor !== 'rgba(0, 0, 0, 0)' &&
         fallback.getBoundingClientRect().height > 0 && getComputedStyle(fallback).visibility === 'visible' &&
         (!image || getComputedStyle(image).backgroundColor === 'rgba(0, 0, 0, 0)');
     })()

--- a/test/huddlz_web/components/components_test.exs
+++ b/test/huddlz_web/components/components_test.exs
@@ -175,7 +175,7 @@ defmodule HuddlzWeb.ComponentsTest do
 
       html =
         rendered_to_string(~H"""
-        <.card href="/groups/foo" gradient={3}>
+        <.card href="/groups/foo">
           <:cover>
             <.date_stamp month="MAY" day={22} />
             <.card_tag variant={:hybrid}>Hybrid</.card_tag>
@@ -193,7 +193,7 @@ defmodule HuddlzWeb.ComponentsTest do
       assert html =~ "<a"
       assert html =~ ~s(href="/groups/foo")
       assert html =~ ~s(class="card)
-      assert html =~ "card-cover gradient-3"
+      assert html =~ ~s(class="card-cover")
       assert html =~ "date-stamp"
       assert html =~ ~s(class="card-tag hybrid")
       assert html =~ "Hybrid"

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -18,7 +18,7 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("#group-detail-hero.group-hero")
       |> assert_has("#group-detail-cover-#{group.id} [aria-hidden='true']")
-      |> assert_has("#group-detail-cover-#{group.id} .group-cover-label", text: "huddlz group")
+      |> assert_has("#group-detail-cover-#{group.id} .group-cover-signal")
       |> refute_has("#group-detail-cover-#{group.id} .cover-image")
     end
 

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -369,9 +369,9 @@ defmodule HuddlzWeb.HuddlLiveTest do
       conn
       |> visit("/discover?scope=groups")
       |> assert_has("#discover-group-cover-#{group.id}[data-testid='group-cover']")
-      |> assert_has(
-        "#discover-group-cover-#{group.id} .group-cover-label",
-        text: "huddlz group"
+      |> assert_has("#discover-group-cover-#{group.id} .group-cover-signal",
+        text: "FC",
+        exact: true
       )
     end
 

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -64,18 +64,20 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> visit("/my-groups")
       |> assert_has(".grid .card .card-title", text: "Hosted Crew")
       |> assert_has(".grid .card .card-title", text: "Joined Crew")
-      |> assert_has(".filters .chip", text: "All · 2")
-      |> assert_has(".filters .chip", text: "Hosting · 1")
-      |> assert_has(".filters .chip", text: "Joined · 1")
+      |> assert_has(".filters .chip", text: "All 2")
+      |> assert_has(".filters .chip", text: "Hosting 1")
+      |> assert_has(".filters .chip", text: "Joined 1")
     end
 
     test "empty state copy", %{conn: conn, member: member} do
       conn
       |> login(member)
       |> visit("/my-groups")
-      |> assert_has("p",
+      |> assert_has(".empty-state h3", text: "No groups yet")
+      |> assert_has(".empty-state p",
         text: "You haven't organized or joined any groups yet. Start one or browse Discover."
       )
+      |> assert_has(".empty-state a[href='/discover?scope=groups']", text: "Browse groups")
     end
   end
 
@@ -98,14 +100,15 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> assert_has(".filters .chip.is-active", text: "Hosting")
       |> assert_has(".grid .card .card-title", text: "Owned One")
       |> refute_has(".grid .card .card-title", text: "Joined One")
-      |> assert_has(".grid .card .card-tag", text: "Owner")
+      |> assert_has(".grid .card .card-tag.owner", text: "Owner")
     end
 
     test "empty state copy", %{conn: conn, member: member} do
       conn
       |> login(member)
       |> visit("/my-groups?filter=hosting")
-      |> assert_has("p", text: "You haven't created a group yet.")
+      |> assert_has(".empty-state p", text: "You haven't created a group yet.")
+      |> refute_has(".empty-state a")
     end
   end
 
@@ -129,14 +132,15 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> assert_has(".filters .chip.is-active", text: "Joined")
       |> assert_has(".grid .card .card-title", text: "Joined One")
       |> refute_has(".grid .card .card-title", text: "Owned One")
-      |> assert_has(".grid .card .card-tag", text: "Member")
+      |> assert_has(".grid .card .card-tag:not(.owner):not(.organizer)", text: "Member")
     end
 
     test "empty state copy", %{conn: conn, member: member} do
       conn
       |> login(member)
       |> visit("/my-groups?filter=joined")
-      |> assert_has("p", text: "You haven't joined any groups yet.")
+      |> assert_has(".empty-state p", text: "You haven't joined any groups yet.")
+      |> assert_has(".empty-state a[href='/discover?scope=groups']", text: "Browse groups")
     end
   end
 
@@ -162,7 +166,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> login(member)
       |> visit("/my-groups")
       |> refute_has(".grid .card .card-title", text: "Strangers Only")
-      |> assert_has(".filters .chip", text: "All · 0")
+      |> assert_has(".filters .chip", text: "All 0")
     end
   end
 
@@ -192,7 +196,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       |> login(member)
       |> visit("/my-groups")
       |> assert_has("#my-group-cover-#{group.id}[data-testid='group-cover']")
-      |> assert_has("#my-group-cover-#{group.id} .group-cover-label", text: "huddlz group")
+      |> assert_has("#my-group-cover-#{group.id} .group-cover-signal", text: "FC", exact: true)
       |> refute_has("#my-group-cover-#{group.id} img")
     end
 


### PR DESCRIPTION
## Summary

- Group covers use a `panel-2` field with the group's initials in a tile instead of six hardcoded dark gradients and the mono "huddlz group" label; the hero and organizer thumb variants are sized accordingly
- `<.card>` and `<.group_cover>` drop the `gradient` attribute; Discover, the group page and My groups no longer index gradients
- My groups uses counted filter chips, `card-tag.owner` / `card-tag.organizer` tints, `<.empty_state>` for the three filters (All and Joined link to Browse groups), and the primary Start a group button with an icon

## Testing

`mix precommit` clean. Cover tests on Discover, My groups, the group page and the organizer workspace now assert the initials tile; the Playwright group cover feature was updated for the solid background and passes locally.