### PR TITLE
feat(nav): highlight the group's organizing row on organizer pages

### DIFF
--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -131,7 +131,8 @@ defmodule HuddlzWeb.GroupLive.Edit do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-groups"
+      active_group_slug={@group.slug}
+      active_organize_section={:overview}
     >
       <div class="page-head">
         <div>

--- a/lib/huddlz_web/live/group_live/locations.ex
+++ b/lib/huddlz_web/live/group_live/locations.ex
@@ -74,7 +74,8 @@ defmodule HuddlzWeb.GroupLive.Locations do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-groups"
+      active_group_slug={@group.slug}
+      active_organize_section={:overview}
     >
       <p class="locations-back">
         <.link navigate={~p"/groups/#{@group.slug}"}>← Back to {@group.name}</.link>

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -193,7 +193,8 @@ defmodule HuddlzWeb.HuddlLive.Edit do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-groups"
+      active_group_slug={@group_slug}
+      active_organize_section={:huddlz}
     >
       <div class="page-head">
         <div>

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -159,7 +159,8 @@ defmodule HuddlzWeb.HuddlLive.New do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-groups"
+      active_group_slug={@group.slug}
+      active_organize_section={:huddlz}
     >
       <div class="page-head">
         <div>

--- a/test/features/organizer_navigation.feature
+++ b/test/features/organizer_navigation.feature
@@ -1,0 +1,29 @@
+@async @database @conn
+Feature: Organizer pages highlight the group's section
+  As a group owner
+  I want organizer pages to highlight my group under Organizing
+  So that scheduling and editing never read as browsing or as my personal lists
+
+  Background:
+    Given the following users exist:
+      | email             | display_name | role    |
+      | owner@example.com | Owner User   | regular |
+    And a public group "Portland Elixir" exists with owner "owner@example.com"
+    And a huddl "Ash workshop" exists in "Portland Elixir" created by "owner@example.com"
+    And I am signed in as "owner@example.com"
+
+  Scenario: Scheduling a huddl highlights the group's huddlz
+    When I visit the new huddl page for group "Portland Elixir"
+    Then navigation should identify "Huddlz" under group "Portland Elixir" as the current destination
+
+  Scenario: Editing a huddl highlights the group's huddlz
+    When I visit the edit page for huddl "Ash workshop"
+    Then navigation should identify "Huddlz" under group "Portland Elixir" as the current destination
+
+  Scenario: Editing a group highlights its overview
+    When I visit the edit page for group "Portland Elixir"
+    Then navigation should identify "Overview" under group "Portland Elixir" as the current destination
+
+  Scenario: Managing locations highlights the group's overview
+    When I visit the locations page for "Portland Elixir"
+    Then navigation should identify "Overview" under group "Portland Elixir" as the current destination

--- a/test/features/step_definitions/current_navigation_steps.exs
+++ b/test/features/step_definitions/current_navigation_steps.exs
@@ -12,6 +12,17 @@ defmodule CurrentNavigationSteps do
     context
   end
 
+  step "navigation should identify {string} under group {string} as the current destination",
+       %{args: [section, group_name], session: session} = context do
+    session
+    |> assert_has(".sb-org-row.active", text: group_name)
+    |> assert_has(".sb-sub-item.active[aria-current='page']", text: section, exact: true)
+    |> refute_has(".sb-item[aria-current]")
+    |> refute_has(".sb-org-row[aria-current]")
+
+    context
+  end
+
   step "view choices should identify {string} as current",
        %{args: [label], session: session} = context do
     session


### PR DESCRIPTION
## Summary

- Schedule a huddl and Edit huddl expand the group's row under Organizing with the Huddlz sub-tab active
- Edit group and Locations do the same with the Overview sub-tab active
- None of the four pages marks My groups as current any more; the top-level items are only active on their own pages

The Organizing list only shows owned groups, so an organizer who is not the owner sees no highlight on these pages rather than a fallback to My groups.

## Testing

`mix precommit` clean. New `organizer_navigation.feature` covers the four pages with a step that asserts the active row and sub-tab and that no top-level item carries `aria-current`.