### PR TITLE
feat(ui): rebuild the group page on the design tokens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2175,6 +2175,30 @@ body .delete-confirm-copy p {
 
 body .delete-confirm-copy strong { color: var(--text); }
 
+body .leave-confirm-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  color: var(--soft);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+body .leave-confirm-list li { display: flex; gap: 10px; align-items: flex-start; }
+body .leave-confirm-list li > .size-4 { flex: 0 0 auto; margin-top: 2px; color: var(--muted); }
+
+body .delete-confirm-copy .leave-confirm-note {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
 body .delete-confirm-series-note {
   margin-top: 12px;
   padding: 10px 12px;
@@ -2791,8 +2815,8 @@ body .member-grid.compact .member-mark { width: 28px; height: 28px; font-size: 1
 
 body .role-pill {
   display: flex;
-  justify-content: center;
-  margin-bottom: 12px;
+  justify-content: flex-start;
+  margin-bottom: 4px;
 }
 
 /* Stacked button stack inside huddl-side (join / leave / manage / create) */
@@ -2803,10 +2827,16 @@ body .side-actions {
 }
 
 body .side-actions > .btn-primary,
-body .side-actions > .btn-secondary {
+body .side-actions > .btn-secondary,
+body .side-actions > .btn-muted {
   width: 100%;
   justify-content: center;
 }
+
+body .side-actions > .side-actions-primary { height: 44px; font-size: 14px; }
+
+body .side-actions-row { display: flex; gap: 8px; }
+body .side-actions-row > .btn-secondary { flex: 1 1 0; justify-content: center; }
 
 /* Warn-colored span inside an eyebrow (e.g. "Group · Private") */
 body .eyebrow .eyebrow-warn { color: var(--warn); }
@@ -3015,7 +3045,8 @@ body .hero-img {
 
 /* The huddl page header: a 16:9 cover on top, then the title block in flow
    (never overlaid on the image, so it reads the same in both themes). */
-body .huddl-hero {
+body .huddl-hero,
+body .group-hero {
   position: static;
   display: flex;
   flex-direction: column;
@@ -3029,7 +3060,8 @@ body .huddl-hero {
   background: none;
 }
 
-body .huddl-hero .hero-media {
+body .huddl-hero .hero-media,
+body .group-hero .hero-media {
   position: relative;
   aspect-ratio: 16 / 9;
   border: 1px solid var(--line);
@@ -3061,7 +3093,8 @@ body .huddl-hero .hero-fallback span {
   letter-spacing: 0.02em;
 }
 
-body .huddl-hero .hero-content {
+body .huddl-hero .hero-content,
+body .group-hero .hero-content {
   position: static;
   display: flex;
   flex-direction: column;
@@ -3071,7 +3104,17 @@ body .huddl-hero .hero-content {
   padding: 24px 0 0;
 }
 
-body .huddl-hero .hero-content h1 { margin: 0; }
+body .huddl-hero .hero-content h1,
+body .group-hero .hero-content h1 { margin: 0; }
+
+body .hero-content .meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+body .hero-content .meta-item > .size-4 { flex: 0 0 auto; color: var(--muted); }
 
 body .hero:not(.group-hero):not(.huddl-hero)::after {
   content: "";
@@ -3079,17 +3122,6 @@ body .hero:not(.group-hero):not(.huddl-hero)::after {
   inset: 0;
   background: linear-gradient(180deg, transparent 40%, rgba(0, 0, 0, 0.72) 100%);
 }
-
-body .group-cover--hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  background: linear-gradient(180deg, transparent 40%, rgba(0, 0, 0, 0.72) 100%);
-  pointer-events: none;
-}
-
-body .group-cover--hero .group-cover-fallback { place-items: start center; padding: 32px; }
 
 body .group-cover--hero .group-cover-signal {
   width: 96px;
@@ -3106,21 +3138,6 @@ body .hero-content {
   right: 0;
   padding: 28px 32px;
   z-index: 2;
-}
-
-body .group-hero {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  height: auto;
-  min-height: 280px;
-}
-
-body .group-hero .hero-content {
-  position: relative;
-  width: 100%;
-  min-width: 0;
-  box-sizing: border-box;
 }
 
 body .group-hero-location {
@@ -3211,6 +3228,30 @@ body .huddl-main > .huddl-intro {
 body .huddl-intro { grid-area: intro; }
 body .huddl-side { grid-area: side; }
 body .huddl-rest { grid-area: rest; display: flex; flex-direction: column; gap: 0; }
+
+body .group-huddlz {
+  gap: 20px;
+  padding-top: 32px;
+  border-top: 1px solid var(--line);
+}
+
+body .list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+body .list-head h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+body .list-head .filters { margin: 0; }
 
 @media (max-width: 1100px) {
 
@@ -4587,38 +4628,8 @@ body .page-nav:disabled {
   body .page-head .actions { flex-wrap: wrap; }
   body .hero:not(.huddl-hero):not(.group-hero) { height: 200px; }
   body .hero { margin-bottom: 20px; }
-  body .group-hero {
-    display: grid;
-    grid-template-rows: auto auto;
-    min-height: 0;
-    background: var(--panel-2);
-  }
-  body .group-hero .group-cover--hero {
-    position: relative;
-    inset: auto;
-    grid-row: 1;
-    width: 100%;
-    aspect-ratio: 16 / 9;
-  }
-  body .group-hero .group-cover--hero::after {
-    background: linear-gradient(180deg, transparent 58%, color-mix(in srgb, var(--bg) 50%, transparent) 100%);
-  }
-  body .group-hero .hero-content {
-    position: relative;
-    inset: auto;
-    grid-row: 2;
-    border-top: 1px solid var(--line);
-  }
   body .hero-content { padding: 18px 16px; }
   body .hero-content h1 { font-size: 26px; }
-  body .group-hero-meta {
-    align-items: flex-start;
-    gap: 6px 12px;
-  }
-  body .group-hero-location {
-    flex: 1 1 100%;
-  }
-  body .group-hero-separator { display: none; }
   body .huddl-side {
     position: static;
     padding: 18px 16px;
@@ -4698,7 +4709,8 @@ body .page-nav:disabled {
 
   body .organizer-update h2 { font-size: 15px; }
 
-  body .huddl-hero {
+  body .huddl-hero,
+  body .group-hero {
     display: block;
     height: auto;
     aspect-ratio: auto;
@@ -4708,9 +4720,11 @@ body .page-nav:disabled {
     margin-bottom: 24px;
   }
 
-  body .huddl-hero::after { display: none; }
+  body .huddl-hero::after,
+  body .group-hero::after { display: none; }
 
-  body .huddl-hero .hero-media {
+  body .huddl-hero .hero-media,
+  body .group-hero .hero-media {
     position: relative;
     width: 100%;
     box-sizing: border-box;
@@ -4720,12 +4734,16 @@ body .page-nav:disabled {
     border-radius: var(--radius);
   }
 
-  body .huddl-hero .hero-content {
+  body .huddl-hero .hero-content,
+  body .group-hero .hero-content {
     display: block;
     position: relative;
     padding: 18px 4px 0;
     color: var(--text);
   }
+
+  body .group-hero .hero-content h1 { margin: 10px 0 0; }
+  body .group-hero .hero-content .meta { display: grid; gap: 6px; margin-top: 12px; }
 
   body .huddl-hero .hero-content .eyebrow {
     display: block;

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -27,6 +27,7 @@ defmodule HuddlzWeb.GroupLive.Show do
      |> assign(:subscribed_group_id, nil)
      |> assign(:members_visible?, false)
      |> assign(:member_grid_extras, 0)
+     |> assign(:huddl_count, 0)
      |> stream(:member_grid, [])
      |> stream(:huddlz, [])}
   end
@@ -154,48 +155,44 @@ defmodule HuddlzWeb.GroupLive.Show do
       active="discover"
     >
       <HuddlzWeb.StructuredData.group group={@group} url={@canonical_url} />
-      <div id="group-detail-hero" class="hero group-hero">
-        <.group_cover
-          id={"group-detail-cover-#{@group.id}"}
-          group={@group}
-          variant={:hero}
-        />
-        <div class="hero-content">
-          <span class="eyebrow">
-            Group ·
-            <%= if @group.is_public do %>
-              Public
-            <% else %>
-              <span class="eyebrow-warn">Private</span>
-            <% end %>
-          </span>
-          <h1>{@group.name}</h1>
-          <div class="meta group-hero-meta">
-            <span :if={@group.location} class="group-hero-location">📍 {@group.location}</span>
-            <span
-              :if={@group.location && @member_count && @member_count > 0}
-              class="group-hero-separator"
-            >
-              ·
-            </span>
-            <span :if={@member_count && @member_count > 0}>
-              {member_count_label(@member_count)}
-            </span>
-          </div>
-        </div>
-      </div>
-
       <div class="huddl-frame">
-        <div class="huddl-intro prose">
-          <%= if @group.description do %>
-            <p :for={paragraph <- description_paragraphs(@group.description)}>{paragraph}</p>
-          <% else %>
-            <p>No description provided.</p>
-          <% end %>
+        <div class="huddl-main">
+          <header id="group-detail-hero" class="hero group-hero">
+            <div class="hero-media">
+              <.group_cover
+                id={"group-detail-cover-#{@group.id}"}
+                group={@group}
+                variant={:hero}
+              />
+            </div>
+            <div class="hero-content">
+              <.pill variant={if @group.is_public, do: :cyan, else: :warn}>
+                {if @group.is_public, do: "Public group", else: "Private group"}
+              </.pill>
+              <h1>{@group.name}</h1>
+              <div class="meta group-hero-meta">
+                <span :if={@group.location} class="meta-item group-hero-location">
+                  <.icon name="hero-map-pin" class="size-4" />
+                  <span>{@group.location}</span>
+                </span>
+                <span :if={@member_count && @member_count > 0} class="meta-item">
+                  <.icon name="hero-users" class="size-4" />
+                  <span>{member_count_label(@member_count)}</span>
+                </span>
+              </div>
+            </div>
+          </header>
+
+          <div class="huddl-intro prose">
+            <%= if @group.description do %>
+              <p :for={paragraph <- description_paragraphs(@group.description)}>{paragraph}</p>
+            <% else %>
+              <p>No description provided.</p>
+            <% end %>
+          </div>
         </div>
 
         <aside class="huddl-side">
-          <h3>This group</h3>
           <ul class="facts">
             <li>
               <svg
@@ -265,34 +262,38 @@ defmodule HuddlzWeb.GroupLive.Show do
           </ul>
 
           <%= if @current_user do %>
-            <div :if={role_pill(assigns)} class="role-pill">
-              <.pill variant={:cyan}>{role_pill(assigns)}</.pill>
-            </div>
             <div class="side-actions">
+              <div :if={role_pill(assigns)} class="role-pill">
+                <.pill variant={:cyan}>{role_pill(assigns)}</.pill>
+              </div>
               <.button
                 :if={@can_create_huddl}
                 variant={:primary}
+                class="side-actions-primary"
                 navigate={~p"/groups/#{@group.slug}/huddlz/new"}
               >
-                + Create Huddl
+                <.icon name="hero-plus" class="size-4" /> Create Huddl
               </.button>
-              <.button
-                :if={@can_edit_group}
-                variant={:secondary}
-                navigate={~p"/groups/#{@group.slug}/edit"}
-              >
-                Edit Group
-              </.button>
-              <.button
-                :if={@can_manage_locations}
-                variant={:secondary}
-                navigate={~p"/groups/#{@group.slug}/locations"}
-              >
-                Locations
-              </.button>
+              <div :if={@can_edit_group or @can_manage_locations} class="side-actions-row">
+                <.button
+                  :if={@can_edit_group}
+                  variant={:secondary}
+                  navigate={~p"/groups/#{@group.slug}/edit"}
+                >
+                  Edit Group
+                </.button>
+                <.button
+                  :if={@can_manage_locations}
+                  variant={:secondary}
+                  navigate={~p"/groups/#{@group.slug}/locations"}
+                >
+                  Locations
+                </.button>
+              </div>
               <.button
                 :if={!@is_member and @can_join_group}
                 variant={:primary}
+                class="side-actions-primary"
                 phx-click="join_group"
                 phx-disable-with="Joining..."
               >
@@ -351,38 +352,40 @@ defmodule HuddlzWeb.GroupLive.Show do
           </div>
         </aside>
 
-        <div class="huddl-rest">
-          <div class="prose">
-            <h2>Huddlz</h2>
+        <section class="huddl-rest group-huddlz" aria-labelledby="group-huddlz-title">
+          <div class="list-head">
+            <h2 id="group-huddlz-title">Huddlz</h2>
+            <nav class="filters" aria-label="Huddl timeframe">
+              <.link
+                id="group-huddlz-upcoming"
+                patch={group_page_path(@group, "upcoming", 1)}
+                aria-current={@active_tab == "upcoming" && "page"}
+                class={["chip", @active_tab == "upcoming" && "is-active"]}
+              >
+                Upcoming
+              </.link>
+              <.link
+                id="group-huddlz-past"
+                patch={group_page_path(@group, "past", 1)}
+                aria-current={@active_tab == "past" && "page"}
+                class={["chip", @active_tab == "past" && "is-active"]}
+              >
+                Past
+              </.link>
+            </nav>
           </div>
 
-          <nav class="filters" aria-label="Huddl timeframe">
-            <.link
-              id="group-huddlz-upcoming"
-              patch={group_page_path(@group, "upcoming", 1)}
-              aria-current={@active_tab == "upcoming" && "page"}
-              class={["chip", @active_tab == "upcoming" && "is-active"]}
-            >
-              Upcoming
-            </.link>
-            <.link
-              id="group-huddlz-past"
-              patch={group_page_path(@group, "past", 1)}
-              aria-current={@active_tab == "past" && "page"}
-              class={["chip", @active_tab == "past" && "is-active"]}
-            >
-              Past
-            </.link>
-          </nav>
-
-          <.huddl_grid
-            huddlz={@streams.huddlz}
-            empty_message={
-              if @active_tab == "upcoming",
-                do: "No upcoming huddlz scheduled.",
-                else: "No past huddlz found."
-            }
-          />
+          <.huddl_grid huddlz={@streams.huddlz} />
+          <.empty_state
+            :if={@huddl_count == 0}
+            id="group-huddl-grid-empty"
+            icon={if @active_tab == "upcoming", do: "hero-calendar", else: "hero-clock"}
+            title={if @active_tab == "upcoming", do: "Nothing scheduled", else: "No past huddlz"}
+          >
+            {if @active_tab == "upcoming",
+              do: "No upcoming huddlz scheduled.",
+              else: "No past huddlz found."}
+          </.empty_state>
           <.pagination
             :if={@active_tab == "past" && @past_total_pages > 1}
             current_page={@past_page}
@@ -390,7 +393,7 @@ defmodule HuddlzWeb.GroupLive.Show do
             id="group-archive-pagination"
             page_path={&group_page_path(@group, "past", &1)}
           />
-        </div>
+        </section>
       </div>
 
       <.share_modal id="share-group-modal" url={@meta.url} label="group" />
@@ -401,46 +404,42 @@ defmodule HuddlzWeb.GroupLive.Show do
         show
         on_cancel={JS.push("cancel_leave_group")}
       >
-        <div class="flex gap-4 pr-8">
-          <div class="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-warning/30 bg-warning/10 text-warning">
-            <.icon name="hero-arrow-right-start-on-rectangle" class="h-5 w-5" />
+        <div class="delete-confirm">
+          <div class="delete-confirm-icon" aria-hidden="true">
+            <.icon name="hero-arrow-right-start-on-rectangle" class="size-5" />
           </div>
-          <div>
-            <h2 id="leave-group-dialog-title" class="text-xl font-bold text-base-content">
-              Leave {@group.name}?
-            </h2>
-            <p class="mt-2 text-sm leading-6 text-base-content/70">
-              Leaving this group will:
+
+          <div class="delete-confirm-copy">
+            <h2 id="leave-group-dialog-title">Leave {@group.name}?</h2>
+            <p>Leaving this group will:</p>
+            <ul class="leave-confirm-list">
+              <li>
+                <.icon name="hero-user-group" class="size-4" />
+                <span>Remove you from the <strong>member roster</strong></span>
+              </li>
+              <li>
+                <.icon name="hero-rectangle-stack" class="size-4" />
+                <span>Remove this group from <strong>My groups</strong></span>
+              </li>
+              <li>
+                <.icon name="hero-bell-slash" class="size-4" />
+                <span>Stop <strong>notifications</strong> from this group</span>
+              </li>
+            </ul>
+            <p class="leave-confirm-note">
+              Leaving does not cancel your existing RSVPs.
+              You can rejoin later if the group is public or you receive another invitation.
             </p>
           </div>
         </div>
 
-        <ul class="mt-5 space-y-3 rounded-hz-card border border-base-300 bg-base-100/50 p-4 text-sm text-base-content/80">
-          <li class="flex gap-3">
-            <.icon name="hero-user-group" class="mt-0.5 h-4 w-4 shrink-0 text-base-content/50" />
-            <span>Remove you from the <strong class="text-base-content">member roster</strong></span>
-          </li>
-          <li class="flex gap-3">
-            <.icon name="hero-rectangle-stack" class="mt-0.5 h-4 w-4 shrink-0 text-base-content/50" />
-            <span>Remove this group from <strong class="text-base-content">My groups</strong></span>
-          </li>
-          <li class="flex gap-3">
-            <.icon name="hero-bell-slash" class="mt-0.5 h-4 w-4 shrink-0 text-base-content/50" />
-            <span>Stop <strong class="text-base-content">notifications</strong> from this group</span>
-          </li>
-        </ul>
-
-        <p class="mt-4 text-sm text-base-content/60">
-          Leaving does not cancel your existing RSVPs.
-          You can rejoin later if the group is public or you receive another invitation.
-        </p>
-
-        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-          <.button id="leave-group-dialog-cancel" phx-click="cancel_leave_group">
+        <div class="delete-confirm-actions">
+          <.button id="leave-group-dialog-cancel" variant={:muted} phx-click="cancel_leave_group">
             Cancel
           </.button>
           <.button
             variant={:destructive}
+            class="delete-confirm-submit"
             phx-click="leave_group"
             phx-disable-with="Leaving..."
           >
@@ -453,26 +452,25 @@ defmodule HuddlzWeb.GroupLive.Show do
   end
 
   attr :huddlz, Phoenix.LiveView.LiveStream, required: true
-  attr :empty_message, :string, required: true
 
   defp huddl_grid(assigns) do
     ~H"""
     <div id="group-huddl-grid" class="grid two" phx-update="stream">
-      <p id="group-huddl-grid-empty" class="empty-state muted hidden only:block col-span-full">
-        {@empty_message}
-      </p>
       <.card
         :for={{id, %{huddl: huddl}} <- @huddlz}
         id={id}
         navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}
       >
         <:cover>
-          <.cover_image
-            :if={huddl.display_image_url}
-            id={"group-huddl-card-cover-#{huddl.id}"}
-            class="card-cover-img"
-            image_url={huddl.display_image_url}
-          />
+          <%= if huddl.display_image_url do %>
+            <.cover_image
+              id={"group-huddl-card-cover-#{huddl.id}"}
+              class="card-cover-img"
+              image_url={huddl.display_image_url}
+            />
+          <% else %>
+            <.cover_fallback name={huddl.group.name} />
+          <% end %>
           <.date_stamp month={huddl_month(huddl)} day={huddl_day(huddl)} />
           <.card_tag variant={tag_variant(huddl.event_type)}>
             {tag_label(huddl.event_type)}
@@ -497,7 +495,9 @@ defmodule HuddlzWeb.GroupLive.Show do
   defp stream_huddlz(socket, huddlz) do
     entries = Enum.map(huddlz, &%{id: &1.id, huddl: &1})
 
-    stream(socket, :huddlz, entries, reset: true)
+    socket
+    |> assign(:huddl_count, length(entries))
+    |> stream(:huddlz, entries, reset: true)
   end
 
   defp refresh_huddlz(%{assigns: %{active_tab: "past"}} = socket) do

--- a/test/browser/features/group_cover.feature
+++ b/test/browser/features/group_cover.feature
@@ -14,7 +14,7 @@ Feature: Group cover rendering
       | missing |
       | failed  |
 
-  Scenario: A desktop cover renders behind readable group details
+  Scenario: A desktop cover renders above readable group details
     Given a group with long details and a "valid" cover
     When I open that group in the browser
     Then its cover has the expected image or visible fallback

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -47,6 +47,113 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
     end
   end
 
+  describe "page layout" do
+    setup do
+      owner = generate(user(role: :user))
+
+      group =
+        generate(
+          group(
+            owner_id: owner.id,
+            is_public: true,
+            name: "Phoenix Elixir",
+            location: "Phoenix, AZ",
+            actor: owner
+          )
+        )
+
+      %{owner: owner, group: group}
+    end
+
+    test "stacks the cover above the title with a visibility pill and meta", %{
+      conn: conn,
+      group: group
+    } do
+      conn
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("header#group-detail-hero.group-hero .hero-media .group-cover--hero")
+      |> assert_has("header#group-detail-hero .hero-content .pill.cyan", text: "Public group")
+      |> assert_has("header#group-detail-hero .hero-content h1", text: "Phoenix Elixir")
+      |> assert_has(".group-hero-meta .group-hero-location", text: "Phoenix, AZ")
+      |> assert_has(".group-hero-meta .meta-item", text: "1 member")
+      |> refute_has(".huddl-side h3", text: "This group")
+    end
+
+    test "groups the owner's actions in the side panel", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has(".side-actions .role-pill .pill", text: "Owner")
+      |> assert_has(
+        ".side-actions a.side-actions-primary[href='/groups/#{group.slug}/huddlz/new']",
+        text: "Create Huddl"
+      )
+      |> assert_has(".side-actions-row a[href='/groups/#{group.slug}/edit']", text: "Edit Group")
+      |> assert_has(".side-actions-row a[href='/groups/#{group.slug}/locations']",
+        text: "Locations"
+      )
+    end
+
+    test "shows an empty state until the group has an upcoming huddl", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      conn
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#group-huddl-grid-empty.empty-state h3", text: "Nothing scheduled")
+      |> assert_has("#group-huddl-grid-empty p", text: "No upcoming huddlz scheduled.")
+      |> assert_has(".group-huddlz .list-head h2", text: "Huddlz")
+      |> assert_has(".group-huddlz .list-head .filters .chip.is-active", text: "Upcoming")
+
+      generate(huddl(group_id: group.id, creator_id: owner.id, is_private: false, actor: owner))
+
+      conn
+      |> visit(~p"/groups/#{group.slug}")
+      |> refute_has("#group-huddl-grid-empty")
+      |> assert_has("#group-huddl-grid .card", count: 1)
+    end
+
+    test "huddl cards fall back to the group's initials without a cover", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      bare =
+        generate(huddl(group_id: group.id, creator_id: owner.id, is_private: false, actor: owner))
+
+      pictured =
+        generate(huddl(group_id: group.id, creator_id: owner.id, is_private: false, actor: owner))
+
+      Huddlz.Communities.HuddlCoverImage
+      |> Ash.Changeset.for_create(:create, %{
+        filename: "cover.jpg",
+        content_type: "image/jpeg",
+        size_bytes: 123,
+        storage_path: "/uploads/huddl_cover_images/#{pictured.id}/cover.jpg",
+        thumbnail_path: "/uploads/huddl_cover_images/#{pictured.id}/cover_thumb.jpg",
+        huddl_id: pictured.id
+      })
+      |> Ash.create!(authorize?: false)
+
+      bare_card = ~s(#group-huddl-grid .card[href="/groups/#{group.slug}/huddlz/#{bare.id}"])
+
+      pictured_card =
+        ~s(#group-huddl-grid .card[href="/groups/#{group.slug}/huddlz/#{pictured.id}"])
+
+      conn
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#{bare_card} .card-cover-fallback", text: "PE", exact: true)
+      |> refute_has("#{bare_card} .cover-image")
+      |> assert_has("#{pictured_card} #group-huddl-card-cover-#{pictured.id}.cover-image")
+      |> refute_has("#{pictured_card} .card-cover-fallback")
+    end
+  end
+
   describe "membership action buttons" do
     setup do
       owner = generate(user(role: :user))

--- a/test/huddlz_web/live/group_live_test.exs
+++ b/test/huddlz_web/live/group_live_test.exs
@@ -229,9 +229,9 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("aside.sidebar")
-      |> assert_has("div.hero .hero-content h1", text: to_string(group.name))
-      |> assert_has(".huddl-side h3", text: "This group")
-      |> assert_has(".facts .label", text: "Members")
+      |> assert_has("header.hero .hero-content h1", text: to_string(group.name))
+      |> assert_has("header.hero .hero-content .pill", text: "Public group")
+      |> assert_has(".huddl-side .facts .label", text: "Members")
     end
 
     test "does not list draft huddlz on the group page", %{
@@ -291,7 +291,7 @@ defmodule HuddlzWeb.GroupLiveTest do
       |> login(owner)
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has(".hero h1", text: to_string(group.name))
-      |> assert_has(".eyebrow", text: "Private")
+      |> assert_has(".hero-content .pill.warn", text: "Private group")
       |> assert_has(".role-pill .pill", text: "Owner")
     end
 


### PR DESCRIPTION
Step 3 of the UI refresh: the group page, rebuilt on the design canvas's Group sheet.

## What changed

- **Header** now uses the same flow layout as the huddl page: a 16:9 cover in a bordered panel, then a Public/Private group pill, the title, and location + member count rows with icons. The dark gradient overlay on the group cover is gone (the title no longer sits on the image), and the initials fallback tile is centered instead of pinned to the top.
- **Side panel** drops the "This group" heading, keeps the facts list, and groups the actions: role pill, a 44px primary (Create Huddl or Join Group), then Edit Group / Locations side by side. Leave Group stays as the muted button.
- **Huddlz section** gets a ruled top, a heading row with the Upcoming/Past chips on the right, group-initials fallback covers on cards without an image, and the shared `<.empty_state>` component. The empty state is driven by a `huddl_count` assign rather than the stream `only-child` trick, so it no longer adds a hidden `<h3>` to the grid.
- **Leave dialog** reuses the confirm-dialog styles from the huddl page instead of daisyUI utility classes.
- Mobile keeps the cover above the details; the old group-specific grid overrides are replaced by the shared hero rules.

Button labels are unchanged so the existing feature files still apply.

## Tests

- New `page layout` tests in `show_test.exs`: hero structure and pill, owner action grouping, empty state that disappears once a huddl exists, card cover fallback vs image.
- Updated the two hero assertions in `group_live_test.exs` (pill instead of eyebrow, no "This group" heading).
- Renamed the desktop Playwright scenario to say the cover renders above the details; its assertions were already layout-agnostic.
