### PR TITLE
feat(ui): align the profile page with the design sheet

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3873,6 +3873,8 @@ body .form-control.read-only {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-height: 40px;
+  box-sizing: border-box;
   padding: 9px 12px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
@@ -3881,6 +3883,8 @@ body .form-control.read-only {
   font-size: 14px;
   line-height: 20px;
 }
+
+body .form-control.read-only > span:first-child { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
 
 body .form-foot {
   margin-top: 20px;
@@ -3919,25 +3923,25 @@ body .location-control {
 body .location-display {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
 body .location-current {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--panel-2) 50%, transparent);
-  color: var(--text);
+  gap: 8px;
+  height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
   font-size: 14px;
   font-weight: 600;
 }
 
-body .location-current svg { color: var(--cyan); flex: 0 0 auto; }
+body .location-current .size-4 { flex: 0 0 auto; }
 
 body .location-actions { display: inline-flex; gap: 8px; flex-wrap: wrap; }
 
@@ -3986,6 +3990,21 @@ body .profile-photo-actions {
   gap: 8px;
   align-items: flex-start;
 }
+
+body .profile-photo-buttons { display: flex; flex-wrap: wrap; gap: 8px; }
+body .profile-photo-buttons > label { cursor: pointer; }
+
+/* Stacked settings panels (profile, settings, notification preferences):
+   one column of full-width panels capped at a readable width. */
+body .settings-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 760px;
+}
+
+body .settings-stack .panel { margin-bottom: 0; }
+body .settings-stack .form-grid { max-width: none; }
 
 /* Inline form row (multiple fields side by side) */
 body .form-row-inline {
@@ -4613,6 +4632,8 @@ body .page-nav:disabled {
     justify-self: start;
   }
   body .panel { padding: 14px 14px; }
+  body .panel-head { margin: -14px -14px 14px; padding: 14px; }
+  body .panel > .form-foot { margin: 14px -14px -14px; padding: 14px; }
   body .panel.split { gap: 18px; }
   body .visibility-panel-head { flex-direction: column; align-items: flex-start; gap: 10px; }
   body .visibility-selection { grid-template-columns: 1fr; }

--- a/lib/huddlz_web/live/location_autocomplete.ex
+++ b/lib/huddlz_web/live/location_autocomplete.ex
@@ -388,20 +388,7 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
         <input :if={@field_name} type="hidden" name={@field_name} value={@selected_text} />
         <div class="location-display" data-testid="location-selected">
           <div class="location-current">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M12 22s7-7.6 7-13a7 7 0 0 0-14 0c0 5.4 7 13 7 13z" />
-              <circle cx="12" cy="9" r="2.5" />
-            </svg>
+            <.icon name="hero-map-pin" class="size-4" />
             <span data-testid="location-display">{@selected_text}</span>
           </div>
           <div class="location-actions">

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -74,261 +74,265 @@ defmodule HuddlzWeb.ProfileLive do
       <div class="page-head">
         <div>
           <h1>Profile</h1>
-          <p>How you show up in huddlz — your name, photo, and how to reach you.</p>
+          <p>How you show up in huddlz: your name, photo, and how to reach you.</p>
         </div>
       </div>
 
-      <div class="panel">
-        <div class="panel-head">
-          <h2>Profile picture</h2>
-        </div>
-        <div class="profile-photo-row">
-          <.big_avatar user={@current_user} />
-          <div class="profile-photo-actions">
-            <label for={@uploads.avatar.ref} class="btn-secondary" style="cursor:pointer">
-              Upload a photo…
-            </label>
-            <%= if @current_user.current_profile_picture_url do %>
-              <button
-                id="open-remove-avatar-dialog"
-                type="button"
-                class="btn-secondary muted-btn"
-                phx-click={JS.push_focus() |> JS.push("open_remove_avatar_dialog")}
-              >
-                Remove
-              </button>
-            <% end %>
-            <div class="muted" style="font-size:12px; margin-top:6px">
-              <span id="avatar-upload-help">JPG, PNG, or WebP · 5 MB max</span>
-            </div>
-            <div id="avatar-upload-status" aria-live="polite">
-              <%= for entry <- @uploads.avatar.entries,
-                      upload_errors(@uploads.avatar, entry) == [] and entry.progress < 100 do %>
-                <p class="muted" role="status">
-                  Uploading {entry.client_name}: {entry.progress}%
-                </p>
-              <% end %>
-            </div>
-            <div
-              :if={avatar_upload_error_messages(@uploads.avatar, @avatar_error) != []}
-              id="avatar-upload-error"
-              class="form-error"
-              role="alert"
-              aria-live="assertive"
-            >
-              <p :for={message <- avatar_upload_error_messages(@uploads.avatar, @avatar_error)}>
-                {message}
-              </p>
-            </div>
-          </div>
-        </div>
-        <form id="avatar-form" phx-change="validate_avatar" class="hidden">
-          <.live_file_input
-            upload={@uploads.avatar}
-            aria-describedby="avatar-upload-help avatar-upload-error"
-            aria-invalid={
-              avatar_upload_error_messages(@uploads.avatar, @avatar_error) != [] && "true"
-            }
-          />
-        </form>
-      </div>
-
-      <.form for={@form} id="profile-form" phx-submit="save" phx-change="validate">
+      <div class="settings-stack">
         <div class="panel">
           <div class="panel-head">
-            <h2>Account information</h2>
+            <h2>Profile picture</h2>
           </div>
-          <div class="form-grid">
-            <div class="form-row">
-              <label class="form-label">Email</label>
-              <div class="form-control read-only">
-                <span>{@current_user.email}</span>
-                <span class={["pill", role_pill_color(@current_user.role)]}>
-                  {role_label(@current_user.role)}
-                </span>
-              </div>
-              <p class="form-help">This is the email you use to sign in.</p>
-            </div>
-            <.input
-              field={@form[:display_name]}
-              value={form_value(@form, :display_name)}
-              label="Display name"
-              placeholder="Enter your display name"
-              help="Names aren't unique on huddlz — pick anything you like."
-            />
-          </div>
-          <div class="form-foot">
-            <.button variant={:primary} type="submit">Save changes</.button>
-          </div>
-        </div>
-      </.form>
-
-      <.form
-        for={@email_form}
-        id="email-change-form"
-        phx-submit="change_email"
-        phx-change="validate_email"
-      >
-        <div class="panel">
-          <div class="panel-head">
-            <div>
-              <h2>Change email</h2>
-              <div class="panel-sub">
-                Update your sign-in email after confirming your current password.
-              </div>
-            </div>
-          </div>
-          <div class="form-grid">
-            <.input
-              field={@email_form[:email]}
-              type="text"
-              label="New email"
-              placeholder="Enter your new email"
-              autocomplete="email"
-              inputmode="email"
-            />
-            <.input
-              field={@email_form[:current_password]}
-              type="password"
-              label="Confirm current password"
-              placeholder="Enter your current password"
-              autocomplete="current-password"
-            />
-          </div>
-          <div class="form-foot">
-            <.button id="change-email-button" variant={:primary} type="submit">
-              Change email
-            </.button>
-          </div>
-        </div>
-      </.form>
-
-      <div class="panel">
-        <div class="panel-head">
-          <div>
-            <h2>Home location</h2>
-            <div class="panel-sub">
-              Used to pre-fill the distance filter when you search huddlz nearby.
-            </div>
-          </div>
-        </div>
-        <form class="form-row">
-          <.live_component
-            module={HuddlzWeb.Live.LocationAutocomplete}
-            id="profile-location"
-            variant={:form}
-            field_name="home_location"
-            value={@current_user.home_location}
-            latitude={@current_user.home_latitude}
-            longitude={@current_user.home_longitude}
-            placeholder="e.g. Austin, TX"
-          />
-          <p :if={@location_error} class="form-error">{@location_error}</p>
-        </form>
-      </div>
-
-      <.form
-        for={@password_form}
-        id="password-form"
-        phx-submit="update_password"
-        phx-change="validate_password"
-      >
-        <div class="panel">
-          <div class="panel-head">
-            <div>
-              <h2>{if @current_user.hashed_password, do: "Change", else: "Set"} password</h2>
-              <div class="panel-sub">
-                <%= if @current_user.hashed_password do %>
-                  Update your password to keep your account secure.
-                <% else %>
-                  Set a password to enable password-based sign in.
+          <div class="profile-photo-row">
+            <.big_avatar user={@current_user} />
+            <div class="profile-photo-actions">
+              <div class="profile-photo-buttons">
+                <label for={@uploads.avatar.ref} class="btn-secondary">
+                  Upload a photo…
+                </label>
+                <%= if @current_user.current_profile_picture_url do %>
+                  <button
+                    id="open-remove-avatar-dialog"
+                    type="button"
+                    class="btn-secondary muted-btn"
+                    phx-click={JS.push_focus() |> JS.push("open_remove_avatar_dialog")}
+                  >
+                    Remove
+                  </button>
                 <% end %>
               </div>
+              <p id="avatar-upload-help" class="form-help">JPG, PNG, or WebP · 5 MB max</p>
+              <div id="avatar-upload-status" aria-live="polite">
+                <%= for entry <- @uploads.avatar.entries,
+                      upload_errors(@uploads.avatar, entry) == [] and entry.progress < 100 do %>
+                  <p class="muted" role="status">
+                    Uploading {entry.client_name}: {entry.progress}%
+                  </p>
+                <% end %>
+              </div>
+              <div
+                :if={avatar_upload_error_messages(@uploads.avatar, @avatar_error) != []}
+                id="avatar-upload-error"
+                class="form-error"
+                role="alert"
+                aria-live="assertive"
+              >
+                <p :for={message <- avatar_upload_error_messages(@uploads.avatar, @avatar_error)}>
+                  {message}
+                </p>
+              </div>
             </div>
           </div>
-          <div class="form-grid">
-            <%= if @current_user.hashed_password do %>
+          <form id="avatar-form" phx-change="validate_avatar" class="hidden">
+            <.live_file_input
+              upload={@uploads.avatar}
+              aria-describedby="avatar-upload-help avatar-upload-error"
+              aria-invalid={
+                avatar_upload_error_messages(@uploads.avatar, @avatar_error) != [] && "true"
+              }
+            />
+          </form>
+        </div>
+
+        <.form for={@form} id="profile-form" phx-submit="save" phx-change="validate">
+          <div class="panel">
+            <div class="panel-head">
+              <h2>Account information</h2>
+            </div>
+            <div class="form-grid">
+              <div class="form-row">
+                <label class="form-label">Email</label>
+                <div class="form-control read-only">
+                  <span>{@current_user.email}</span>
+                  <span class={["pill", role_pill_color(@current_user.role)]}>
+                    {role_label(@current_user.role)}
+                  </span>
+                </div>
+                <p class="form-help">This is the email you use to sign in.</p>
+              </div>
               <.input
-                field={@password_form[:current_password]}
-                id={"password-#{@password_input_reset_generation}-current-password"}
-                value=""
+                field={@form[:display_name]}
+                value={form_value(@form, :display_name)}
+                label="Display name"
+                placeholder="Enter your display name"
+                help="Names aren't unique on huddlz. Pick anything you like."
+              />
+            </div>
+            <div class="form-foot">
+              <.button variant={:primary} type="submit">Save changes</.button>
+            </div>
+          </div>
+        </.form>
+
+        <.form
+          for={@email_form}
+          id="email-change-form"
+          phx-submit="change_email"
+          phx-change="validate_email"
+        >
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>Change email</h2>
+                <div class="panel-sub">
+                  Update your sign-in email after confirming your current password.
+                </div>
+              </div>
+            </div>
+            <div class="form-grid">
+              <.input
+                field={@email_form[:email]}
+                type="text"
+                label="New email"
+                placeholder="Enter your new email"
+                autocomplete="email"
+                inputmode="email"
+              />
+              <.input
+                field={@email_form[:current_password]}
                 type="password"
-                phx-update="ignore"
-                label="Current password"
+                label="Confirm current password"
                 placeholder="Enter your current password"
                 autocomplete="current-password"
               />
-            <% end %>
-            <.input
-              field={@password_form[:password]}
-              id={"password-#{@password_input_reset_generation}-password"}
-              value=""
-              type="password"
-              phx-update="ignore"
-              label="New password"
-              placeholder="Enter your new password"
-              autocomplete="new-password"
-              help="At least 8 characters."
-            />
-            <.input
-              field={@password_form[:password_confirmation]}
-              id={"password-#{@password_input_reset_generation}-password-confirmation"}
-              value=""
-              type="password"
-              phx-update="ignore"
-              label="Confirm new password"
-              placeholder="Confirm your new password"
-              autocomplete="new-password"
-            />
+            </div>
+            <div class="form-foot">
+              <.button id="change-email-button" variant={:primary} type="submit">
+                Change email
+              </.button>
+            </div>
           </div>
-          <div class="form-foot">
-            <.button variant={:primary} type="submit">
-              {if @current_user.hashed_password, do: "Update", else: "Set"} password
+        </.form>
+
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Home location</h2>
+              <div class="panel-sub">
+                Used to pre-fill the distance filter when you search huddlz nearby.
+              </div>
+            </div>
+          </div>
+          <form class="form-row">
+            <label class="form-label" for="profile-location-input">Location</label>
+            <.live_component
+              module={HuddlzWeb.Live.LocationAutocomplete}
+              id="profile-location"
+              variant={:form}
+              field_name="home_location"
+              value={@current_user.home_location}
+              latitude={@current_user.home_latitude}
+              longitude={@current_user.home_longitude}
+              placeholder="e.g. Austin, TX"
+            />
+            <p :if={@location_error} class="form-error">{@location_error}</p>
+          </form>
+        </div>
+
+        <.form
+          for={@password_form}
+          id="password-form"
+          phx-submit="update_password"
+          phx-change="validate_password"
+        >
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>{if @current_user.hashed_password, do: "Change", else: "Set"} password</h2>
+                <div class="panel-sub">
+                  <%= if @current_user.hashed_password do %>
+                    Update your password to keep your account secure.
+                  <% else %>
+                    Set a password to enable password-based sign in.
+                  <% end %>
+                </div>
+              </div>
+            </div>
+            <div class="form-grid">
+              <%= if @current_user.hashed_password do %>
+                <.input
+                  field={@password_form[:current_password]}
+                  id={"password-#{@password_input_reset_generation}-current-password"}
+                  value=""
+                  type="password"
+                  phx-update="ignore"
+                  label="Current password"
+                  placeholder="Enter your current password"
+                  autocomplete="current-password"
+                />
+              <% end %>
+              <.input
+                field={@password_form[:password]}
+                id={"password-#{@password_input_reset_generation}-password"}
+                value=""
+                type="password"
+                phx-update="ignore"
+                label="New password"
+                placeholder="Enter your new password"
+                autocomplete="new-password"
+                help="At least 8 characters."
+              />
+              <.input
+                field={@password_form[:password_confirmation]}
+                id={"password-#{@password_input_reset_generation}-password-confirmation"}
+                value=""
+                type="password"
+                phx-update="ignore"
+                label="Confirm new password"
+                placeholder="Confirm your new password"
+                autocomplete="new-password"
+              />
+            </div>
+            <div class="form-foot">
+              <.button variant={:primary} type="submit">
+                {if @current_user.hashed_password, do: "Update", else: "Set"} password
+              </.button>
+            </div>
+          </div>
+        </.form>
+
+        <.modal
+          :if={@remove_avatar_dialog_open}
+          id="remove-avatar-dialog"
+          show
+          on_cancel={JS.push("cancel_remove_avatar")}
+        >
+          <div class="delete-confirm">
+            <div class="delete-confirm-icon" aria-hidden="true">
+              <.icon name="hero-user-circle" class="h-6 w-6" />
+            </div>
+
+            <div class="delete-confirm-copy">
+              <span class="eyebrow eyebrow-magenta">Profile picture</span>
+              <h2 id="remove-avatar-dialog-title">Remove your profile picture?</h2>
+              <p>
+                Your current picture will be removed. Your
+                <strong>initials will appear instead</strong>
+                everywhere your profile is shown.
+              </p>
+            </div>
+          </div>
+
+          <div class="delete-confirm-actions">
+            <.button
+              variant={:muted}
+              id="cancel-remove-avatar"
+              phx-click="cancel_remove_avatar"
+            >
+              Keep picture
+            </.button>
+            <.button
+              variant={:destructive}
+              class="delete-confirm-submit"
+              id="confirm-remove-avatar"
+              phx-click="remove_avatar"
+              phx-disable-with="Removing…"
+            >
+              Remove picture
             </.button>
           </div>
-        </div>
-      </.form>
-
-      <.modal
-        :if={@remove_avatar_dialog_open}
-        id="remove-avatar-dialog"
-        show
-        on_cancel={JS.push("cancel_remove_avatar")}
-      >
-        <div class="delete-confirm">
-          <div class="delete-confirm-icon" aria-hidden="true">
-            <.icon name="hero-user-circle" class="h-6 w-6" />
-          </div>
-
-          <div class="delete-confirm-copy">
-            <span class="eyebrow eyebrow-magenta">Profile picture</span>
-            <h2 id="remove-avatar-dialog-title">Remove your profile picture?</h2>
-            <p>
-              Your current picture will be removed. Your <strong>initials will appear instead</strong>
-              everywhere your profile is shown.
-            </p>
-          </div>
-        </div>
-
-        <div class="delete-confirm-actions">
-          <.button
-            variant={:muted}
-            id="cancel-remove-avatar"
-            phx-click="cancel_remove_avatar"
-          >
-            Keep picture
-          </.button>
-          <.button
-            variant={:destructive}
-            class="delete-confirm-submit"
-            id="confirm-remove-avatar"
-            phx-click="remove_avatar"
-            phx-disable-with="Removing…"
-          >
-            Remove picture
-          </.button>
-        </div>
-      </.modal>
+        </.modal>
+      </div>
     </Layouts.app>
     """
   end

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -135,6 +135,22 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> assert_has("*", text: to_string(user.email))
     end
 
+    test "stacks the settings panels with the photo actions in a row", %{
+      conn: conn,
+      user: user
+    } do
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> assert_has(".settings-stack > .panel, .settings-stack > form > .panel", count: 5)
+      |> assert_has(".profile-photo-actions .profile-photo-buttons label.btn-secondary",
+        text: "Upload a photo…"
+      )
+      |> assert_has(".profile-photo-actions #avatar-upload-help.form-help")
+      |> assert_has(".form-control.read-only .pill", text: "User")
+      |> assert_has("label.form-label[for='profile-location-input']", text: "Location")
+    end
+
     test "shows the profile form", %{conn: conn, user: user} do
       conn
       |> login(user)
@@ -736,7 +752,11 @@ defmodule HuddlzWeb.ProfileLiveTest do
       view |> element("[role='option']", "Saint Augustine") |> render_click()
       render_async(view)
 
-      assert render(view) =~ "Home location updated"
+      html = render(view)
+      assert html =~ "Home location updated"
+      assert html =~ ~s(class="location-current")
+      assert html =~ ~s(hero-map-pin)
+      assert html =~ "Change location…"
     end
 
     test "handles autocomplete API errors", %{conn: conn, user: user} do


### PR DESCRIPTION
Step 3 of the UI refresh: the profile page, aligned to the design canvas's Profile sheet.

The page already used the shared panels and form components, so this is a small pass.

## What changed

- **Settings stack**: a new `.settings-stack` wrapper caps the page at 760px, spaces the five panels 24px apart, and lets the form grids fill the panel instead of stopping at 560px. Settings and notification preferences will reuse it.
- **Profile picture**: the Upload / Remove buttons sit in a row beside the avatar with the file hint under them as regular form help text.
- **Account information**: the read-only email control lets the address take the space and keeps the role pill at the right edge.
- **Home location**: the field gets a "Location" label, and a selected place renders as an accent chip with a map-pin hero icon (replacing the inline SVG) next to the Change / Clear buttons, per the sheet.
- **Copy**: the two em-dash sentences in the intro and the display-name help become plain sentences.
- **Mobile fix**: panel heads and form foots used negative margins sized for 24px panel padding, so on phones (14px padding) their rules poked past the panel edge. They now match the mobile padding. This applies to every panel, not just the profile.

Not done: the sheet shows a lock icon inside password inputs; the shared `<.input>` has no leading-icon slot, so that's left for a components follow-up if wanted.

## Tests

- New assertion in the profile LiveView tests for the stack, the photo button row, the role pill inside the read-only control, and the location label.
- The autocomplete selection test now checks the chip markup after a place is chosen.
