### PR TITLE
feat(ui): align the settings page with the design sheet

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -4006,6 +4006,37 @@ body .settings-stack {
 body .settings-stack .panel { margin-bottom: 0; }
 body .settings-stack .form-grid { max-width: none; }
 
+/* Preference rows bleed to the panel edges so their rules run full width. */
+body .settings-stack .settings-list { margin: -20px -24px; }
+
+body .settings-stack .settings-list .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 52px;
+  padding: 8px 24px;
+  cursor: default;
+}
+
+body .settings-stack .settings-list .row:first-child { padding-top: 8px; }
+body .settings-stack .settings-list .row .row-title { font-weight: 500; color: var(--text); }
+
+body .appearance-tabs { margin: 0; padding: 4px; border: 1px solid var(--line); }
+body .appearance-tabs .scope-tab { gap: 8px; }
+body .appearance-tabs .scope-tab .size-4 { color: var(--muted); }
+body .appearance-tabs .scope-tab.is-active .size-4 { color: var(--accent-ink); }
+
+body .settings-actions { display: flex; justify-content: flex-end; }
+
+body .toggle.is-locked { opacity: 0.6; cursor: default; }
+
+/* daisyUI's .toggle paints its own knob in ::before on a non-input element;
+   the knob here lives in .track::after. */
+body .toggle::before,
+body .toggle::after { content: none; }
+body .toggle .toggle-text { white-space: nowrap; }
+
 /* Inline form row (multiple fields side by side) */
 body .form-row-inline {
   flex-direction: row;
@@ -4633,6 +4664,12 @@ body .page-nav:disabled {
   }
   body .panel { padding: 14px 14px; }
   body .panel-head { margin: -14px -14px 14px; padding: 14px; }
+  body .settings-stack .settings-list { margin: -14px; }
+  body .settings-stack .settings-list .row { padding: 8px 14px; }
+  body .settings-stack .appearance-row { flex-direction: column; align-items: stretch; gap: 10px; padding: 12px 14px; }
+  body .settings-stack .appearance-row .row-title { text-align: left; }
+  body .appearance-tabs { display: flex; margin: 0; }
+  body .appearance-tabs .scope-tab { flex: 1 1 0; justify-content: center; }
   body .panel > .form-foot { margin: 14px -14px -14px; padding: 14px; }
   body .panel.split { gap: 18px; }
   body .visibility-panel-head { flex-direction: column; align-items: flex-start; gap: 10px; }

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -86,63 +86,71 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
         <div>
           <h1>Settings</h1>
           <p>
-            Notification preferences and other knobs. We'll add more here as huddlz grows.
+            Appearance, notification preferences and other knobs. We'll add more here as huddlz grows.
           </p>
         </div>
       </div>
 
-      <form id="appearance-form" phx-change="set_theme">
-        <div class="panel">
-          <div class="panel-head">
-            <div>
-              <h2>Appearance</h2>
-              <div class="panel-sub">System follows your device. Light and Dark stay put.</div>
+      <div class="settings-stack">
+        <form id="appearance-form" phx-change="set_theme">
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>Appearance</h2>
+                <div class="panel-sub">System follows your device. Light and Dark stay put.</div>
+              </div>
+            </div>
+            <div class="settings-list row-list">
+              <div class="row appearance-row">
+                <div class="row-title">Theme</div>
+                <fieldset class="scope-tabs appearance-tabs">
+                  <legend class="sr-only">Theme</legend>
+                  <label
+                    :for={{value, label, icon} <- theme_options()}
+                    class={["scope-tab", @current_user.theme_preference == value && "is-active"]}
+                  >
+                    <input
+                      type="radio"
+                      name="theme"
+                      value={value}
+                      checked={@current_user.theme_preference == value}
+                      class="sr-only"
+                    />
+                    <.icon name={icon} class="size-4" />
+                    {label}
+                  </label>
+                </fieldset>
+              </div>
             </div>
           </div>
-          <fieldset class="scope-tabs appearance-tabs">
-            <legend class="sr-only">Theme</legend>
-            <label
-              :for={{value, label} <- theme_options()}
-              class={["scope-tab", @current_user.theme_preference == value && "is-active"]}
-            >
-              <input
-                type="radio"
-                name="theme"
-                value={value}
-                checked={@current_user.theme_preference == value}
-                class="sr-only"
-              />
-              {label}
-            </label>
-          </fieldset>
-        </div>
-      </form>
+        </form>
 
-      <form phx-submit="save">
-        <.read_only_panel
-          title="Transactional"
-          description="Critical account and huddl updates. Always on — these can't be disabled."
-          triggers={@triggers_by_category.transactional}
-        />
+        <form phx-submit="save" class="settings-stack">
+          <.read_only_panel
+            title="Transactional"
+            description="Critical account and huddl updates. Always on, these can't be disabled."
+            triggers={@triggers_by_category.transactional}
+          />
 
-        <.category_panel
-          title="Activity"
-          description="Things that happen in groups and huddlz you're part of."
-          triggers={@triggers_by_category.activity}
-          user={@current_user}
-        />
+          <.category_panel
+            title="Activity"
+            description="Things that happen in groups and huddlz you're part of."
+            triggers={@triggers_by_category.activity}
+            user={@current_user}
+          />
 
-        <.category_panel
-          title="Digest"
-          description="Optional summaries. Off by default."
-          triggers={@triggers_by_category.digest}
-          user={@current_user}
-        />
+          <.category_panel
+            title="Digest"
+            description="Optional summaries. Off by default."
+            triggers={@triggers_by_category.digest}
+            user={@current_user}
+          />
 
-        <div class="form-foot" style="border:0; margin:0 0 32px">
-          <.button variant={:primary} type="submit">Save preferences</.button>
-        </div>
-      </form>
+          <div class="settings-actions">
+            <.button variant={:primary} type="submit">Save preferences</.button>
+          </div>
+        </form>
+      </div>
     </Layouts.app>
     """
   end
@@ -206,10 +214,10 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
           <div>
             <div class="row-title">{entry.label}</div>
           </div>
-          <span class="toggle">
+          <span class="toggle is-locked">
             <input type="checkbox" checked disabled />
             <span class="track"></span>
-            <span class="toggle-text">On</span>
+            <span class="toggle-text">Always on</span>
           </span>
         </div>
       </div>
@@ -217,7 +225,13 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
     """
   end
 
-  defp theme_options, do: [system: "System", light: "Light", dark: "Dark"]
+  defp theme_options do
+    [
+      {:system, "System", "hero-computer-desktop"},
+      {:light, "Light", "hero-sun"},
+      {:dark, "Dark", "hero-moon"}
+    ]
+  end
 
   defp group_triggers do
     %{

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -7,7 +7,7 @@ Feature: Notification preferences settings page
   Scenario: User opts out of an activity-tier notification
     Given I am signed in as "settings@example.com" with password "Password123!"
     When I visit "/profile/notifications"
-    Then I should see "Notification preferences"
+    Then I should see "notification preferences and other knobs"
     And I should see "Activity"
     When I uncheck "Confirmation when I RSVP to a huddl"
     And I click "Save preferences"
@@ -17,4 +17,4 @@ Feature: Notification preferences settings page
     Given I am signed in as "linknav@example.com" with password "Password123!"
     When I go to my profile page
     And I click "Settings"
-    Then I should see "Notification preferences and other knobs"
+    Then I should see "notification preferences and other knobs"

--- a/test/features/unsubscribe.feature
+++ b/test/features/unsubscribe.feature
@@ -11,7 +11,7 @@ Feature: Unsubscribe URL
     And the user "unsub@example.com" should not have trigger "rsvp_received" disabled
     When I confirm the unsubscribe
     Then I should see "Unsubscribed from"
-    And I should see "Notification preferences and other knobs"
+    And I should see "notification preferences and other knobs"
     And the user "unsub@example.com" should have trigger "rsvp_received" disabled
 
   Scenario: An invalid unsubscribe token redirects with an error

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -39,7 +39,25 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       conn
       |> login(user)
       |> visit("/profile/notifications")
-      |> assert_has(".row .toggle input[type=checkbox][disabled]")
+      |> assert_has(".row .toggle.is-locked input[type=checkbox][disabled]")
+      |> assert_has(".row .toggle.is-locked .toggle-text", text: "Always on")
+    end
+
+    test "stacks the appearance and preference panels", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile/notifications")
+      |> assert_has(".settings-stack #appearance-form .panel .appearance-row .row-title",
+        text: "Theme"
+      )
+      |> assert_has(".appearance-row .appearance-tabs label.scope-tab", count: 3)
+      |> assert_has(".appearance-tabs label.scope-tab.is-active .hero-computer-desktop")
+      |> assert_has(".appearance-tabs label.scope-tab .hero-sun")
+      |> assert_has(".appearance-tabs label.scope-tab .hero-moon")
+      |> assert_has(".settings-stack form.settings-stack .panel", count: 3)
+      |> assert_has(".settings-stack .settings-actions button[type=submit]",
+        text: "Save preferences"
+      )
     end
 
     test "saving with an activity preference unchecked persists the change",


### PR DESCRIPTION
Step 3 of the UI refresh: the settings page (`/profile/notifications`), aligned to the design canvas's Settings sheet.

## What changed

- **Stack**: the page uses the `.settings-stack` column introduced for the profile page, so the Appearance panel, the three preference panels, and the save button line up at 760px with even spacing.
- **Appearance**: the theme choice is now a row inside the panel, "Theme" on the left and the System / Light / Dark segmented control on the right, each option with a hero icon (desktop, sun, moon). The radios still sit inside their labels, so the appearance feature's `choose "Light"` step works unchanged. On phones the row stacks and the control spans the width.
- **Preference rows** bleed to the panel edges so their rules run the full width, at 52px min height per the sheet.
- **Transactional toggles** read "Always on" and are dimmed via `.toggle.is-locked`; the disabled checkbox assertion is unchanged.
- **Toggle knob fix**: daisyUI's `.toggle::before` was painting a 40px knob on the read-only `<span class="toggle">` rows (the editable `<label>` variant happened to size it to zero). The pseudo-elements are now disabled on `.toggle`; the real knob lives in `.track::after`.
- **Copy**: the intro reads "Appearance, notification preferences and other knobs…"; the transactional blurb drops its em dash. Two feature files that asserted the old intro text are updated.
- The save button sits in a `.settings-actions` row instead of a `.form-foot` with inline style overrides.

## Tests

- New LiveView test for the appearance row (three labelled options with icons, active option marked), the stacked preference panels, and the save action.
- Locked toggle test now checks the "Always on" text.
