### PR TITLE
feat(ui): align the notifications page with the design sheet

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2866,11 +2866,36 @@ body .huddl-side-section h3 {
 /* Notification preference rows (settings page) */
 body .pref-list .row { grid-template-columns: 1fr auto; gap: 18px; }
 
-/* Notification row */
-body .row.notif-row { grid-template-columns: 14px minmax(0, 1fr) auto; gap: 14px; }
-body .row.notif-row.unread .row-title { color: var(--text); }
-body .row.notif-row:not(.unread) .row-title { color: var(--soft); }
-body .row.notif-row:not(.unread) .meta { color: var(--muted); }
+/* Notification row (inbox + invites) — rows bleed to the panel edge */
+body .notif-panel { padding: 0; overflow: hidden; }
+
+body .notif-list .row.notif-row {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 16px;
+  padding: 16px 24px;
+  border-top: 0;
+  border-bottom: 1px solid var(--line);
+  transition: background-color 120ms ease;
+}
+
+body .notif-list .row.notif-row:last-child { border-bottom: 0; }
+
+body .row.notif-row.unread {
+  background: color-mix(in srgb, var(--accent-soft) 40%, transparent);
+}
+
+body .notif-body { min-width: 0; }
+body .notif-row .row-title {
+  color: var(--soft);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+body .notif-row.unread .row-title,
+body .invitation-row .row-title { color: var(--text); font-weight: 600; }
+body .notif-row .meta { margin-top: 2px; color: var(--muted); font-size: 13px; }
+
 body .notif-actions {
   display: flex;
   align-items: center;
@@ -2878,32 +2903,39 @@ body .notif-actions {
   gap: 8px;
   flex-wrap: wrap;
 }
+
 body .notif-actions .pill {
-  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--soft);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease;
 }
-body .invitation-open-action {
-  min-width: 88px;
-  min-height: 36px;
-  padding-inline: 16px;
-  justify-content: center;
+
+body .notif-actions .pill:hover { border-color: var(--accent); color: var(--accent-ink); }
+
+body .notif-actions .pill.is-primary {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
 }
-body .notif-actions a.pill:hover,
-body .notif-actions button.pill:hover {
-  color: var(--text);
-  border-color: var(--cyan-dim);
-  background: var(--cyan-soft);
-}
-body .notif-actions a.pill:focus-visible,
-body .notif-actions button.pill:focus-visible {
-  outline: 2px solid var(--cyan);
+
+body .notif-actions .pill.is-primary:hover { background: var(--accent); color: var(--on-accent); }
+
+body .notif-actions .pill:focus-visible {
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
 body .notif-resolved {
   max-width: 12rem;
   color: var(--muted);
-  font-family: var(--mono);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.35;
   text-align: right;
 }
@@ -2913,7 +2945,6 @@ body .notif-mark {
   height: 8px;
   border-radius: 50%;
   background: var(--line-strong);
-  margin-top: 6px;
 }
 
 body .notif-mark.cyan { background: var(--accent); }
@@ -2942,17 +2973,19 @@ body .invitation-back-link:focus-visible {
 body .invitation-detail-head h2 { overflow-wrap: anywhere; }
 
 @media (max-width: 760px) {
-  body .row.notif-row {
-    grid-template-columns: 14px minmax(0, 1fr);
+  body .notif-list .row.notif-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 8px 12px;
+    padding: 14px 16px;
   }
+
+  body .notif-row .notif-actions { grid-column: 2; justify-content: flex-start; }
+  body .notif-actions .pill { height: 36px; padding: 0 14px; }
 
   body .notif-resolved {
     max-width: none;
     text-align: left;
   }
-
-  body .invitation-row .notif-actions { width: 100%; }
-  body .invitation-row .invitation-open-action { width: 100%; }
   body .invitation-detail-head {
     flex-direction: column;
     align-items: flex-start;
@@ -4702,9 +4735,6 @@ body .page-nav:disabled {
   /* Listings on org pages: collapse multi-column rows */
   body .row.huddlz-row, body .row.members-row { grid-template-columns: 56px 1fr; row-gap: 8px; }
   body .row.members-row { grid-template-columns: 48px 1fr; }
-  body .row.notif-row { grid-template-columns: 14px minmax(0, 1fr); }
-  body .notif-actions { grid-column: 2; justify-content: flex-start; }
-  body .notif-actions .pill { min-width: 44px; height: 44px; justify-content: center; }
   /* Land marketing */
   body .land-topbar { height: 64px; padding: 0 16px; }
   body .land-hero { padding: 48px 16px 40px; }

--- a/lib/huddlz_web/components/chip.ex
+++ b/lib/huddlz_web/components/chip.ex
@@ -8,7 +8,11 @@ defmodule HuddlzWeb.Components.Chip do
   use Phoenix.Component
 
   attr :active, :boolean, default: false
-  attr :count, :integer, default: nil, doc: "optional result count shown after the label"
+
+  attr :count, :any,
+    default: nil,
+    doc: "optional result count (or short count label) shown after the label"
+
   attr :class, :any, default: nil
 
   attr :rest, :global,

--- a/lib/huddlz_web/live/notifications_live.ex
+++ b/lib/huddlz_web/live/notifications_live.ex
@@ -223,40 +223,48 @@ defmodule HuddlzWeb.NotificationsLive do
         </div>
       </div>
 
-      <div class="filters">
-        <.chip patch={filter_path(:inbox, 1)} active={@filter == :inbox}>
-          Inbox · {@counts.inbox} unread
+      <nav class="filters" aria-label="Notification filters">
+        <.chip
+          patch={filter_path(:inbox, 1)}
+          active={@filter == :inbox}
+          count={"#{@counts.inbox} unread"}
+        >
+          Inbox
         </.chip>
-        <.chip patch={filter_path(:invites, 1)} active={@filter == :invites}>
-          Invites · {@counts.invites}
+        <.chip
+          patch={filter_path(:invites, 1)}
+          active={@filter == :invites}
+          count={@counts.invites}
+        >
+          Invites
         </.chip>
-      </div>
+      </nav>
 
       <%= if @items_empty? do %>
-        <p class="muted">{empty_message(@filter)}</p>
+        <.empty_state id="notifications-empty" icon={empty_icon(@filter)} title={empty_title(@filter)}>
+          {empty_message(@filter)}
+        </.empty_state>
       <% else %>
-        <div class="panel" style="padding:0">
-          <div class="row-list" style="padding:6px 20px">
-            <%= if @filter == :invites do %>
-              <div id="invitation-items" phx-update="stream">
-                <.invitation_row
-                  :for={{dom_id, invitation} <- @streams.invitations}
-                  id={dom_id}
-                  invitation={invitation}
-                />
-              </div>
-            <% else %>
-              <div id="notification-items" phx-update="stream">
-                <.notification_row
-                  :for={{dom_id, notification} <- @streams.notifications}
-                  id={dom_id}
-                  notification={notification}
-                  target={Map.get(@notification_targets, notification.id, :none)}
-                />
-              </div>
-            <% end %>
-          </div>
-        </div>
+        <section class="panel notif-panel" aria-label={panel_label(@filter)}>
+          <%= if @filter == :invites do %>
+            <div id="invitation-items" phx-update="stream" class="row-list notif-list">
+              <.invitation_row
+                :for={{dom_id, invitation} <- @streams.invitations}
+                id={dom_id}
+                invitation={invitation}
+              />
+            </div>
+          <% else %>
+            <div id="notification-items" phx-update="stream" class="row-list notif-list">
+              <.notification_row
+                :for={{dom_id, notification} <- @streams.notifications}
+                id={dom_id}
+                notification={notification}
+                target={Map.get(@notification_targets, notification.id, :none)}
+              />
+            </div>
+          <% end %>
+        </section>
         <.pagination
           :if={@page_info.total_pages > 1}
           current_page={@page_info.current_page}
@@ -281,8 +289,8 @@ defmodule HuddlzWeb.NotificationsLive do
       id={@id}
       class={["row", "notif-row", @unread && "unread"]}
     >
-      <div class={["notif-mark", mark_color(@notification)]} aria-hidden="true"></div>
-      <div>
+      <span class={["notif-mark", mark_color(@notification)]} aria-hidden="true"></span>
+      <div class="notif-body">
         <div class="row-title">{@notification.title}</div>
         <div :if={meta_line(@notification)} class="meta">{meta_line(@notification)}</div>
       </div>
@@ -310,7 +318,7 @@ defmodule HuddlzWeb.NotificationsLive do
         <button
           :if={@unread}
           type="button"
-          class="pill"
+          class="pill is-primary"
           id={"mark-notification-read-#{@notification.id}"}
           phx-click="mark_read"
           phx-value-id={@notification.id}
@@ -341,8 +349,8 @@ defmodule HuddlzWeb.NotificationsLive do
   defp invitation_row(assigns) do
     ~H"""
     <div id={@id} class="row notif-row invitation-row">
-      <div class="notif-mark cyan" aria-hidden="true"></div>
-      <div>
+      <span class="notif-mark cyan" aria-hidden="true"></span>
+      <div class="notif-body">
         <div class="row-title">Invitation to {@invitation.group.name}</div>
         <div class="meta">{invitation_meta_line(@invitation)}</div>
       </div>
@@ -373,11 +381,20 @@ defmodule HuddlzWeb.NotificationsLive do
   defp filter_blurb(:invites),
     do: "Things that need a response from you."
 
+  defp panel_label(:inbox), do: "Inbox"
+  defp panel_label(:invites), do: "Pending invitations"
+
+  defp empty_icon(:inbox), do: "hero-bell"
+  defp empty_icon(:invites), do: "hero-envelope"
+
+  defp empty_title(:inbox), do: "No notifications yet"
+  defp empty_title(:invites), do: "No pending invitations"
+
   defp empty_message(:inbox),
-    do: "No notifications yet. Reminders and group activity will appear here as they happen."
+    do: "Reminders and group activity will appear here as they happen."
 
   defp empty_message(:invites),
-    do: "No pending invitations. When organizers invite you to a group, they'll show up here."
+    do: "When organizers invite you to a group, they'll show up here."
 
   defp mark_color(%{read_at: %DateTime{}}), do: "muted"
 

--- a/test/features/individual_notification_read.feature
+++ b/test/features/individual_notification_read.feature
@@ -8,15 +8,15 @@ Feature: Individual notification read state
     Given I am signed in as "reader@example.com" with password "Password123!"
     And I have an unread waitlist promotion notification for "Elixir Picnic"
     When I visit "/notifications"
-    Then I should see "Inbox · 1 unread"
+    Then I should see "Inbox 1 unread"
     And persistent navigation should show one unread notification
     When I click the "Mark read" button
-    Then I should see "Inbox · 0 unread"
+    Then I should see "Inbox 0 unread"
     And persistent navigation should show no unread notifications
     And I should see "Waitlist promoted: Elixir Picnic"
     And I should see "Open"
     And the "Mark read" button should not be visible
     When I visit "/notifications?filter=invites"
-    Then I should see "Invites · 0"
-    And I should see "No pending invitations."
+    Then I should see "Invites 0"
+    And I should see "No pending invitations"
     And I should not see "Waitlist promoted: Elixir Picnic"

--- a/test/features/private_group_invitations.feature
+++ b/test/features/private_group_invitations.feature
@@ -19,11 +19,11 @@ Feature: Private group invitations
     When I try to visit the group page for "Quiet Makers"
     Then I should see the branded not found recovery page
     When I visit "/notifications"
-    Then I should see "Inbox · 1 unread"
-    And I should see "Invites · 1"
+    Then I should see "Inbox 1 unread"
+    And I should see "Invites 1"
     When I click "Mark all as read"
-    Then I should see "Inbox · 0 unread"
-    And I should see "Invites · 1"
+    Then I should see "Inbox 0 unread"
+    And I should see "Invites 1"
     When I visit "/notifications?filter=invites"
     Then I should see "Invitation to Quiet Makers"
     When I click "Open"
@@ -32,8 +32,8 @@ Feature: Private group invitations
     Then I should see "Welcome to Quiet Makers."
     And I should see "You accepted this invitation."
     When I click "Back to invitations"
-    Then I should see "Invites · 0"
-    And I should see "No pending invitations."
+    Then I should see "Invites 0"
+    And I should see "No pending invitations"
     When I visit "/my-groups"
     Then I should see "Quiet Makers"
 
@@ -108,8 +108,8 @@ Feature: Private group invitations
     When I reopen the invitation email
     Then I should see "You declined this invitation."
     When I visit "/notifications"
-    Then I should see "Inbox · 1 unread"
-    And I should see "Invites · 0"
+    Then I should see "Inbox 1 unread"
+    And I should see "Invites 0"
     When I try to visit the group page for "Quiet Makers"
     Then I should see the branded not found recovery page
 
@@ -185,7 +185,7 @@ Feature: Private group invitations
     And I complete registration as "new-maker@example.com"
     Then no invitation email should be sent to "new-maker@example.com"
     When I visit "/notifications?filter=invites"
-    Then I should see "No pending invitations."
+    Then I should see "No pending invitations"
     When I confirm the registration email sent to "new-maker@example.com"
     Then an invitation email should be sent to "new-maker@example.com" for "Quiet Makers"
     And that invitation email includes notification preferences and unsubscribe links

--- a/test/huddlz_web/live/notifications_live_test.exs
+++ b/test/huddlz_web/live/notifications_live_test.exs
@@ -120,6 +120,40 @@ defmodule HuddlzWeb.NotificationsLiveTest do
     end
   end
 
+  describe "page layout" do
+    test "renders rows inside an edge-to-edge panel with chip counts", %{conn: conn, user: user} do
+      {group, huddl} = create_huddl_target(user)
+      unread = huddl_notification(user, group, huddl)
+      read = seed_notification(user, :group_member_removed, %{"group_name" => "Old Club"})
+      {:ok, _} = Notifications.mark_read_and_notify(read, user)
+
+      conn
+      |> login(user)
+      |> visit("/notifications")
+      |> assert_has(".filters .chip.is-active .chip-count", text: "1 unread")
+      |> assert_has(".filters .chip .chip-count", text: "0", exact: true)
+      |> assert_has("section.notif-panel #notification-items.row-list.notif-list")
+      |> assert_has("#notification-#{unread.id}.notif-row.unread .notif-mark.cyan")
+      |> assert_has("#notification-#{unread.id} .notif-body .row-title", text: "Boat Drinks")
+      |> assert_has("#mark-notification-read-#{unread.id}.pill.is-primary", text: "Mark read")
+      |> assert_has("#notification-#{read.id}.notif-row:not(.unread) .notif-mark.muted")
+      |> refute_has("#notifications-empty")
+    end
+
+    test "renders pending invitations as rows of the same list", %{conn: conn, user: user} do
+      owner = generate(user(role: :user, confirmed_at: DateTime.utc_now()))
+      group = generate(group(owner_id: owner.id, actor: owner, is_public: false))
+      {:ok, invitation} = Communities.invite_to_group(group.id, user.id, :member, actor: owner)
+
+      conn
+      |> login(user)
+      |> visit("/notifications?filter=invites")
+      |> assert_has("section.notif-panel #invitation-items.notif-list .row.notif-row")
+      |> assert_has("#invitation-#{invitation.id} .notif-mark.cyan")
+      |> assert_has("#open-invitation-#{invitation.id}.pill", text: "Open")
+    end
+  end
+
   describe "Inbox filter (default)" do
     test "lists the actor's notifications", %{conn: conn, user: user} do
       deliver!(user, :password_changed, %{})
@@ -140,16 +174,16 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       conn
       |> login(user)
       |> visit("/notifications")
-      |> assert_has(".filters .chip", text: "Inbox · 2 unread")
+      |> assert_has(".filters .chip", text: "Inbox 2 unread")
     end
 
     test "empty state copy", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/notifications")
-      |> assert_has("p",
-        text:
-          "No notifications yet. Reminders and group activity will appear here as they happen."
+      |> assert_has("#notifications-empty.empty-state h3", text: "No notifications yet")
+      |> assert_has("#notifications-empty p",
+        text: "Reminders and group activity will appear here as they happen."
       )
     end
 
@@ -169,9 +203,9 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       conn
       |> login(user)
       |> visit("/notifications")
-      |> assert_has(".filters .chip", text: "Inbox · 1 unread")
+      |> assert_has(".filters .chip", text: "Inbox 1 unread")
       |> click_button("Mark all as read")
-      |> assert_has(".filters .chip", text: "Inbox · 0 unread")
+      |> assert_has(".filters .chip", text: "Inbox 0 unread")
     end
 
     test "Mark all as read clears unread beyond the visible page", %{conn: conn, user: user} do
@@ -182,9 +216,9 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       conn
       |> login(user)
       |> visit("/notifications")
-      |> assert_has(".filters .chip", text: "Inbox · 25 unread")
+      |> assert_has(".filters .chip", text: "Inbox 25 unread")
       |> click_button("Mark all as read")
-      |> assert_has(".filters .chip", text: "Inbox · 0 unread")
+      |> assert_has(".filters .chip", text: "Inbox 0 unread")
     end
   end
 
@@ -196,7 +230,7 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       |> login(user)
       |> visit("/notifications?filter=invites")
       |> assert_has(".filters .chip.is-active", text: "Invites")
-      |> assert_has(".filters .chip", text: "Invites · 1")
+      |> assert_has(".filters .chip", text: "Invites 1")
       |> assert_has(".row-title", text: "Invitation to #{group.name}")
       |> assert_has(
         ~s|#open-invitation-#{invitation.id}[href="/invitations/#{invitation.id}"]|,
@@ -219,10 +253,10 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       conn
       |> login(user)
       |> visit("/notifications?filter=invites")
-      |> assert_has(".filters .chip", text: "Invites · 0")
-      |> assert_has("p",
-        text:
-          "No pending invitations. When organizers invite you to a group, they'll show up here."
+      |> assert_has(".filters .chip", text: "Invites 0")
+      |> assert_has("#notifications-empty.empty-state h3", text: "No pending invitations")
+      |> assert_has("#notifications-empty p",
+        text: "When organizers invite you to a group, they'll show up here."
       )
     end
 
@@ -230,9 +264,9 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       conn
       |> login(user)
       |> visit("/notifications?filter=invites")
-      |> assert_has("p",
-        text:
-          "No pending invitations. When organizers invite you to a group, they'll show up here."
+      |> assert_has("#notifications-empty.empty-state h3", text: "No pending invitations")
+      |> assert_has("#notifications-empty p",
+        text: "When organizers invite you to a group, they'll show up here."
       )
     end
 
@@ -252,11 +286,11 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       |> element("#mark-notification-read-#{notification.id}")
       |> render_click()
 
-      assert has_element?(view, ".filters .chip", "Inbox · 0 unread")
+      assert has_element?(view, ".filters .chip", "Inbox 0 unread")
 
       {:ok, invites_view, _html} = live(conn, "/notifications?filter=invites")
 
-      assert has_element?(invites_view, ".filters .chip", "Invites · 1")
+      assert has_element?(invites_view, ".filters .chip", "Invites 1")
       assert has_element?(invites_view, "#invitation-#{invitation.id}")
     end
 
@@ -331,9 +365,9 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       |> login(user)
       |> visit("/notifications")
       |> refute_has(".notif-row .row-title", text: "Password changed")
-      |> assert_has("p",
-        text:
-          "No notifications yet. Reminders and group activity will appear here as they happen."
+      |> assert_has("#notifications-empty.empty-state h3", text: "No notifications yet")
+      |> assert_has("#notifications-empty p",
+        text: "Reminders and group activity will appear here as they happen."
       )
     end
   end
@@ -374,7 +408,7 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       )
       |> refute_has("#notification-#{notification.id}-open")
       |> click_button("#notification-#{notification.id} button", "Mark read")
-      |> assert_has(".filters .chip", text: "Inbox · 0 unread")
+      |> assert_has(".filters .chip", text: "Inbox 0 unread")
     end
 
     test "deleted groups render a resolved state without a broken link", %{
@@ -650,13 +684,13 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       untouched = seed_notification(user, :password_changed, %{})
       {:ok, view, _html} = conn |> login(user) |> live("/notifications")
 
-      assert has_element?(view, ".filters .chip", "Inbox · 2 unread")
+      assert has_element?(view, ".filters .chip", "Inbox 2 unread")
 
       view
       |> element("#mark-notification-read-#{notification.id}")
       |> render_click()
 
-      assert has_element?(view, ".filters .chip", "Inbox · 1 unread")
+      assert has_element?(view, ".filters .chip", "Inbox 1 unread")
       assert has_element?(view, "#notification-#{notification.id}")
       assert has_element?(view, "#notification-actions-#{notification.id} a", "Open")
       refute has_element?(view, "#mark-notification-read-#{notification.id}")
@@ -695,7 +729,7 @@ defmodule HuddlzWeb.NotificationsLiveTest do
       conn
       |> login(user)
       |> visit("/notifications")
-      |> assert_has(".filters .chip", text: "Inbox · 22 unread")
+      |> assert_has(".filters .chip", text: "Inbox 22 unread")
       |> assert_has(".pagination .page-num", text: "2")
     end
 


### PR DESCRIPTION
## Summary

Aligns `/notifications` with the Notifications design sheet, the last page in the step 3 series.

- Rows now bleed to the panel edge with a 16px/24px rhythm, an 8px status mark, and a 40% accent-soft tint on unread rows. Read rows drop to the soft text colour and medium weight.
- Row actions are 28px outlined pills; "Mark read" gets the accent primary variant. "Destination unavailable" is plain muted text instead of the mono label.
- Filter chips use the shared chip count slot ("Inbox 4 unread", "Invites 1"). `chip`'s `count` attr now accepts a string label as well as an integer.
- Empty states use the shared `empty_state` component with a title and one line of guidance.
- Mobile rows collapse to mark + body with the actions wrapping underneath at a 36px tap height; the duplicate mobile rule at the end of app.css is removed.

## Tests

- New "page layout" tests cover the panel/list structure, unread vs read marks, the primary "Mark read" pill, chip counts, and invitation rows.
- Existing assertions updated for the new chip text and the split empty-state title/body. Two feature files updated the same way.
