### PR TITLE
feat(ui): draw a lock icon inside password fields

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3899,6 +3899,20 @@ body .form-input:focus, body .form-textarea:focus, body .form-select:focus {
 
 body .form-textarea { min-height: 96px; resize: vertical; line-height: 1.5; padding: 10px 12px; }
 
+/* Leading icon inside a text control (password fields) */
+body .form-input-wrap { position: relative; }
+body .form-input-wrap.has-icon .form-input { padding-left: 38px; }
+body .form-input-wrap .form-input-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  pointer-events: none;
+  transition: color 120ms ease;
+}
+body .form-input-wrap:has(.form-input:focus) .form-input-icon { color: var(--accent-ink); }
+
 body .form-help { color: var(--muted); font-size: 12px; line-height: 1.5; }
 body .form-error { color: var(--danger); font-size: 12px; font-weight: 500; }
 

--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -9,6 +9,8 @@ defmodule HuddlzWeb.Components.Input do
   """
   use Phoenix.Component
 
+  import HuddlzWeb.Components.Icon
+
   alias Phoenix.HTML.Form
   alias Phoenix.HTML.FormField
 
@@ -66,6 +68,10 @@ defmodule HuddlzWeb.Components.Input do
   attr :class, :any, default: nil
   attr :control_class, :any, default: nil
 
+  attr :icon, :string,
+    default: nil,
+    doc: ~s(hero icon drawn inside the control's leading edge, e.g. "hero-lock-closed")
+
   slot :prefix
   slot :details
 
@@ -106,7 +112,22 @@ defmodule HuddlzWeb.Components.Input do
     """
   end
 
+  defp input_control(%{icon: icon} = assigns) when is_binary(icon) do
+    ~H"""
+    <div class="form-input-wrap has-icon">
+      <.icon name={@icon} class="size-4 form-input-icon" />
+      <.bare_input {assigns} />
+    </div>
+    """
+  end
+
   defp input_control(assigns) do
+    ~H"""
+    <.bare_input {assigns} />
+    """
+  end
+
+  defp bare_input(assigns) do
     ~H"""
     <input
       type={@type}

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -191,6 +191,7 @@ defmodule HuddlzWeb.ProfileLive do
               <.input
                 field={@email_form[:current_password]}
                 type="password"
+                icon="hero-lock-closed"
                 label="Confirm current password"
                 placeholder="Enter your current password"
                 autocomplete="current-password"
@@ -255,6 +256,7 @@ defmodule HuddlzWeb.ProfileLive do
                   id={"password-#{@password_input_reset_generation}-current-password"}
                   value=""
                   type="password"
+                  icon="hero-lock-closed"
                   phx-update="ignore"
                   label="Current password"
                   placeholder="Enter your current password"
@@ -266,6 +268,7 @@ defmodule HuddlzWeb.ProfileLive do
                 id={"password-#{@password_input_reset_generation}-password"}
                 value=""
                 type="password"
+                icon="hero-lock-closed"
                 phx-update="ignore"
                 label="New password"
                 placeholder="Enter your new password"
@@ -277,6 +280,7 @@ defmodule HuddlzWeb.ProfileLive do
                 id={"password-#{@password_input_reset_generation}-password-confirmation"}
                 value=""
                 type="password"
+                icon="hero-lock-closed"
                 phx-update="ignore"
                 label="Confirm new password"
                 placeholder="Confirm your new password"

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -239,6 +239,17 @@ defmodule HuddlzWeb.ProfileLiveTest do
       refute has_element?(view, "#profile-form", "must not equal")
     end
 
+    test "password fields carry a leading lock icon", %{conn: conn, user: user} do
+      conn
+      |> login(user)
+      |> visit("/profile")
+      |> assert_has("#password-form .form-input-wrap.has-icon .hero-lock-closed", count: 2)
+      |> assert_has("#password-form .form-input-wrap.has-icon input[type=password]", count: 2)
+      |> assert_has(
+        "#email-change-form .form-input-wrap.has-icon .hero-lock-closed + input[type=password]"
+      )
+    end
+
     test "never renders password values on load", %{conn: conn, user: user} do
       view = conn |> login(user) |> visit("/profile") |> Map.fetch!(:view)
 


### PR DESCRIPTION
## Summary

- `<.input>` accepts an optional `icon` attr. When set, the control is wrapped in `.form-input-wrap.has-icon` with the hero icon drawn at the leading edge (muted, accent on focus) and the input padded to clear it.
- The profile page's four password fields (email confirmation, current, new, confirm) use `hero-lock-closed`, matching the Profile design sheet.

## Tests

- New profile test asserts the wrapped password inputs and icons in both forms.