### PR TITLE
fix(photos): keep photo tiles in place across huddl refreshes

### DIFF
--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -1228,8 +1228,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
       end)
     )
     |> assign(:photo_count, length(photos))
-    |> assign(:photo_urls, Enum.map(photos, &HuddlPhotos.url(&1.storage_path)))
-    |> stream(:huddl_photos, photos, reset: true)
+    |> restream_photos(photos, urls)
   end
 
   defp load_photos(socket, _huddl, _user, false) do
@@ -1239,8 +1238,20 @@ defmodule HuddlzWeb.HuddlLive.Show do
     |> assign(:confirming_delete_photo_id, nil)
     |> assign(:confirming_delete_photo, nil)
     |> assign(:photo_count, 0)
-    |> assign(:photo_urls, [])
-    |> stream(:huddl_photos, [], reset: true)
+    |> restream_photos([], [])
+  end
+
+  # Every photo upload broadcasts `huddl_changed`, which lands here as a full
+  # refresh. Resetting the stream on each one tears the tiles down and rebuilds
+  # them, which drops keyboard focus mid-interaction, so only reset when the set
+  # of photos actually changed. The first load always streams: `photo_urls` is
+  # unset until then.
+  defp restream_photos(socket, photos, urls) do
+    changed? = Map.get(socket.assigns, :photo_urls) != urls
+
+    socket = assign(socket, :photo_urls, urls)
+
+    if changed?, do: stream(socket, :huddl_photos, photos, reset: true), else: socket
   end
 
   defp photo_position(urls, url), do: (Enum.find_index(urls, &(&1 == url)) || 0) + 1

--- a/test/browser/steps/huddl_photos_steps.exs
+++ b/test/browser/steps/huddl_photos_steps.exs
@@ -105,7 +105,12 @@ defmodule BrowserPhotoSteps do
   end
 
   step "I share the selected photos and open the first one", context do
-    conn = context.conn |> click_button("Upload photos") |> assert_has(".photo-tile", count: 2)
+    conn =
+      context.conn
+      |> click_button("Upload photos")
+      |> assert_has(".photo-tile", count: 2)
+      |> refute_has(".photo-upload-entry")
+
     conn = press(conn, ".photo-tile:first-child .photo-open", "Enter")
     Map.put(context, :conn, conn)
   end
@@ -147,7 +152,7 @@ defmodule BrowserPhotoSteps do
     conn =
       context.conn
       |> press(":focus", "Escape")
-      |> refute_has("#photo-lightbox")
+      |> assert_browser("!document.querySelector('#photo-lightbox')")
       |> assert_has(".photo-tile:first-child .photo-open:focus")
 
     Map.put(context, :conn, conn)

--- a/test/huddlz_web/live/huddl_live/show_photos_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_photos_test.exs
@@ -367,6 +367,34 @@ defmodule HuddlzWeb.HuddlLive.ShowPhotosTest do
       refute has_element?(view, "#photo-lightbox")
     end
 
+    test "a huddl change broadcast keeps the lightbox open and picks up new photos", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      huddl = generate(past_huddl(group_id: group.id, creator_id: owner.id))
+      {:ok, _first} = create_photo(huddl, owner, "first.jpg")
+
+      {:ok, view, _html} =
+        conn
+        |> login(owner)
+        |> live(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+
+      view |> element(".photo-tile button.photo-open") |> render_click()
+      assert has_element?(view, "#photo-lightbox img.lightbox-image")
+
+      send(view.pid, {:huddl_changed, huddl.id})
+      assert has_element?(view, "#photo-lightbox img.lightbox-image")
+      assert has_element?(view, ".photo-tile button[phx-value-url$='first.jpg']")
+
+      {:ok, _second} = create_photo(huddl, owner, "second.jpg")
+      send(view.pid, {:huddl_changed, huddl.id})
+
+      assert has_element?(view, "#photo-lightbox img.lightbox-image")
+      assert has_element?(view, ".photo-tile button[phx-value-url$='second.jpg']")
+      assert has_element?(view, "#photo-position", "of 2")
+    end
+
     test "clicking the next arrow advances the lightbox to the next photo", %{
       conn: conn,
       owner: owner,
@@ -631,5 +659,19 @@ defmodule HuddlzWeb.HuddlLive.ShowPhotosTest do
 
       assert has_element?(view, "#photo-lightbox img.lightbox-image[src='#{third_url}']")
     end
+  end
+
+  defp create_photo(huddl, actor, filename) do
+    Communities.create_huddl_photo(
+      %{
+        filename: filename,
+        content_type: "image/jpeg",
+        size_bytes: 1000,
+        storage_path: "/uploads/huddl_photos/#{huddl.id}/#{filename}",
+        thumbnail_path: "/uploads/huddl_photos/#{huddl.id}/thumb_#{filename}",
+        huddl_id: huddl.id
+      },
+      actor: actor
+    )
   end
 end


### PR DESCRIPTION
## Summary

The "Sharing and viewing memories with the keyboard on a narrow screen" browser scenario failed intermittently on #462 (CI) and on main locally. The Playwright traces showed two races, one in the app and one in the steps.

**App:** every uploaded photo publishes `huddl_changed`, and the huddl page answers each one with a full refresh that reset the photo stream. Right after an upload the tiles were torn down and rebuilt twice, which drops keyboard focus mid-interaction (in the trace, Enter on a tile landed on a detached node and never opened the lightbox). `load_photos/4` now resets the stream only when the set of photo URLs changed; the first load still initialises it.

**Steps:** the lightbox's outer element has no box of its own, so `refute_has("#photo-lightbox")` after Escape passed before the server had removed the dialog, and the next keypress raced the close. The step now waits for the element to leave the DOM. The upload step also waits for the upload queue to clear before opening a photo.

## Tests

- New LiveView test: a `huddl_changed` broadcast keeps the lightbox open and the tiles in place, and a broadcast after a new photo picks it up.
- Browser suite run three times locally on this branch: 12/12 each time (it failed 1 in 5 before).
