### PR TITLE
feat(api): expose the group hosting a huddl

### DIFF
--- a/docs/api-hosting-group.md
+++ b/docs/api-hosting-group.md
@@ -1,0 +1,64 @@
+# Hosting group API
+
+Clients can identify the group hosting a huddl through the read-only `group`
+relationship. Existing huddl and group visibility rules apply independently,
+using the request's authenticated viewer (or anonymous access).
+
+## GraphQL
+
+Send this query to `POST /gql` with the huddl ID in the `id` variable:
+
+```graphql
+query HuddlDetail($id: ID!) {
+  getHuddl(id: $id) {
+    id
+    title
+    group {
+      id
+      name
+      slug
+    }
+  }
+}
+```
+
+`Huddl.group` is a nullable `Group`. Its existing public fields are selectable;
+`name` is enough to display the host, and `slug` supports linking to the group.
+The relationship is also selectable on huddlz returned by list queries.
+
+## JSON:API
+
+Request the relationship explicitly to fetch the huddl and group together:
+
+```http
+GET /api/json/huddlz/:id?include=group&fields[group]=name,slug
+```
+
+The response's `data.relationships.group.data` contains the group's `type`
+(`group`) and `id`. Match these to the group resource in the top-level `included`
+array, where `attributes.name` and `attributes.slug` contain its display name
+and slug. The same include works on huddl list endpoints. Omitting
+`fields[group]` requests the group's existing public fields.
+
+Without `include=group`, the response does not embed the group or provide its
+name. Clients must not interpret an unrequested relationship as an unavailable
+host.
+
+## Unavailable hosts
+
+A viewer may be allowed to see a huddl without being allowed to see its group.
+For example, a former member with RSVP history can still see a cancelled huddl
+in a private group.
+
+In that case, the requested relationship is `group: null` in GraphQL and
+`relationships.group.data: null` in JSON:API, with no included group. The huddl
+remains in the response. Clients can display "Host unavailable" without
+inferring why the group is unavailable. Unexpected request failures remain
+errors.
+
+If the viewer cannot read the huddl itself, the existing inaccessible-huddl
+response still applies. Including its group does not grant access.
+
+The raw `group_id` / `groupId` field is private. The relationship does not expose
+group owners' accounts, membership records, or invitations, and does not add
+relationship mutation endpoints.

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -15,6 +15,9 @@ defmodule Huddlz.Communities.Huddl do
   graphql do
     type :huddl
 
+    # A viewer may retain access to a cancelled huddl after leaving its private group.
+    nullable_fields [:group]
+
     queries do
       get :get_huddl, :read
       list :search_huddlz, :search
@@ -36,6 +39,7 @@ defmodule Huddlz.Communities.Huddl do
 
   json_api do
     type "huddl"
+    includes [:group]
 
     default_fields [
       :id,
@@ -886,8 +890,10 @@ defmodule Huddlz.Communities.Huddl do
 
     belongs_to :group, Huddlz.Communities.Group do
       attribute_type :uuid
+      attribute_public? false
       allow_nil? false
       primary_key? false
+      public? true
     end
 
     belongs_to :group_location, Huddlz.Communities.GroupLocation do

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -5,12 +5,9 @@ defmodule HuddlzWeb.Router do
 
   import AshAuthentication.Plug.Helpers
 
-  # Bound total GraphQL query cost. Resource relationships aren't exposed as
-  # GraphQL fields, so deep nesting isn't possible — this caps query *breadth*,
-  # chiefly alias amplification (N aliased list queries -> N DB queries) from an
-  # anonymous client. A list query costs ~3 and legitimate requests are shallow
-  # (a handful of fields), so 100 leaves ample headroom while blocking alias
-  # floods. Tune as the schema grows.
+  # Bound total GraphQL query cost, including alias amplification and the
+  # hosting group relationship. Group exposes no further relationships, so
+  # legitimate requests remain shallow. Tune as the schema grows.
   @graphql_max_complexity 100
 
   pipeline :graphql do

--- a/test/features/api_hosting_group.feature
+++ b/test/features/api_hosting_group.feature
@@ -1,0 +1,49 @@
+@async @database @conn @api_hosting_group
+Feature: Identify the group hosting a huddl through the API
+  As a person viewing a huddl in an API client
+  I want to know which group is hosting it
+  So that I can recognize the community organizing it
+
+  Scenario: A visitor identifies a public huddl's host through GraphQL
+    Given a public huddl hosted by "Brooklyn Coffee Club"
+    When I request the huddl's hosting group through "GraphQL"
+    Then the API identifies "Brooklyn Coffee Club" as the hosting group
+
+  Scenario: A visitor identifies a public huddl's host through JSON:API
+    Given a public huddl hosted by "Brooklyn Coffee Club"
+    When I request the huddl's hosting group through "JSON:API"
+    Then the API identifies "Brooklyn Coffee Club" as the hosting group
+
+  Scenario Outline: A member identifies the group hosting a private huddl
+    Given I belong to the private group hosting "Saturday Coffee"
+    When I request the huddl's hosting group through "<api>"
+    Then the API identifies "Brooklyn Coffee Club" as the hosting group
+
+    Examples:
+      | api      |
+      | GraphQL  |
+      | JSON:API |
+
+  Scenario Outline: A former member can see a cancellation without seeing the private host
+    Given I belong to the private group hosting "Saturday Coffee"
+    And I have RSVP history for the cancelled huddl but have left its group
+    When I request the huddl's hosting group through "<api>"
+    Then the API returns the huddl with unavailable hosting information
+
+    Examples:
+      | api      |
+      | GraphQL  |
+      | JSON:API |
+
+  Scenario Outline: An outsider cannot reveal a private huddl by requesting its host
+    Given I belong to the private group hosting "Saturday Coffee"
+    But I am requesting the host as "<viewer>"
+    When I request the huddl's hosting group through "<api>"
+    Then the API does not reveal the huddl or its hosting group
+
+    Examples:
+      | api      | viewer    |
+      | GraphQL  | anonymous |
+      | JSON:API | anonymous |
+      | GraphQL  | nonmember |
+      | JSON:API | nonmember |

--- a/test/features/step_definitions/api_hosting_group_steps.exs
+++ b/test/features/step_definitions/api_hosting_group_steps.exs
@@ -1,0 +1,151 @@
+defmodule ApiHostingGroupSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+
+  step "a public huddl hosted by {string}", %{args: [name]} = context do
+    owner = generate(user())
+    group = generate(group(name: name, actor: owner, is_public: true))
+    huddl = generate(huddl(group_id: group.id, actor: owner, title: "Saturday Coffee"))
+
+    Map.merge(context, %{hosting_group: group, hosted_huddl: huddl})
+  end
+
+  step "I request the huddl's hosting group through {string}", %{args: [api]} = context do
+    response = request_host(context.conn, context.hosted_huddl.id, api)
+    Map.merge(context, %{hosting_response: response, hosting_api: api})
+  end
+
+  step "I belong to the private group hosting {string}", %{args: [title]} = context do
+    owner = generate(user())
+    viewer = generate(user())
+
+    {group, [membership]} =
+      generate_group_with_members(
+        owner: owner,
+        group: [name: "Brooklyn Coffee Club", is_public: false],
+        members: [%{user: viewer, role: :member}]
+      )
+
+    huddl = generate(huddl(group_id: group.id, actor: owner, title: title))
+
+    Map.merge(context, %{
+      hosting_group: group,
+      hosted_huddl: huddl,
+      hosting_owner: owner,
+      hosting_viewer: viewer,
+      hosting_membership: membership,
+      conn: HuddlzWeb.ApiCase.authenticated_conn(context.conn, viewer)
+    })
+  end
+
+  step "I have RSVP history for the cancelled huddl but have left its group", context do
+    Huddlz.Communities.rsvp_huddl!(context.hosted_huddl, actor: context.hosting_viewer)
+
+    cancelled =
+      Huddlz.Communities.cancel_huddl!(context.hosted_huddl, nil, %{},
+        actor: context.hosting_owner
+      )
+
+    context.hosting_membership
+    |> Ash.Changeset.for_destroy(:leave_group, %{}, actor: context.hosting_viewer)
+    |> Ash.destroy!()
+
+    Map.put(context, :hosted_huddl, cancelled)
+  end
+
+  step "the API returns the huddl with unavailable hosting information", context do
+    response = Phoenix.ConnTest.json_response(context.hosting_response, 200)
+    refute Map.has_key?(response, "errors")
+    assert_unavailable_host(response, context.hosting_api, context.hosted_huddl.id)
+    refute context.hosting_response.resp_body =~ context.hosting_group.id
+    refute context.hosting_response.resp_body =~ to_string(context.hosting_group.name)
+    refute context.hosting_response.resp_body =~ context.hosting_group.slug
+    context
+  end
+
+  step "I am requesting the host as {string}", %{args: [viewer]} = context do
+    Map.put(context, :conn, outsider_conn(viewer))
+  end
+
+  step "the API does not reveal the huddl or its hosting group", context do
+    assert_inaccessible_huddl(context.hosting_response, context.hosting_api)
+    refute context.hosting_response.resp_body =~ context.hosted_huddl.title
+    refute context.hosting_response.resp_body =~ context.hosting_group.id
+    refute context.hosting_response.resp_body =~ to_string(context.hosting_group.name)
+    context
+  end
+
+  step "the API identifies {string} as the hosting group", %{args: [name]} = context do
+    response = Phoenix.ConnTest.json_response(context.hosting_response, 200)
+    refute Map.has_key?(response, "errors")
+    group = hosting_group(response, context.hosting_api)
+
+    assert group == %{
+             "id" => context.hosting_group.id,
+             "name" => name,
+             "slug" => context.hosting_group.slug
+           }
+
+    context
+  end
+
+  defp request_host(conn, id, "GraphQL") do
+    HuddlzWeb.ApiCase.gql_post(
+      conn,
+      """
+      query HuddlDetail($id: ID!) {
+        getHuddl(id: $id) { id title group { id name slug } }
+      }
+      """,
+      %{"id" => id}
+    )
+  end
+
+  defp request_host(conn, id, "JSON:API") do
+    Phoenix.ConnTest.dispatch(conn, HuddlzWeb.Endpoint, :get, "/api/json/huddlz/#{id}", %{
+      "include" => "group",
+      "fields" => %{"group" => "name,slug"}
+    })
+  end
+
+  defp outsider_conn("anonymous"), do: Phoenix.ConnTest.build_conn()
+
+  defp outsider_conn("nonmember") do
+    HuddlzWeb.ApiCase.authenticated_conn(Phoenix.ConnTest.build_conn(), generate(user()))
+  end
+
+  defp assert_inaccessible_huddl(conn, "GraphQL") do
+    response = Phoenix.ConnTest.json_response(conn, 200)
+    assert %{"data" => %{"getHuddl" => nil}} = response
+  end
+
+  defp assert_inaccessible_huddl(conn, "JSON:API") do
+    response = Phoenix.ConnTest.json_response(conn, 404)
+    assert [%{"code" => "not_found"}] = response["errors"]
+  end
+
+  defp assert_unavailable_host(response, "GraphQL", id) do
+    assert %{"id" => ^id, "title" => "Saturday Coffee", "group" => nil} =
+             response["data"]["getHuddl"]
+  end
+
+  defp assert_unavailable_host(response, "JSON:API", id) do
+    assert response["data"]["id"] == id
+    assert response["data"]["attributes"]["title"] == "Saturday Coffee"
+    assert %{"data" => nil} = response["data"]["relationships"]["group"]
+    assert response["included"] == []
+  end
+
+  defp hosting_group(response, "GraphQL"), do: response["data"]["getHuddl"]["group"]
+
+  defp hosting_group(response, "JSON:API") do
+    linkage = response["data"]["relationships"]["group"]["data"]
+    assert %{"type" => "group", "id" => id} = linkage
+    assert [group] = response["included"]
+    assert group["type"] == "group"
+    assert group["id"] == id
+    Map.put(group["attributes"], "id", id)
+  end
+end

--- a/test/huddlz_web/api/sensitive_fields_audit_test.exs
+++ b/test/huddlz_web/api/sensitive_fields_audit_test.exs
@@ -10,6 +10,8 @@ defmodule HuddlzWeb.Api.SensitiveFieldsAuditTest do
 
   use HuddlzWeb.ApiCase, async: true
 
+  @moduletag :sensitive_fields_audit
+
   @forbidden_huddl_fields ~w(virtualLink virtual_link)
   # `User` is reachable via `me` query only, where the actor sees their own
   # record. `Author` / `UserPublicProfile` are cross-user shapes — they
@@ -18,6 +20,17 @@ defmodule HuddlzWeb.Api.SensitiveFieldsAuditTest do
   @forbidden_others_fields ~w(email role hashedPassword hashed_password homeLatitude homeLongitude)
 
   describe "Huddl GraphQL type" do
+    test "exposes the hosting group without exposing raw account or group identifiers", %{
+      conn: conn
+    } do
+      fields = type_field_names(conn, "Huddl")
+      assert "group" in fields
+
+      for field <- ~w(groupId creator creatorId publishedBy cancelledBy) do
+        refute field in fields, "Huddl type unexpectedly exposes #{field}"
+      end
+    end
+
     test "does not expose virtual_link directly", %{conn: conn} do
       fields = type_field_names(conn, "Huddl")
       refute Enum.empty?(fields), "Huddl type should be present in the schema"
@@ -26,6 +39,54 @@ defmodule HuddlzWeb.Api.SensitiveFieldsAuditTest do
       for f <- @forbidden_huddl_fields do
         refute f in fields, "Huddl type unexpectedly exposes #{f}"
       end
+    end
+  end
+
+  describe "Group GraphQL type" do
+    test "does not expose accounts or memberships through the hosting group", %{conn: conn} do
+      fields = type_field_names(conn, "Group")
+      assert "name" in fields
+
+      for field <- ~w(owner ownerId members groupMembers groupInvitations) do
+        refute field in fields, "Group type unexpectedly exposes #{field}"
+      end
+    end
+  end
+
+  describe "JSON:API hosting group" do
+    test "including all public group fields does not expose accounts or memberships", %{
+      conn: conn
+    } do
+      owner = generate(user())
+      group = generate(group(actor: owner))
+      huddl = generate(huddl(group_id: group.id, actor: owner))
+
+      response =
+        conn
+        |> get("/api/json/huddlz/#{huddl.id}", %{"include" => "group"})
+        |> json_response(200)
+
+      assert [included] = response["included"]
+      assert included["attributes"]["name"] == to_string(group.name)
+      assert included["relationships"] == %{}
+      refute Map.has_key?(included["attributes"], "owner_id")
+      refute Map.has_key?(response["data"]["attributes"], "group_id")
+      refute Jason.encode!(response) =~ owner.id
+      refute Jason.encode!(response) =~ to_string(owner.email)
+    end
+
+    test "a sparse field request cannot expose the raw group identifier", %{conn: conn} do
+      owner = generate(user())
+      group = generate(group(actor: owner))
+      huddl = generate(huddl(group_id: group.id, actor: owner))
+
+      response =
+        conn
+        |> get("/api/json/huddlz/#{huddl.id}", %{"fields" => %{"huddl" => "group_id"}})
+        |> json_response(400)
+
+      assert [_ | _] = response["errors"]
+      refute Jason.encode!(response) =~ group.id
     end
   end
 


### PR DESCRIPTION
API clients can now identify the group hosting a huddl through GraphQL's `group { id name slug }` or JSON:API's `include=group&fields[group]=name,slug`.

Existing huddl and group visibility rules apply independently. A viewer who can still see a cancelled huddl after leaving its private group receives a null host. Raw group identifiers, accounts, and memberships remain private. JSON:API clients must explicitly include the group to receive its name.

Cucumber scenarios exercise both APIs for public visitors, private-group members, former members, and outsiders. Client request examples are documented in `docs/api-hosting-group.md`.

Closes #465.
