### PR TITLE
feat(nav): live navigation for the app chrome and an accent progress bar

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -143,9 +143,15 @@ const liveSocket = new LiveSocket("/live", Socket, {
   hooks: Hooks
 })
 
-// Show progress bar on live navigation and form submits
-topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
-window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
+// Progress bar on live navigation and form submits. The colour is read from
+// the accent token at show time so it follows the active theme.
+const accentColor = () =>
+  getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#18cbd4"
+
+window.addEventListener("phx:page-loading-start", _info => {
+  topbar.config({barColors: {0: accentColor()}, barThickness: 2, shadowBlur: 0, shadowColor: "transparent"})
+  topbar.show(300)
+})
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
 // connect if there are any LiveViews on the page

--- a/assets/js/mobile_navigation.mjs
+++ b/assets/js/mobile_navigation.mjs
@@ -18,27 +18,50 @@ export class MobileNavigation {
     this.handleClick = this.handleClick.bind(this)
     this.handleKeydown = this.handleKeydown.bind(this)
     this.handleBreakpointChange = this.handleBreakpointChange.bind(this)
+    this.handlePageLoaded = this.handlePageLoaded.bind(this)
   }
 
   mount() {
-    this.trigger = this.document.querySelector("[data-mobile-nav-trigger]")
-    this.drawer = this.document.querySelector("#mobile-navigation-drawer")
-    this.scrim = this.document.querySelector("[data-mobile-nav-scrim]")
-    this.background = this.document.querySelector("[data-mobile-nav-background]")
-    this.closeButton = this.document.querySelector("[data-mobile-nav-close]")
-
-    if (!this.trigger || !this.drawer || !this.scrim || !this.background || !this.closeButton) {
-      return false
-    }
+    if (!this.resolveElements()) return false
 
     this.mobileQuery = this.window.matchMedia(MOBILE_NAVIGATION_QUERY)
     this.listen(this.document, "click", this.handleClick)
     this.listen(this.document, "keydown", this.handleKeydown)
     this.listen(this.mobileQuery, "change", this.handleBreakpointChange)
+    if (this.window.addEventListener) {
+      this.listen(this.window, "phx:page-loading-stop", this.handlePageLoaded)
+    }
     this.syncResponsiveState()
     this.observeLiveViewPatches()
 
     return true
+  }
+
+  resolveElements() {
+    const trigger = this.document.querySelector("[data-mobile-nav-trigger]")
+    const drawer = this.document.querySelector("#mobile-navigation-drawer")
+    const scrim = this.document.querySelector("[data-mobile-nav-scrim]")
+    const background = this.document.querySelector("[data-mobile-nav-background]")
+    const closeButton = this.document.querySelector("[data-mobile-nav-close]")
+
+    if (!trigger || !drawer || !scrim || !background || !closeButton) return false
+
+    Object.assign(this, {trigger, drawer, scrim, background, closeButton})
+    return true
+  }
+
+  // Live navigation renders a fresh chrome, so the nodes mounted against are
+  // detached afterwards. LiveView fires page-loading-stop once when the old
+  // view is swapped out and again once the new one has rendered; rebind as
+  // soon as the new nodes exist and put them in the closed state.
+  handlePageLoaded() {
+    if (this.drawer.isConnected !== false) return
+    if (!this.resolveElements()) return
+
+    if (this.observer) this.observer.disconnect()
+    this.opened = false
+    this.syncDomState()
+    this.observeLiveViewPatches()
   }
 
   destroy() {

--- a/assets/js/mobile_navigation_test.mjs
+++ b/assets/js/mobile_navigation_test.mjs
@@ -29,6 +29,7 @@ class FakeElement {
     this.dataset = {}
     this.focusable = []
     this.closestMatches = new Set()
+    this.isConnected = true
   }
 
   setAttribute(name, value) {
@@ -113,7 +114,8 @@ function setup({mobile = true} = {}) {
 
   const mediaQuery = new FakeEventTarget()
   mediaQuery.matches = mobile
-  const windowRef = {matchMedia: () => mediaQuery}
+  const windowRef = new FakeEventTarget()
+  windowRef.matchMedia = () => mediaQuery
 
   const navigation = new MobileNavigation(documentRef, windowRef)
   assert.equal(navigation.mount(), true)
@@ -121,6 +123,8 @@ function setup({mobile = true} = {}) {
   return {
     navigation,
     documentRef,
+    windowRef,
+    elements,
     mediaQuery,
     trigger,
     drawer,
@@ -227,5 +231,37 @@ test("switching to desktop removes drawer and background restrictions", () => {
   assert.equal(drawer.dataset.mobileNavState, "desktop")
   assert.equal(drawer.hasAttribute("inert"), false)
   assert.equal(background.hasAttribute("inert"), false)
+  assert.equal(trigger.attributes.get("aria-expanded"), "false")
+})
+
+test("live navigation swaps in the freshly rendered drawer and closes it", () => {
+  const {navigation, documentRef, windowRef, elements, drawer, trigger, firstLink} = setup()
+  navigation.open()
+  navigation.handleClick({target: firstLink})
+
+  for (const element of elements.values()) element.isConnected = false
+  const previousDrawer = elements.get("#mobile-navigation-drawer")
+  elements.set("#mobile-navigation-drawer", undefined)
+  windowRef.listeners.get("phx:page-loading-stop")()
+  assert.equal(navigation.drawer, previousDrawer, "keeps the old nodes until the new chrome exists")
+
+  const nextDrawer = new FakeElement(documentRef)
+  const nextTrigger = new FakeElement(documentRef)
+  const nextBackground = new FakeElement(documentRef)
+  elements.set("#mobile-navigation-drawer", nextDrawer)
+  elements.set("[data-mobile-nav-trigger]", nextTrigger)
+  elements.set("[data-mobile-nav-background]", nextBackground)
+
+  windowRef.listeners.get("phx:page-loading-stop")()
+
+  assert.equal(navigation.drawer, nextDrawer)
+  assert.equal(nextDrawer.dataset.mobileNavState, "closed")
+  assert.equal(nextDrawer.hasAttribute("inert"), true)
+  assert.equal(nextBackground.hasAttribute("inert"), false)
+  assert.equal(nextTrigger.attributes.get("aria-expanded"), "false")
+
+  navigation.open()
+  assert.equal(nextDrawer.dataset.mobileNavState, "open")
+  assert.equal(drawer.dataset.mobileNavState, "closed")
   assert.equal(trigger.attributes.get("aria-expanded"), "false")
 })

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -62,10 +62,10 @@ defmodule HuddlzWeb.Layouts do
         aria-label="Primary navigation"
       >
         <div class="sidebar-brand">
-          <a href="/" aria-label="huddlz home">
+          <.link navigate={~p"/"} aria-label="huddlz home">
             <div class="brand-glyph">h</div>
             <div class="brand-text">huddlz</div>
-          </a>
+          </.link>
           <button
             type="button"
             id="mobile-nav-close"
@@ -78,47 +78,47 @@ defmodule HuddlzWeb.Layouts do
         </div>
 
         <nav class="sb-nav">
-          <a
+          <.link
             class={["sb-item", @active == "discover" && "active"]}
-            href="/discover"
+            navigate={~p"/discover"}
             aria-current={@active == "discover" && "page"}
           >
             <.nav_icon name="search" />
             <span class="label">Discover</span>
-          </a>
-          <a
+          </.link>
+          <.link
             class={["sb-item", @active == "my-huddlz" && "active"]}
-            href="/my-huddlz"
+            navigate={~p"/my-huddlz"}
             aria-current={@active == "my-huddlz" && "page"}
           >
             <.nav_icon name="ticket" />
             <span class="label">My huddlz</span>
-          </a>
-          <a
+          </.link>
+          <.link
             class={["sb-item", @active == "my-groups" && "active"]}
-            href="/my-groups"
+            navigate={~p"/my-groups"}
             aria-current={@active == "my-groups" && "page"}
           >
             <.nav_icon name="users" />
             <span class="label">My groups</span>
-          </a>
-          <a
+          </.link>
+          <.link
             class={["sb-item", @active == "calendar" && "active"]}
-            href="/calendar"
+            navigate={~p"/calendar"}
             aria-current={@active == "calendar" && "page"}
           >
             <.nav_icon name="calendar" />
             <span class="label">My calendar</span>
-          </a>
+          </.link>
 
           <div class="sb-orgs">
             <%= for {group, idx} <- Enum.with_index(@sidebar_owned_groups) do %>
-              <a
+              <.link
                 class={[
                   "sb-org-row",
                   @active_group_slug == group.slug && "active"
                 ]}
-                href={"/organize/#{group.slug}"}
+                navigate={~p"/organize/#{group.slug}"}
                 aria-current={
                   @active_group_slug == group.slug && is_nil(@active_organize_section) && "page"
                 }
@@ -135,63 +135,63 @@ defmodule HuddlzWeb.Layouts do
                     {role}
                   </span>
                 </span>
-              </a>
+              </.link>
               <div :if={@active_group_slug == group.slug} class="sb-sub">
-                <a
+                <.link
                   class={["sb-sub-item", @active_organize_section == :overview && "active"]}
-                  href={"/organize/#{group.slug}"}
+                  navigate={~p"/organize/#{group.slug}"}
                   aria-current={@active_organize_section == :overview && "page"}
                 >
                   Overview
-                </a>
-                <a
+                </.link>
+                <.link
                   class={["sb-sub-item", @active_organize_section == :huddlz && "active"]}
-                  href={"/organize/#{group.slug}/huddlz"}
+                  navigate={~p"/organize/#{group.slug}/huddlz"}
                   aria-current={@active_organize_section == :huddlz && "page"}
                 >
                   Huddlz
-                </a>
-                <a
+                </.link>
+                <.link
                   class={["sb-sub-item", @active_organize_section == :members && "active"]}
-                  href={"/organize/#{group.slug}/members"}
+                  navigate={~p"/organize/#{group.slug}/members"}
                   aria-current={@active_organize_section == :members && "page"}
                 >
                   Members
-                </a>
+                </.link>
               </div>
             <% end %>
-            <a class="sb-org-row create" href="/groups/new">
+            <.link class="sb-org-row create" navigate={~p"/groups/new"}>
               <div class="plus-mark">+</div>
               <span class="name">New group</span>
-            </a>
+            </.link>
           </div>
         </nav>
 
         <div class="sb-account">
-          <a
+          <.link
             class={["sb-item", @active == "profile" && "active"]}
-            href="/profile"
+            navigate={~p"/profile"}
             aria-current={@active == "profile" && "page"}
           >
             <.nav_icon name="user" />
             <span class="label">Profile</span>
-          </a>
-          <a
+          </.link>
+          <.link
             class={["sb-item", @active == "settings" && "active"]}
-            href="/profile/notifications"
+            navigate={~p"/profile/notifications"}
             aria-current={@active == "settings" && "page"}
           >
             <.nav_icon name="cog" />
             <span class="label">Settings</span>
-          </a>
-          <a
+          </.link>
+          <.link
             class={["sb-item", @active == "help" && "active"]}
-            href="/help"
+            navigate={~p"/help"}
             aria-current={@active == "help" && "page"}
           >
             <.nav_icon name="help" />
             <span class="label">Help</span>
-          </a>
+          </.link>
           <.link
             id="sign-out-link"
             class="sb-item"
@@ -203,24 +203,24 @@ defmodule HuddlzWeb.Layouts do
             <span class="label">Sign out</span>
           </.link>
           <%= if User.admin?(@current_user) do %>
-            <a
+            <.link
               class={["sb-item", @active == "admin" && "active"]}
-              href="/admin"
+              navigate={~p"/admin"}
               aria-current={@active == "admin" && "page"}
             >
               <.nav_icon name="shield" />
               <span class="label">Admin</span>
-            </a>
+            </.link>
           <% end %>
         </div>
 
-        <a id="sidebar-user" class="sb-user" href="/profile" aria-label="View profile">
+        <.link id="sidebar-user" class="sb-user" navigate={~p"/profile"} aria-label="View profile">
           <.sb_user_avatar user={@current_user} />
           <div class="who">
             <div class="name">{display_name(@current_user)}</div>
             <div class="role">{@current_user.email}</div>
           </div>
-        </a>
+        </.link>
       </aside>
     <% end %>
 
@@ -239,10 +239,10 @@ defmodule HuddlzWeb.Layouts do
             <.nav_icon name="bars" />
           </button>
         <% else %>
-          <a class="topbar-brand" href="/" aria-label="huddlz home">
+          <.link class="topbar-brand" navigate={~p"/"} aria-label="huddlz home">
             <div class="brand-glyph">h</div>
             <div class="brand-text">huddlz</div>
-          </a>
+          </.link>
         <% end %>
         <form class="topbar-search" action="/discover" method="get" role="search">
           <span class="lead-key" aria-hidden="true">/</span>
@@ -256,10 +256,10 @@ defmodule HuddlzWeb.Layouts do
         </form>
         <div class="content-actions">
           <%= if @signed_in do %>
-            <a
+            <.link
               id="notification-nav-link"
               class={["icon-pill", @active == "notifications" && "active"]}
-              href="/notifications"
+              navigate={~p"/notifications"}
               aria-label={notification_label(@unread_notification_count)}
               aria-current={@active == "notifications" && "page"}
             >
@@ -272,7 +272,7 @@ defmodule HuddlzWeb.Layouts do
               >
                 {compact_notification_count(@unread_notification_count)}
               </span>
-            </a>
+            </.link>
           <% else %>
             <a class="btn-secondary" href="/sign-in">Sign in</a>
             <a class="btn-primary" href="/register">Sign up</a>

--- a/test/huddlz_web/components/layouts_test.exs
+++ b/test/huddlz_web/components/layouts_test.exs
@@ -39,6 +39,34 @@ defmodule HuddlzWeb.LayoutsTest do
     end
   end
 
+  describe "app/1 chrome navigation" do
+    test "sidebar and topbar destinations use live navigation" do
+      document = render_app(0)
+
+      anchors =
+        document
+        |> LazyHTML.query(".sidebar a[href], .content-topbar a[href]")
+        |> Enum.map(fn anchor ->
+          {LazyHTML.attribute(anchor, "href"), LazyHTML.attribute(anchor, "data-phx-link")}
+        end)
+
+      assert anchors != []
+
+      for {href, link_kind} <- anchors, href != ["/sign-out"] do
+        assert link_kind == ["redirect"], "#{href} should navigate without a full page load"
+      end
+    end
+
+    test "sign out stays a full request so the session cookie is cleared" do
+      document = render_app(0)
+
+      assert has_selector?(
+               document,
+               ~s|#sign-out-link[data-method="delete"]:not([data-phx-link])|
+             )
+    end
+  end
+
   defp render_app(unread_notification_count) do
     assigns = %{
       current_user: %{email: "person@example.com", display_name: "Test Person"},

--- a/test/huddlz_web/structured_data_test.exs
+++ b/test/huddlz_web/structured_data_test.exs
@@ -235,16 +235,14 @@ defmodule HuddlzWeb.StructuredDataTest do
     assert html |> Floki.parse_document!() |> structured_data() |> Map.fetch!("@id") ==
              url(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
 
-    {:ok, home_conn} =
+    {:ok, _home_view, home_html} =
       huddl_view
       |> Phoenix.LiveViewTest.element("a[aria-label='huddlz home']")
       |> Phoenix.LiveViewTest.render_click()
       |> Phoenix.LiveViewTest.follow_redirect(conn)
 
-    assert Floki.find(
-             Floki.parse_document!(html_response(home_conn, 200)),
-             "script[type='application/ld+json']"
-           ) == []
+    assert Floki.find(Floki.parse_document!(home_html), "script[type='application/ld+json']") ==
+             []
   end
 
   test "recurring occurrences have separate identities and local dates across daylight saving",


### PR DESCRIPTION
## Summary

Every link in the app chrome was a plain anchor, so each sidebar click reloaded the page even though all of those destinations live in the same live session. This PR moves the chrome to live navigation and makes the progress bar match the design tokens.

- Sidebar items, organizing group rows and their sub-navigation, account links, the sidebar user card, the brand link and the notification bell now use `<.link navigate>`. Sign out keeps its full DELETE request.
- The page progress bar reads `--accent` when it shows, so it follows the active theme, drops the shadow, and is two pixels tall.
- The mobile drawer controller rebinds its nodes after live navigation. LiveView swaps in a fresh chrome, so the previous nodes were detached and the new drawer never became inert.
- One structured-data test followed the brand link as a full redirect; it now follows it as a live redirect.

## Verification

- `mix precommit` clean, with the exit code checked directly.
- Playwright suite green. The mobile drawer scenario caught the rebinding bug on the first run.
- In the browser: a marker set on `window` survives sidebar navigation on desktop and from the mobile drawer, the drawer closes and the trigger resets after navigating, and the active sidebar item updates.
