### PR TITLE
feat(ui): shimmer covers until their picture decodes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1491,6 +1491,46 @@ body .cover-image {
 
 body .huddl-hero .cover-image { background-size: cover; }
 
+/* Loading surface while the picture is still arriving (see the CoverImage
+   hook). The panel paints over the fallback, then fades out to reveal the
+   picture; a failed picture drops the surface and leaves the fallback. */
+body .cover-image::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--panel-2);
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+body .cover-image.is-pending { overflow: hidden; }
+body .cover-image.is-pending::before { opacity: 1; transition: none; }
+
+body .cover-image.is-pending::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--line-strong) 55%, transparent) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: cover-shimmer 1.6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes cover-shimmer {
+  to { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body .cover-image::before { transition: none; }
+  body .cover-image.is-pending::after { animation: none; }
+}
+
 body .group-cover-image {
   position: absolute;
   inset: 0;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,6 +24,7 @@ import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 import {mountMobileNavigation} from "./mobile_navigation.mjs"
+import {createCoverImageHook} from "./cover_image.mjs"
 
 // The appearance setting lives on <html data-theme>, outside any LiveView.
 // Settings pushes a "theme" event after saving; "system" drops the attribute
@@ -37,6 +38,8 @@ window.addEventListener("phx:theme", ({detail}) => {
 })
 
 const Hooks = {}
+
+Hooks.CoverImage = createCoverImageHook()
 
 Hooks.LocationAutocomplete = {
   mounted() {

--- a/assets/js/cover_image.mjs
+++ b/assets/js/cover_image.mjs
@@ -1,0 +1,60 @@
+// Reveals a `.cover-image` once its picture has decoded.
+//
+// The element paints its picture as a CSS background, so a missing or failed
+// file leaves the surrounding fallback visible with no client-side state.
+// This hook only layers a loading surface on top while the picture is still
+// arriving, and only after a short delay so cached pictures never flash it.
+export const PENDING_DELAY_MS = 150
+
+export function createCoverImageHook({
+  ImageCtor = globalThis.Image,
+  setTimeoutFn = globalThis.setTimeout,
+  clearTimeoutFn = globalThis.clearTimeout
+} = {}) {
+  return {
+    mounted() {
+      this.watch()
+    },
+
+    updated() {
+      if (this.url !== this.el.dataset.coverUrl) this.watch()
+    },
+
+    destroyed() {
+      this.release()
+    },
+
+    watch() {
+      this.release()
+      this.url = this.el.dataset.coverUrl
+      this.el.classList.remove("is-pending")
+      delete this.el.dataset.coverState
+      if (!this.url) return
+
+      const probe = new ImageCtor()
+      this.probe = probe
+      probe.onload = () => this.settle("loaded")
+      probe.onerror = () => this.settle("failed")
+      probe.src = this.url
+
+      this.timer = setTimeoutFn(() => this.el.classList.add("is-pending"), PENDING_DELAY_MS)
+    },
+
+    settle(state) {
+      this.release()
+      this.el.classList.remove("is-pending")
+      this.el.dataset.coverState = state
+    },
+
+    release() {
+      if (this.timer) clearTimeoutFn(this.timer)
+      this.timer = null
+
+      if (this.probe) {
+        this.probe.onload = null
+        this.probe.onerror = null
+        this.probe = null
+      }
+    }
+  }
+}

--- a/assets/js/cover_image_test.mjs
+++ b/assets/js/cover_image_test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {PENDING_DELAY_MS, createCoverImageHook} from "./cover_image.mjs"
+
+function setup(url = "/uploads/cover.jpg") {
+  const probes = []
+  const timers = []
+
+  class FakeImage {
+    constructor() {
+      probes.push(this)
+    }
+  }
+
+  const hook = createCoverImageHook({
+    ImageCtor: FakeImage,
+    setTimeoutFn: (callback, delay) => {
+      const timer = {callback, delay, cleared: false}
+      timers.push(timer)
+      return timer
+    },
+    clearTimeoutFn: timer => {
+      timer.cleared = true
+    }
+  })
+
+  const classes = new Set()
+  hook.el = {
+    dataset: {coverUrl: url},
+    classList: {
+      add: value => classes.add(value),
+      remove: (...values) => values.forEach(value => classes.delete(value)),
+      contains: value => classes.has(value)
+    }
+  }
+
+  hook.mounted()
+
+  return {hook, probes, timers, classes}
+}
+
+test("probes the picture and marks the element once it decodes", () => {
+  const {hook, probes, timers, classes} = setup()
+
+  assert.equal(probes.length, 1)
+  assert.equal(probes[0].src, "/uploads/cover.jpg")
+  assert.equal(classes.has("is-pending"), false)
+
+  probes[0].onload()
+
+  assert.equal(hook.el.dataset.coverState, "loaded")
+  assert.equal(classes.has("is-pending"), false)
+  assert.equal(timers[0].cleared, true)
+})
+
+test("shows the pending surface only after the delay, then clears it", () => {
+  const {hook, probes, timers, classes} = setup()
+
+  assert.equal(timers[0].delay, PENDING_DELAY_MS)
+  timers[0].callback()
+  assert.equal(classes.has("is-pending"), true)
+
+  probes[0].onload()
+
+  assert.equal(classes.has("is-pending"), false)
+  assert.equal(hook.el.dataset.coverState, "loaded")
+})
+
+test("a picture that fails to load leaves the fallback visible", () => {
+  const {hook, probes, timers, classes} = setup()
+  timers[0].callback()
+
+  probes[0].onerror()
+
+  assert.equal(classes.has("is-pending"), false)
+  assert.equal(hook.el.dataset.coverState, "failed")
+})
+
+test("a new picture URL starts over", () => {
+  const {hook, probes, classes} = setup()
+  probes[0].onload()
+
+  hook.el.dataset.coverUrl = "/uploads/next.jpg"
+  hook.updated()
+
+  assert.equal(probes.length, 2)
+  assert.equal(probes[1].src, "/uploads/next.jpg")
+  assert.equal(hook.el.dataset.coverState, undefined)
+  assert.equal(classes.has("is-pending"), false)
+})
+
+test("an unchanged update keeps the settled state", () => {
+  const {hook, probes} = setup()
+  probes[0].onload()
+
+  hook.updated()
+
+  assert.equal(probes.length, 1)
+  assert.equal(hook.el.dataset.coverState, "loaded")
+})
+
+test("destroying the hook stops listening to the probe", () => {
+  const {hook, probes, timers} = setup()
+  const probe = probes[0]
+
+  hook.destroyed()
+
+  assert.equal(timers[0].cleared, true)
+  assert.equal(probe.onload, null)
+  assert.equal(probe.onerror, null)
+})

--- a/lib/huddlz_web/components/cover_image.ex
+++ b/lib/huddlz_web/components/cover_image.ex
@@ -2,8 +2,10 @@ defmodule HuddlzWeb.Components.CoverImage do
   @moduledoc """
   Decorative cover media layered over the surrounding fallback.
 
-  A missing or failed CSS background leaves the fallback visible without
-  client-side state or image load handlers.
+  A missing or failed CSS background leaves the fallback visible without any
+  server-side state. The `CoverImage` hook layers a loading surface over the
+  element while the picture is still arriving and records the outcome in
+  `data-cover-state`; without JavaScript the picture simply paints when ready.
   """
   use Phoenix.Component
 
@@ -12,15 +14,24 @@ defmodule HuddlzWeb.Components.CoverImage do
   attr :class, :any, required: true
 
   def cover_image(assigns) do
-    url =
-      assigns.image_url
-      |> Huddlz.Storage.url()
-      |> URI.encode(&(URI.char_unescaped?(&1) or &1 == ?%))
+    url = Huddlz.Storage.url(assigns.image_url)
+    css_url = URI.encode(url, &(URI.char_unescaped?(&1) or &1 == ?%))
 
-    assigns = assign(assigns, :background, ~s|background-image: url("#{url}")|)
+    assigns =
+      assigns
+      |> assign(:url, url)
+      |> assign(:background, ~s|background-image: url("#{css_url}")|)
 
     ~H"""
-    <div id={@id} class={["cover-image", @class]} style={@background} aria-hidden="true"></div>
+    <div
+      id={@id}
+      class={["cover-image", @class]}
+      style={@background}
+      data-cover-url={@url}
+      phx-hook="CoverImage"
+      aria-hidden="true"
+    >
+    </div>
     """
   end
 end

--- a/test/browser/steps/group_cover_steps.exs
+++ b/test/browser/steps/group_cover_steps.exs
@@ -120,6 +120,10 @@ defmodule BrowserCoverSteps do
       fn decoded -> assert decoded == (state == "valid") end
     )
 
+    outcome = if state == "valid", do: "loaded", else: "failed"
+    conn = assert_has(conn, "#group-detail-hero .cover-image[data-cover-state='#{outcome}']")
+    refute_has(conn, "#group-detail-hero .cover-image.is-pending")
+
     if state == "failed", do: assert_fallback(conn), else: assert_painted_cover(conn)
   end
 

--- a/test/huddlz_web/components/cover_image_test.exs
+++ b/test/huddlz_web/components/cover_image_test.exs
@@ -4,7 +4,7 @@ defmodule HuddlzWeb.Components.CoverImageTest do
   import Phoenix.LiveViewTest
   import HuddlzWeb.Components.CoverImage
 
-  test "renders decorative CSS media without image load handlers" do
+  test "renders decorative CSS media revealed by the cover hook" do
     html =
       render_component(&cover_image/1,
         id: "cover",
@@ -20,7 +20,12 @@ defmodule HuddlzWeb.Components.CoverImageTest do
              ~s|background-image: url("/uploads/cover.png")|
            ]
 
-    assert Floki.find(document, "img, [phx-hook], [onerror], [onload]") == []
+    assert Floki.find(
+             document,
+             ~s|#cover[phx-hook="CoverImage"][data-cover-url="/uploads/cover.png"]|
+           ) != []
+
+    assert Floki.find(document, "img, [onerror], [onload]") == []
   end
 
   test "escapes CSS string delimiters without double-encoding a URL" do


### PR DESCRIPTION
## Summary

First step of the loading-states pass from the design canvas's Loading sheet. Cover pictures are CSS backgrounds layered over an initials fallback, so they popped in whenever the file arrived. They now shimmer until the picture decodes, then fade in.

- New `CoverImage` hook probes the picture. After 150ms without a result it adds `is-pending`; when the picture decodes or fails it clears that and records `data-cover-state` as `loaded` or `failed`. Cached pictures never show the surface.
- `<.cover_image>` carries the hook and `data-cover-url`. The background-image style, the fallback behaviour and the absence of `<img>` load handlers are unchanged.
- CSS: a `panel-2` layer over the cover with a translucent sweep of the line token while pending, fading out over 200ms once settled. Reduced motion drops the sweep and the fade.
- The group cover browser scenarios now also wait for the settled state and assert the pending surface is gone, for both valid and failed pictures.

Card grids for full replacements and the autocomplete rows are the next steps in this pass.

## Verification

- `mix precommit` clean, with the exit code checked directly.
- Playwright suite green, including the four cover scenarios across valid, missing and failed pictures.
- Node tests for the hook cover decode, delay, failure, URL change and teardown.
