### PR TITLE
feat(discover): paint the shell first after live navigation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1676,10 +1676,16 @@ body .grid-skeleton { animation: skeleton-in 120ms ease 250ms both; }
   from { opacity: 0; }
 }
 
+/* Results dimmed while a filter patch is in flight (see page_loading.mjs).
+   The delay means a patch that finishes quickly never dims anything. */
+body [data-stale-on-patch] { transition: opacity 120ms ease; }
+body [data-stale-on-patch].is-stale { opacity: 0.45; transition-delay: 250ms; }
+
 @media (prefers-reduced-motion: reduce) {
   body .skel::after { animation: none; }
   body .skel { animation: skel-pulse 1.6s ease-in-out infinite; }
   body .grid-skeleton { animation: none; }
+  body [data-stale-on-patch] { transition: none; }
 }
 
 @keyframes skel-pulse {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1635,6 +1635,57 @@ body .card-foot {
 body .card-foot-note { color: var(--muted); font-size: 12px; }
 body .card-foot .pill.cyan::before { background: var(--success); }
 
+/* Placeholder cards while a full set of results is on its way
+   (`card_skeleton_grid`). One shimmer surface, reused by every block. */
+body .skel {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+}
+
+body .skel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--line-strong) 55%, transparent) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: cover-shimmer 1.6s ease-in-out infinite;
+}
+
+body .card.is-skeleton { pointer-events: none; }
+body .card.is-skeleton:hover { transform: none; border-color: var(--line); }
+body .card.is-skeleton .card-cover { border-radius: 0; }
+body .skel-line { height: 10px; width: var(--w, 100%); }
+body .skel-title { height: 14px; margin-top: 2px; }
+body .skel-meta { margin-top: 6px; }
+body .skel-note { width: 64px; }
+body .skel-count { width: 80px; height: 12px; }
+body .skel-pill { width: 72px; height: 24px; border-radius: var(--radius-pill); }
+
+/* Held back for the loading delay so a fast search never flashes it. */
+body .grid-skeleton { animation: skeleton-in 120ms ease 250ms both; }
+
+@keyframes skeleton-in {
+  from { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body .skel::after { animation: none; }
+  body .skel { animation: skel-pulse 1.6s ease-in-out infinite; }
+  body .grid-skeleton { animation: none; }
+}
+
+@keyframes skel-pulse {
+  50% { opacity: 0.6; }
+}
+
 body .stack { display: flex; align-items: center; }
 
 body .stack .pip {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,7 @@ import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 import {mountMobileNavigation} from "./mobile_navigation.mjs"
 import {createCoverImageHook} from "./cover_image.mjs"
+import {mountPageLoading} from "./page_loading.mjs"
 
 // The appearance setting lives on <html data-theme>, outside any LiveView.
 // Settings pushes a "theme" event after saving; "system" drops the attribute
@@ -146,16 +147,9 @@ const liveSocket = new LiveSocket("/live", Socket, {
   hooks: Hooks
 })
 
-// Progress bar on live navigation and form submits. The colour is read from
-// the accent token at show time so it follows the active theme.
-const accentColor = () =>
-  getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#18cbd4"
-
-window.addEventListener("phx:page-loading-start", _info => {
-  topbar.config({barColors: {0: accentColor()}, barThickness: 2, shadowBlur: 0, shadowColor: "transparent"})
-  topbar.show(300)
-})
-window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
+// Progress bar on live navigation and form submits, and stale dimming of
+// results while a filter patch is in flight.
+mountPageLoading({topbar})
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/assets/js/page_loading.mjs
+++ b/assets/js/page_loading.mjs
@@ -1,0 +1,41 @@
+// Page-level loading feedback driven by LiveView's page-loading events.
+//
+// Every navigation and submit shows the progress bar in the accent colour.
+// A patch additionally marks `[data-stale-on-patch]` regions stale; the
+// stylesheet delays the dim so a patch that finishes quickly never dims.
+export function mountPageLoading({
+  topbar,
+  windowRef = globalThis.window,
+  documentRef = globalThis.document,
+  accentColor = () => readAccent(documentRef)
+}) {
+  const start = event => {
+    topbar.config({barColors: {0: accentColor()}, barThickness: 2, shadowBlur: 0, shadowColor: "transparent"})
+    topbar.show(300)
+    if (event.detail && event.detail.kind === "patch") setStale(documentRef, true)
+  }
+
+  const stop = () => {
+    topbar.hide()
+    setStale(documentRef, false)
+  }
+
+  windowRef.addEventListener("phx:page-loading-start", start)
+  windowRef.addEventListener("phx:page-loading-stop", stop)
+
+  return () => {
+    windowRef.removeEventListener("phx:page-loading-start", start)
+    windowRef.removeEventListener("phx:page-loading-stop", stop)
+  }
+}
+
+function setStale(documentRef, stale) {
+  for (const element of documentRef.querySelectorAll("[data-stale-on-patch]")) {
+    element.classList.toggle("is-stale", stale)
+  }
+}
+
+function readAccent(documentRef) {
+  const value = getComputedStyle(documentRef.documentElement).getPropertyValue("--accent").trim()
+  return value || "#18cbd4"
+}

--- a/assets/js/page_loading_test.mjs
+++ b/assets/js/page_loading_test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {mountPageLoading} from "./page_loading.mjs"
+
+function setup() {
+  const listeners = new Map()
+  const windowRef = {
+    addEventListener: (name, handler) => listeners.set(name, handler),
+    removeEventListener: name => listeners.delete(name)
+  }
+
+  const region = {stale: false, classList: {toggle(name, force) { region.stale = force }}}
+  const documentRef = {querySelectorAll: () => [region]}
+
+  const calls = []
+  const topbar = {
+    config: options => calls.push(["config", options]),
+    show: delay => calls.push(["show", delay]),
+    hide: () => calls.push(["hide"])
+  }
+
+  const unmount = mountPageLoading({topbar, windowRef, documentRef, accentColor: () => "#123456"})
+  const fire = (name, kind) => listeners.get(name)({detail: {kind}})
+
+  return {fire, calls, region, listeners, unmount}
+}
+
+test("shows the accent progress bar on every page load and hides it after", () => {
+  const {fire, calls} = setup()
+
+  fire("phx:page-loading-start", "redirect")
+  assert.deepEqual(calls[0], ["config", {barColors: {0: "#123456"}, barThickness: 2, shadowBlur: 0, shadowColor: "transparent"}])
+  assert.deepEqual(calls[1], ["show", 300])
+
+  fire("phx:page-loading-stop", "redirect")
+  assert.deepEqual(calls[2], ["hide"])
+})
+
+test("marks stale regions only for patches and clears them when the patch lands", () => {
+  const {fire, region} = setup()
+
+  fire("phx:page-loading-start", "redirect")
+  assert.equal(region.stale, false)
+
+  fire("phx:page-loading-start", "patch")
+  assert.equal(region.stale, true)
+
+  fire("phx:page-loading-stop", "patch")
+  assert.equal(region.stale, false)
+})
+
+test("unmounting removes both listeners", () => {
+  const {listeners, unmount} = setup()
+
+  unmount()
+
+  assert.equal(listeners.size, 0)
+})

--- a/lib/huddlz_web/components/card.ex
+++ b/lib/huddlz_web/components/card.ex
@@ -41,6 +41,43 @@ defmodule HuddlzWeb.Components.Card do
     """
   end
 
+  @skeleton_shapes [
+    %{group: 40, title: 85, second: 55, meta: 70},
+    %{group: 55, title: 70, second: nil, meta: 70},
+    %{group: 40, title: 85, second: 40, meta: 55}
+  ]
+
+  @doc """
+  Renders placeholder cards sharing the huddl card's anatomy for a grid whose
+  results are still on their way. The grid fades in after a short delay so a
+  fast search never flashes it.
+  """
+  attr :label, :string, required: true, doc: "accessible name for the busy region"
+  attr :count, :integer, default: 3
+
+  def card_skeleton_grid(assigns) do
+    shapes = @skeleton_shapes |> Stream.cycle() |> Enum.take(assigns.count)
+    assigns = assign(assigns, :shapes, shapes)
+
+    ~H"""
+    <div class="grid grid-skeleton" role="status" aria-busy="true" aria-label={@label}>
+      <div :for={shape <- @shapes} class="card is-skeleton" aria-hidden="true">
+        <div class="card-cover skel"></div>
+        <div class="card-body">
+          <span class="skel skel-line" style={"--w: #{shape.group}%"}></span>
+          <span class="skel skel-line skel-title" style={"--w: #{shape.title}%"}></span>
+          <span :if={shape.second} class="skel skel-line skel-title" style={"--w: #{shape.second}%"}></span>
+          <span class="skel skel-line skel-meta" style={"--w: #{shape.meta}%"}></span>
+        </div>
+        <div class="card-foot">
+          <span class="skel skel-pill"></span>
+          <span class="skel skel-line skel-note"></span>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   @doc """
   Renders group cover media over a neutral fallback, a `panel-2` field with
   the group's initials in a tile, that stays visible when the image is absent

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -37,7 +37,18 @@ defmodule HuddlzWeb.HuddlLive do
      |> assign(:default_location_lat, user && user.home_latitude)
      |> assign(:default_location_lng, user && user.home_longitude)
      |> assign(:default_location_time_zone, user && user.home_time_zone)
+     |> assign(:live_navigation?, live_navigation?(socket))
+     |> assign(:results_loading?, false)
+     |> assign(:search_ref, nil)
      |> assign_search_defaults()}
+  end
+
+  # A mount reached by live navigation renders before its results exist, so
+  # the shell (and a skeleton grid) paints first and the search runs off the
+  # socket. Full page loads keep the results in the first render, and filter
+  # patches stay synchronous because they finish within the loading delay.
+  defp live_navigation?(socket) do
+    connected?(socket) and is_binary(get_connect_params(socket)["_live_referer"])
   end
 
   defp assign_search_defaults(socket) do
@@ -84,25 +95,86 @@ defmodule HuddlzWeb.HuddlLive do
         |> assign(:canonical_url, canonical_url)
         |> assign(:meta, %{url: canonical_url})
         |> assign_filters_from_params(params)
-        |> perform_search(offset: (page - 1) * @page_size)
 
-      total_pages = socket.assigns.page_info.total_pages
-
-      if page > total_pages do
-        cleared? = location_explicitly_cleared?(socket.assigns)
-
-        path =
-          scoped_path(scope, yours, form_params_from_assigns(socket),
-            override_location_with_cleared: cleared?,
-            page: total_pages
-          )
-
-        {:noreply, push_patch(socket, to: path)}
+      if socket.assigns.live_navigation? do
+        {:noreply, socket |> assign(:live_navigation?, false) |> start_search(page)}
       else
-        {:noreply, socket}
+        {:noreply, socket |> perform_search(page) |> patch_page_overflow(page)}
       end
     end
   end
+
+  defp patch_page_overflow(socket, page) do
+    total_pages = socket.assigns.page_info.total_pages
+
+    if page > total_pages do
+      cleared? = location_explicitly_cleared?(socket.assigns)
+
+      path =
+        scoped_path(socket.assigns.scope, socket.assigns.yours, form_params_from_assigns(socket),
+          override_location_with_cleared: cleared?,
+          page: total_pages
+        )
+
+      push_patch(socket, to: path)
+    else
+      socket
+    end
+  end
+
+  defp start_search(socket, page) do
+    ref = make_ref()
+    input = search_input(socket.assigns)
+
+    socket
+    |> assign(:search_ref, ref)
+    |> assign(:results_loading?, true)
+    |> start_async({:search, ref, page}, fn -> search_results(input, page) end)
+  end
+
+  @search_input_keys [
+    :scope,
+    :yours,
+    :search_query,
+    :event_type_filter,
+    :date_filter,
+    :distance_miles,
+    :sort,
+    :location_active,
+    :location_lat,
+    :location_lng,
+    :location_time_zone,
+    :browser_time_zone,
+    :current_user
+  ]
+
+  # Everything the search reads, as a plain map so the async task never
+  # carries the socket's assigns.
+  defp search_input(assigns), do: Map.take(assigns, @search_input_keys)
+
+  @impl true
+  def handle_async({:search, ref, page}, {:ok, results}, %{assigns: %{search_ref: ref}} = socket) do
+    {:noreply,
+     socket
+     |> assign(results)
+     |> assign(results_loading?: false, search_ref: nil)
+     |> patch_page_overflow(page)}
+  end
+
+  def handle_async(
+        {:search, ref, _page},
+        {:exit, reason},
+        %{assigns: %{search_ref: ref}} = socket
+      ) do
+    Logger.warning("Discover search crashed: #{inspect(reason)}")
+
+    {:noreply,
+     socket
+     |> assign(huddls: [], groups: [], page_info: empty_page_info())
+     |> assign(results_loading?: false, search_ref: nil)}
+  end
+
+  def handle_async({:search, _stale_ref, _page}, _result, socket), do: {:noreply, socket}
 
   defp assign_filters_from_params(socket, params) do
     {location_text, location_lat, location_lng, location_time_zone, location_active} =
@@ -189,6 +261,9 @@ defmodule HuddlzWeb.HuddlLive do
   defp page_title(:huddlz, :hosting), do: "huddlz you're hosting"
   defp page_title(:huddlz, :attending), do: "huddlz you're attending"
   defp page_title(:huddlz, :all), do: "huddlz"
+
+  defp skeleton_label(:groups), do: "Loading groups"
+  defp skeleton_label(:huddlz), do: "Loading huddlz"
 
   defp sign_in_prompt(:hosting), do: "huddlz you're hosting"
   defp sign_in_prompt(:attending), do: "huddlz you're attending"
@@ -330,18 +405,19 @@ defmodule HuddlzWeb.HuddlLive do
   defp put_scope(params, :huddlz), do: params
   defp put_scope(params, :groups), do: [{"scope", "groups"} | params]
 
-  defp perform_search(%{assigns: %{scope: :huddlz}} = socket, opts) do
-    offset = Keyword.get(opts, :offset, 0)
+  defp perform_search(socket, page),
+    do: assign(socket, search_results(search_input(socket.assigns), page))
 
-    base_args = build_search_args(socket)
+  defp search_results(%{scope: :huddlz} = assigns, page) do
+    offset = (page - 1) * @page_size
 
     main_page =
-      run_search(base_args, socket.assigns[:current_user],
-        relationship: yours_to_relationship(socket.assigns.yours),
+      run_search(build_search_args(assigns), assigns[:current_user],
+        relationship: yours_to_relationship(assigns.yours),
         page: [limit: @page_size, offset: offset, count: true]
       )
 
-    {huddls, distances} = load_results_with_distances(main_page, socket)
+    {huddls, distances} = load_results_with_distances(main_page, assigns)
     page_info = extract_page_info(main_page)
 
     page_info =
@@ -349,18 +425,11 @@ defmodule HuddlzWeb.HuddlLive do
         do: Map.put(page_info, :current_page, div(offset, @page_size) + 1),
         else: page_info
 
-    socket
-    |> assign(huddls: Enum.zip(huddls, distances))
-    |> assign(groups: [])
-    |> assign(page_info: page_info)
+    %{huddls: Enum.zip(huddls, distances), groups: [], page_info: page_info}
   end
 
-  defp perform_search(%{assigns: %{scope: :groups}} = socket, opts) do
-    offset = Keyword.get(opts, :offset, 0)
-    page = div(offset, @page_size) + 1
-    actor = socket.assigns[:current_user]
-
-    {groups, total} = list_groups(socket.assigns.search_query, page, actor)
+  defp search_results(%{scope: :groups} = assigns, page) do
+    {groups, total} = list_groups(assigns.search_query, page, assigns[:current_user])
 
     page_info =
       if total > 0 do
@@ -370,41 +439,40 @@ defmodule HuddlzWeb.HuddlLive do
           total_count: total
         }
       else
-        %{total_pages: 1, current_page: 1, total_count: 0}
+        empty_page_info()
       end
 
-    socket
-    |> assign(huddls: [])
-    |> assign(groups: groups)
-    |> assign(page_info: page_info)
+    %{huddls: [], groups: groups, page_info: page_info}
   end
 
-  defp build_search_args(socket) do
+  defp empty_page_info, do: %{total_pages: 1, current_page: 1, total_count: 0}
+
+  defp build_search_args(assigns) do
     {search_lat, search_lng, distance} =
-      if socket.assigns.location_active do
-        {socket.assigns.location_lat, socket.assigns.location_lng, socket.assigns.distance_miles}
+      if assigns.location_active do
+        {assigns.location_lat, assigns.location_lng, assigns.distance_miles}
       else
         {nil, nil, nil}
       end
 
     event_type_atom =
-      if socket.assigns.event_type_filter && socket.assigns.event_type_filter != "",
-        do: String.to_existing_atom(socket.assigns.event_type_filter),
+      if assigns.event_type_filter && assigns.event_type_filter != "",
+        do: String.to_existing_atom(assigns.event_type_filter),
         else: nil
 
     %{
-      query: socket.assigns.search_query,
-      date_filter: String.to_existing_atom(socket.assigns.date_filter),
+      query: assigns.search_query,
+      date_filter: String.to_existing_atom(assigns.date_filter),
       event_type: event_type_atom,
       search_latitude: search_lat,
       search_longitude: search_lng,
       distance_miles: distance,
       search_time_zone:
-        if(socket.assigns.location_active and socket.assigns.location_time_zone,
-          do: socket.assigns.location_time_zone,
-          else: socket.assigns.browser_time_zone
+        if(assigns.location_active and assigns.location_time_zone,
+          do: assigns.location_time_zone,
+          else: assigns.browser_time_zone
         ),
-      sort: socket.assigns.sort
+      sort: assigns.sort
     }
   end
 
@@ -452,23 +520,23 @@ defmodule HuddlzWeb.HuddlLive do
     end
   end
 
-  defp load_results_with_distances({:ok, %{results: results}}, socket) do
-    dists = compute_distances(results, socket)
+  defp load_results_with_distances({:ok, %{results: results}}, assigns) do
+    dists = compute_distances(results, assigns)
     {results, dists}
   end
 
-  defp load_results_with_distances({:error, reason}, _socket) do
+  defp load_results_with_distances({:error, reason}, _assigns) do
     Logger.warning("Huddl search failed: #{inspect(reason)}")
     {[], []}
   end
 
-  defp load_results_with_distances(_, _socket), do: {[], []}
+  defp load_results_with_distances(_, _assigns), do: {[], []}
 
-  defp compute_distances(huddls, %{assigns: %{location_active: false}}) do
+  defp compute_distances(huddls, %{location_active: false}) do
     List.duplicate(nil, length(huddls))
   end
 
-  defp compute_distances(huddls, %{assigns: assigns}) do
+  defp compute_distances(huddls, assigns) do
     origin = {assigns.location_lat, assigns.location_lng}
 
     Enum.map(huddls, fn h ->
@@ -674,47 +742,56 @@ defmodule HuddlzWeb.HuddlLive do
         </div>
       </div>
 
-      <div class="discover-meta">
-        <span>{result_count_label(@page_info.total_count, @scope)}</span>
-        <%= if any_filter_active?(assigns) and not results_empty?(assigns) do %>
-          <span aria-hidden="true">·</span>
-          <button type="button" phx-click="clear_filters" class="button-link">
-            Clear filters
-          </button>
+      <div id="discover-results" data-stale-on-patch>
+        <%= if @results_loading? do %>
+          <div class="discover-meta" aria-hidden="true">
+            <span class="skel skel-line skel-count"></span>
+          </div>
+          <.card_skeleton_grid label={skeleton_label(@scope)} />
+        <% else %>
+          <div class="discover-meta">
+            <span>{result_count_label(@page_info.total_count, @scope)}</span>
+            <%= if any_filter_active?(assigns) and not results_empty?(assigns) do %>
+              <span aria-hidden="true">·</span>
+              <button type="button" phx-click="clear_filters" class="button-link">
+                Clear filters
+              </button>
+            <% end %>
+          </div>
+
+          <%= if @scope == :huddlz do %>
+            <%= if Enum.empty?(@huddls) do %>
+              <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
+            <% else %>
+              <div class="grid">
+                <.huddl_card :for={{huddl, distance} <- @huddls} huddl={huddl} distance={distance} />
+              </div>
+              <.pagination
+                :if={@page_info.total_pages > 1}
+                id="discovery-pagination"
+                current_page={@page_info.current_page}
+                total_pages={@page_info.total_pages}
+                page_path={&pagination_path(&1, assigns)}
+              />
+            <% end %>
+          <% else %>
+            <%= if @groups == [] do %>
+              <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
+            <% else %>
+              <div class="grid">
+                <.group_card :for={group <- @groups} group={group} />
+              </div>
+              <.pagination
+                :if={@page_info.total_pages > 1}
+                id="discovery-pagination"
+                current_page={@page_info.current_page}
+                total_pages={@page_info.total_pages}
+                page_path={&pagination_path(&1, assigns)}
+              />
+            <% end %>
+          <% end %>
         <% end %>
       </div>
-
-      <%= if @scope == :huddlz do %>
-        <%= if Enum.empty?(@huddls) do %>
-          <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
-        <% else %>
-          <div class="grid">
-            <.huddl_card :for={{huddl, distance} <- @huddls} huddl={huddl} distance={distance} />
-          </div>
-          <.pagination
-            :if={@page_info.total_pages > 1}
-            id="discovery-pagination"
-            current_page={@page_info.current_page}
-            total_pages={@page_info.total_pages}
-            page_path={&pagination_path(&1, assigns)}
-          />
-        <% end %>
-      <% else %>
-        <%= if @groups == [] do %>
-          <.discover_empty {empty_state_copy(assigns)} clearable={any_filter_active?(assigns)} />
-        <% else %>
-          <div class="grid">
-            <.group_card :for={group <- @groups} group={group} />
-          </div>
-          <.pagination
-            :if={@page_info.total_pages > 1}
-            id="discovery-pagination"
-            current_page={@page_info.current_page}
-            total_pages={@page_info.total_pages}
-            page_path={&pagination_path(&1, assigns)}
-          />
-        <% end %>
-      <% end %>
     </Layouts.app>
     """
   end

--- a/test/browser/features/discover_navigation.feature
+++ b/test/browser/features/discover_navigation.feature
@@ -1,0 +1,7 @@
+@browser_smoke
+Feature: Discover over live navigation
+  Scenario: Following Discover from the sidebar fills the results in place
+    Given a public huddl titled "Riverside Sketch Walk" is upcoming
+    And I have opened my huddlz in a browser
+    When I follow Discover in the sidebar
+    Then the discover results arrive without a page load

--- a/test/browser/steps/discover_navigation_steps.exs
+++ b/test/browser/steps/discover_navigation_steps.exs
@@ -1,0 +1,58 @@
+defmodule BrowserDiscoverNavigationSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+  import PhoenixTest.Playwright, only: [evaluate: 3]
+
+  step "a public huddl titled {string} is upcoming", %{args: [title]} = context do
+    host = generate(user(role: :user))
+    group = generate(group(is_public: true, owner_id: host.id, actor: host))
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          title: title,
+          actor: host
+        )
+      )
+
+    Map.put(context, :huddl, huddl)
+  end
+
+  step "I have opened my huddlz in a browser", context do
+    member = generate(user(role: :user))
+
+    conn =
+      context.conn
+      |> sign_in(member)
+      |> visit("/my-huddlz")
+      |> assert_has(".phx-connected")
+      |> assert_has("h1", text: "My huddlz")
+
+    Map.merge(context, %{conn: conn, member: member})
+  end
+
+  step "I follow Discover in the sidebar", context do
+    evaluate(context.conn, "window.__huddlzPage = 'kept'", fn _ -> :ok end)
+
+    conn = click_link(context.conn, ".sb-nav a", "Discover")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the discover results arrive without a page load", context do
+    conn =
+      context.conn
+      |> assert_has("h1", text: "Browse huddlz")
+      |> assert_has("h3.card-title", text: context.huddl.title)
+      |> refute_has(".grid-skeleton")
+      |> assert_browser("window.__huddlzPage === 'kept'")
+
+    Map.put(context, :conn, conn)
+  end
+end

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -565,4 +565,63 @@ defmodule HuddlzWeb.HuddlLiveTest do
       assert_patch(view, "/discover?cleared=1")
     end
   end
+
+  describe "live navigation" do
+    setup do
+      host = generate(user(role: :user))
+      group = generate(group(is_public: true, owner_id: host.id, actor: host))
+
+      huddl =
+        generate(
+          huddl(
+            group_id: group.id,
+            creator_id: host.id,
+            is_private: false,
+            title: "Async Arrival",
+            actor: host
+          )
+        )
+
+      %{huddl: huddl}
+    end
+
+    test "renders a skeleton grid until the search completes", %{conn: conn, huddl: huddl} do
+      {:ok, view, html} = live_navigate(conn, ~p"/discover")
+      document = Floki.parse_document!(html)
+
+      assert Floki.find(document, ".grid-skeleton[aria-busy='true'] .card.is-skeleton") != []
+      assert Floki.find(document, "h3.card-title") == []
+
+      html = render_async(view)
+
+      assert html =~ huddl.title
+      refute html =~ "grid-skeleton"
+    end
+
+    test "a filter patch after arrival keeps results in the response", %{
+      conn: conn,
+      huddl: huddl
+    } do
+      {:ok, view, _html} = live_navigate(conn, ~p"/discover")
+      render_async(view)
+
+      html = view |> element(".chip-group a.chip", "Newest") |> render_click()
+
+      assert html =~ huddl.title
+      refute html =~ "grid-skeleton"
+    end
+
+    test "a full page load keeps the results in the first render", %{conn: conn, huddl: huddl} do
+      {:ok, _view, html} = live(conn, ~p"/discover")
+
+      assert html =~ huddl.title
+      refute html =~ "grid-skeleton"
+    end
+  end
+
+  defp live_navigate(conn, path) do
+    conn
+    |> put_connect_params(%{"_live_referer" => "http://localhost/my-huddlz"})
+    |> live(path)
+  end
 end


### PR DESCRIPTION
## Summary

Second step of the loading-states pass. Discover now paints its shell first when you reach it by live navigation, with a skeleton grid standing in for the results until the search completes. Filter patches keep their synchronous search and instead dim the results they are about to replace.

- **Async search on live navigation only.** A mount whose connect params carry `_live_referer` renders `results_loading?` and runs the search with `start_async`; the results and the page-overflow patch land in `handle_async`. A full page load keeps the results in the first render, so hydration never flashes a skeleton, and filter patches stay synchronous because they finish inside the loading delay. A stale search result is dropped by matching a per-search ref.
- **`card_skeleton_grid` component** with three placeholder cards sharing the huddl card's frame, cover ratio and padding. The grid is a busy `status` region with an accessible label; its blocks are `aria-hidden`. It fades in only after 250ms, so a fast search shows nothing rather than a flash.
- **Stale dimming for patches.** `page_loading.mjs` now owns the progress bar and marks `[data-stale-on-patch]` regions stale while a patch is in flight. The stylesheet delays the dim by 250ms and drops it instantly when the patch lands, so quick patches never dim.
- Reduced motion swaps the shimmer for a slow pulse and removes the fade.

## Verification

- `mix precommit` clean, with the exit code checked directly.
- Playwright suite green, including a new scenario that follows Discover from the sidebar and asserts the results arrive without a page load.
- LiveView tests cover the skeleton render, the async arrival, a patch after arrival, and the full-page-load path. The page-overflow patch after an async search shares `patch_page_overflow/2` with the synchronous path, which the existing pagination tests cover; the async arm can't be reached from `live/2` because the dead render redirects first.
- Node tests cover the page-loading module.

Screenshots in the first comment were taken with a temporary 1.5s search delay so the states are visible.
