### PR TITLE
feat(api): expose private profile search defaults

### DIFF
--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -2,6 +2,76 @@
 
 Anonymous clients can discover public huddlz with `GET /api/json/huddlz`.
 
+## Private profile and home search defaults
+
+Authenticated clients can read their current private profile with
+`GET /api/json/profile`, using `Authorization: Bearer <JWT-or-API-key>`.
+This Ash action returns a JSON object directly, without a JSON:API `data`
+envelope:
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000001",
+  "display_name": "Alex",
+  "email": "alex@example.com",
+  "search_defaults": {
+    "home_location": {
+      "label": "Austin, TX",
+      "latitude": 30.2672,
+      "longitude": -97.7431,
+      "time_zone": "America/Chicago"
+    },
+    "distance_miles": 25
+  }
+}
+```
+
+The endpoint accepts no member ID and reads only the authenticated member's
+current profile. Anonymous requests receive 403; invalid credentials receive
+401. These fields are not added to public profiles. The existing
+`/api/auth/me` identity response remains supported.
+
+`home_location` is `null` when unset, cleared, missing either coordinate, or
+missing a valid canonical IANA time zone. Its `label` may be null even when
+the coordinates and time zone are usable; clients can identify that area by
+its coordinates. There is no persisted radius preference: `distance_miles`
+is the application's 25-mile default (search supports 5–100 miles).
+
+Client location selection should follow this order:
+
+1. Use an explicit place or an explicit "everywhere" choice for this search.
+2. Otherwise, use the profile's usable home search location.
+3. Otherwise, omit both coordinates and clearly indicate an unrestricted search.
+
+For a geographic search, map `latitude`, `longitude`, and `time_zone` to
+`search_latitude`, `search_longitude`, and `search_time_zone`, and send
+`distance_miles`. For example:
+
+```text
+/api/json/huddlz?date_filter=upcoming&search_latitude=30.2672&search_longitude=-97.7431&distance_miles=25&search_time_zone=America%2FChicago
+```
+
+For "everywhere", omit both coordinates; the search API does not implicitly
+apply the profile default. A radius alone does not restrict results. Search
+requests do not update the saved home search location.
+
+`this_week` and `this_month` require a canonical IANA `search_time_zone` for
+local calendar boundaries. Use the chosen search location's zone, including
+when traveling. Without a search location, use the client's local zone (the
+browser zone on the website). If unavailable, ask the user to choose a zone
+or use `upcoming`, which does not require one. A home search location's zone
+is not a general member time-zone preference.
+
+Fetch the profile again at the start of a subsequent session, or when the
+member refreshes their preferences. Each request reads current saved values;
+existing credentials continue to work after a location change. Avoid keeping
+a separate permanent home preference in the client.
+
+The generated contract is available at `/api/json/open_api` and
+`/api/json/swaggerui`.
+
+## Ordering
+
 The `sort` query parameter uses standard JSON:API field sorting. Fields sort
 ascending unless prefixed with `-`; comma-separated fields are applied in order.
 

--- a/lib/huddlz/accounts.ex
+++ b/lib/huddlz/accounts.ex
@@ -11,6 +11,7 @@ defmodule Huddlz.Accounts do
     resource Huddlz.Accounts.Token
 
     resource Huddlz.Accounts.User do
+      define :get_current_user, action: :me
       # Define proper code interfaces for actions
       define :search_by_email, action: :search_by_email, args: [:email]
       define :update_role, action: :update_role, args: [:role]
@@ -34,5 +35,9 @@ defmodule Huddlz.Accounts do
     end
 
     resource Huddlz.Accounts.ApiKey
+
+    resource Huddlz.Accounts.Profile do
+      define :get_profile, action: :get
+    end
   end
 end

--- a/lib/huddlz/accounts/profile.ex
+++ b/lib/huddlz/accounts/profile.ex
@@ -1,0 +1,71 @@
+defmodule Huddlz.Accounts.Profile do
+  @moduledoc """
+  The authenticated member's private profile contract for API clients.
+  """
+
+  use Ash.Resource,
+    otp_app: :huddlz,
+    domain: Huddlz.Accounts,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshJsonApi.Resource]
+
+  json_api do
+    type "profile"
+
+    routes do
+      route :get, "/profile", :get
+    end
+  end
+
+  actions do
+    action :get, :map do
+      description "Read your current private profile and saved home search defaults."
+
+      constraints fields: [
+                    id: [type: :uuid, allow_nil?: false],
+                    display_name: [type: :string],
+                    email: [type: :string, allow_nil?: false],
+                    search_defaults: [
+                      type: :map,
+                      allow_nil?: false,
+                      constraints: [
+                        fields: [
+                          home_location: [
+                            type: :map,
+                            description:
+                              "Saved home search location, or null when unset or incomplete.",
+                            constraints: [
+                              fields: [
+                                label: [type: :string],
+                                latitude: [type: :float, allow_nil?: false],
+                                longitude: [type: :float, allow_nil?: false],
+                                time_zone: [
+                                  type: :string,
+                                  allow_nil?: false,
+                                  description:
+                                    "Canonical IANA zone for relative calendar searches."
+                                ]
+                              ]
+                            ]
+                          ],
+                          distance_miles: [
+                            type: :integer,
+                            allow_nil?: false,
+                            description:
+                              "Default search radius; not a persisted member preference."
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+
+      run Huddlz.Accounts.Profile.Actions.Get
+    end
+  end
+
+  policies do
+    policy action(:get) do
+      authorize_if actor_present()
+    end
+  end
+end

--- a/lib/huddlz/accounts/profile/actions/get.ex
+++ b/lib/huddlz/accounts/profile/actions/get.ex
@@ -1,0 +1,34 @@
+defmodule Huddlz.Accounts.Profile.Actions.Get do
+  @moduledoc false
+  use Ash.Resource.Actions.Implementation
+
+  @impl true
+  def run(_input, _opts, context) do
+    with {:ok, user} <- Huddlz.Accounts.get_current_user(scope: context) do
+      {:ok,
+       %{
+         id: user.id,
+         display_name: user.display_name,
+         email: to_string(user.email),
+         search_defaults: %{
+           home_location: home_location(user),
+           distance_miles: 25
+         }
+       }}
+    end
+  end
+
+  defp home_location(%{home_latitude: lat, home_longitude: lng} = user)
+       when is_number(lat) and is_number(lng) do
+    if Huddlz.TimeZone.canonical?(user.home_time_zone) do
+      %{
+        label: user.home_location,
+        latitude: lat,
+        longitude: lng,
+        time_zone: user.home_time_zone
+      }
+    end
+  end
+
+  defp home_location(_user), do: nil
+end

--- a/test/features/api_search_defaults.feature
+++ b/test/features/api_search_defaults.feature
@@ -1,0 +1,40 @@
+@async @database @conn @api_search_defaults
+Feature: Home search location for API clients
+  As a member using an API client
+  I want to use my saved home search location
+  So that I do not maintain a separate preference in each client
+
+  Scenario: Discover my home search location
+    Given I have saved Austin as my home search location
+    When I request my search defaults with a bearer token and an API key
+    Then both clients receive Austin and a 25 mile default radius
+
+  Scenario Outline: Missing and incomplete home search locations
+    Given my home search location is "<state>"
+    When I request my search defaults with a bearer token and an API key
+    Then both clients know there is no usable home search location
+
+    Examples:
+      | state             |
+      | unset             |
+      | cleared           |
+      | missing latitude  |
+      | missing longitude |
+      | missing time zone |
+      | invalid time zone |
+
+  Scenario: Private profile access belongs to the authenticated member
+    Given I have saved Austin as my home search location
+    When clients request private profiles with different credentials
+    Then only my credentials reveal my profile and home search location
+
+  Scenario: Clients see changes without replacing their credentials
+    Given I have saved Austin as my home search location
+    When I change my home search location after clients have read my profile
+    Then the same clients receive my updated home search location
+
+  Scenario: Searching elsewhere does not change my home search location
+    Given I have saved Austin as my home search location
+    And public huddlz are available in Austin and New York
+    When I search near home, near New York, and everywhere through the API
+    Then each search uses the chosen area and my profile still defaults to Austin

--- a/test/features/step_definitions/api_search_defaults_steps.exs
+++ b/test/features/step_definitions/api_search_defaults_steps.exs
@@ -1,0 +1,243 @@
+defmodule ApiSearchDefaultsSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import HuddlzWeb.ApiCase, only: [authenticated_conn: 2, api_key_conn: 2]
+
+  step "I have saved Austin as my home search location", context do
+    member = generate(user())
+
+    Huddlz.Accounts.update_home_location!(
+      member,
+      "Austin, TX",
+      30.2672,
+      -97.7431,
+      "America/Chicago",
+      actor: member
+    )
+
+    Map.put(context, :defaults_member, member)
+  end
+
+  step "I request my search defaults with a bearer token and an API key", context do
+    connections = [
+      authenticated_conn(context.conn, context.defaults_member),
+      api_key_conn(context.conn, context.defaults_member)
+    ]
+
+    Map.put(context, :defaults_responses, Enum.map(connections, &get_defaults/1))
+  end
+
+  step "both clients receive Austin and a 25 mile default radius", context do
+    for response <- context.defaults_responses do
+      assert Phoenix.ConnTest.json_response(response, 200)["search_defaults"] == %{
+               "home_location" => %{
+                 "label" => "Austin, TX",
+                 "latitude" => 30.2672,
+                 "longitude" => -97.7431,
+                 "time_zone" => "America/Chicago"
+               },
+               "distance_miles" => 25
+             }
+    end
+
+    context
+  end
+
+  defp get_defaults(conn) do
+    Phoenix.ConnTest.dispatch(conn, HuddlzWeb.Endpoint, :get, "/api/json/profile", nil)
+  end
+
+  step "clients request private profiles with different credentials", context do
+    other = generate(user())
+
+    Map.merge(context, %{
+      own_profile: context.conn |> authenticated_conn(context.defaults_member) |> get_defaults(),
+      other_profile: context.conn |> authenticated_conn(other) |> get_defaults(),
+      anonymous_profile: get_defaults(context.conn),
+      invalid_profile:
+        context.conn
+        |> Plug.Conn.put_req_header("authorization", "Bearer invalid")
+        |> get_defaults(),
+      other_member: other
+    })
+  end
+
+  step "only my credentials reveal my profile and home search location", context do
+    own = Phoenix.ConnTest.json_response(context.own_profile, 200)
+    assert own["id"] == context.defaults_member.id
+    assert own["email"] == to_string(context.defaults_member.email)
+    assert own["display_name"] == context.defaults_member.display_name
+    assert own["search_defaults"]["home_location"]["label"] == "Austin, TX"
+
+    other = Phoenix.ConnTest.json_response(context.other_profile, 200)
+    assert other["id"] == context.other_member.id
+    assert other["search_defaults"]["home_location"] == nil
+    assert Phoenix.ConnTest.json_response(context.anonymous_profile, 403)["errors"] != []
+
+    assert Phoenix.ConnTest.json_response(context.invalid_profile, 401)["error"] ==
+             "Authentication required"
+
+    context
+  end
+
+  step "my home search location is {string}", %{args: [state]} = context do
+    member = generate(user())
+
+    location = %{
+      home_location: "Austin, TX",
+      home_latitude: 30.2672,
+      home_longitude: -97.7431,
+      home_time_zone: "America/Chicago"
+    }
+
+    case state do
+      "unset" ->
+        :ok
+
+      "cleared" ->
+        saved = Ash.Seed.update!(member, location)
+        Huddlz.Accounts.update_home_location!(saved, nil, nil, nil, nil, actor: saved)
+
+      "missing latitude" ->
+        Ash.Seed.update!(member, %{location | home_latitude: nil})
+
+      "missing longitude" ->
+        Ash.Seed.update!(member, %{location | home_longitude: nil})
+
+      "missing time zone" ->
+        Ash.Seed.update!(member, %{location | home_time_zone: nil})
+
+      "invalid time zone" ->
+        Ash.Seed.update!(member, %{location | home_time_zone: "Invalid/Zone"})
+    end
+
+    Map.put(context, :defaults_member, member)
+  end
+
+  step "I change my home search location after clients have read my profile", context do
+    connections = [
+      authenticated_conn(context.conn, context.defaults_member),
+      api_key_conn(context.conn, context.defaults_member)
+    ]
+
+    for conn <- connections do
+      assert Phoenix.ConnTest.json_response(get_defaults(conn), 200)["search_defaults"][
+               "home_location"
+             ]["label"] == "Austin, TX"
+    end
+
+    member = context.defaults_member
+
+    Huddlz.Accounts.update_home_location!(
+      member,
+      "New York, NY",
+      40.7128,
+      -74.006,
+      "America/New_York",
+      actor: member
+    )
+
+    Map.put(context, :defaults_responses, Enum.map(connections, &get_defaults/1))
+  end
+
+  step "the same clients receive my updated home search location", context do
+    for response <- context.defaults_responses do
+      assert Phoenix.ConnTest.json_response(response, 200)["search_defaults"]["home_location"] ==
+               %{
+                 "label" => "New York, NY",
+                 "latitude" => 40.7128,
+                 "longitude" => -74.006,
+                 "time_zone" => "America/New_York"
+               }
+    end
+
+    context
+  end
+
+  step "both clients know there is no usable home search location", context do
+    for response <- context.defaults_responses do
+      assert Phoenix.ConnTest.json_response(response, 200)["search_defaults"] == %{
+               "home_location" => nil,
+               "distance_miles" => 25
+             }
+    end
+
+    context
+  end
+
+  step "public huddlz are available in Austin and New York", context do
+    owner = generate(user())
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+
+    for {title, lat, lng} <- [
+          {"Austin huddl", 30.2672, -97.7431},
+          {"New York huddl", 40.7128, -74.006}
+        ] do
+      generate(
+        huddl_at_location(
+          group_id: group.id,
+          creator_id: owner.id,
+          title: title,
+          latitude: lat,
+          longitude: lng
+        )
+      )
+    end
+
+    context
+  end
+
+  step "I search near home, near New York, and everywhere through the API", context do
+    conn = authenticated_conn(context.conn, context.defaults_member)
+    defaults = Phoenix.ConnTest.json_response(get_defaults(conn), 200)["search_defaults"]
+    home = defaults["home_location"]
+
+    parameters = [
+      %{
+        "search_latitude" => home["latitude"],
+        "search_longitude" => home["longitude"],
+        "search_time_zone" => home["time_zone"],
+        "distance_miles" => defaults["distance_miles"]
+      },
+      %{
+        "search_latitude" => 40.7128,
+        "search_longitude" => -74.006,
+        "search_time_zone" => "America/New_York"
+      },
+      %{}
+    ]
+
+    responses =
+      for params <- parameters do
+        conn
+        |> Phoenix.ConnTest.dispatch(
+          HuddlzWeb.Endpoint,
+          :get,
+          "/api/json/huddlz",
+          Map.put(params, "date_filter", "upcoming")
+        )
+        |> Phoenix.ConnTest.json_response(200)
+        |> Map.fetch!("data")
+        |> Enum.map(& &1["attributes"]["title"])
+        |> Enum.sort()
+      end
+
+    Map.merge(context, %{area_results: responses, defaults_responses: [get_defaults(conn)]})
+  end
+
+  step "each search uses the chosen area and my profile still defaults to Austin", context do
+    assert context.area_results == [
+             ["Austin huddl"],
+             ["New York huddl"],
+             ["Austin huddl", "New York huddl"]
+           ]
+
+    assert Phoenix.ConnTest.json_response(hd(context.defaults_responses), 200)["search_defaults"][
+             "home_location"
+           ]["label"] == "Austin, TX"
+
+    context
+  end
+end

--- a/test/huddlz_web/api/json/profile_test.exs
+++ b/test/huddlz_web/api/json/profile_test.exs
@@ -1,0 +1,39 @@
+defmodule HuddlzWeb.Api.Json.ProfileTest do
+  use HuddlzWeb.ApiCase, async: true
+
+  @moduletag :api_search_defaults
+
+  test "OpenAPI describes private profile search defaults without exposing user fields", %{
+    conn: conn
+  } do
+    spec = conn |> get("/api/json/open_api") |> response(200) |> Jason.decode!()
+
+    profile =
+      get_in(spec, [
+        "paths",
+        "/api/json/profile",
+        "get",
+        "responses",
+        "200",
+        "content",
+        "application/vnd.api+json",
+        "schema"
+      ])
+
+    assert profile["properties"]["id"]["type"] == "string"
+    defaults = profile["properties"]["search_defaults"]
+    assert defaults["properties"]["distance_miles"]["type"] == "integer"
+    location = defaults["properties"]["home_location"]
+    assert %{"type" => "null"} in location["anyOf"]
+
+    assert Enum.any?(
+             location["anyOf"],
+             &match?(
+               %{"properties" => %{"latitude" => _, "longitude" => _, "time_zone" => _}},
+               &1
+             )
+           )
+
+    refute Map.has_key?(spec["components"]["schemas"], "user")
+  end
+end


### PR DESCRIPTION
Authenticated clients can now read their identity and saved home search defaults from `GET /api/json/profile`. The private Ash action returns a nullable home location and an explicit 25-mile default radius, reading current preferences on each request.

Documents missing-location behavior, timezone selection, and client overrides. Searching elsewhere or everywhere preserves the saved home location, and public profiles remain unchanged.

Closes #440
