### PR TITLE
feat(api): expose huddl waitlist membership

### DIFF
--- a/docs/api-attendance.md
+++ b/docs/api-attendance.md
@@ -1,0 +1,42 @@
+# Attendance API
+
+Authenticate with a bearer JWT or API key. Attendance operations act on the
+current caller and preserve the website's huddl visibility, lifecycle, and
+capacity rules.
+
+| Operation | JSON:API | GraphQL mutation |
+| --- | --- | --- |
+| RSVP | `PATCH /api/json/huddlz/:id/rsvp` | `rsvpToHuddl(id: ID!)` |
+| Join a full huddl's waitlist | `PATCH /api/json/huddlz/:id/join_waitlist` | `joinHuddlWaitlist(id: ID!)` |
+| Cancel RSVP or leave waitlist | `PATCH /api/json/huddlz/:id/cancel_rsvp` | `cancelRsvpToHuddl(id: ID!)` |
+
+JSON:API requests use `Content-Type: application/vnd.api+json` and this body:
+
+```json
+{"data":{"type":"huddl","id":"HUDDL_ID","attributes":{}}}
+```
+
+The returned huddl includes `data.attributes.attendance_state` by default.
+When using sparse fieldsets, request `attendance_state` explicitly. GraphQL
+clients select `attendanceState` on the result:
+
+```graphql
+mutation JoinWaitlist($id: ID!) {
+  joinHuddlWaitlist(id: $id) {
+    result { id attendanceState }
+    errors { message }
+  }
+}
+```
+
+`attendance_state` / `attendanceState` describes the current caller's recorded
+attendance: `none`, `waitlisted`, or `confirmed`. It is also available when
+reading huddlz; anonymous callers receive `none`. It does not expose anyone
+else's attendance or a waitlist position.
+
+Check API errors before interpreting the returned state. A successful RSVP
+can return `waitlisted` when the caller already has a waitlist entry. Repeated
+waitlist requests do not create duplicate attendance. A confirmed caller who
+requests the waitlist of a full huddl remains `confirmed`. Joining the waitlist
+fails when seats are available or capacity is unlimited; use RSVP instead.
+Unavailable or unauthorized huddlz remain failures.

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -32,6 +32,7 @@ defmodule Huddlz.Communities.Huddl do
       update :publish_huddl, :publish
       update :cancel_huddl, :cancel
       update :rsvp_to_huddl, :rsvp
+      update :join_huddl_waitlist, :join_waitlist
       update :cancel_rsvp_to_huddl, :cancel_rsvp
       destroy :delete_huddl, :destroy
     end
@@ -53,6 +54,7 @@ defmodule Huddlz.Communities.Huddl do
       :is_private,
       :thumbnail_url,
       :max_attendees,
+      :attendance_state,
       :lifecycle_state,
       :published_at,
       :cancelled_at,
@@ -75,6 +77,7 @@ defmodule Huddlz.Communities.Huddl do
       patch :publish, route: "/:id/publish"
       patch :cancel, route: "/:id/cancel"
       patch :rsvp, route: "/:id/rsvp"
+      patch :join_waitlist, route: "/:id/join_waitlist"
       patch :cancel_rsvp, route: "/:id/cancel_rsvp"
       delete :destroy
     end
@@ -918,6 +921,24 @@ defmodule Huddlz.Communities.Huddl do
   end
 
   calculations do
+    calculate :attendance_state, :string do
+      public? true
+      description "The current caller's attendance: none, waitlisted, or confirmed"
+
+      calculation expr(
+                    cond do
+                      exists(attendees, user_id == ^actor(:id) and not is_nil(waitlisted_at)) ->
+                        "waitlisted"
+
+                      exists(attendees, user_id == ^actor(:id) and is_nil(waitlisted_at)) ->
+                        "confirmed"
+
+                      true ->
+                        "none"
+                    end
+                  )
+    end
+
     calculate :status, :atom do
       calculation expr(
                     cond do

--- a/test/features/api_waitlist.feature
+++ b/test/features/api_waitlist.feature
@@ -1,0 +1,109 @@
+@async @database @conn @api_waitlist
+Feature: Join a huddl waitlist through the API
+  As an authenticated API client
+  I want to join a full huddl's waitlist and read my attendance state
+  So that I can distinguish waiting from confirmed attendance
+
+  Scenario Outline: Join a full huddl's waitlist
+    Given a full public huddl and an authenticated API caller
+    When I join the huddl waitlist through "<api>"
+    Then the API reports my attendance as "waitlisted"
+    And my API attendance history contains one waitlist entry
+    And the API does not list me as a confirmed attendee
+
+    Examples:
+      | api      |
+      | JSON:API |
+      | GraphQL  |
+
+  Scenario Outline: Repeat a waitlist request
+    Given a full public huddl and an authenticated API caller
+    And I authenticate the waitlist caller with an API key
+    When I join the huddl waitlist through "<api>"
+    And I join the huddl waitlist through "<api>"
+    Then the API reports my attendance as "waitlisted"
+    And my API attendance history contains one waitlist entry
+    And the API does not list me as a confirmed attendee
+
+    Examples:
+      | api      |
+      | JSON:API |
+      | GraphQL  |
+
+  Scenario Outline: RSVP success does not imply confirmed attendance
+    Given a full public huddl and an authenticated API caller
+    When I join the huddl waitlist through "<api>"
+    And I RSVP to the huddl through "<api>"
+    Then the API reports my attendance as "waitlisted"
+    And my API attendance history contains one waitlist entry
+
+    Examples:
+      | api      |
+      | JSON:API |
+      | GraphQL  |
+
+  Scenario Outline: An API key client confirms and cancels attendance
+    Given a full public huddl and an authenticated API caller
+    And I authenticate the waitlist caller with an API key
+    And the last confirmed attendee cancels
+    When I RSVP to the huddl through "<api>"
+    Then the API reports my attendance as "confirmed"
+    When I cancel my attendance through "<api>"
+    Then the API reports my attendance as "none"
+
+    Examples:
+      | api      |
+      | JSON:API |
+      | GraphQL  |
+
+  Scenario Outline: Unavailable or unauthorized waitlist requests fail
+    Given a full public huddl and an authenticated API caller
+    But the waitlist request is unavailable because "<reason>"
+    When I join the huddl waitlist through "<api>"
+    Then the API rejects the waitlist request
+    And my API attendance history is empty
+
+    Examples:
+      | api      | reason          |
+      | JSON:API | anonymous       |
+      | GraphQL  | anonymous       |
+      | JSON:API | private huddl   |
+      | GraphQL  | private huddl   |
+      | JSON:API | cancelled huddl |
+      | GraphQL  | cancelled huddl |
+      | JSON:API | open seats      |
+      | GraphQL  | open seats      |
+      | JSON:API | unlimited seats |
+      | GraphQL  | unlimited seats |
+      | JSON:API | missing huddl   |
+      | GraphQL  | missing huddl   |
+      | JSON:API | draft huddl     |
+      | GraphQL  | draft huddl     |
+      | JSON:API | completed huddl |
+      | GraphQL  | completed huddl |
+
+  Scenario Outline: Attendance state belongs to the current caller
+    Given a full public huddl and an authenticated API caller
+    When I join the huddl waitlist through "<api>"
+    And I read the huddl attendance through "<api>" as "myself"
+    Then the API reports my attendance as "waitlisted"
+    When I read the huddl attendance through "<api>" as "another caller"
+    Then the API reports my attendance as "none"
+    When I read the huddl attendance through "<api>" as "anonymous"
+    Then the API reports my attendance as "none"
+
+    Examples:
+      | api      |
+      | JSON:API |
+      | GraphQL  |
+
+  Scenario Outline: A confirmed caller stays confirmed when requesting the waitlist
+    Given a full public huddl and an authenticated API caller
+    And I am the confirmed attendee
+    When I join the huddl waitlist through "<api>"
+    Then the API reports my attendance as "confirmed"
+
+    Examples:
+      | api      |
+      | JSON:API |
+      | GraphQL  |

--- a/test/features/step_definitions/api_waitlist_steps.exs
+++ b/test/features/step_definitions/api_waitlist_steps.exs
@@ -1,0 +1,247 @@
+defmodule ApiWaitlistSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import HuddlzWeb.ApiCase
+  import Phoenix.ConnTest
+
+  step "a full public huddl and an authenticated API caller", context do
+    owner = generate(user())
+    group = generate(group(actor: owner, is_public: true))
+    huddl = generate(huddl(group_id: group.id, actor: owner, max_attendees: 1))
+    Huddlz.Communities.rsvp_huddl!(huddl, actor: owner)
+    caller = generate(user())
+
+    Map.merge(context, %{
+      waitlist_huddl: huddl,
+      waitlist_owner: owner,
+      waitlist_caller: caller,
+      conn: authenticated_conn(context.conn, caller)
+    })
+  end
+
+  step "I join the huddl waitlist through {string}", %{args: [api]} = context do
+    request_attendance(context, api, "join_waitlist")
+  end
+
+  step "I RSVP to the huddl through {string}", %{args: [api]} = context do
+    request_attendance(context, api, "rsvp")
+  end
+
+  step "I authenticate the waitlist caller with an API key", context do
+    Map.put(context, :conn, api_key_conn(build_conn(), context.waitlist_caller))
+  end
+
+  step "the last confirmed attendee cancels", context do
+    Huddlz.Communities.cancel_rsvp_huddl!(context.waitlist_huddl, actor: context.waitlist_owner)
+    context
+  end
+
+  step "I cancel my attendance through {string}", %{args: [api]} = context do
+    request_attendance(context, api, "cancel_rsvp")
+  end
+
+  step "the waitlist request is unavailable because {string}", %{args: [reason]} = context do
+    unavailable_request(context, reason)
+  end
+
+  step "the API rejects the waitlist request", context do
+    assert_rejected(context.waitlist_response, context.waitlist_api)
+    context
+  end
+
+  step "my API attendance history is empty", context do
+    response =
+      build_conn()
+      |> authenticated_conn(context.waitlist_caller)
+      |> Phoenix.ConnTest.dispatch(
+        HuddlzWeb.Endpoint,
+        :get,
+        "/api/json/huddl_attendees/mine",
+        %{}
+      )
+      |> json_response(200)
+
+    assert response["data"] == []
+    context
+  end
+
+  step "I read the huddl attendance through {string} as {string}",
+       %{args: [api, viewer]} = context do
+    conn =
+      case viewer do
+        "myself" -> context.conn
+        "another caller" -> authenticated_conn(build_conn(), generate(user()))
+        "anonymous" -> build_conn()
+      end
+
+    response = read_attendance(conn, context.waitlist_huddl.id, api)
+
+    Map.merge(context, %{
+      waitlist_response: response,
+      waitlist_api: api,
+      attendance_action: "read"
+    })
+  end
+
+  step "I am the confirmed attendee", context do
+    Map.put(context, :conn, authenticated_conn(build_conn(), context.waitlist_owner))
+  end
+
+  step "the API reports my attendance as {string}", %{args: [state]} = context do
+    response = json_response(context.waitlist_response, 200)
+    assert attendance_state(response, context.waitlist_api, context.attendance_action) == state
+    context
+  end
+
+  step "my API attendance history contains one waitlist entry", context do
+    response =
+      context.conn
+      |> Phoenix.ConnTest.dispatch(
+        HuddlzWeb.Endpoint,
+        :get,
+        "/api/json/huddl_attendees/mine",
+        %{}
+      )
+      |> json_response(200)
+
+    assert [entry] = response["data"]
+    assert entry["attributes"]["waitlisted_at"] != nil
+    context
+  end
+
+  step "the API does not list me as a confirmed attendee", context do
+    response =
+      context.conn
+      |> gql_post("{ searchHuddlz(query: null, relationship: \"attending\") { results { id } } }")
+      |> json_response(200)
+
+    assert response["data"]["searchHuddlz"]["results"] == []
+    context
+  end
+
+  defp request_attendance(context, api, action) do
+    response = attendance_request(context.conn, context.waitlist_huddl.id, api, action)
+
+    Map.merge(context, %{
+      waitlist_response: response,
+      waitlist_api: api,
+      attendance_action: action
+    })
+  end
+
+  defp attendance_request(conn, id, "JSON:API", action) do
+    conn
+    |> Plug.Conn.put_req_header("content-type", "application/vnd.api+json")
+    |> Phoenix.ConnTest.dispatch(
+      HuddlzWeb.Endpoint,
+      :patch,
+      "/api/json/huddlz/#{id}/#{action}",
+      %{
+        "data" => %{"type" => "huddl", "id" => id, "attributes" => %{}}
+      }
+    )
+  end
+
+  defp attendance_request(conn, id, "GraphQL", action) do
+    gql_post(conn, """
+    mutation {
+      #{mutation_name(action)}(id: "#{id}") {
+        result { id attendanceState }
+        errors { message }
+      }
+    }
+    """)
+  end
+
+  defp attendance_state(response, "JSON:API", _action),
+    do: response["data"]["attributes"]["attendance_state"]
+
+  defp attendance_state(response, "GraphQL", "read") do
+    refute Map.has_key?(response, "errors")
+    response["data"]["getHuddl"]["attendanceState"]
+  end
+
+  defp attendance_state(response, "GraphQL", action) do
+    assert response["data"][mutation_name(action)]["errors"] == []
+    response["data"][mutation_name(action)]["result"]["attendanceState"]
+  end
+
+  defp read_attendance(conn, id, "JSON:API") do
+    Phoenix.ConnTest.dispatch(conn, HuddlzWeb.Endpoint, :get, "/api/json/huddlz/#{id}", %{})
+  end
+
+  defp read_attendance(conn, id, "GraphQL") do
+    gql_post(conn, ~s|{ getHuddl(id: "#{id}") { id attendanceState } }|)
+  end
+
+  defp unavailable_request(context, "anonymous"), do: Map.put(context, :conn, build_conn())
+
+  defp unavailable_request(context, "missing huddl") do
+    Map.put(context, :waitlist_huddl, %{id: Ash.UUID.generate()})
+  end
+
+  defp unavailable_request(context, "cancelled huddl") do
+    Huddlz.Communities.cancel_huddl!(context.waitlist_huddl, nil, %{},
+      actor: context.waitlist_owner
+    )
+
+    context
+  end
+
+  defp unavailable_request(context, "draft huddl") do
+    huddl =
+      generate(
+        huddl(
+          group_id: context.waitlist_huddl.group_id,
+          actor: context.waitlist_owner,
+          lifecycle_state: :draft,
+          max_attendees: 1
+        )
+      )
+
+    Map.put(context, :waitlist_huddl, huddl)
+  end
+
+  defp unavailable_request(context, "completed huddl") do
+    ended =
+      Ash.Seed.update!(context.waitlist_huddl, %{
+        starts_at: DateTime.add(DateTime.utc_now(), -2, :hour),
+        ends_at: DateTime.add(DateTime.utc_now(), -1, :hour)
+      })
+
+    completed = Huddlz.Communities.complete_huddl!(ended, authorize?: false)
+    Map.put(context, :waitlist_huddl, completed)
+  end
+
+  defp unavailable_request(context, reason) do
+    changes =
+      case reason do
+        "private huddl" -> %{is_private: true}
+        "open seats" -> %{max_attendees: 2}
+        "unlimited seats" -> %{max_attendees: nil}
+      end
+
+    Huddlz.Communities.update_huddl!(context.waitlist_huddl, changes,
+      actor: context.waitlist_owner
+    )
+
+    context
+  end
+
+  defp assert_rejected(conn, "JSON:API") do
+    assert conn.status in [400, 401, 403, 404, 422]
+    assert [_ | _] = json_response(conn, conn.status)["errors"]
+  end
+
+  defp assert_rejected(conn, "GraphQL") do
+    response = json_response(conn, 200)
+    assert response["data"]["joinHuddlWaitlist"]["result"] == nil
+    assert [_ | _] = response["data"]["joinHuddlWaitlist"]["errors"]
+  end
+
+  defp mutation_name("join_waitlist"), do: "joinHuddlWaitlist"
+  defp mutation_name("cancel_rsvp"), do: "cancelRsvpToHuddl"
+  defp mutation_name("rsvp"), do: "rsvpToHuddl"
+end


### PR DESCRIPTION
Authenticated clients can join a full huddl's waitlist through JSON:API or GraphQL and distinguish `waitlisted` from `confirmed` attendance. Repeated requests preserve existing membership and reuse the website's authorization and capacity rules.

Closes #445.

## Before and after

This is an API-only change. These screenshots render actual local JSON:API requests and responses from the starting revision (`20dbd168`) and this branch (`4b4322cb`), using equivalent sandbox fixtures and omitting authentication credentials.

### Before

The waitlist request returns HTTP 404 because the route is unavailable.

![Before: authenticated waitlist request returns HTTP 404](https://github.com/user-attachments/assets/f7cfaf75-86aa-4f5b-a263-cd1c2ad97345)

### After

The waitlist request returns HTTP 200 with `attendance_state: "waitlisted"`.

![After: authenticated waitlist request returns HTTP 200 and waitlisted attendance](https://github.com/user-attachments/assets/ee64d64d-870d-4a6f-a5a0-1ab74fd2b81f)
