### PR TITLE
feat(huddl): link the hosting group from the huddl page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1875,7 +1875,8 @@ body .row.organizer-group-row {
   grid-template-columns: 48px minmax(0, 1fr) auto;
 }
 
-body .organizer-group-row .group-cover--thumb {
+body .organizer-group-row .group-cover--thumb,
+body .group-row .group-cover--thumb {
   position: relative;
   inset: auto;
   width: 48px;
@@ -2221,6 +2222,53 @@ body .share-modal-link .form-row {
 
 /* "Organized by" row in huddl-side */
 body .creator-row { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+
+/* Hosting group on the huddl page: a small mark above the hero title and a
+   linked row in the sidebar (see HuddlLive.Show). */
+body .hero-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--soft);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+body .hero-group:hover { color: var(--text); }
+
+body .hero-group .group-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  font-size: 10px;
+}
+
+body .group-row {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+body .group-row:hover { border-color: var(--line-strong); }
+body .group-row .group-cover--thumb { width: 48px; }
+body .group-row-copy { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+body .group-row-name { font-size: 14px; font-weight: 600; color: var(--text); overflow-wrap: anywhere; }
+body .group-row-meta { font-size: 12px; color: var(--muted); }
+body .group-row-chevron { color: var(--muted); transition: color 120ms ease, transform 120ms ease; }
+body .group-row:hover .group-row-chevron { color: var(--accent-ink); transform: translateX(2px); }
 
 /* Cancelled-hero strikethrough on title */
 body .hero.is-cancelled .hero-content h1 {

--- a/lib/huddlz_web/components/card.ex
+++ b/lib/huddlz_web/components/card.ex
@@ -155,12 +155,22 @@ defmodule HuddlzWeb.Components.Card do
   defp tag_class(:online), do: "online"
   defp tag_class(:hybrid), do: "hybrid"
 
-  defp group_initials(name) do
+  @doc """
+  Initials for a group name, accepting the `Ash.CiString` the resource
+  stores as well as a plain string. Shared by the sidebar, covers and the
+  huddl page hero.
+  """
+  def group_initials(nil), do: "??"
+
+  def group_initials(name) do
     name
     |> to_string()
-    |> String.split(~r/\s+/, trim: true)
-    |> Enum.take(2)
-    |> Enum.map_join(&String.first/1)
-    |> String.upcase()
+    |> String.trim()
+    |> String.split(~r/[\s\-_]+/, trim: true)
+    |> case do
+      [] -> "??"
+      [single] -> single |> String.slice(0, 2) |> String.upcase()
+      [first, second | _] -> String.upcase(String.first(first) <> String.first(second))
+    end
   end
 end

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -581,20 +581,6 @@ defmodule HuddlzWeb.Layouts do
     """
   end
 
-  defp group_initials(nil), do: "??"
-
-  defp group_initials(name) do
-    name
-    |> to_string()
-    |> String.trim()
-    |> String.split(~r/[\s\-_]+/, trim: true)
-    |> case do
-      [] -> "??"
-      [single] -> single |> String.slice(0, 2) |> String.upcase()
-      [first, second | _] -> String.upcase(String.first(first) <> String.first(second))
-    end
-  end
-
   defp group_mark_variant(idx) do
     case rem(idx, 3) do
       0 -> ""

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -21,7 +21,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
     :at_capacity,
     :visible_virtual_link,
     :display_image_url,
-    :group,
+    group: [:member_count, :current_image_url],
     creator: [:current_profile_picture_url]
   ]
 
@@ -113,10 +113,20 @@ defmodule HuddlzWeb.HuddlLive.Show do
                 image_url={@huddl.display_image_url}
               />
               <div :if={!@huddl.display_image_url} class="hero-fallback" aria-hidden="true">
-                <span>{HuddlzWeb.Avatar.initials(%{display_name: @huddl.group.name})}</span>
+                <span>{group_initials(@huddl.group.name)}</span>
               </div>
             </div>
             <div class="hero-content">
+              <.link
+                id="huddl-hero-group"
+                navigate={~p"/groups/#{@huddl.group.slug}"}
+                class="hero-group"
+              >
+                <span class="group-mark" aria-hidden="true">
+                  {group_initials(@huddl.group.name)}
+                </span>
+                <span>{@huddl.group.name}</span>
+              </.link>
               <span class={["eyebrow", HuddlStatus.eyebrow_class(@huddl.status)]}>
                 {hero_eyebrow(@huddl)}
               </span>
@@ -400,9 +410,18 @@ defmodule HuddlzWeb.HuddlLive.Show do
             </div>
           </div>
 
-          <div class="huddl-side-section">
-            <h3>Organized by</h3>
+          <div id="huddl-group" class="huddl-side-section">
+            <h3>Hosted by</h3>
+            <.link id="huddl-group-link" navigate={~p"/groups/#{@huddl.group.slug}"} class="group-row">
+              <.group_cover group={@huddl.group} id="huddl-group-cover" variant={:thumb} />
+              <span class="group-row-copy">
+                <span class="group-row-name">{@huddl.group.name}</span>
+                <span class="group-row-meta">{group_meta(@huddl.group)}</span>
+              </span>
+              <.icon name="hero-chevron-right" class="size-4 group-row-chevron" />
+            </.link>
             <div class="creator-row">
+              <span class="muted">Organized by</span>
               <.avatar user={@huddl.creator} size={:sm} />
               <span>{@huddl.creator.display_name || @huddl.creator.email}</span>
             </div>
@@ -1208,6 +1227,18 @@ defmodule HuddlzWeb.HuddlLive.Show do
     |> Ash.count!(authorize?: false)
   end
 
+  defp group_meta(group) do
+    members =
+      case group.member_count do
+        1 -> "1 member"
+        count -> "#{count} members"
+      end
+
+    [members, group.location, if(group.is_public, do: nil, else: "Private group")]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+  end
+
   defp hero_eyebrow(huddl) do
     "#{event_type_label(huddl.event_type)} · #{HuddlStatus.label(huddl.status)}"
   end
@@ -1300,9 +1331,10 @@ defmodule HuddlzWeb.HuddlLive.Show do
   defp event_type_label(:hybrid), do: "Hybrid huddl"
   defp event_type_label(_), do: "Huddl"
 
+  # The group is named by the linked mark above the title, so the meta row
+  # only carries the schedule and place.
   defp hero_meta_segments(huddl) do
     [
-      huddl.group.name,
       hero_when_segment(huddl),
       hero_location_segment(huddl)
     ]

--- a/test/browser/steps/huddl_photos_steps.exs
+++ b/test/browser/steps/huddl_photos_steps.exs
@@ -78,7 +78,7 @@ defmodule BrowserPhotoSteps do
   step "I choose two photos using the keyboard upload control", context do
     conn =
       context.conn
-      |> press("#notification-nav-link", "Tab")
+      |> press("#huddl-hero-group", "Tab")
       |> assert_has("#browse-photos:focus")
       |> press(":focus", "Enter")
 

--- a/test/features/huddl_group_link.feature
+++ b/test/features/huddl_group_link.feature
@@ -1,0 +1,12 @@
+@database @conn
+Feature: Reaching a huddl's group from its page
+  A huddl page names the group hosting it, so a visitor can learn about the
+  group and get to it in one step.
+
+  Scenario: A visitor follows the hosting group from a huddl
+    Given a public group "Phoenix Elixir Meetup" in "Saint Augustine, FL" with 3 other members
+    And an upcoming huddl "LiveView streams in practice" hosted by that group
+    When I read the huddl page for "LiveView streams in practice"
+    Then the huddl says it is hosted by "Phoenix Elixir Meetup" with "4 members"
+    When I follow the hosting group link
+    Then I am on the group page for "Phoenix Elixir Meetup"

--- a/test/features/step_definitions/huddl_group_link_steps.exs
+++ b/test/features/step_definitions/huddl_group_link_steps.exs
@@ -1,0 +1,80 @@
+defmodule HuddlGroupLinkSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import PhoenixTest
+
+  alias Huddlz.Communities.GroupMember
+
+  step "a public group {string} in {string} with {int} other members",
+       %{args: [name, location, extra_members]} = context do
+    owner = generate(user(role: :user))
+
+    group =
+      generate(
+        group(name: name, location: location, is_public: true, owner_id: owner.id, actor: owner)
+      )
+
+    for _ <- 1..extra_members do
+      member = generate(user(role: :user))
+
+      GroupMember
+      |> Ash.Changeset.for_create(
+        :add_member,
+        %{group_id: group.id, user_id: member.id, role: "member"},
+        actor: owner
+      )
+      |> Ash.create!()
+    end
+
+    Map.merge(context, %{group: group, owner: owner})
+  end
+
+  step "an upcoming huddl {string} hosted by that group", %{args: [title]} = context do
+    huddl =
+      generate(
+        huddl(
+          group_id: context.group.id,
+          creator_id: context.owner.id,
+          is_private: false,
+          title: title,
+          actor: context.owner
+        )
+      )
+
+    Map.put(context, :huddl, huddl)
+  end
+
+  step "I read the huddl page for {string}", %{args: [title]} = context do
+    session =
+      context.conn
+      |> visit("/groups/#{context.group.slug}/huddlz/#{context.huddl.id}")
+      |> assert_has("h1", text: title)
+
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "the huddl says it is hosted by {string} with {string}",
+       %{args: [group_name, members]} = context do
+    context.conn
+    |> assert_has("#huddl-hero-group", text: group_name)
+    |> assert_has("#huddl-group-link", text: group_name)
+    |> assert_has("#huddl-group-link", text: members)
+
+    context
+  end
+
+  step "I follow the hosting group link", context do
+    session = click_link(context.conn, "#huddl-group-link", to_string(context.group.name))
+
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "I am on the group page for {string}", %{args: [group_name]} = context do
+    context.conn
+    |> assert_path("/groups/#{context.group.slug}")
+    |> assert_has("h1", text: group_name)
+
+    context
+  end
+end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -76,6 +76,23 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       }
     end
 
+    test "links to the hosting group from the hero and the sidebar", %{
+      conn: conn,
+      group: group,
+      huddl: huddl
+    } do
+      session = visit(conn, "/groups/#{group.slug}/huddlz/#{huddl.id}")
+
+      session
+      |> assert_has("#huddl-hero-group[href='/groups/#{group.slug}']", text: "Test Group")
+      |> assert_has("#huddl-hero-group .group-mark", text: "TG", exact: true)
+      |> assert_has(".hero-fallback span", text: "TG", exact: true)
+      |> assert_has("#huddl-group-link[href='/groups/#{group.slug}']", text: "Test Group")
+      |> assert_has("#huddl-group-link .group-row-meta", text: "Saint Augustine, FL")
+      |> assert_has("#huddl-group-link .group-cover-signal", text: "TG")
+      |> assert_has("#huddl-group .creator-row", text: "Organized by")
+    end
+
     test "renders v3 chrome with hero and huddl-frame", %{
       conn: conn,
       member: member,


### PR DESCRIPTION
## Summary

A huddl page had no way to reach the group hosting it. This adds two touchpoints, both linking to the group page.

- **Hero.** The group's mark and name sit above the status eyebrow and title, in the same position the group label holds on a huddl card. Muted weight so the title stays dominant. The group name leaves the hero meta row, which now carries only the schedule and place.
- **Sidebar.** A "Hosted by" section replaces "Organized by": a linked row with the group's cover thumb, name, member count, place and, for private groups, a "Private group" note, with a chevron that nudges on hover. The organizer stays beneath it as "Organized by".
- Group initials now come from one public `group_initials/1` in `Card`, used by the sidebar, the covers and the huddl hero. That also fixes the huddl hero fallback tile rendering blank, since the previous call didn't handle the `Ash.CiString` the resource stores.

## Verification

- New feature `huddl_group_link.feature`: a visitor reads a huddl, sees it is hosted by the group with its member count, follows the link and lands on the group page.
- Show-page test covers both links' hrefs, the meta line, the thumb initials, the hero mark initials and the organizer row.
- `mix precommit` clean and the Playwright suite green, with exit codes checked directly.
- Checked in the browser in dark and light and at phone width.
