### PR TITLE
feat(ui): show placeholder rows while a place search runs

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1292,6 +1292,16 @@ body .filter-location-option .opt-secondary {
   color: var(--muted);
 }
 
+/* Place search in flight: placeholder rows before the first answer, a
+   delayed dim on the rows of an earlier list while a newer search runs.
+   The rows dim rather than the panel so the dropdown stays opaque. */
+body .filter-location-option { transition: opacity 120ms ease; }
+body .filter-location-listbox.is-stale .filter-location-option { opacity: 0.45; transition-delay: 250ms; }
+body .filter-location-listbox.is-searching { animation: skeleton-in 120ms ease 250ms both; }
+body .filter-location-option.is-skeleton { align-items: flex-start; gap: 6px; pointer-events: none; }
+body .filter-location-option.is-skeleton .skel-line { height: 10px; }
+body .filter-location-option.is-skeleton .skel-secondary { width: 45%; height: 8px; }
+
 body .filter-location-error {
   margin: 6px 0 0;
   color: var(--warn);
@@ -1642,7 +1652,7 @@ body .skel {
   display: block;
   overflow: hidden;
   border-radius: var(--radius-sm);
-  background: var(--panel-2);
+  background: var(--line);
 }
 
 body .skel::after {
@@ -1685,6 +1695,8 @@ body [data-stale-on-patch].is-stale { opacity: 0.45; transition-delay: 250ms; }
   body .skel::after { animation: none; }
   body .skel { animation: skel-pulse 1.6s ease-in-out infinite; }
   body .grid-skeleton { animation: none; }
+  body .filter-location-listbox.is-searching { animation: none; }
+  body .filter-location-option { transition: none; }
   body [data-stale-on-patch] { transition: none; }
 }
 

--- a/lib/huddlz_web/live/location_autocomplete.ex
+++ b/lib/huddlz_web/live/location_autocomplete.ex
@@ -199,11 +199,13 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
       </form>
 
       <%!-- Suggestion dropdown --%>
+      <.suggestion_loading :if={!@selected && @loading && @suggestions == []} id={@id} />
+
       <div
         :if={!@selected && @show_suggestions && @suggestions != []}
         id={"#{@id}-listbox"}
         role="listbox"
-        class="filter-location-listbox"
+        class={["filter-location-listbox", @loading && "is-stale"]}
       >
         <button
           :for={{s, idx} <- Enum.with_index(@suggestions)}
@@ -312,11 +314,13 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
           </button>
         </div>
 
+        <.suggestion_loading :if={@loading && @suggestions == []} id={@id} style="min-width: 100%" />
+
         <div
           :if={@show_suggestions && @suggestions != []}
           id={"#{@id}-listbox"}
           role="listbox"
-          class="filter-location-listbox"
+          class={["filter-location-listbox", @loading && "is-stale"]}
           style="min-width: 100%"
         >
           <button
@@ -346,6 +350,30 @@ defmodule HuddlzWeb.Live.LocationAutocomplete do
       <% end %>
 
       <p :if={@error} class="form-error">{@error}</p>
+    </div>
+    """
+  end
+
+  # Placeholder rows shown while a place search is in flight and there is no
+  # earlier list to keep on screen. Held back by the stylesheet for the
+  # loading delay so a fast answer never flashes it.
+  attr :id, :string, required: true
+  attr :style, :string, default: nil
+
+  defp suggestion_loading(assigns) do
+    ~H"""
+    <div
+      id={"#{@id}-searching"}
+      class="filter-location-listbox is-searching"
+      role="status"
+      aria-busy="true"
+      aria-label="Searching places"
+      style={@style}
+    >
+      <div :for={width <- [70, 55, 80]} class="filter-location-option is-skeleton" aria-hidden="true">
+        <span class="skel skel-line" style={"--w: #{width}%"}></span>
+        <span class="skel skel-line skel-secondary"></span>
+      </div>
     </div>
     """
   end

--- a/test/huddlz_web/live/location_autocomplete_test.exs
+++ b/test/huddlz_web/live/location_autocomplete_test.exs
@@ -1,0 +1,68 @@
+defmodule HuddlzWeb.Live.LocationAutocompleteTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias HuddlzWeb.Live.LocationAutocomplete
+
+  @suggestion %{
+    place_id: "place-1",
+    display_text: "Austin, TX, USA",
+    main_text: "Austin",
+    secondary_text: "TX, USA"
+  }
+
+  describe "while a place search is in flight" do
+    for variant <- [:filter_pill, :form] do
+      @variant variant
+
+      test "the #{variant} variant shows placeholder rows before the first answer", %{conn: _conn} do
+        document = render_autocomplete(variant: @variant, loading: true, suggestions: [])
+
+        assert [status] =
+                 Floki.find(
+                   document,
+                   ~s|#location-searching[role="status"][aria-busy="true"][aria-label="Searching places"]|
+                 )
+
+        assert length(Floki.find(status, ".filter-location-option.is-skeleton[aria-hidden]")) == 3
+        assert Floki.find(document, "[role='option']") == []
+        assert Floki.find(document, ".filter-location-listbox.empty") == []
+      end
+
+      test "the #{variant} variant keeps an earlier list on screen, marked stale", %{conn: _conn} do
+        document =
+          render_autocomplete(
+            variant: @variant,
+            loading: true,
+            suggestions: [@suggestion],
+            show_suggestions: true
+          )
+
+        assert [_option] =
+                 Floki.find(document, ".filter-location-listbox.is-stale [role='option']")
+
+        assert Floki.find(document, "#location-searching") == []
+      end
+
+      test "the #{variant} variant drops both once the answer lands", %{conn: _conn} do
+        document =
+          render_autocomplete(
+            variant: @variant,
+            loading: false,
+            suggestions: [@suggestion],
+            show_suggestions: true
+          )
+
+        assert [_option] = Floki.find(document, "[role='option']")
+        assert Floki.find(document, ".is-stale, #location-searching") == []
+      end
+    end
+  end
+
+  defp render_autocomplete(assigns) do
+    LocationAutocomplete
+    |> render_component(Keyword.merge([id: "location", field_name: "location"], assigns))
+    |> Floki.parse_fragment!()
+  end
+end


### PR DESCRIPTION
## Summary

Last step of the loading-states pass. The location autocomplete is the app's one genuinely asynchronous control, and until now its dropdown was simply absent while a place search ran.

- **Placeholder rows before the first answer.** Both variants (the discover filter pill and the profile form) render three shimmer rows in the dropdown's own row anatomy, as a busy `status` region labelled "Searching places". The stylesheet holds it back for 250ms, so a fast answer never flashes it.
- **An earlier list stays on screen while a newer search runs**, with its rows dimmed after the same delay. The rows dim rather than the panel, so the floating dropdown stays opaque over the page.
- The shared skeleton surface now uses the line token. On a panel background the previous panel-2 base was too close to see, which also nudges the discover card skeleton slightly more visible.
- Reduced motion drops the fade and the dim transition.

## Verification

- Component tests render both variants in the three states: searching with no list, searching over an earlier list, and settled.
- `mix precommit` clean and the Playwright suite green, exit codes checked directly.
- Screenshots in the first comment were taken with a temporary 1.5s delay on the place search.
