### PR TITLE
feat(seo): draw a link-preview card for huddlz without a cover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN mix release
 FROM ${RUNNER_IMAGE} AS final
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends libstdc++6 openssl libncurses6 locales ca-certificates libvips \
+  && apt-get install -y --no-install-recommends libstdc++6 openssl libncurses6 locales ca-certificates libvips fontconfig fonts-inter \
   && rm -rf /var/lib/apt/lists/*
 
 # Set the locale

--- a/lib/huddlz_web/controllers/og_image_controller.ex
+++ b/lib/huddlz_web/controllers/og_image_controller.ex
@@ -1,0 +1,54 @@
+defmodule HuddlzWeb.OgImageController do
+  @moduledoc """
+  Serves the generated link-preview card for a public huddl. Private or
+  unpublished huddlz are as invisible here as they are on their page.
+  """
+  use HuddlzWeb, :controller
+
+  alias Huddlz.Communities
+  alias HuddlzWeb.OgImage
+
+  require Logger
+
+  def huddl(conn, %{"id" => id}) do
+    with {:ok, huddl} <- Communities.get_huddl(id, load: [:status, :group], actor: nil),
+         true <- shareable?(huddl) do
+      send_card(conn, huddl)
+    else
+      _ -> send_resp(conn, 404, "Not found")
+    end
+  end
+
+  defp send_card(conn, huddl) do
+    etag = OgImage.etag(huddl)
+
+    conn =
+      conn
+      |> put_resp_header("cache-control", "public, max-age=3600")
+      |> put_resp_header("etag", etag)
+      |> put_resp_header("x-content-type-options", "nosniff")
+
+    if etag in get_req_header(conn, "if-none-match") do
+      send_resp(conn, 304, "")
+    else
+      draw(conn, huddl)
+    end
+  end
+
+  defp draw(conn, huddl) do
+    case OgImage.huddl_card(huddl) do
+      {:ok, png} ->
+        conn |> put_resp_content_type("image/png") |> send_resp(200, png)
+
+      {:error, reason} ->
+        Logger.error("Could not draw the preview card for huddl #{huddl.id}: #{inspect(reason)}")
+        conn |> delete_resp_header("cache-control") |> send_resp(500, "Preview unavailable")
+    end
+  end
+
+  defp shareable?(%{is_private: false, group: %{is_public: true}, lifecycle_state: state})
+       when state in [:published, :completed, :cancelled],
+       do: true
+
+  defp shareable?(_huddl), do: false
+end

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -1189,7 +1189,9 @@ defmodule HuddlzWeb.HuddlLive.Show do
       description: MetaHelpers.description(huddl, "Find and join this huddl on huddlz."),
       type: "event",
       url: url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"),
-      image: MetaHelpers.image_url(huddl.display_image_url, HuddlCoverImages)
+      image:
+        MetaHelpers.image_url(huddl.display_image_url, HuddlCoverImages) ||
+          url(~p"/og/huddlz/#{huddl.id}/card.png")
     }
   end
 

--- a/lib/huddlz_web/og_image.ex
+++ b/lib/huddlz_web/og_image.ex
@@ -1,0 +1,163 @@
+defmodule HuddlzWeb.OgImage do
+  @moduledoc """
+  Draws the link-preview card advertised as `og:image` for a huddl that has
+  no cover picture.
+
+  Chat apps and social sites fetch that picture when someone pastes a huddl
+  link, so this is the first thing many people see of a huddl. The card is
+  an SVG on the app's dark tokens, rasterised to PNG through libvips.
+  """
+
+  alias HuddlzWeb.Components.Card
+
+  @width 1200
+  @height 630
+  @title_chars_per_line 28
+  @version 1
+
+  def width, do: @width
+  def height, do: @height
+
+  @doc "Renders the card as a PNG binary."
+  def huddl_card(huddl) do
+    with {:ok, image} <- Image.from_binary(huddl_svg(huddl)) do
+      Image.write(image, :memory, suffix: ".png")
+    end
+  end
+
+  @doc """
+  A strong ETag for the card, derived from everything drawn on it, so a
+  shared link keeps its cached preview until the huddl actually changes.
+  """
+  def etag(huddl) do
+    fingerprint =
+      {@version, huddl.title, huddl.starts_at, huddl.ends_at, huddl.time_zone, huddl.status,
+       huddl.event_type, huddl.physical_location, to_string(huddl.group.name)}
+
+    ~s("og-#{:erlang.phash2(fingerprint)}")
+  end
+
+  @doc "The card as SVG markup."
+  def huddl_svg(huddl) do
+    group_name = to_string(huddl.group.name)
+    title_lines = wrap_title(huddl.title)
+    title_top = if length(title_lines) == 1, do: 372, else: 336
+    detail_top = title_top + 76 * length(title_lines) + 4
+
+    """
+    <svg xmlns="http://www.w3.org/2000/svg" width="#{@width}" height="#{@height}" viewBox="0 0 #{@width} #{@height}">
+      <rect width="#{@width}" height="#{@height}" fill="#0b1112"/>
+      <rect x="0" y="#{@height - 6}" width="#{@width}" height="6" fill="#18cbd4"/>
+      <rect x="72" y="72" width="44" height="44" rx="12" fill="#18cbd4"/>
+      <text x="94" y="103" text-anchor="middle" font-family="#{font()}" font-size="26" font-weight="700" fill="#05191b">h</text>
+      <text x="132" y="103" font-family="#{font()}" font-size="30" font-weight="700" fill="#eef5f5">huddlz</text>
+      <rect x="960" y="72" width="168" height="168" rx="24" fill="#10181a" stroke="#2c3a3d" stroke-width="2"/>
+      <text x="1044" y="176" text-anchor="middle" font-family="#{font()}" font-size="56" font-weight="700" letter-spacing="1" fill="#35d6de">#{escape(Card.group_initials(group_name))}</text>
+      <text x="72" y="#{title_top - 60}" font-family="#{font()}" font-size="22" font-weight="600" letter-spacing="2" fill="#{eyebrow_colour(huddl)}">#{escape(String.upcase(eyebrow(huddl, group_name)))}</text>
+    #{title_markup(title_lines, title_top)}
+      <text x="72" y="#{detail_top}" font-family="#{font()}" font-size="30" font-weight="500" fill="#b3bfc1">#{escape(when_line(huddl))}</text>
+    #{place_markup(huddl, detail_top + 48)}
+    </svg>
+    """
+  end
+
+  defp title_markup(lines, top) do
+    lines
+    |> Enum.with_index()
+    |> Enum.map_join("\n", fn {line, index} ->
+      ~s(  <text x="72" y="#{top + index * 76}" font-family="#{font()}" font-size="62" font-weight="700" letter-spacing="-1" fill="#eef5f5">#{escape(line)}</text>)
+    end)
+  end
+
+  defp place_markup(huddl, y) do
+    case place_line(huddl) do
+      nil ->
+        ""
+
+      place ->
+        ~s(  <text x="72" y="#{y}" font-family="#{font()}" font-size="28" fill="#7f8c8f">#{escape(place)}</text>)
+    end
+  end
+
+  defp font, do: "Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif"
+
+  defp eyebrow(%{status: :cancelled}, group_name), do: "#{group_name} · Cancelled"
+  defp eyebrow(%{status: :in_progress}, group_name), do: "#{group_name} · Happening now"
+  defp eyebrow(%{status: :completed}, group_name), do: "#{group_name} · Completed"
+  defp eyebrow(%{event_type: :virtual}, group_name), do: "#{group_name} · Online"
+  defp eyebrow(%{event_type: :hybrid}, group_name), do: "#{group_name} · Hybrid"
+  defp eyebrow(_huddl, group_name), do: "#{group_name} · In person"
+
+  defp eyebrow_colour(%{status: :cancelled}), do: "#e84fb4"
+  defp eyebrow_colour(%{status: :completed}), do: "#7f8c8f"
+  defp eyebrow_colour(_huddl), do: "#35d6de"
+
+  defp when_line(huddl) do
+    starts_at = DateTime.shift_zone!(huddl.starts_at, huddl.time_zone)
+    ends_at = huddl.ends_at && DateTime.shift_zone!(huddl.ends_at, huddl.time_zone)
+
+    cond do
+      ends_at && DateTime.to_date(ends_at) == DateTime.to_date(starts_at) ->
+        "#{date(starts_at)} · #{time(starts_at)} – #{time(ends_at)} #{starts_at.zone_abbr}"
+
+      ends_at ->
+        "#{date(starts_at)} #{time(starts_at)} → #{date(ends_at)} #{time(ends_at)} #{starts_at.zone_abbr}"
+
+      true ->
+        "#{date(starts_at)} · #{time(starts_at)} #{starts_at.zone_abbr}"
+    end
+  end
+
+  defp date(datetime), do: Calendar.strftime(datetime, "%a, %b %-d")
+  defp time(datetime), do: Calendar.strftime(datetime, "%-I:%M %p")
+
+  defp place_line(%{event_type: :hybrid, physical_location: place}) when is_binary(place),
+    do: "#{place} · & online"
+
+  defp place_line(%{event_type: :in_person, physical_location: place}) when is_binary(place),
+    do: place
+
+  defp place_line(%{event_type: :virtual}), do: "Online"
+  defp place_line(_huddl), do: nil
+
+  # SVG has no automatic wrapping: break the title into at most two lines of
+  # roughly the width the card can hold, and end a cut-off title with an
+  # ellipsis.
+  def wrap_title(title) do
+    title
+    |> to_string()
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.flat_map(&split_long_word/1)
+    |> Enum.reduce([], fn word, lines ->
+      case lines do
+        [] ->
+          [word]
+
+        [line | rest] when byte_size(line) + 1 + byte_size(word) <= @title_chars_per_line ->
+          [line <> " " <> word | rest]
+
+        _ ->
+          [word | lines]
+      end
+    end)
+    |> Enum.reverse()
+    |> case do
+      [first, second | rest] when rest != [] ->
+        [first, String.slice(second, 0, @title_chars_per_line - 1) <> "…"]
+
+      lines ->
+        lines
+    end
+  end
+
+  defp split_long_word(word) when byte_size(word) <= 28, do: [word]
+
+  defp split_long_word(word) do
+    word
+    |> String.graphemes()
+    |> Enum.chunk_every(@title_chars_per_line)
+    |> Enum.map(&Enum.join/1)
+  end
+
+  defp escape(text), do: text |> to_string() |> Plug.HTML.html_escape()
+end

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -40,6 +40,7 @@ defmodule HuddlzWeb.Router do
     get "/robots.txt", SitemapController, :robots
     get "/sitemap.xml", SitemapController, :index
     get "/sitemap-:file", SitemapController, :child
+    get "/og/huddlz/:id/card.png", OgImageController, :huddl
   end
 
   scope "/gql" do

--- a/test/features/link_preview_image.feature
+++ b/test/features/link_preview_image.feature
@@ -1,0 +1,15 @@
+@database @conn
+Feature: Link previews for huddlz without a cover picture
+  When someone pastes a huddl link into a chat, the preview should carry a
+  picture even if the organizer never uploaded a cover.
+
+  Scenario: A public huddl without a cover advertises a generated preview picture
+    Given a public group "Phoenix Elixir Meetup" hosting an upcoming huddl "Hands-on with Ash Framework" with no cover picture
+    When a link preview fetches the huddl page
+    Then the page advertises a generated preview picture
+    And that picture is a 1200 by 630 PNG
+
+  Scenario: A private huddl has no preview picture to fetch
+    Given a private huddl "Board planning session" with no cover picture
+    When a link preview fetches that huddl's preview picture
+    Then there is nothing to fetch

--- a/test/features/link_preview_image.feature
+++ b/test/features/link_preview_image.feature
@@ -1,13 +1,20 @@
 @database @conn
 Feature: Link previews for huddlz without a cover picture
   When someone pastes a huddl link into a chat, the preview should carry a
-  picture even if the organizer never uploaded a cover.
+  picture even if the organizer never uploaded a cover. The picture cascades:
+  the huddl's own cover, then its group's cover, then a card drawn on the fly.
 
   Scenario: A public huddl without a cover advertises a generated preview picture
     Given a public group "Phoenix Elixir Meetup" hosting an upcoming huddl "Hands-on with Ash Framework" with no cover picture
     When a link preview fetches the huddl page
     Then the page advertises a generated preview picture
     And that picture is a 1200 by 630 PNG
+
+  Scenario: A huddl without its own cover shares its group's cover picture
+    Given a public group "Phoenix Elixir Meetup" with a cover picture
+    And an upcoming huddl "Hands-on with Ash Framework" in that group with no cover of its own
+    When a link preview fetches the huddl page
+    Then the page advertises the group's cover picture
 
   Scenario: A private huddl has no preview picture to fetch
     Given a private huddl "Board planning session" with no cover picture

--- a/test/features/step_definitions/link_preview_image_steps.exs
+++ b/test/features/step_definitions/link_preview_image_steps.exs
@@ -1,0 +1,88 @@
+defmodule LinkPreviewImageSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Phoenix.ConnTest
+
+  @endpoint HuddlzWeb.Endpoint
+
+  step "a public group {string} hosting an upcoming huddl {string} with no cover picture",
+       %{args: [group_name, title]} = context do
+    owner = generate(user(role: :user))
+    group = generate(group(name: group_name, is_public: true, owner_id: owner.id, actor: owner))
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          is_private: false,
+          title: title,
+          actor: owner
+        )
+      )
+
+    Map.merge(context, %{group: group, huddl: huddl})
+  end
+
+  step "a private huddl {string} with no cover picture", %{args: [title]} = context do
+    owner = generate(user(role: :user))
+    group = generate(group(is_public: false, owner_id: owner.id, actor: owner))
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          is_private: true,
+          title: title,
+          actor: owner
+        )
+      )
+
+    Map.merge(context, %{group: group, huddl: huddl})
+  end
+
+  step "a link preview fetches the huddl page", context do
+    html =
+      context.conn
+      |> get("/groups/#{context.group.slug}/huddlz/#{context.huddl.id}")
+      |> html_response(200)
+
+    Map.put(context, :page_html, html)
+  end
+
+  step "the page advertises a generated preview picture", context do
+    [image_url] =
+      context.page_html
+      |> Floki.parse_document!()
+      |> Floki.attribute(~s(meta[property="og:image"]), "content")
+
+    assert image_url == HuddlzWeb.Endpoint.url() <> "/og/huddlz/#{context.huddl.id}/card.png"
+
+    Map.put(context, :image_url, image_url)
+  end
+
+  step "that picture is a 1200 by 630 PNG", context do
+    path = URI.parse(context.image_url).path
+    response = get(build_conn(), path)
+
+    assert response.status == 200
+    assert response_content_type(response, :png) =~ "image/png"
+
+    {:ok, image} = Image.from_binary(response.resp_body)
+    assert {Image.width(image), Image.height(image)} == {1200, 630}
+
+    context
+  end
+
+  step "a link preview fetches that huddl's preview picture", context do
+    Map.put(context, :response, get(build_conn(), "/og/huddlz/#{context.huddl.id}/card.png"))
+  end
+
+  step "there is nothing to fetch", context do
+    assert context.response.status == 404
+    context
+  end
+end

--- a/test/features/step_definitions/link_preview_image_steps.exs
+++ b/test/features/step_definitions/link_preview_image_steps.exs
@@ -26,6 +26,54 @@ defmodule LinkPreviewImageSteps do
     Map.merge(context, %{group: group, huddl: huddl})
   end
 
+  step "a public group {string} with a cover picture", %{args: [group_name]} = context do
+    owner = generate(user(role: :user))
+    group = generate(group(name: group_name, is_public: true, owner_id: owner.id, actor: owner))
+    thumbnail_path = "/uploads/group_images/#{group.id}/cover_thumb.jpg"
+
+    Huddlz.Communities.create_group_image!(
+      %{
+        filename: "cover.jpg",
+        content_type: "image/jpeg",
+        size_bytes: 1234,
+        storage_path: "/uploads/group_images/#{group.id}/cover.jpg",
+        thumbnail_path: thumbnail_path,
+        group_id: group.id
+      },
+      actor: owner
+    )
+
+    Map.merge(context, %{group: group, owner: owner, group_cover_path: thumbnail_path})
+  end
+
+  step "an upcoming huddl {string} in that group with no cover of its own",
+       %{args: [title]} = context do
+    huddl =
+      generate(
+        huddl(
+          group_id: context.group.id,
+          creator_id: context.owner.id,
+          is_private: false,
+          title: title,
+          actor: context.owner
+        )
+      )
+
+    Map.put(context, :huddl, huddl)
+  end
+
+  step "the page advertises the group's cover picture", context do
+    [image_url] =
+      context.page_html
+      |> Floki.parse_document!()
+      |> Floki.attribute(~s(meta[property="og:image"]), "content")
+
+    assert image_url == HuddlzWeb.Endpoint.url() <> context.group_cover_path
+    refute image_url =~ "/og/huddlz/"
+
+    context
+  end
+
   step "a private huddl {string} with no cover picture", %{args: [title]} = context do
     owner = generate(user(role: :user))
     group = generate(group(is_public: false, owner_id: owner.id, actor: owner))

--- a/test/huddlz_web/controllers/og_image_controller_test.exs
+++ b/test/huddlz_web/controllers/og_image_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule HuddlzWeb.OgImageControllerTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import Huddlz.Generator
+
+  setup do
+    owner = generate(user(role: :user))
+    group = generate(group(is_public: true, owner_id: owner.id, actor: owner))
+
+    huddl =
+      generate(huddl(group_id: group.id, creator_id: owner.id, is_private: false, actor: owner))
+
+    %{huddl: huddl}
+  end
+
+  test "serves the card with a strong ETag and honours If-None-Match", %{conn: conn, huddl: huddl} do
+    first = get(conn, ~p"/og/huddlz/#{huddl.id}/card.png")
+
+    assert first.status == 200
+    assert [etag] = get_resp_header(first, "etag")
+    assert ["public, max-age=3600"] = get_resp_header(first, "cache-control")
+
+    cached =
+      conn
+      |> put_req_header("if-none-match", etag)
+      |> get(~p"/og/huddlz/#{huddl.id}/card.png")
+
+    assert cached.status == 304
+    assert cached.resp_body == ""
+  end
+
+  test "an unknown huddl is not found", %{conn: conn} do
+    assert conn |> get(~p"/og/huddlz/#{Ecto.UUID.generate()}/card.png") |> response(404)
+  end
+end

--- a/test/huddlz_web/og_image_test.exs
+++ b/test/huddlz_web/og_image_test.exs
@@ -1,0 +1,71 @@
+defmodule HuddlzWeb.OgImageTest do
+  use ExUnit.Case, async: true
+
+  alias HuddlzWeb.OgImage
+
+  @huddl %{
+    title: "Hands-on with Ash Framework",
+    starts_at: ~U[2030-09-10 22:30:00Z],
+    ends_at: ~U[2030-09-11 00:30:00Z],
+    time_zone: "America/New_York",
+    status: :upcoming,
+    event_type: :in_person,
+    physical_location: "Saint Augustine, FL",
+    group: %{name: Ash.CiString.new("Phoenix Elixir Meetup")}
+  }
+
+  test "draws the group, title, schedule and place in the local time zone" do
+    svg = OgImage.huddl_svg(@huddl)
+
+    assert svg =~ "PHOENIX ELIXIR MEETUP · IN PERSON"
+    assert svg =~ ">PE<"
+    assert svg =~ "Hands-on with Ash Framework"
+    assert svg =~ "Tue, Sep 10 · 6:30 PM – 8:30 PM EDT"
+    assert svg =~ "Saint Augustine, FL"
+  end
+
+  test "escapes markup in huddl titles" do
+    svg = OgImage.huddl_svg(%{@huddl | title: ~s|Tom & Jerry <script>alert("x")</script>|})
+
+    refute svg =~ "<script>"
+    assert svg =~ "Tom &amp; Jerry"
+    assert svg =~ "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"
+  end
+
+  test "wraps long titles onto two lines and ends a cut-off title with an ellipsis" do
+    assert OgImage.wrap_title("Short title") == ["Short title"]
+
+    assert OgImage.wrap_title("Building resilient LiveView applications together") ==
+             ["Building resilient LiveView", "applications together"]
+
+    assert [_first, second] =
+             OgImage.wrap_title(
+               "A very long huddl title that keeps going well past what the card can show"
+             )
+
+    assert String.ends_with?(second, "…")
+    assert String.length(second) <= 28
+  end
+
+  test "names cancelled and completed huddlz in the eyebrow" do
+    assert OgImage.huddl_svg(%{@huddl | status: :cancelled}) =~
+             "PHOENIX ELIXIR MEETUP · CANCELLED"
+
+    assert OgImage.huddl_svg(%{@huddl | status: :completed}) =~
+             "PHOENIX ELIXIR MEETUP · COMPLETED"
+
+    assert OgImage.huddl_svg(%{@huddl | event_type: :virtual}) =~ "PHOENIX ELIXIR MEETUP · ONLINE"
+  end
+
+  test "the ETag changes with what is drawn" do
+    assert OgImage.etag(@huddl) == OgImage.etag(@huddl)
+    refute OgImage.etag(@huddl) == OgImage.etag(%{@huddl | title: "Renamed"})
+  end
+
+  test "renders to a PNG of the advertised size" do
+    {:ok, png} = OgImage.huddl_card(@huddl)
+    {:ok, image} = Image.from_binary(png)
+
+    assert {Image.width(image), Image.height(image)} == {OgImage.width(), OgImage.height()}
+  end
+end


### PR DESCRIPTION
## Summary

Chat apps and social sites turn a pasted link into a card from the page's Open Graph tags. A huddl without a cover picture advertised no `og:image`, so most huddl links unfurled as text. Public huddlz now advertise a generated card.

- **`HuddlzWeb.OgImage`** draws a 1200×630 card as SVG on the app's dark tokens: the huddlz mark, the group's initials tile, an eyebrow with the group name and kind (in person, online, hybrid, happening now, completed, or cancelled in pink), the title wrapped to at most two lines with an ellipsis, the schedule in the huddl's time zone, and the place. It rasterises through libvips, which the app already uses for thumbnails. Titles are HTML-escaped.
- **`GET /og/huddlz/:id/card.png`** serves the card for public, published huddlz with a strong ETag built from everything drawn, an hour of public caching, and a 304 on `If-None-Match`. Private or unpublished huddlz are 404, matching their pages.
- The huddl page's `og:image` falls back to the card when there is no cover picture. Uploaded covers keep winning.
- The runtime Docker image adds `fontconfig` and `fonts-inter` so the text renders with the brand face in production. Without any font installed, libvips would draw the card with no text at all.

## Verification

- Feature `link_preview_image.feature` states the picture cascade and covers it: a public huddl without a cover advertises the card and the card is a 1200×630 PNG; a huddl without its own cover shares its group's cover; a private huddl's card is not found. The huddl-with-its-own-cover case stays in the existing show-page test.
- Unit tests cover the eyebrow states, time-zone formatting, title wrapping and ellipsis, escaping, the ETag, and the PNG size. Controller test covers caching headers and the 304.
- `mix precommit` clean and the Playwright suite green, exit codes checked directly.
- Not verified here: the production image build with the new font packages. That needs a deploy to confirm, and the first thing to check is that a card fetched from production shows text.

Sample cards in the first comment.
