### PR TITLE
feat(seo): draw a link-preview card for groups without a cover

### DIFF
--- a/lib/huddlz_web/controllers/og_image_controller.ex
+++ b/lib/huddlz_web/controllers/og_image_controller.ex
@@ -1,7 +1,7 @@
 defmodule HuddlzWeb.OgImageController do
   @moduledoc """
-  Serves the generated link-preview card for a public huddl. Private or
-  unpublished huddlz are as invisible here as they are on their page.
+  Serves the generated link-preview card for a public huddl or group. Private
+  or unpublished ones are as invisible here as they are on their page.
   """
   use HuddlzWeb, :controller
 
@@ -13,15 +13,28 @@ defmodule HuddlzWeb.OgImageController do
   def huddl(conn, %{"id" => id}) do
     with {:ok, huddl} <- Communities.get_huddl(id, load: [:status, :group], actor: nil),
          true <- shareable?(huddl) do
-      send_card(conn, huddl)
+      send_card(conn, OgImage.etag(huddl), fn -> OgImage.huddl_card(huddl) end, "huddl #{id}")
     else
       _ -> send_resp(conn, 404, "Not found")
     end
   end
 
-  defp send_card(conn, huddl) do
-    etag = OgImage.etag(huddl)
+  def group(conn, %{"slug" => slug}) do
+    case Communities.get_by_slug(slug, load: [:member_count], actor: nil) do
+      {:ok, %{is_public: true} = group} ->
+        send_card(
+          conn,
+          OgImage.group_etag(group),
+          fn -> OgImage.group_card(group) end,
+          "group #{slug}"
+        )
 
+      _ ->
+        send_resp(conn, 404, "Not found")
+    end
+  end
+
+  defp send_card(conn, etag, draw, subject) do
     conn =
       conn
       |> put_resp_header("cache-control", "public, max-age=3600")
@@ -31,19 +44,17 @@ defmodule HuddlzWeb.OgImageController do
     if etag in get_req_header(conn, "if-none-match") do
       send_resp(conn, 304, "")
     else
-      draw(conn, huddl)
+      respond(conn, draw.(), subject)
     end
   end
 
-  defp draw(conn, huddl) do
-    case OgImage.huddl_card(huddl) do
-      {:ok, png} ->
-        conn |> put_resp_content_type("image/png") |> send_resp(200, png)
+  defp respond(conn, {:ok, png}, _subject) do
+    conn |> put_resp_content_type("image/png") |> send_resp(200, png)
+  end
 
-      {:error, reason} ->
-        Logger.error("Could not draw the preview card for huddl #{huddl.id}: #{inspect(reason)}")
-        conn |> delete_resp_header("cache-control") |> send_resp(500, "Preview unavailable")
-    end
+  defp respond(conn, {:error, reason}, subject) do
+    Logger.error("Could not draw the preview card for #{subject}: #{inspect(reason)}")
+    conn |> delete_resp_header("cache-control") |> send_resp(500, "Preview unavailable")
   end
 
   defp shareable?(%{is_private: false, group: %{is_public: true}, lifecycle_state: state})

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -601,9 +601,16 @@ defmodule HuddlzWeb.GroupLive.Show do
       description: MetaHelpers.description(group, "Find and join this group on huddlz."),
       type: "website",
       url: url(~p"/groups/#{group.slug}"),
-      image: MetaHelpers.image_url(group.current_image_url, GroupImages)
+      image:
+        MetaHelpers.image_url(group.current_image_url, GroupImages) ||
+          generated_card_url(group)
     }
   end
+
+  defp generated_card_url(%{is_public: true, slug: slug}),
+    do: url(~p"/og/groups/#{slug}/card.png")
+
+  defp generated_card_url(_group), do: nil
 
   defp current_user_membership(_group, nil), do: nil
 

--- a/lib/huddlz_web/og_image.ex
+++ b/lib/huddlz_web/og_image.ex
@@ -1,11 +1,11 @@
 defmodule HuddlzWeb.OgImage do
   @moduledoc """
-  Draws the link-preview card advertised as `og:image` for a huddl that has
-  no cover picture.
+  Draws the link-preview card advertised as `og:image` for a huddl or group
+  that has no cover picture.
 
-  Chat apps and social sites fetch that picture when someone pastes a huddl
-  link, so this is the first thing many people see of a huddl. The card is
-  an SVG on the app's dark tokens, rasterised to PNG through libvips.
+  Chat apps and social sites fetch that picture when someone pastes a link,
+  so this is the first thing many people see of a huddl or group. The card
+  is an SVG on the app's dark tokens, rasterised to PNG through libvips.
   """
 
   alias HuddlzWeb.Components.Card
@@ -13,14 +13,20 @@ defmodule HuddlzWeb.OgImage do
   @width 1200
   @height 630
   @title_chars_per_line 28
+  @secondary_chars 72
   @version 1
 
   def width, do: @width
   def height, do: @height
 
-  @doc "Renders the card as a PNG binary."
-  def huddl_card(huddl) do
-    with {:ok, image} <- Image.from_binary(huddl_svg(huddl)) do
+  @doc "Renders a huddl's card as a PNG binary."
+  def huddl_card(huddl), do: huddl |> huddl_svg() |> render_png()
+
+  @doc "Renders a group's card as a PNG binary."
+  def group_card(group), do: group |> group_svg() |> render_png()
+
+  defp render_png(svg) do
+    with {:ok, image} <- Image.from_binary(svg) do
       Image.write(image, :memory, suffix: ".png")
     end
   end
@@ -37,10 +43,49 @@ defmodule HuddlzWeb.OgImage do
     ~s("og-#{:erlang.phash2(fingerprint)}")
   end
 
-  @doc "The card as SVG markup."
+  @doc """
+  A strong ETag for a group's card, derived from everything drawn on it.
+  """
+  def group_etag(group) do
+    fingerprint =
+      {@version, :group, to_string(group.name), group.member_count, group.location,
+       group.description && to_string(group.description)}
+
+    ~s("og-#{:erlang.phash2(fingerprint)}")
+  end
+
+  @doc "A huddl's card as SVG markup."
   def huddl_svg(huddl) do
     group_name = to_string(huddl.group.name)
-    title_lines = wrap_title(huddl.title)
+
+    card_svg(%{
+      initials: Card.group_initials(group_name),
+      eyebrow: eyebrow(huddl, group_name),
+      eyebrow_colour: eyebrow_colour(huddl),
+      title: huddl.title,
+      detail: when_line(huddl),
+      secondary: place_line(huddl)
+    })
+  end
+
+  @doc "A group's card as SVG markup."
+  def group_svg(group) do
+    name = to_string(group.name)
+
+    card_svg(%{
+      initials: Card.group_initials(name),
+      eyebrow: group_eyebrow(group),
+      eyebrow_colour: "#35d6de",
+      title: name,
+      detail: group.location || "Meets online",
+      secondary: description_line(group)
+    })
+  end
+
+  # One anatomy for every card: the brand, the initials tile, an eyebrow, a
+  # title of up to two lines, a detail line and an optional muted line.
+  defp card_svg(card) do
+    title_lines = wrap_title(card.title)
     title_top = if length(title_lines) == 1, do: 372, else: 336
     detail_top = title_top + 76 * length(title_lines) + 4
 
@@ -52,11 +97,11 @@ defmodule HuddlzWeb.OgImage do
       <text x="94" y="103" text-anchor="middle" font-family="#{font()}" font-size="26" font-weight="700" fill="#05191b">h</text>
       <text x="132" y="103" font-family="#{font()}" font-size="30" font-weight="700" fill="#eef5f5">huddlz</text>
       <rect x="960" y="72" width="168" height="168" rx="24" fill="#10181a" stroke="#2c3a3d" stroke-width="2"/>
-      <text x="1044" y="176" text-anchor="middle" font-family="#{font()}" font-size="56" font-weight="700" letter-spacing="1" fill="#35d6de">#{escape(Card.group_initials(group_name))}</text>
-      <text x="72" y="#{title_top - 60}" font-family="#{font()}" font-size="22" font-weight="600" letter-spacing="2" fill="#{eyebrow_colour(huddl)}">#{escape(String.upcase(eyebrow(huddl, group_name)))}</text>
+      <text x="1044" y="176" text-anchor="middle" font-family="#{font()}" font-size="56" font-weight="700" letter-spacing="1" fill="#35d6de">#{escape(card.initials)}</text>
+      <text x="72" y="#{title_top - 60}" font-family="#{font()}" font-size="22" font-weight="600" letter-spacing="2" fill="#{card.eyebrow_colour}">#{escape(String.upcase(card.eyebrow))}</text>
     #{title_markup(title_lines, title_top)}
-      <text x="72" y="#{detail_top}" font-family="#{font()}" font-size="30" font-weight="500" fill="#b3bfc1">#{escape(when_line(huddl))}</text>
-    #{place_markup(huddl, detail_top + 48)}
+      <text x="72" y="#{detail_top}" font-family="#{font()}" font-size="30" font-weight="500" fill="#b3bfc1">#{escape(card.detail)}</text>
+    #{secondary_markup(card.secondary, detail_top + 48)}
     </svg>
     """
   end
@@ -69,14 +114,10 @@ defmodule HuddlzWeb.OgImage do
     end)
   end
 
-  defp place_markup(huddl, y) do
-    case place_line(huddl) do
-      nil ->
-        ""
+  defp secondary_markup(nil, _y), do: ""
 
-      place ->
-        ~s(  <text x="72" y="#{y}" font-family="#{font()}" font-size="28" fill="#7f8c8f">#{escape(place)}</text>)
-    end
+  defp secondary_markup(text, y) do
+    ~s(  <text x="72" y="#{y}" font-family="#{font()}" font-size="28" fill="#7f8c8f">#{escape(text)}</text>)
   end
 
   defp font, do: "Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif"
@@ -91,6 +132,34 @@ defmodule HuddlzWeb.OgImage do
   defp eyebrow_colour(%{status: :cancelled}), do: "#e84fb4"
   defp eyebrow_colour(%{status: :completed}), do: "#7f8c8f"
   defp eyebrow_colour(_huddl), do: "#35d6de"
+
+  defp group_eyebrow(%{member_count: 1}), do: "Group · 1 member"
+
+  defp group_eyebrow(%{member_count: count}) when is_integer(count),
+    do: "Group · #{count} members"
+
+  defp group_eyebrow(_group), do: "Group"
+
+  # The description runs on a single muted line, so keep the first sentence
+  # or so and end a cut-off description with an ellipsis.
+  defp description_line(%{description: description}) when not is_nil(description) do
+    description
+    |> to_string()
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+    |> case do
+      "" ->
+        nil
+
+      text when byte_size(text) <= @secondary_chars ->
+        text
+
+      text ->
+        String.slice(text, 0, @secondary_chars - 1) |> String.trim_trailing() |> Kernel.<>("…")
+    end
+  end
+
+  defp description_line(_group), do: nil
 
   defp when_line(huddl) do
     starts_at = DateTime.shift_zone!(huddl.starts_at, huddl.time_zone)

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -41,6 +41,7 @@ defmodule HuddlzWeb.Router do
     get "/sitemap.xml", SitemapController, :index
     get "/sitemap-:file", SitemapController, :child
     get "/og/huddlz/:id/card.png", OgImageController, :huddl
+    get "/og/groups/:slug/card.png", OgImageController, :group
   end
 
   scope "/gql" do

--- a/test/features/link_preview_image.feature
+++ b/test/features/link_preview_image.feature
@@ -1,8 +1,9 @@
 @database @conn
-Feature: Link previews for huddlz without a cover picture
-  When someone pastes a huddl link into a chat, the preview should carry a
-  picture even if the organizer never uploaded a cover. The picture cascades:
-  the huddl's own cover, then its group's cover, then a card drawn on the fly.
+Feature: Link previews without a cover picture
+  When someone pastes a huddl or group link into a chat, the preview should
+  carry a picture even if the organizer never uploaded a cover. For a huddl the
+  picture cascades: its own cover, then its group's cover, then a card drawn on
+  the fly. For a group: its cover, then a card.
 
   Scenario: A public huddl without a cover advertises a generated preview picture
     Given a public group "Phoenix Elixir Meetup" hosting an upcoming huddl "Hands-on with Ash Framework" with no cover picture
@@ -19,4 +20,15 @@ Feature: Link previews for huddlz without a cover picture
   Scenario: A private huddl has no preview picture to fetch
     Given a private huddl "Board planning session" with no cover picture
     When a link preview fetches that huddl's preview picture
+    Then there is nothing to fetch
+
+  Scenario: A public group without a cover advertises a generated preview picture
+    Given a public group "Phoenix Elixir Meetup" with no cover picture
+    When a link preview fetches the group page
+    Then the page advertises a generated group preview picture
+    And that picture is a 1200 by 630 PNG
+
+  Scenario: A private group has no preview picture to fetch
+    Given a private group "Board of directors"
+    When a link preview fetches that group's preview picture
     Then there is nothing to fetch

--- a/test/features/step_definitions/link_preview_image_steps.exs
+++ b/test/features/step_definitions/link_preview_image_steps.exs
@@ -133,4 +133,51 @@ defmodule LinkPreviewImageSteps do
     assert context.response.status == 404
     context
   end
+
+  step "a public group {string} with no cover picture", %{args: [group_name]} = context do
+    owner = generate(user(role: :user))
+
+    group =
+      generate(
+        group(
+          name: group_name,
+          is_public: true,
+          location: "Saint Augustine, FL",
+          owner_id: owner.id,
+          actor: owner
+        )
+      )
+
+    Map.put(context, :group, group)
+  end
+
+  step "a private group {string}", %{args: [group_name]} = context do
+    owner = generate(user(role: :user))
+    group = generate(group(name: group_name, is_public: false, owner_id: owner.id, actor: owner))
+    Map.put(context, :group, group)
+  end
+
+  step "a link preview fetches the group page", context do
+    html =
+      context.conn
+      |> get("/groups/#{context.group.slug}")
+      |> html_response(200)
+
+    Map.put(context, :page_html, html)
+  end
+
+  step "the page advertises a generated group preview picture", context do
+    [image_url] =
+      context.page_html
+      |> Floki.parse_document!()
+      |> Floki.attribute(~s(meta[property="og:image"]), "content")
+
+    assert image_url == HuddlzWeb.Endpoint.url() <> "/og/groups/#{context.group.slug}/card.png"
+
+    Map.put(context, :image_url, image_url)
+  end
+
+  step "a link preview fetches that group's preview picture", context do
+    Map.put(context, :response, get(build_conn(), "/og/groups/#{context.group.slug}/card.png"))
+  end
 end

--- a/test/huddlz_web/controllers/og_image_controller_test.exs
+++ b/test/huddlz_web/controllers/og_image_controller_test.exs
@@ -10,7 +10,7 @@ defmodule HuddlzWeb.OgImageControllerTest do
     huddl =
       generate(huddl(group_id: group.id, creator_id: owner.id, is_private: false, actor: owner))
 
-    %{huddl: huddl}
+    %{huddl: huddl, group: group, owner: owner}
   end
 
   test "serves the card with a strong ETag and honours If-None-Match", %{conn: conn, huddl: huddl} do
@@ -31,5 +31,36 @@ defmodule HuddlzWeb.OgImageControllerTest do
 
   test "an unknown huddl is not found", %{conn: conn} do
     assert conn |> get(~p"/og/huddlz/#{Ecto.UUID.generate()}/card.png") |> response(404)
+  end
+
+  describe "group cards" do
+    test "serves the card with a strong ETag and honours If-None-Match", %{
+      conn: conn,
+      group: group
+    } do
+      first = get(conn, ~p"/og/groups/#{group.slug}/card.png")
+
+      assert first.status == 200
+      assert response_content_type(first, :png) =~ "image/png"
+      assert [etag] = get_resp_header(first, "etag")
+      assert ["public, max-age=3600"] = get_resp_header(first, "cache-control")
+
+      cached =
+        conn
+        |> put_req_header("if-none-match", etag)
+        |> get(~p"/og/groups/#{group.slug}/card.png")
+
+      assert cached.status == 304
+    end
+
+    test "a private group is not found", %{conn: conn, owner: owner} do
+      group = generate(group(is_public: false, owner_id: owner.id, actor: owner))
+
+      assert conn |> get(~p"/og/groups/#{group.slug}/card.png") |> response(404)
+    end
+
+    test "an unknown group is not found", %{conn: conn} do
+      assert conn |> get(~p"/og/groups/no-such-group/card.png") |> response(404)
+    end
   end
 end

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -132,6 +132,32 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
       assert meta_content(html, ~s(meta[name="twitter:card"])) == "summary_large_image"
     end
 
+    test "advertises a generated preview card when the group has no cover", %{
+      conn: conn,
+      group: group
+    } do
+      html =
+        conn
+        |> get(~p"/groups/#{group.slug}")
+        |> html_response(200)
+
+      card_url = HuddlzWeb.Endpoint.url() <> "/og/groups/#{group.slug}/card.png"
+      assert meta_content(html, ~s(meta[property="og:image"])) == card_url
+      assert meta_content(html, ~s(meta[name="twitter:image"])) == card_url
+    end
+
+    test "a private group advertises no preview picture", %{conn: conn, user: user} do
+      group = generate(group(owner_id: user.id, is_public: false, actor: user))
+
+      html =
+        conn
+        |> login(user)
+        |> get(~p"/groups/#{group.slug}")
+        |> html_response(200)
+
+      refute html =~ "/og/groups/"
+    end
+
     test "renders fallback description metadata", %{conn: conn, user: user} do
       group = generate(group(owner_id: user.id, is_public: true, actor: user, description: nil))
 

--- a/test/huddlz_web/og_image_test.exs
+++ b/test/huddlz_web/og_image_test.exs
@@ -68,4 +68,65 @@ defmodule HuddlzWeb.OgImageTest do
 
     assert {Image.width(image), Image.height(image)} == {OgImage.width(), OgImage.height()}
   end
+
+  describe "group cards" do
+    @group %{
+      name: Ash.CiString.new("Phoenix Elixir Meetup"),
+      member_count: 12,
+      location: "Saint Augustine, FL",
+      description:
+        Ash.CiString.new("Monthly hands-on sessions for Elixir folks in the Phoenix ecosystem.")
+    }
+
+    test "draws the member count, name, place and description" do
+      svg = OgImage.group_svg(@group)
+
+      assert svg =~ "GROUP · 12 MEMBERS"
+      assert svg =~ ">PE<"
+      assert svg =~ "Phoenix Elixir Meetup"
+      assert svg =~ "Saint Augustine, FL"
+      assert svg =~ "Monthly hands-on sessions for Elixir folks in the Phoenix ecosystem."
+    end
+
+    test "reads naturally for one member and for groups that meet online" do
+      svg = OgImage.group_svg(%{@group | member_count: 1, location: nil, description: nil})
+
+      assert svg =~ "GROUP · 1 MEMBER<"
+      assert svg =~ "Meets online"
+    end
+
+    test "keeps the description to one line with an ellipsis" do
+      long = String.duplicate("A community for people who like long words. ", 4)
+      svg = OgImage.group_svg(%{@group | description: long})
+
+      assert [_, line] = Regex.run(~r/fill="#7f8c8f">([^<]+)<\/text>/, svg)
+      assert String.ends_with?(line, "…")
+      assert String.length(line) <= 72
+    end
+
+    test "escapes markup in group names and descriptions" do
+      svg =
+        OgImage.group_svg(%{
+          @group
+          | name: "Tom & Jerry <b>fans</b>",
+            description: ~s|<script>alert("x")</script>|
+        })
+
+      refute svg =~ "<script>"
+      refute svg =~ "<b>"
+      assert svg =~ "Tom &amp; Jerry"
+    end
+
+    test "the ETag changes with what is drawn" do
+      assert OgImage.group_etag(@group) == OgImage.group_etag(@group)
+      refute OgImage.group_etag(@group) == OgImage.group_etag(%{@group | member_count: 13})
+    end
+
+    test "renders to a PNG of the advertised size" do
+      {:ok, png} = OgImage.group_card(@group)
+      {:ok, image} = Image.from_binary(png)
+
+      assert {Image.width(image), Image.height(image)} == {OgImage.width(), OgImage.height()}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #475. A group page advertised no `og:image` until an organizer uploaded a cover, so a pasted group link unfurled as text in chat apps. Public groups now fall back to a generated card.

- **`GET /og/groups/:slug/card.png`** draws the group with the same anatomy as the huddl card: the huddlz mark, the group's initials tile, an eyebrow with the member count, the name wrapped to at most two lines, the place or "Meets online", and one line of the description with an ellipsis. Same caching: a strong ETag from everything drawn, an hour of public caching, 304 on `If-None-Match`. Private and unknown groups are 404.
- The group page's `og:image` falls back to the card only for public groups. Uploaded covers keep winning, and the JSON-LD image is untouched.
- `OgImage` now has one private card layout that both the huddl and group cards feed, so the two stay identical in geometry and type.

## Verification

- `link_preview_image.feature` gains two scenarios: a public group without a cover advertises the card and it is a 1200×630 PNG; a private group's card is not found.
- Unit tests cover the member-count eyebrow (singular and plural), the online fallback, the single-line description, escaping, the ETag and the PNG size. Controller tests cover caching, the 304, and the private and unknown cases. The group page test covers the fallback and that private groups advertise nothing.
- `mix precommit` clean, exit code checked directly. No JS or CSS changed, so the Playwright suite was not rerun.
- Production font rendering is the same open item as #475: check a card fetched from production shows text after deploy.

Sample cards in the first comment.
