### PR TITLE
feat(ui): dock the RSVP action to the bottom edge on phones

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2033,6 +2033,56 @@ body .rsvp-state .btn-secondary { width: 100%; justify-content: center; }
 body .rsvp-state .btn-primary { height: 44px; font-size: 14px; }
 body .rsvp-state .rsvp-banner { width: 100%; }
 
+/* Docked RSVP on phones. The aside's RSVP block itself pins to the bottom
+   edge (so there is one control, not a copy), joined by a share shortcut
+   that only exists in the dock. Cards, drawers and toasts stack above it. */
+body .rsvp-dock-share { display: none; }
+
+@media (max-width: 760px) {
+  body .content-body:has(.rsvp-state[data-dock]) { padding-bottom: 112px; }
+
+  body .rsvp-state[data-dock] {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 40;
+    margin: 0;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    border-top: 1px solid var(--line);
+    background: color-mix(in srgb, var(--panel) 94%, transparent);
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+  }
+
+  body .rsvp-state[data-dock] .btn-primary.rsvp-cta { flex: 1 1 auto; width: auto; }
+  body .rsvp-state[data-dock] .btn-secondary.rsvp-cta { flex: 0 0 auto; width: auto; height: 44px; }
+  body .rsvp-state[data-dock] .rsvp-banner { flex: 1 1 0; min-width: 0; width: auto; height: 44px; }
+  body .rsvp-state[data-dock] .rsvp-banner span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  body .rsvp-state[data-dock] .virtual-link { flex: 1 1 100%; order: 10; }
+  body .rsvp-state[data-dock] .virtual-hint { display: none; }
+
+  body .rsvp-state[data-dock] .rsvp-dock-share {
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 auto;
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--soft);
+    cursor: pointer;
+  }
+
+  body .rsvp-state[data-dock] .rsvp-dock-share:hover { color: var(--accent-ink); border-color: var(--accent); }
+  body .rsvp-state[data-dock] .rsvp-dock-share:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+}
+
 /* Inline "Join virtually" link inside .facts .value */
 body .facts .value .virtual-link-text { color: var(--accent-ink); font-weight: 700; }
 body .facts .value .virtual-link-text:hover { text-decoration: underline; }

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -7,6 +7,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
   alias Huddlz.Communities
   alias Huddlz.Storage.HuddlCoverImages
   alias Huddlz.Storage.HuddlPhotos
+  alias HuddlzWeb.Components.Modal
   alias HuddlzWeb.HuddlStatus
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.MetaHelpers
@@ -375,8 +376,18 @@ defmodule HuddlzWeb.HuddlLive.Show do
             <span style={"width:#{capacity_percent(@huddl)}%"}></span>
           </div>
 
-          <div class="rsvp-state">
+          <div class="rsvp-state" data-dock={dock_rsvp?(@huddl)}>
             {render_rsvp_state(assigns)}
+            <button
+              :if={dock_rsvp?(@huddl)}
+              type="button"
+              id="huddl-rsvp-share"
+              class="rsvp-dock-share"
+              aria-label="Share this huddl"
+              phx-click={Modal.show_modal("share-huddl-modal")}
+            >
+              <.icon name="hero-share" class="size-5" />
+            </button>
           </div>
 
           <div class="huddl-side-section">
@@ -802,6 +813,12 @@ defmodule HuddlzWeb.HuddlLive.Show do
       """
     end
   end
+
+  # On phones the RSVP block is pinned to the bottom edge, but only while
+  # there is something to do: a finished, cancelled or draft huddl shows a
+  # status banner that can stay in the aside.
+  defp dock_rsvp?(%{status: status}) when status in [:draft, :completed, :cancelled], do: nil
+  defp dock_rsvp?(_huddl), do: true
 
   defp rsvp_sign_in_path(group_slug, huddl_id) do
     return_to = "/groups/#{group_slug}/huddlz/#{huddl_id}"

--- a/test/browser/features/mobile_rsvp.feature
+++ b/test/browser/features/mobile_rsvp.feature
@@ -1,0 +1,13 @@
+@browser_smoke @mobile @rsvp_browser
+Feature: RSVP within reach on a phone
+  On a narrow screen the RSVP panel sits below the cover, title and
+  description, so the primary action would otherwise be off screen. It is
+  docked to the bottom edge instead, and stays there as the page scrolls.
+
+  Scenario: The RSVP action is docked to the bottom of a narrow screen
+    Given I am viewing an upcoming huddl in a narrow browser
+    Then the RSVP button is docked to the bottom edge before I scroll
+    When I scroll to the end of the page
+    Then the dock still sits on the bottom edge and covers nothing
+    When I RSVP from the dock
+    Then the dock shows I am attending and offers to cancel

--- a/test/browser/steps/mobile_rsvp_steps.exs
+++ b/test/browser/steps/mobile_rsvp_steps.exs
@@ -1,0 +1,96 @@
+defmodule BrowserMobileRsvpSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+
+  step "I am viewing an upcoming huddl in a narrow browser", context do
+    owner = generate(user(display_name: "Sam Rivera"))
+    member = generate(user(display_name: "Ada Park"))
+    group = generate(group(owner_id: owner.id, actor: owner))
+    generate(group_member(group_id: group.id, user_id: member.id, role: :member))
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          is_private: false,
+          description: String.duplicate("Bring a laptop and questions. ", 40),
+          actor: owner
+        )
+      )
+
+    conn =
+      context.conn
+      |> sign_in(member)
+      |> visit("/groups/#{group.slug}/huddlz/#{huddl.id}")
+      |> assert_has(".phx-connected")
+
+    Map.merge(context, %{conn: conn, huddl: huddl})
+  end
+
+  step "the RSVP button is docked to the bottom edge before I scroll", context do
+    assert_browser(context.conn, """
+    (() => {
+      const dock = document.querySelector('.rsvp-state[data-dock]');
+      if (!dock) return false;
+      const rect = dock.getBoundingClientRect();
+      const button = dock.querySelector('.rsvp-cta').getBoundingClientRect();
+      return Math.abs(rect.bottom - innerHeight) < 1 &&
+        button.top >= rect.top && button.bottom <= rect.bottom &&
+        document.documentElement.scrollWidth <= innerWidth;
+    })()
+    """)
+
+    context
+  end
+
+  step "I scroll to the end of the page", context do
+    assert_browser(context.conn, """
+    (() => {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      return window.scrollY > 0;
+    })()
+    """)
+
+    context
+  end
+
+  step "the dock still sits on the bottom edge and covers nothing", context do
+    assert_browser(context.conn, """
+    (() => {
+      const dock = document.querySelector('.rsvp-state[data-dock]').getBoundingClientRect();
+      const last = document.querySelector('#huddl-group').getBoundingClientRect();
+      return Math.abs(dock.bottom - innerHeight) < 1 && last.bottom <= dock.top;
+    })()
+    """)
+
+    context
+  end
+
+  step "I RSVP from the dock", context do
+    Map.put(
+      context,
+      :conn,
+      click_button(context.conn, ".rsvp-state[data-dock]", "RSVP to this huddl")
+    )
+  end
+
+  step "the dock shows I am attending and offers to cancel", context do
+    conn =
+      context.conn
+      |> assert_has(".rsvp-state[data-dock] .rsvp-banner.cyan", text: "You're attending")
+      |> assert_has(".rsvp-state[data-dock] button", text: "Cancel RSVP")
+
+    assert_browser(conn, """
+    (() => {
+      const dock = document.querySelector('.rsvp-state[data-dock]').getBoundingClientRect();
+      return Math.abs(dock.bottom - innerHeight) < 1 && document.documentElement.scrollWidth <= innerWidth;
+    })()
+    """)
+
+    Map.put(context, :conn, conn)
+  end
+end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -273,6 +273,30 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has(".facts .value", text: "2 people attending")
     end
 
+    test "docks the RSVP block with a share shortcut while there is something to do", %{
+      conn: conn,
+      member: member,
+      owner: owner,
+      group: group,
+      huddl: huddl
+    } do
+      session =
+        conn
+        |> login(member)
+        |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}")
+        |> assert_has(".rsvp-state[data-dock] .rsvp-cta", text: "RSVP to this huddl")
+        |> assert_has(
+          ".rsvp-state[data-dock] #huddl-rsvp-share[aria-label='Share this huddl'][phx-click*='share-huddl-modal']"
+        )
+
+      Communities.cancel_huddl!(huddl, "Cancelled", actor: owner)
+
+      session
+      |> assert_has(".rsvp-state .rsvp-banner", text: "cancelled")
+      |> refute_has(".rsvp-state[data-dock]")
+      |> refute_has("#huddl-rsvp-share")
+    end
+
     test "shows virtual link after RSVP", %{
       conn: conn,
       member: member,


### PR DESCRIPTION
## Summary

On a phone the huddl page stacks cover, title and description above the RSVP panel, so the primary action started below the fold. It is now docked to the bottom edge, as the mobile huddl artboard on the design canvas shows.

- **The aside's RSVP block itself is the dock.** At phone widths `.rsvp-state` becomes a fixed bar on the bottom edge (panel background at 94% with blur, top rule, safe-area padding) with the same buttons laid out in a row. There is one RSVP control in the page, not a copy, so every existing state (RSVP, waitlist, attending with cancel, sign in) and every existing test keeps working unchanged.
- **A share shortcut lives only in the dock**: a 44px icon button that opens the QR code modal. The aside keeps its Email and QR code buttons.
- **Only while there is something to do.** A draft, completed or cancelled huddl shows its status banner in the aside as before, and no dock appears.
- The dock sits above the sticky topbar and below the navigation drawer, modals and toasts. The page gets extra bottom clearance so the last row is never under the bar. The attending banner truncates with an ellipsis at 320px so the row never wraps; the online room link, when present, takes a full row beneath it.

## Verification

- New browser scenario `mobile_rsvp.feature` at a 320×720 viewport: the RSVP button is on the bottom edge before scrolling, still there after scrolling to the end with the last content row above it, and an RSVP from the dock swaps it to the attending row with a cancel button and no horizontal overflow.
- Show-page test covers the dock attribute and the share shortcut for an upcoming huddl, and both gone once the huddl is cancelled.
- `mix precommit` clean and the Playwright suite green, exit codes checked directly.

Screenshots at 390px in the first comment: top of page, end of page, attending, and the share modal over the dock.
