### PR TITLE
feat(ui): add owner-only group settings and danger zone

### DIFF
--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -33,7 +33,7 @@ defmodule HuddlzWeb.Layouts do
 
   attr :active_organize_section, :atom,
     default: nil,
-    values: [nil, :overview, :huddlz, :members],
+    values: [nil, :overview, :huddlz, :members, :settings],
     doc: "active sub-tab inside an organize-group section"
 
   attr :sidebar_owned_groups, :list,
@@ -157,6 +157,14 @@ defmodule HuddlzWeb.Layouts do
                   aria-current={@active_organize_section == :members && "page"}
                 >
                   Members
+                </.link>
+                <.link
+                  :if={group.owner_id == @current_user.id}
+                  class={["sb-sub-item", @active_organize_section == :settings && "active"]}
+                  navigate={~p"/organize/#{group.slug}/settings"}
+                  aria-current={@active_organize_section == :settings && "page"}
+                >
+                  Group settings
                 </.link>
               </div>
             <% end %>

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -423,7 +423,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
         >Restore group</.button>
         <.link
           :if={@group.archived_at}
-          navigate={~p"/organize/#{@group.slug}/members"}
+          navigate={~p"/organize/#{@group.slug}/settings"}
           class="btn-secondary"
         >Manage ownership</.link>
       </section>

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -10,6 +10,7 @@ defmodule HuddlzWeb.OrganizeLive do
     * `/organize/:group_slug` — overview (KPIs + upcoming huddlz)
     * `/organize/:group_slug/huddlz` — huddlz list, lifecycle filters
     * `/organize/:group_slug/members` — roster grouped by role
+    * `/organize/:group_slug/settings` — owner-only group administration
   """
   use HuddlzWeb, :live_view
 
@@ -59,6 +60,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
     socket =
       socket
+      |> assign(:pending_member_action, nil)
       |> assign(:huddlz_filter, parse_huddlz_filter(params["filter"]))
       |> load_action(action, params, user)
 
@@ -116,6 +118,16 @@ defmodule HuddlzWeb.OrganizeLive do
     |> assign_members(members)
     |> assign(:invitation_count, length(invitations))
     |> stream(:invitations, invitations, reset: true)
+  end
+
+  defp load_section(socket, :settings, group, user) when group.owner_id == user.id do
+    assign_members(socket, list_group_members(group, user))
+  end
+
+  defp load_section(socket, :settings, group, _user) do
+    socket
+    |> assign(:pending_member_action, nil)
+    |> push_navigate(to: ~p"/organize/#{group.slug}")
   end
 
   defp load_group(slug, user) do
@@ -251,7 +263,7 @@ defmodule HuddlzWeb.OrganizeLive do
           :if={@group.owner_id == @current_user.id || @current_user.role == :admin}
           navigate={~p"/groups/#{@group.slug}/edit"}
           class="btn-secondary"
-        >Group settings</.link>
+        >Manage archival</.link>
       </section>
       <%= case @live_action do %>
         <% :index -> %>
@@ -273,8 +285,6 @@ defmodule HuddlzWeb.OrganizeLive do
             organizer_members={@streams.organizer_members}
             regular_members={@streams.regular_members}
             role_counts={@member_role_counts}
-            transfer_candidates={@transfer_candidates}
-            transfer_target_form={@transfer_target_form}
             current_user={@current_user}
           />
           <.invitations_view
@@ -284,6 +294,13 @@ defmodule HuddlzWeb.OrganizeLive do
             invitation_form={@invitation_form}
             invitations={@streams.invitations}
             invitation_count={@invitation_count}
+          />
+        <% :settings -> %>
+          <.settings_view
+            :if={@group.owner_id == @current_user.id}
+            group={@group}
+            transfer_candidates={@transfer_candidates}
+            transfer_target_form={@transfer_target_form}
           />
       <% end %>
 
@@ -300,6 +317,7 @@ defmodule HuddlzWeb.OrganizeLive do
   defp active_section(:overview), do: :overview
   defp active_section(:huddlz), do: :huddlz
   defp active_section(:members), do: :members
+  defp active_section(:settings), do: :settings
   defp active_section(_), do: nil
 
   # ─────────────────────────────────────────  PICKER (/organize)  ───
@@ -582,8 +600,6 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :organizer_members, :any, required: true
   attr :regular_members, :any, required: true
   attr :role_counts, :map, required: true
-  attr :transfer_candidates, :list, required: true
-  attr :transfer_target_form, Phoenix.HTML.Form, required: true
   attr :current_user, :map, required: true
 
   attr :can_edit_group, :boolean, required: true
@@ -595,17 +611,7 @@ defmodule HuddlzWeb.OrganizeLive do
       {:member, assigns.regular_members, assigns.role_counts.member}
     ]
 
-    assigns =
-      assigns
-      |> assign(:grouped, grouped)
-      |> assign(
-        :can_transfer_ownership,
-        assigns.group.owner_id == assigns.current_user.id and assigns.transfer_candidates != []
-      )
-      |> assign(
-        :transfer_candidate_options,
-        Enum.map(assigns.transfer_candidates, &{member_name(&1), &1.id})
-      )
+    assigns = assign(assigns, :grouped, grouped)
 
     ~H"""
     <div class="page-head">
@@ -660,23 +666,61 @@ defmodule HuddlzWeb.OrganizeLive do
         </div>
       <% end %>
     </div>
+    """
+  end
+
+  attr :group, :map, required: true
+  attr :transfer_candidates, :list, required: true
+  attr :transfer_target_form, Phoenix.HTML.Form, required: true
+
+  defp settings_view(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :transfer_candidate_options,
+        Enum.map(assigns.transfer_candidates, &{member_name(&1), &1.id})
+      )
+
+    ~H"""
+    <div class="page-head">
+      <div>
+        <h1>Group settings</h1>
+        <p>Owner-only administration for {@group.name}.</p>
+      </div>
+    </div>
+    <section id="group-details-settings" class="panel">
+      <div class="panel-head">
+        <h2>Group details</h2>
+      </div>
+      <p class="muted">Manage the group's details, cover image, visibility, and archival.</p>
+      <.link
+        id="edit-group-details"
+        navigate={~p"/groups/#{@group.slug}/edit"}
+        class="btn-secondary mt-4"
+      >
+        Edit group details
+      </.link>
+    </section>
 
     <section
-      :if={@can_transfer_ownership}
       id="ownership-danger-zone"
       class="panel mt-6 border-error/40"
       aria-labelledby="ownership-danger-zone-title"
     >
       <div class="panel-head">
         <div>
-          <h2 id="ownership-danger-zone-title">Ownership</h2>
+          <h2 id="ownership-danger-zone-title">Danger zone</h2>
           <p class="panel-sub">
             Transfer final control of this group. You will remain an organizer.
           </p>
         </div>
       </div>
 
+      <p :if={@transfer_candidates == []} class="muted mt-4">
+        Add a member before transferring ownership.
+      </p>
       <.form
+        :if={@transfer_candidates != []}
         for={@transfer_target_form}
         id="transfer-ownership-target-form"
         phx-submit="open_transfer_action"
@@ -948,7 +992,7 @@ defmodule HuddlzWeb.OrganizeLive do
   def handle_event(
         "open_transfer_action",
         %{"transfer_target" => %{"member_id" => id}},
-        socket
+        %{assigns: %{live_action: :settings}} = socket
       ) do
     open_member_action(socket, id, :transfer)
   end
@@ -1085,8 +1129,9 @@ defmodule HuddlzWeb.OrganizeLive do
     end
   end
 
-  defp refresh_members_if_visible(%{assigns: %{live_action: :members}} = socket, group, user) do
-    load_section(socket, :members, group, user)
+  defp refresh_members_if_visible(%{assigns: %{live_action: action}} = socket, group, user)
+       when action in [:members, :settings] do
+    load_section(socket, action, group, user)
   end
 
   defp refresh_members_if_visible(socket, _group, _user), do: socket
@@ -1155,7 +1200,6 @@ defmodule HuddlzWeb.OrganizeLive do
   defp parse_member_action("promote"), do: {:ok, :promote}
   defp parse_member_action("demote"), do: {:ok, :demote}
   defp parse_member_action("remove"), do: {:ok, :remove}
-  defp parse_member_action("transfer"), do: {:ok, :transfer}
   defp parse_member_action(_action), do: :error
 
   defp confirmation_valid?(:transfer, socket) do
@@ -1201,7 +1245,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp member_action_description(%{type: :transfer}, group),
     do:
-      "You will become an organizer. The new owner will control #{group.name}, including roles and ownership."
+      "The selected member becomes the owner of #{group.name}. You will become an organizer. You cannot reverse this transfer without the new owner’s cooperation."
 
   defp member_action_confirm_label(:promote), do: "Promote to organizer"
   defp member_action_confirm_label(:demote), do: "Demote to member"

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -128,6 +128,7 @@ defmodule HuddlzWeb.Router do
       live "/organize/:group_slug", OrganizeLive, :overview
       live "/organize/:group_slug/huddlz", OrganizeLive, :huddlz
       live "/organize/:group_slug/members", OrganizeLive, :members
+      live "/organize/:group_slug/settings", OrganizeLive, :settings
 
       # Group routes
       live "/groups/new", GroupLive.New, :new

--- a/test/features/group_settings.feature
+++ b/test/features/group_settings.feature
@@ -1,0 +1,38 @@
+@database @conn @group_settings
+Feature: Owner-only group settings
+  Owners manage group governance separately from the member roster.
+
+  Scenario: The owner opens settings from the organizer workspace
+    Given the following users exist:
+      | email             | role | display_name |
+      | owner@example.com | user | Owner        |
+    And a public group "Council" exists with owner "owner@example.com"
+    And I am signed in as "owner@example.com"
+    When I visit "/organize/council/members"
+    Then I should not see "Transfer group ownership"
+    When I click "Group settings"
+    Then I should see "Danger zone"
+    And I should see "Edit group details"
+    And I should see "Add a member before transferring ownership"
+
+  Scenario: Transfer keeps the former owner in the organizer workspace
+    Given the following users exist:
+      | email              | role | display_name |
+      | owner@example.com  | user | Owner        |
+      | member@example.com | user | Successor    |
+    And a public group "Council" exists with owner "owner@example.com"
+    And "member@example.com" is a member of "Council"
+    And I am signed in as "owner@example.com"
+    When I visit "/organize/council/settings"
+    And I select "Successor" from "New owner"
+    And I click "Transfer group ownership"
+    Then I should see "The selected member becomes the owner of Council"
+    And I should see "You will become an organizer"
+    And I should see "cannot reverse this transfer without the new owner’s cooperation"
+    When I fill in "Type Council to confirm" with "Council"
+    And I click "Transfer ownership"
+    Then I should see "Ownership transferred to Successor"
+    And I should not see "Group settings"
+    When I click "Members"
+    Then I should see "Successor"
+    And I should not see "Transfer group ownership"

--- a/test/features/step_definitions/group_membership_visibility_steps.exs
+++ b/test/features/step_definitions/group_membership_visibility_steps.exs
@@ -51,7 +51,7 @@ defmodule GroupMembershipVisibilitySteps do
 
     Phoenix.ConnTest.build_conn()
     |> login(owner)
-    |> visit("/organize/#{group.slug}/members")
+    |> visit("/organize/#{group.slug}/settings")
     |> select("New owner", option: target.display_name)
     |> click_button("Transfer group ownership")
     |> fill_in("Type #{name} to confirm", with: name)

--- a/test/huddlz/communities/group_test.exs
+++ b/test/huddlz/communities/group_test.exs
@@ -654,6 +654,13 @@ defmodule Huddlz.Communities.GroupTest do
 
       assert Enum.any?(memberships, &(&1.user_id == new_owner.id and &1.role == :owner))
       assert Enum.any?(memberships, &(&1.user_id == owner.id and &1.role == :organizer))
+
+      assert {:ok, _} = Huddlz.Communities.get_group_for_organize(transferred.slug, actor: owner)
+      refute Ash.can?({transferred, :update_details}, owner)
+      refute Ash.can?({transferred, :transfer_ownership, %{new_owner_id: owner.id}}, owner)
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               Huddlz.Communities.transfer_group_ownership(transferred, owner.id, actor: owner)
     end
 
     test "owner cannot transfer ownership to a non-member", %{
@@ -688,6 +695,21 @@ defmodule Huddlz.Communities.GroupTest do
                group
                |> Ash.Changeset.for_update(:transfer_ownership, %{new_owner_id: target.id})
                |> Ash.update(actor: stranger)
+    end
+
+    for role <- [:member, :organizer] do
+      test "#{role} cannot transfer ownership", %{owner: owner, group: group} do
+        member = generate(user(role: :user))
+
+        generate(
+          group_member(group_id: group.id, user_id: member.id, role: unquote(role), actor: owner)
+        )
+
+        refute Ash.can?({group, :transfer_ownership, %{new_owner_id: member.id}}, member)
+
+        assert {:error, %Ash.Error.Forbidden{}} =
+                 Huddlz.Communities.transfer_group_ownership(group, member.id, actor: member)
+      end
     end
 
     test "rejects transferring ownership to the existing owner", %{owner: owner, group: group} do

--- a/test/huddlz_web/live/organize_live_members_test.exs
+++ b/test/huddlz_web/live/organize_live_members_test.exs
@@ -7,6 +7,8 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
   alias Huddlz.Communities.Group
   alias Huddlz.Communities.GroupMember
 
+  @moduletag :organize_members
+
   setup do
     owner = generate(user(role: :user, display_name: "Owner Olivia"))
     organizer = generate(user(role: :user, display_name: "Organizer Oscar"))
@@ -46,8 +48,8 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     |> assert_has("#remove-member-#{member_membership.id}", text: "Remove")
     |> assert_has("#demote-member-#{organizer_membership.id}", text: "Demote")
     |> assert_has("#remove-member-#{organizer_membership.id}", text: "Remove")
-    |> assert_has("#ownership-danger-zone")
-    |> assert_has("#open-transfer-ownership", text: "Transfer group ownership")
+    |> refute_has("#ownership-danger-zone")
+    |> refute_has("#open-transfer-ownership")
     |> refute_has("[id^='transfer-owner-']")
     |> refute_has("[id^='remove-member-']", text: "Owner Olivia")
   end
@@ -186,10 +188,13 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
     session =
       conn
       |> login(owner)
-      |> visit(~p"/organize/#{group.slug}/members")
+      |> visit(~p"/organize/#{group.slug}/settings")
       |> select("New owner", option: "Organizer Oscar")
       |> click_button("#open-transfer-ownership", "Transfer group ownership")
       |> assert_has("#member-action-dialog-title", text: "Transfer ownership to Organizer Oscar?")
+      |> assert_has("#member-action-dialog",
+        text: "cannot reverse this transfer without the new owner’s cooperation"
+      )
       |> assert_has("#member-action-confirm[disabled]", text: "Transfer ownership")
 
     session =
@@ -202,6 +207,11 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
       click_button(session, "Transfer ownership")
     end)
     |> assert_has("div[role='alert']", text: "Ownership transferred to Organizer Oscar.")
+    |> assert_path(~p"/organize/#{group.slug}")
+    |> refute_has("a[href='/organize/#{group.slug}/settings']")
+    |> click_link("Members")
+    |> assert_has("#member-member-rows")
+    |> refute_has("#ownership-danger-zone")
 
     reloaded_group = Ash.get!(Group, group.id, authorize?: false)
     assert reloaded_group.owner_id == organizer.id
@@ -212,6 +222,83 @@ defmodule HuddlzWeb.OrganizeLiveMembersTest do
 
     assert memberships[owner.id] == :organizer
     assert memberships[organizer.id] == :owner
+  end
+
+  test "organizers cannot see settings or open them directly", %{
+    conn: conn,
+    organizer: organizer,
+    group: group
+  } do
+    conn = login(conn, organizer)
+    {:ok, view, _} = live(conn, ~p"/organize/#{group.slug}/members")
+    refute has_element?(view, "a[href='/organize/#{group.slug}/settings']")
+
+    assert {:error, {:live_redirect, %{to: path}}} =
+             live(conn, ~p"/organize/#{group.slug}/settings")
+
+    assert path == ~p"/organize/#{group.slug}"
+  end
+
+  test "regular members cannot open settings directly", %{
+    conn: conn,
+    member: member,
+    group: group
+  } do
+    assert {:error, {:live_redirect, %{to: "/organize"}}} =
+             conn |> login(member) |> live(~p"/organize/#{group.slug}/settings")
+  end
+
+  test "transfer rejects wrong confirmation and cancellation leaves ownership unchanged", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    member_membership: membership
+  } do
+    {:ok, view, _} = conn |> login(owner) |> live(~p"/organize/#{group.slug}/settings")
+
+    view
+    |> form("#transfer-ownership-target-form", transfer_target: %{member_id: membership.id})
+    |> render_submit()
+
+    view
+    |> form("#member-action-form", member_action: %{confirmation: "wrong"})
+    |> render_change()
+
+    render_submit(view, "confirm_member_action", %{})
+    assert has_element?(view, "#member-action-confirm[disabled]")
+    assert has_element?(view, "[role='alert']", "Type the group name exactly")
+    view |> element("#member-action-cancel") |> render_click()
+    refute has_element?(view, "#member-action-dialog")
+    assert has_element?(view, "#ownership-danger-zone")
+    assert Ash.get!(Group, group.id, actor: owner).owner_id == owner.id
+  end
+
+  test "a mounted settings page loses access when ownership changes elsewhere", %{
+    conn: conn,
+    owner: owner,
+    member: member,
+    group: group
+  } do
+    {:ok, view, _} = conn |> login(owner) |> live(~p"/organize/#{group.slug}/settings")
+    assert {:ok, _} = Communities.transfer_group_ownership(group, member.id, actor: owner)
+    assert_redirect(view, ~p"/organize/#{group.slug}")
+  end
+
+  test "the roster rejects forged transfer controls", %{
+    conn: conn,
+    owner: owner,
+    group: group,
+    member_membership: membership
+  } do
+    {:ok, view, _} = conn |> login(owner) |> live(~p"/organize/#{group.slug}/members")
+
+    render_submit(view, "open_transfer_action", %{
+      "transfer_target" => %{"member_id" => membership.id}
+    })
+
+    refute has_element?(view, "#member-action-dialog")
+    render_click(view, "open_member_action", %{"id" => membership.id, "action" => "transfer"})
+    refute has_element?(view, "#member-action-dialog")
   end
 
   test "an already-mounted organizer workspace redirects after role loss", %{


### PR DESCRIPTION
Group owners can open Group settings from the organizer workspace. Ownership transfer now lives in a separate Danger zone, with an existing-member chooser, explicit consequences, and typed group-name confirmation. The former owner retains organizer access; group details and archival remain in the linked editor.

Closes #369.
