### PR TITLE
feat(ui): explain empty pages on an account's first run

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2908,7 +2908,13 @@ body .empty-state p {
   color: var(--muted);
 }
 
-body .empty-state-action { margin-top: 4px; }
+body .empty-state-action {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
 
 /* Sub-section inside huddl-side */
 body .huddl-side-section {

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -46,10 +46,8 @@ defmodule HuddlzWeb.CalendarLive do
     {grid_start, grid_end} = month_grid_window(focus_month)
     user = socket.assigns.current_user
 
-    entries =
-      user
-      |> load_entries(grid_start, grid_end, socket.assigns.time_zone)
-      |> Enum.map(&put_calendar_time(&1, socket.assigns.time_zone))
+    {entries, first_run?} = load_entries(user, grid_start, grid_end, socket.assigns.time_zone)
+    entries = Enum.map(entries, &put_calendar_time(&1, socket.assigns.time_zone))
 
     entries_by_day = group_by_day(entries)
     in_month_count = Enum.count(entries, &in_focus_month?(&1, focus_month))
@@ -62,6 +60,7 @@ defmodule HuddlzWeb.CalendarLive do
      |> assign(:grid_start, grid_start)
      |> assign(:grid_end, grid_end)
      |> assign(:entries, entries)
+     |> assign(:first_run?, first_run?)
      |> assign(:entries_by_day, entries_by_day)
      |> assign(:in_month_count, in_month_count)
      |> assign(:legend_empty?, legend_items == [])
@@ -102,19 +101,28 @@ defmodule HuddlzWeb.CalendarLive do
     {grid_start, grid_end}
   end
 
+  # Returns the entries inside the visible grid and whether the account has
+  # no huddlz in any month at all (a first run): the search already fetches
+  # every huddl the person hosts, attends or waits on, so the answer is free.
   defp load_entries(user, grid_start, grid_end, time_zone) do
     grid_start_dt = utc_boundary(grid_start, ~T[00:00:00], time_zone)
     grid_end_dt = utc_boundary(grid_end, ~T[23:59:59], time_zone)
 
-    [:hosting, :attending, :waitlisted]
-    |> Enum.flat_map(fn role -> fetch(user, role) end)
-    |> merge_entry_roles()
-    |> Enum.filter(fn %{huddl: h} ->
-      h.starts_at &&
-        DateTime.compare(h.starts_at, grid_start_dt) != :lt &&
-        DateTime.compare(h.starts_at, grid_end_dt) != :gt
-    end)
-    |> Enum.sort_by(& &1.huddl.starts_at, DateTime)
+    all =
+      [:hosting, :attending, :waitlisted]
+      |> Enum.flat_map(fn role -> fetch(user, role) end)
+      |> merge_entry_roles()
+
+    entries =
+      all
+      |> Enum.filter(fn %{huddl: h} ->
+        h.starts_at &&
+          DateTime.compare(h.starts_at, grid_start_dt) != :lt &&
+          DateTime.compare(h.starts_at, grid_end_dt) != :gt
+      end)
+      |> Enum.sort_by(& &1.huddl.starts_at, DateTime)
+
+    {entries, all == []}
   end
 
   defp fetch(user, role) do
@@ -466,8 +474,14 @@ defmodule HuddlzWeb.CalendarLive do
           entries_by_day={@entries_by_day}
           today={@today}
         />
+        <.first_run_empty :if={@first_run?} />
       <% else %>
-        <.agenda_view entries={@entries} focus_month={@focus_month} today={@today} />
+        <.agenda_view
+          entries={@entries}
+          focus_month={@focus_month}
+          today={@today}
+          first_run?={@first_run?}
+        />
       <% end %>
 
       <div
@@ -619,40 +633,65 @@ defmodule HuddlzWeb.CalendarLive do
     if Date.compare(day, today) == :eq, do: "cal-day-num is-today", else: "cal-day-num"
   end
 
+  # The calendar's first run: no huddl in any month. Says what the page
+  # holds and offers the action that fills it.
+  defp first_run_empty(assigns) do
+    ~H"""
+    <.empty_state
+      id="calendar-first-run"
+      icon="hero-calendar"
+      title="Your calendar is empty"
+      data-first-run
+    >
+      Huddlz you RSVP to show up here, in their own time zone.
+      <:action>
+        <.button variant={:primary} navigate={~p"/discover"}>
+          <.icon name="hero-magnifying-glass" class="size-4" /> Find a huddl
+        </.button>
+      </:action>
+    </.empty_state>
+    """
+  end
+
   attr :entries, :list, required: true
   attr :focus_month, Date, required: true
   attr :today, Date, required: true
+  attr :first_run?, :boolean, default: false
 
   defp agenda_view(assigns) do
     sorted = agenda_entries(assigns.entries, assigns.focus_month)
     assigns = assign(assigns, :sorted, sorted)
 
     ~H"""
-    <%= if @sorted == [] do %>
-      <.empty_state id="calendar-agenda-empty" icon="hero-calendar" title="Nothing this month">
-        Nothing on the calendar this month.
-      </.empty_state>
+    <%= if @first_run? do %>
+      <.first_run_empty />
     <% else %>
-      <div class="cal-agenda-panel">
-        <div class="row-list cal-agenda-list">
-          <.link
-            :for={entry <- @sorted}
-            id={"calendar-entry-#{entry.huddl.id}"}
-            navigate={huddl_path(entry)}
-            class="row cal-agenda-row"
-          >
-            <span class="meta">{format_agenda_when(entry.huddl)}</span>
-            <span class="row-title">{entry.huddl.title}</span>
-            <.pill
-              variant={entry_status(entry, @today).variant}
-              class="cal-entry-status"
-              data-status={entry_status(entry, @today).key}
+      <%= if @sorted == [] do %>
+        <.empty_state id="calendar-agenda-empty" icon="hero-calendar" title="Nothing this month">
+          Nothing on the calendar this month.
+        </.empty_state>
+      <% else %>
+        <div class="cal-agenda-panel">
+          <div class="row-list cal-agenda-list">
+            <.link
+              :for={entry <- @sorted}
+              id={"calendar-entry-#{entry.huddl.id}"}
+              navigate={huddl_path(entry)}
+              class="row cal-agenda-row"
             >
-              {entry_status(entry, @today).label}
-            </.pill>
-          </.link>
+              <span class="meta">{format_agenda_when(entry.huddl)}</span>
+              <span class="row-title">{entry.huddl.title}</span>
+              <.pill
+                variant={entry_status(entry, @today).variant}
+                class="cal-entry-status"
+                data-status={entry_status(entry, @today).key}
+              >
+                {entry_status(entry, @today).label}
+              </.pill>
+            </.link>
+          </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
     """
   end

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -410,9 +410,12 @@ defmodule HuddlzWeb.GroupLive.Show do
             icon={if @active_tab == "upcoming", do: "hero-calendar", else: "hero-clock"}
             title={if @active_tab == "upcoming", do: "Nothing scheduled", else: "No past huddlz"}
           >
-            {if @active_tab == "upcoming",
-              do: "No upcoming huddlz scheduled.",
-              else: "No past huddlz found."}
+            {empty_huddlz_message(@active_tab, @can_create_huddl)}
+            <:action :if={@active_tab == "upcoming" && @can_create_huddl}>
+              <.button variant={:secondary} navigate={~p"/groups/#{@group.slug}/huddlz/new"}>
+                <.icon name="hero-plus" class="size-4" /> Schedule a huddl
+              </.button>
+            </:action>
           </.empty_state>
           <.pagination
             :if={@active_tab == "past" && @past_total_pages > 1}
@@ -626,6 +629,13 @@ defmodule HuddlzWeb.GroupLive.Show do
       {:error, _} -> {:error, :not_found}
     end
   end
+
+  # Someone who can schedule for this group gets the organizer's version of
+  # the empty grid, with the action that fills it. Everyone else reads the
+  # plain fact.
+  defp empty_huddlz_message("upcoming", true), do: "Members will see your next huddl here."
+  defp empty_huddlz_message("upcoming", _can_create), do: "No upcoming huddlz scheduled."
+  defp empty_huddlz_message(_past, _can_create), do: "No past huddlz found."
 
   defp group_meta(group) do
     %{

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -150,7 +150,10 @@ defmodule HuddlzWeb.MyGroupsLive do
           <h1>My groups</h1>
           <p>{filter_blurb(@filter)}</p>
         </div>
-        <.button variant={:primary} navigate={~p"/groups/new"}>
+        <.button
+          variant={if @counts.all == 0, do: :secondary, else: :primary}
+          navigate={~p"/groups/new"}
+        >
           <.icon name="hero-plus" class="size-4" /> Start a group
         </.button>
       </div>
@@ -173,9 +176,19 @@ defmodule HuddlzWeb.MyGroupsLive do
       </div>
 
       <%= if Enum.empty?(@groups) do %>
-        <.empty_state icon={empty_icon(@filter)} title={empty_title(@filter)}>
+        <.empty_state
+          icon={empty_icon(@filter)}
+          title={empty_title(@filter)}
+          data-first-run={@filter == :all || nil}
+        >
           {empty_message(@filter)}
-          <:action :if={@filter != :hosting}>
+          <:action :if={@filter == :all}>
+            <.button variant={:primary} navigate={~p"/discover?scope=groups"}>
+              <.icon name="hero-magnifying-glass" class="size-4" /> Browse groups
+            </.button>
+            <.button variant={:secondary} navigate={~p"/groups/new"}>Start your own</.button>
+          </:action>
+          <:action :if={@filter == :joined}>
             <.button variant={:secondary} navigate={~p"/discover?scope=groups"}>
               Browse groups
             </.button>
@@ -237,11 +250,13 @@ defmodule HuddlzWeb.MyGroupsLive do
 
   defp empty_message(:archived), do: "Your archived groups will appear here."
 
+  # An empty "All" is a first run: the account belongs to no group at all,
+  # so this page explains what groups are for and offers both ways in.
   defp empty_message(:all),
-    do: "You haven't organized or joined any groups yet. Start one or browse Discover."
+    do: "Groups are where huddlz come from. Join one to follow its huddlz, or start your own."
 
-  defp empty_message(:hosting), do: "You haven't created a group yet."
-  defp empty_message(:joined), do: "You haven't joined any groups yet."
+  defp empty_message(:hosting), do: "Start a group and its huddlz will show up here."
+  defp empty_message(:joined), do: "Join a group to follow its huddlz here."
 
   defp role_class(:owner), do: "owner"
   defp role_class(:organizer), do: "organizer"

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -157,7 +157,10 @@ defmodule HuddlzWeb.MyHuddlzLive do
           <h1>My huddlz</h1>
           <p>{filter_blurb(@filter)}</p>
         </div>
-        <.button variant={:primary} navigate={~p"/discover"}>
+        <.button
+          variant={if first_run?(@counts), do: :secondary, else: :primary}
+          navigate={~p"/discover"}
+        >
           <.icon name="hero-magnifying-glass" class="size-4" /> Find another huddl
         </.button>
       </div>
@@ -183,10 +186,19 @@ defmodule HuddlzWeb.MyHuddlzLive do
       </div>
 
       <%= if Enum.empty?(@huddls) do %>
-        <.empty_state icon={empty_icon(@filter)} title={empty_title(@filter)}>
-          {empty_message(@filter)}
+        <.empty_state
+          icon={empty_icon(@filter)}
+          title={empty_title(@filter, first_run?(@counts))}
+          data-first-run={first_run?(@counts) || nil}
+        >
+          {empty_message(@filter, first_run?(@counts))}
           <:action :if={@filter == :upcoming}>
-            <.button variant={:secondary} navigate={~p"/discover"}>Browse huddlz</.button>
+            <.button :if={first_run?(@counts)} variant={:primary} navigate={~p"/discover"}>
+              <.icon name="hero-magnifying-glass" class="size-4" /> Find a huddl
+            </.button>
+            <.button :if={!first_run?(@counts)} variant={:secondary} navigate={~p"/discover"}>
+              Browse huddlz
+            </.button>
           </:action>
         </.empty_state>
       <% else %>
@@ -259,17 +271,26 @@ defmodule HuddlzWeb.MyHuddlzLive do
   defp empty_icon(:waitlisted), do: "hero-clock"
   defp empty_icon(:past), do: "hero-check-circle"
 
-  defp empty_title(:upcoming), do: "Nothing coming up"
-  defp empty_title(:waitlisted), do: "No waitlists"
-  defp empty_title(:past), do: "Nothing attended yet"
+  # A first run is an account with no RSVP history at all. Its empty page
+  # says what the page is for and hands over the one action that fills it;
+  # once there is history, the same page goes quiet instead.
+  defp first_run?(counts), do: counts.upcoming + counts.waitlisted + counts.past == 0
 
-  defp empty_message(:upcoming),
-    do: "No upcoming RSVPs yet. Find one to attend."
+  defp empty_title(:upcoming, true), do: "No upcoming RSVPs yet"
+  defp empty_title(:upcoming, false), do: "Nothing coming up"
+  defp empty_title(:waitlisted, _first_run), do: "No waitlists"
+  defp empty_title(:past, _first_run), do: "Nothing attended yet"
 
-  defp empty_message(:waitlisted),
+  defp empty_message(:upcoming, true),
+    do: "Find a huddl worth showing up to and it will land here."
+
+  defp empty_message(:upcoming, false),
+    do: "Your next RSVP will land here."
+
+  defp empty_message(:waitlisted, _first_run),
     do: "You're not on a waitlist right now."
 
-  defp empty_message(:past),
+  defp empty_message(:past, _first_run),
     do: "No past attendance yet."
 
   defp pill_variant(%{status: status}, filter) do

--- a/test/features/first_run_empty_states.feature
+++ b/test/features/first_run_empty_states.feature
@@ -1,0 +1,49 @@
+@database @conn
+Feature: First-run empty states
+  A new account has no RSVPs, no groups and an empty calendar. Rather than
+  saying "nothing here", each empty page explains what it will hold and
+  offers the one action that fills it. Once someone has history, the same
+  page goes quiet instead of instructive.
+
+  Background:
+    Given the following users exist:
+      | email                | display_name | role |
+      | newcomer@example.com | Ada Park     | user |
+    And I am signed in as "newcomer@example.com"
+
+  Scenario: A newcomer's My huddlz sends them to find a huddl
+    When I visit "/my-huddlz"
+    Then I should see "No upcoming RSVPs yet"
+    And I should see "Find a huddl worth showing up to and it will land here."
+    When I click link "Find a huddl"
+    Then I should see "Browse huddlz"
+
+  Scenario: A newcomer's My groups offers both ways in
+    When I visit "/my-groups"
+    Then I should see "No groups yet"
+    And I should see "Groups are where huddlz come from."
+    And I am offered "Browse groups" and "Start your own"
+    When I click link "Start your own"
+    Then I should see "Create a group"
+
+  Scenario: A newcomer's calendar explains what fills it
+    When I visit "/calendar"
+    Then I should see "Your calendar is empty"
+    And I should see "Huddlz you RSVP to show up here"
+    When I click link "Find a huddl"
+    Then I should see "Browse huddlz"
+
+  Scenario: Someone who has attended before sees a quieter My huddlz
+    Given I attended a huddl last month
+    When I visit "/my-huddlz"
+    Then I should see "Nothing coming up"
+    And I should not see "No upcoming RSVPs yet"
+    And I should see "Browse huddlz"
+
+  Scenario: The owner of a new group is invited to schedule its first huddl
+    Given I own a group with no huddlz
+    When I visit my group's page
+    Then I should see "Nothing scheduled"
+    And I should see "Members will see your next huddl here."
+    When I click link "Schedule a huddl"
+    Then I should see "Schedule a huddl"

--- a/test/features/step_definitions/first_run_empty_states_steps.exs
+++ b/test/features/step_definitions/first_run_empty_states_steps.exs
@@ -1,0 +1,49 @@
+defmodule FirstRunEmptyStatesSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import PhoenixTest
+
+  step "I attended a huddl last month", context do
+    host = generate(user(role: :user))
+    group = generate(group(owner_id: host.id, actor: host))
+    huddl = generate(past_huddl(group_id: group.id, creator_id: host.id))
+
+    huddl
+    |> Ash.Changeset.for_update(:rsvp, %{}, actor: context.current_user)
+    |> Ash.update!(authorize?: false)
+
+    context
+  end
+
+  step "I own a group with no huddlz", context do
+    group =
+      generate(
+        group(
+          name: "Sunrise Runners",
+          is_public: true,
+          owner_id: context.current_user.id,
+          actor: context.current_user
+        )
+      )
+
+    Map.put(context, :group, group)
+  end
+
+  step "I visit my group's page", context do
+    session = visit(context.conn, "/groups/#{context.group.slug}")
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I am offered {string} and {string}", %{args: [first, second]} = context do
+    session = context[:session] || context[:conn]
+
+    session
+    |> assert_has(".empty-state a", text: first)
+    |> assert_has(".empty-state a", text: second)
+
+    assert true
+    context
+  end
+end

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -568,13 +568,40 @@ defmodule HuddlzWeb.CalendarLiveTest do
       )
     end
 
-    test "empty agenda shows helpful copy", %{conn: conn, attendee: attendee} do
+    test "empty agenda shows helpful copy", %{
+      conn: conn,
+      host: host,
+      attendee: attendee,
+      public_group: public_group
+    } do
+      past = create_past_huddl(host, public_group, title: "Old Workshop")
+      rsvp!(past, attendee, :rsvp)
+
       conn
       |> login(attendee)
-      |> visit("/calendar?view=agenda")
+      |> visit(calendar_path_for(Date.add(Huddlz.Generator.eastern_today(), 400), view: "agenda"))
       |> assert_has("#calendar-agenda-empty.empty-state h3", text: "Nothing this month")
       |> assert_has("p", text: "Nothing on the calendar this month.")
       |> refute_has(".cal-agenda-panel")
+      |> refute_has("#calendar-first-run")
+    end
+
+    test "a first run explains the calendar in both views", %{conn: conn, attendee: attendee} do
+      session =
+        conn
+        |> login(attendee)
+        |> visit("/calendar?view=agenda")
+        |> assert_has("#calendar-first-run.empty-state h3", text: "Your calendar is empty")
+        |> assert_has("#calendar-first-run p",
+          text: "Huddlz you RSVP to show up here, in their own time zone."
+        )
+        |> assert_has("#calendar-first-run a.btn-primary[href='/discover']", text: "Find a huddl")
+        |> refute_has("#calendar-agenda-empty")
+
+      session
+      |> visit("/calendar")
+      |> assert_has("#month-calendar")
+      |> assert_has("#calendar-first-run.empty-state h3", text: "Your calendar is empty")
     end
   end
 

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -107,6 +107,7 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("#group-huddl-grid-empty.empty-state h3", text: "Nothing scheduled")
       |> assert_has("#group-huddl-grid-empty p", text: "No upcoming huddlz scheduled.")
+      |> refute_has("#group-huddl-grid-empty a")
       |> assert_has(".group-huddlz .list-head h2", text: "Huddlz")
       |> assert_has(".group-huddlz .list-head .filters .chip.is-active", text: "Upcoming")
 
@@ -116,6 +117,20 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> visit(~p"/groups/#{group.slug}")
       |> refute_has("#group-huddl-grid-empty")
       |> assert_has("#group-huddl-grid .card", count: 1)
+    end
+
+    test "invites someone who can schedule to fill the empty grid", %{
+      conn: conn,
+      owner: owner,
+      group: group
+    } do
+      conn
+      |> login(owner)
+      |> visit(~p"/groups/#{group.slug}")
+      |> assert_has("#group-huddl-grid-empty p", text: "Members will see your next huddl here.")
+      |> assert_has("#group-huddl-grid-empty a[href='/groups/#{group.slug}/huddlz/new']",
+        text: "Schedule a huddl"
+      )
     end
 
     test "huddl cards fall back to the group's initials without a cover", %{

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -73,11 +73,16 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       conn
       |> login(member)
       |> visit("/my-groups")
-      |> assert_has(".empty-state h3", text: "No groups yet")
+      |> assert_has(".empty-state[data-first-run] h3", text: "No groups yet")
       |> assert_has(".empty-state p",
-        text: "You haven't organized or joined any groups yet. Start one or browse Discover."
+        text:
+          "Groups are where huddlz come from. Join one to follow its huddlz, or start your own."
       )
-      |> assert_has(".empty-state a[href='/discover?scope=groups']", text: "Browse groups")
+      |> assert_has(".empty-state a.btn-primary[href='/discover?scope=groups']",
+        text: "Browse groups"
+      )
+      |> assert_has(".empty-state a.btn-secondary[href='/groups/new']", text: "Start your own")
+      |> assert_has(".page-head a.btn-secondary", text: "Start a group")
     end
   end
 
@@ -107,7 +112,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       conn
       |> login(member)
       |> visit("/my-groups?filter=hosting")
-      |> assert_has(".empty-state p", text: "You haven't created a group yet.")
+      |> assert_has(".empty-state p", text: "Start a group and its huddlz will show up here.")
       |> refute_has(".empty-state a")
     end
   end
@@ -139,8 +144,9 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       conn
       |> login(member)
       |> visit("/my-groups?filter=joined")
-      |> assert_has(".empty-state p", text: "You haven't joined any groups yet.")
+      |> assert_has(".empty-state p", text: "Join a group to follow its huddlz here.")
       |> assert_has(".empty-state a[href='/discover?scope=groups']", text: "Browse groups")
+      |> refute_has(".empty-state a", text: "Start your own")
     end
   end
 

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -145,13 +145,41 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> assert_has(".pill", text: "Cancelled")
     end
 
-    test "empty state shows helpful copy", %{conn: conn, attendee: attendee} do
+    test "empty state on a first run explains the page and offers to find a huddl", %{
+      conn: conn,
+      attendee: attendee
+    } do
       conn
       |> login(attendee)
       |> visit("/my-huddlz")
-      |> assert_has(".empty-state h3", text: "Nothing coming up")
-      |> assert_has(".empty-state p", text: "No upcoming RSVPs yet. Find one to attend.")
-      |> assert_has(".empty-state a[href=\"/discover\"]", text: "Browse huddlz")
+      |> assert_has(".empty-state[data-first-run] h3", text: "No upcoming RSVPs yet")
+      |> assert_has(".empty-state p",
+        text: "Find a huddl worth showing up to and it will land here."
+      )
+      |> assert_has(".empty-state a.btn-primary[href=\"/discover\"]", text: "Find a huddl")
+      |> assert_has(".page-head a.btn-secondary", text: "Find another huddl")
+    end
+
+    test "empty state goes quiet once there is attendance history", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: group
+    } do
+      past = generate(past_huddl(group_id: group.id, creator_id: host.id, title: "Old Workshop"))
+
+      past
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!(authorize?: false)
+
+      conn
+      |> login(attendee)
+      |> visit("/my-huddlz")
+      |> assert_has(".empty-state:not([data-first-run]) h3", text: "Nothing coming up")
+      |> assert_has(".empty-state p", text: "Your next RSVP will land here.")
+      |> assert_has(".empty-state a.btn-secondary[href=\"/discover\"]", text: "Browse huddlz")
+      |> assert_has(".page-head a.btn-primary", text: "Find another huddl")
+      |> refute_has(".empty-state", text: "Find a huddl")
     end
 
     test "Upcoming count reflects attended huddlz", %{


### PR DESCRIPTION
## Summary

A new account sees four empty pages before it has done anything: My huddlz, My groups, the calendar, and any group it starts. Those pages said "nothing here". They now explain what the page will hold and offer the one action that fills it, and they go quiet again once there is history.

- **My huddlz.** With no RSVP history at all, Upcoming reads "No upcoming RSVPs yet · Find a huddl worth showing up to and it will land here" with a primary "Find a huddl". Once the account has attended or waited on anything, the same page reads "Nothing coming up · Your next RSVP will land here" with a secondary "Browse huddlz". The counts the chips already load decide which.
- **My groups.** An empty All now explains that groups are where huddlz come from and offers both ways in: a primary "Browse groups" and a secondary "Start your own". Hosting and Joined get plainer, action-led copy.
- **Calendar.** With no huddl in any month, both the month grid and the agenda show "Your calendar is empty · Huddlz you RSVP to show up here, in their own time zone" with "Find a huddl". The search behind the calendar already fetches everything the person hosts, attends or waits on, so the check is free. Months with history elsewhere keep "Nothing this month".
- **Group page.** Someone who can schedule for a group with nothing upcoming reads "Members will see your next huddl here" with a "Schedule a huddl" link. Members and visitors keep the plain "No upcoming huddlz scheduled."
- The empty-state action row lays out as a wrapping flex row so two actions sit side by side.
- **One primary per surface.** On a first run the page head's "Find another huddl" and "Start a group" step down to secondary, so the empty state's action is the only cyan button on the page. They return to primary once the list has content.

The distinction is recorded on the design board's Feedback sheet: first run gets the primary action, quiet gets a secondary way on, a filtered miss gets Clear filters.

## Verification

- New feature `first_run_empty_states.feature`, written first: a newcomer's My huddlz, My groups and calendar each explain themselves and lead to Discover or group creation; someone with past attendance sees the quiet My huddlz; the owner of a new group is led to schedule its first huddl.
- LiveView tests updated for the new copy, with first-run and quiet cases side by side on My huddlz and the calendar, and the organizer and visitor variants on the group page.
- `mix precommit` clean, exit code checked directly. No JS changed and the CSS change is one flex rule, so the Playwright suite was not rerun.

Screenshots of the three first-run pages in the first comment, taken with a freshly registered account.
