### PR TITLE
feat(ui): group the calendar agenda by day

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2822,6 +2822,14 @@ body .cal-agenda-day[data-past] .cal-agenda-time { color: var(--muted); }
 body .cal-agenda-day[data-past] .cal-agenda-title { color: var(--soft); }
 body .cal-agenda-day[data-past] .cal-agenda-thumb { opacity: 0.7; filter: saturate(0.5); }
 
+body .cal-agenda-more {
+  margin: 12px 4px 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body .cal-agenda-more a { color: var(--accent-ink); font-weight: 600; }
+
 body .cal-agenda-quiet {
   display: flex;
   align-items: center;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2826,14 +2826,11 @@ body .cal-agenda-quiet {
   display: flex;
   align-items: center;
   min-height: 76px;
+  margin: 0;
   padding: 12px 20px;
   color: var(--muted);
   font-size: 14px;
-  line-height: 1.5;
 }
-
-body .cal-agenda-quiet p { margin: 0; }
-body .cal-agenda-quiet a { color: var(--accent-ink); font-weight: 600; }
 
 /* Touch agenda: the same list under the month grid, shown where hover
    tooltips don't work (narrow screens and coarse pointers). */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2644,32 +2644,199 @@ body .cal-cell:last-child .cal-pill-tooltip::after {
   left: auto;
 }
 
-/* Agenda view: one row per huddl in the focused month. */
-body .cal-agenda-panel {
+/* Agenda: the month's huddlz grouped by day. A date rail on the left, one
+   horizontal card per huddl on the right. Today is always drawn as the
+   anchor between what has passed and what is next; past days go quiet. */
+body .cal-agenda {
+  display: flex;
+  flex-direction: column;
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--panel);
-  padding: 4px 20px;
+  overflow: hidden;
 }
 
-body .cal-agenda-row {
-  grid-template-columns: 200px minmax(0, 1fr) auto;
+body .cal-agenda-day {
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  border-bottom: 1px solid var(--line);
+}
+
+body .cal-agenda-day:last-child { border-bottom: 0; }
+
+body .cal-agenda-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 16px 12px 16px 20px;
+  border-right: 1px solid var(--line);
+}
+
+body .cal-agenda-weekday {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+body .cal-agenda-daynum {
+  color: var(--text);
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+body .cal-agenda-daynum.is-today {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: var(--on-accent);
+  font-size: 17px;
+}
+
+body .cal-agenda-day-context {
+  color: var(--accent-ink);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+body .cal-agenda-day[data-past] .cal-agenda-weekday,
+body .cal-agenda-day[data-past] .cal-agenda-daynum { color: var(--muted); }
+
+body .cal-agenda-entries {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+body .cal-agenda-entry {
+  display: grid;
+  grid-template-columns: 128px minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 20px 12px 16px;
+  border-bottom: 1px solid var(--line);
   color: inherit;
   text-decoration: none;
+  transition: background 120ms ease;
 }
 
-body .cal-agenda-row .row-title {
+body .cal-agenda-entry:last-child { border-bottom: 0; }
+
+body .cal-agenda-entry:hover,
+body .cal-agenda-entry:focus-visible { background: var(--panel-2); }
+
+body .cal-agenda-entry:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+body .cal-agenda-thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  overflow: hidden;
+}
+
+body .cal-agenda-thumb-img {
+  position: absolute;
+  inset: 0;
+  background-position: center;
+  background-size: cover;
+}
+
+body .cal-agenda-thumb .card-cover-fallback span {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+
+body .cal-agenda-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   min-width: 0;
-  overflow-wrap: anywhere;
+}
+
+body .cal-agenda-time {
+  color: var(--soft);
+  font-size: 12px;
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+body .cal-agenda-title {
   color: var(--text);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: color 120ms ease;
 }
 
-body .cal-agenda-row:hover .row-title { color: var(--accent-ink); }
+body .cal-agenda-entry:hover .cal-agenda-title { color: var(--accent-ink); }
 
-/* Touch agenda: the same entries as a list, shown where hover tooltips
-   don't work (narrow screens and coarse pointers). */
+body .cal-agenda-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body .cal-agenda-meta .dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+body .cal-agenda-side {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+body .cal-agenda-relative {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+body .cal-agenda-day[data-past] .cal-agenda-time { color: var(--muted); }
+body .cal-agenda-day[data-past] .cal-agenda-title { color: var(--soft); }
+body .cal-agenda-day[data-past] .cal-agenda-thumb { opacity: 0.7; filter: saturate(0.5); }
+
+body .cal-agenda-quiet {
+  display: flex;
+  align-items: center;
+  min-height: 76px;
+  padding: 12px 20px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+body .cal-agenda-quiet p { margin: 0; }
+body .cal-agenda-quiet a { color: var(--accent-ink); font-weight: 600; }
+
+/* Touch agenda: the same list under the month grid, shown where hover
+   tooltips don't work (narrow screens and coarse pointers). */
 body .cal-touch-agenda {
   display: none;
   margin-top: 16px;
@@ -2699,49 +2866,9 @@ body .cal-touch-agenda-kicker {
   text-transform: uppercase;
 }
 
-body .cal-touch-agenda-list { display: grid; }
-
-body .cal-touch-entry {
-  display: grid;
-  grid-template-columns: minmax(112px, auto) minmax(0, 1fr);
-  gap: 3px 12px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--line);
-  color: var(--soft);
-  text-decoration: none;
-  transition: background 120ms ease;
-}
-
-body .cal-touch-entry:last-child { border-bottom: 0; }
-
-body .cal-touch-entry:hover,
-body .cal-touch-entry:focus-visible { background: var(--panel-2); }
-
-body .cal-touch-entry:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-
-body .cal-touch-entry time {
-  grid-row: 1 / span 2;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-}
-
-body .cal-touch-entry-title {
-  min-width: 0;
-  overflow-wrap: anywhere;
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 600;
-}
-
-body .cal-touch-entry-status {
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 500;
+body .cal-touch-agenda .cal-agenda {
+  border: 0;
+  border-radius: 0;
 }
 
 body .cal-legend {
@@ -2788,11 +2915,37 @@ body .cal-legend-note { margin-left: auto; font-size: 12px; }
   body .cal-day-heading { min-height: 20px; gap: 4px; }
   body .cal-day-context { font-size: 9px; }
   body .cal-legend-note { margin-left: 0; flex: 1 1 100%; }
-  body .cal-agenda-panel { padding: 0 14px; }
-  body .cal-agenda-row { grid-template-columns: minmax(0, 1fr) auto; gap: 4px 12px; }
-  body .cal-agenda-row .meta { grid-column: 1 / -1; }
   body .cal-touch-agenda { display: block; }
-  body .cal-touch-entry { grid-template-columns: 96px minmax(0, 1fr); padding: 11px 12px; }
+  body .cal-agenda-day { grid-template-columns: minmax(0, 1fr); }
+  body .cal-agenda-rail {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    background: var(--panel-2);
+  }
+  body .cal-agenda-daynum { font-size: 15px; }
+  body .cal-agenda-daynum.is-today { width: 28px; height: 28px; font-size: 13px; }
+  body .cal-agenda-day-context { margin-left: auto; }
+  body .cal-agenda-entry {
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 4px 12px;
+    align-items: start;
+    padding: 12px 14px;
+  }
+  body .cal-agenda-title { white-space: normal; font-size: 15px; }
+  body .cal-agenda-meta { flex-direction: column; align-items: flex-start; gap: 2px; }
+  body .cal-agenda-meta .dot { display: none; }
+  body .cal-agenda-side {
+    grid-column: 2;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+  }
+  body .cal-agenda-quiet { min-height: 60px; padding: 12px 14px; }
 }
 
 @media (hover: none) and (pointer: coarse) {

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -3,9 +3,9 @@ defmodule HuddlzWeb.CalendarLive do
   LiveView at `/calendar`. Personal calendar of huddlz the signed-in user
   is hosting, attending, or watching from the waitlist. Month grid by
   default with an agenda toggle; `?month=YYYY-MM` and `?view=month|agenda`
-  drive state. The agenda groups the month's huddlz by day, one entry per
-  huddl, and always draws today as the anchor between what has passed and
-  what is next.
+  drive state. The agenda ignores the month: it starts at today and runs
+  forward through the next few days that have huddlz, one entry per huddl,
+  leaving the past to the month grid.
   """
   use HuddlzWeb, :live_view
 
@@ -24,6 +24,10 @@ defmodule HuddlzWeb.CalendarLive do
   end
 
   @card_loads [:status, :group, :display_image_url]
+
+  # How many days with huddlz the agenda shows after today before pointing
+  # at the month view for the rest.
+  @agenda_days 7
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -48,12 +52,16 @@ defmodule HuddlzWeb.CalendarLive do
     {grid_start, grid_end} = month_grid_window(focus_month)
     user = socket.assigns.current_user
 
-    {entries, first_run?} = load_entries(user, grid_start, grid_end, socket.assigns.time_zone)
-    entries = Enum.map(entries, &put_calendar_time(&1, socket.assigns.time_zone))
+    today = socket.assigns.today
+    all = load_entries(user, socket.assigns.time_zone)
+    entries = grid_entries(all, grid_start, grid_end, socket.assigns.time_zone)
+    {agenda_days, agenda_more} = agenda_window(all, today)
+    agenda_entries = Enum.flat_map(agenda_days, & &1.entries)
 
     entries_by_day = group_by_day(entries)
     in_month_count = Enum.count(entries, &in_focus_month?(&1, focus_month))
-    legend_items = legend_items(entries, focus_month, view_mode, socket.assigns.today)
+    visible = if view_mode == :month, do: entries, else: agenda_entries
+    legend_items = legend_items(visible, today)
 
     {:noreply,
      socket
@@ -62,9 +70,12 @@ defmodule HuddlzWeb.CalendarLive do
      |> assign(:grid_start, grid_start)
      |> assign(:grid_end, grid_end)
      |> assign(:entries, entries)
-     |> assign(:first_run?, first_run?)
+     |> assign(:first_run?, all == [])
      |> assign(:entries_by_day, entries_by_day)
      |> assign(:in_month_count, in_month_count)
+     |> assign(:agenda_days, agenda_days)
+     |> assign(:agenda_more, agenda_more)
+     |> assign(:agenda_count, length(agenda_entries))
      |> assign(:legend_empty?, legend_items == [])
      |> stream(:legend_items, legend_items, reset: true)}
   end
@@ -103,28 +114,26 @@ defmodule HuddlzWeb.CalendarLive do
     {grid_start, grid_end}
   end
 
-  # Returns the entries inside the visible grid and whether the account has
-  # no huddlz in any month at all (a first run): the search already fetches
-  # every huddl the person hosts, attends or waits on, so the answer is free.
-  defp load_entries(user, grid_start, grid_end, time_zone) do
+  # Every huddl the person hosts, attends or waits on, in calendar time,
+  # soonest first. The search already fetches them all, so the month grid,
+  # the agenda and the first-run check all read from this one list.
+  defp load_entries(user, time_zone) do
+    [:hosting, :attending, :waitlisted]
+    |> Enum.flat_map(fn role -> fetch(user, role) end)
+    |> merge_entry_roles()
+    |> Enum.filter(& &1.huddl.starts_at)
+    |> Enum.map(&put_calendar_time(&1, time_zone))
+    |> Enum.sort_by(& &1.huddl.starts_at, DateTime)
+  end
+
+  defp grid_entries(entries, grid_start, grid_end, time_zone) do
     grid_start_dt = utc_boundary(grid_start, ~T[00:00:00], time_zone)
     grid_end_dt = utc_boundary(grid_end, ~T[23:59:59], time_zone)
 
-    all =
-      [:hosting, :attending, :waitlisted]
-      |> Enum.flat_map(fn role -> fetch(user, role) end)
-      |> merge_entry_roles()
-
-    entries =
-      all
-      |> Enum.filter(fn %{huddl: h} ->
-        h.starts_at &&
-          DateTime.compare(h.starts_at, grid_start_dt) != :lt &&
-          DateTime.compare(h.starts_at, grid_end_dt) != :gt
-      end)
-      |> Enum.sort_by(& &1.huddl.starts_at, DateTime)
-
-    {entries, all == []}
+    Enum.filter(entries, fn %{huddl: h} ->
+      DateTime.compare(h.starts_at, grid_start_dt) != :lt &&
+        DateTime.compare(h.starts_at, grid_end_dt) != :gt
+    end)
   end
 
   defp fetch(user, role) do
@@ -283,12 +292,6 @@ defmodule HuddlzWeb.CalendarLive do
   defp huddl_path(%{huddl: %{id: id, group: %{slug: slug}}}),
     do: ~p"/groups/#{slug}/huddlz/#{id}"
 
-  defp agenda_entries(entries, focus_month) do
-    entries
-    |> Enum.filter(&in_focus_month?(&1, focus_month))
-    |> Enum.sort_by(fn %{huddl: %{starts_at: dt}} -> dt end, DateTime)
-  end
-
   defp entry_status(%{huddl: %{status: status}} = entry, %Date{} = today) do
     case HuddlStatus.contextual_override(status) do
       nil -> timed_entry_status(entry, today)
@@ -382,16 +385,12 @@ defmodule HuddlzWeb.CalendarLive do
     end
   end
 
-  defp legend_items(entries, focus_month, view_mode, today) do
+  defp legend_items(entries, today) do
     entries
-    |> visible_entries(focus_month, view_mode)
     |> Enum.map(&entry_status(&1, today))
     |> Enum.uniq_by(& &1.key)
     |> Enum.sort_by(& &1.rank)
   end
-
-  defp visible_entries(entries, _focus_month, :month), do: entries
-  defp visible_entries(entries, focus_month, :agenda), do: agenda_entries(entries, focus_month)
 
   defp legend_swatch_class(%{variant: variant}), do: ["cal-legend-swatch", variant]
 
@@ -415,33 +414,40 @@ defmodule HuddlzWeb.CalendarLive do
       </div>
 
       <div class="cal-toolbar">
-        <div class="cal-nav">
-          <.link
-            patch={month_path(shift_month(@focus_month, -1), @view_mode, @today)}
-            class="cal-nav-btn"
-            aria-label="Previous month"
-          >
-            <.icon name="hero-chevron-left" class="size-4" />
-          </.link>
-          <.link
-            patch={month_path(first_of_month(@today), @view_mode, @today)}
-            class="cal-nav-today"
-          >
-            Today
-          </.link>
-          <.link
-            patch={month_path(shift_month(@focus_month, 1), @view_mode, @today)}
-            class="cal-nav-btn"
-            aria-label="Next month"
-          >
-            <.icon name="hero-chevron-right" class="size-4" />
-          </.link>
-        </div>
+        <%= if @view_mode == :month do %>
+          <div class="cal-nav">
+            <.link
+              patch={month_path(shift_month(@focus_month, -1), @view_mode, @today)}
+              class="cal-nav-btn"
+              aria-label="Previous month"
+            >
+              <.icon name="hero-chevron-left" class="size-4" />
+            </.link>
+            <.link
+              patch={month_path(first_of_month(@today), @view_mode, @today)}
+              class="cal-nav-today"
+            >
+              Today
+            </.link>
+            <.link
+              patch={month_path(shift_month(@focus_month, 1), @view_mode, @today)}
+              class="cal-nav-btn"
+              aria-label="Next month"
+            >
+              <.icon name="hero-chevron-right" class="size-4" />
+            </.link>
+          </div>
 
-        <div class="cal-month-title">
-          <span class="cal-month-name">{format_month(@focus_month)}</span>
-          <span class="cal-month-count">{format_count(@in_month_count)}</span>
-        </div>
+          <div class="cal-month-title">
+            <span class="cal-month-name">{format_month(@focus_month)}</span>
+            <span class="cal-month-count">{format_count(@in_month_count)}</span>
+          </div>
+        <% else %>
+          <div class="cal-month-title">
+            <span class="cal-month-name">What's next</span>
+            <span class="cal-month-count">{format_count(@agenda_count)}</span>
+          </div>
+        <% end %>
 
         <div class="cal-view-tabs">
           <.link
@@ -454,7 +460,7 @@ defmodule HuddlzWeb.CalendarLive do
           </.link>
           <.link
             id="calendar-view-agenda"
-            patch={month_path(@focus_month, :agenda, @today)}
+            patch={~p"/calendar?view=agenda"}
             class={["scope-tab", @view_mode == :agenda && "is-active"]}
             aria-current={if @view_mode == :agenda, do: "page"}
           >
@@ -474,8 +480,8 @@ defmodule HuddlzWeb.CalendarLive do
         <.first_run_empty :if={@first_run?} />
       <% else %>
         <.agenda_view
-          entries={@entries}
-          focus_month={@focus_month}
+          days={@agenda_days}
+          more={@agenda_more}
           today={@today}
           first_run?={@first_run?}
         />
@@ -641,26 +647,22 @@ defmodule HuddlzWeb.CalendarLive do
     """
   end
 
-  attr :entries, :list, required: true
-  attr :focus_month, Date, required: true
+  attr :days, :list, required: true
+  attr :more, :any, required: true, doc: "first day with huddlz beyond the window, or nil"
   attr :today, Date, required: true
   attr :first_run?, :boolean, default: false
 
   defp agenda_view(assigns) do
-    days =
-      assigns.entries
-      |> agenda_entries(assigns.focus_month)
-      |> agenda_days(assigns.focus_month, assigns.today, anchor_today: true)
-
-    assigns = assign(assigns, :days, days)
-
     ~H"""
     <%= if @first_run? do %>
       <.first_run_empty />
     <% else %>
       <%= if Enum.all?(@days, &(&1.entries == [])) do %>
-        <.empty_state id="calendar-agenda-empty" icon="hero-calendar" title="Nothing this month">
-          Nothing on the calendar this month.
+        <.empty_state id="calendar-agenda-empty" icon="hero-calendar" title="Nothing coming up">
+          Your next RSVP will land here.
+          <:action>
+            <.button variant={:secondary} navigate={~p"/discover"}>Browse huddlz</.button>
+          </:action>
         </.empty_state>
       <% else %>
         <.agenda_list
@@ -669,15 +671,20 @@ defmodule HuddlzWeb.CalendarLive do
           days={@days}
           today={@today}
         />
+        <p :if={@more} id="calendar-agenda-more" class="cal-agenda-more">
+          More after {Calendar.strftime(List.last(@days).date, "%A, %B %-d")}.
+          <.link patch={month_path(first_of_month(@more), :month, @today)}>
+            Open {format_month(@more)} in the month view
+          </.link>
+        </p>
       <% end %>
     <% end %>
     """
   end
 
   # The agenda list: one group per day with a date rail on the left and
-  # the day's huddlz on the right, in time order. Today is always drawn
-  # when it falls in the month, with or without a huddl on it. The next
-  # row is the next thing, so an empty today says no more than that.
+  # the day's huddlz on the right, in time order. The next row is the next
+  # thing, so an empty today says no more than that.
   attr :id, :string, required: true
   attr :entry_prefix, :string, required: true
   attr :days, :list, required: true
@@ -771,14 +778,28 @@ defmodule HuddlzWeb.CalendarLive do
     """
   end
 
+  # The agenda window: today, then the next @agenda_days days that have
+  # huddlz, whatever month they fall in. Returns the day groups and the
+  # first day with huddlz beyond the window, if any.
+  defp agenda_window(entries, today) do
+    upcoming = Enum.filter(entries, &(Date.compare(&1.calendar_date, today) != :lt))
+    dates = upcoming |> Enum.map(& &1.calendar_date) |> Enum.uniq()
+    {shown, rest} = Enum.split(dates, @agenda_days)
+    shown = MapSet.new(shown)
+    windowed = Enum.filter(upcoming, &MapSet.member?(shown, &1.calendar_date))
+
+    {agenda_days(windowed, first_of_month(today), today, anchor_today: true), List.first(rest)}
+  end
+
   # Groups entries by calendar day, in date order. With `anchor_today: true`
-  # the focused month always gets a row for today, with or without a huddl
-  # on it, so the list reads as what has passed, today, what is next.
-  defp agenda_days(entries, focus_month, today, anchor_today: anchor?) do
+  # the list always gets a row for today, with or without a huddl on it, so
+  # it reads as today, then what is next. Days outside `reference_month`
+  # name their month on the rail.
+  defp agenda_days(entries, reference_month, today, anchor_today: anchor?) do
     grouped = Enum.group_by(entries, & &1.calendar_date)
 
     dates =
-      if anchor? and day_in_focus?(today, focus_month),
+      if anchor?,
         do: Enum.uniq([today | Map.keys(grouped)]),
         else: Map.keys(grouped)
 
@@ -790,7 +811,7 @@ defmodule HuddlzWeb.CalendarLive do
         entries: Map.get(grouped, date, []),
         today?: Date.compare(date, today) == :eq,
         past?: Date.compare(date, today) == :lt,
-        other_month?: !day_in_focus?(date, focus_month)
+        other_month?: !day_in_focus?(date, reference_month)
       }
     end)
   end

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -1,9 +1,9 @@
 defmodule HuddlzWeb.CalendarLive do
   @moduledoc """
   LiveView at `/calendar`. Personal calendar of huddlz the signed-in user
-  is hosting, attending, or watching from the waitlist. Month grid by
-  default with an agenda toggle; `?month=YYYY-MM` and `?view=month|agenda`
-  drive state. The agenda ignores the month: it starts at today and runs
+  is hosting, attending, or watching from the waitlist. Agenda by default
+  with a month grid behind `?view=month`; `?month=YYYY-MM` drives the grid.
+  The agenda ignores the month: it starts at today and runs
   forward through the next few days that have huddlz, one entry per huddl,
   leaving the past to the month grid.
   """
@@ -100,8 +100,8 @@ defmodule HuddlzWeb.CalendarLive do
 
   defp parse_month(_, today), do: first_of_month(today)
 
-  defp parse_view("agenda"), do: :agenda
-  defp parse_view(_), do: :month
+  defp parse_view("month"), do: :month
+  defp parse_view(_), do: :agenda
 
   defp first_of_month(date), do: %{date | day: 1}
 
@@ -194,7 +194,7 @@ defmodule HuddlzWeb.CalendarLive do
 
   defp month_path(month, view, today) do
     base = month_param(month, today)
-    view_str = if view == :agenda, do: "agenda"
+    view_str = if view == :month, do: "month"
 
     cond do
       base && view_str -> ~p"/calendar?#{[month: base, view: view_str]}"
@@ -451,20 +451,20 @@ defmodule HuddlzWeb.CalendarLive do
 
         <div class="cal-view-tabs">
           <.link
+            id="calendar-view-agenda"
+            patch={~p"/calendar"}
+            class={["scope-tab", @view_mode == :agenda && "is-active"]}
+            aria-current={if @view_mode == :agenda, do: "page"}
+          >
+            Agenda
+          </.link>
+          <.link
             id="calendar-view-month"
             patch={month_path(@focus_month, :month, @today)}
             class={["scope-tab", @view_mode == :month && "is-active"]}
             aria-current={if @view_mode == :month, do: "page"}
           >
             Month
-          </.link>
-          <.link
-            id="calendar-view-agenda"
-            patch={~p"/calendar?view=agenda"}
-            class={["scope-tab", @view_mode == :agenda && "is-active"]}
-            aria-current={if @view_mode == :agenda, do: "page"}
-          >
-            Agenda
           </.link>
         </div>
       </div>
@@ -770,7 +770,7 @@ defmodule HuddlzWeb.CalendarLive do
         <.pill variant={@status.variant} class="cal-entry-status" data-status={@status.key}>
           {@status.label}
         </.pill>
-        <span :if={@status.variant != :muted} class="cal-agenda-relative">
+        <span :if={countdown?(@status)} class="cal-agenda-relative">
           {HuddlCardHelpers.relative_time(@entry.huddl.starts_at)}
         </span>
       </div>
@@ -815,6 +815,12 @@ defmodule HuddlzWeb.CalendarLive do
       }
     end)
   end
+
+  # A countdown only makes sense for something still going ahead: not for
+  # the past, and not for a cancelled huddl.
+  defp countdown?(%EntryStatus{variant: :muted}), do: false
+  defp countdown?(%EntryStatus{key: "cancelled"}), do: false
+  defp countdown?(_status), do: true
 
   defp place_label(%{event_type: :virtual}), do: "Online"
 

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -676,8 +676,8 @@ defmodule HuddlzWeb.CalendarLive do
 
   # The agenda list: one group per day with a date rail on the left and
   # the day's huddlz on the right, in time order. Today is always drawn
-  # when it falls in the month, with or without a huddl on it, so the
-  # list reads as "what has passed, today, what is next".
+  # when it falls in the month, with or without a huddl on it. The next
+  # row is the next thing, so an empty today says no more than that.
   attr :id, :string, required: true
   attr :entry_prefix, :string, required: true
   attr :days, :list, required: true
@@ -716,17 +716,7 @@ defmodule HuddlzWeb.CalendarLive do
             entry={entry}
             today={@today}
           />
-          <div :if={day.entries == []} class="cal-agenda-quiet">
-            <p>
-              Nothing today.
-              <%= if day.next_up do %>
-                Next up is <.link navigate={huddl_path(day.next_up)}>{day.next_up.huddl.title}</.link>
-                on {Calendar.strftime(day.next_up.calendar_date, "%A")}.
-              <% else %>
-                Nothing else this month.
-              <% end %>
-            </p>
-          </div>
+          <p :if={day.entries == []} class="cal-agenda-quiet">Nothing today.</p>
         </div>
       </div>
     </div>
@@ -782,8 +772,8 @@ defmodule HuddlzWeb.CalendarLive do
   end
 
   # Groups entries by calendar day, in date order. With `anchor_today: true`
-  # the focused month always gets a row for today, carrying the next huddl
-  # after it so an empty today still points somewhere.
+  # the focused month always gets a row for today, with or without a huddl
+  # on it, so the list reads as what has passed, today, what is next.
   defp agenda_days(entries, focus_month, today, anchor_today: anchor?) do
     grouped = Enum.group_by(entries, & &1.calendar_date)
 
@@ -800,14 +790,9 @@ defmodule HuddlzWeb.CalendarLive do
         entries: Map.get(grouped, date, []),
         today?: Date.compare(date, today) == :eq,
         past?: Date.compare(date, today) == :lt,
-        other_month?: !day_in_focus?(date, focus_month),
-        next_up: next_up(entries, date)
+        other_month?: !day_in_focus?(date, focus_month)
       }
     end)
-  end
-
-  defp next_up(entries, date) do
-    Enum.find(entries, &(Date.compare(&1.calendar_date, date) == :gt))
   end
 
   defp place_label(%{event_type: :virtual}), do: "Online"

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -3,7 +3,9 @@ defmodule HuddlzWeb.CalendarLive do
   LiveView at `/calendar`. Personal calendar of huddlz the signed-in user
   is hosting, attending, or watching from the waitlist. Month grid by
   default with an agenda toggle; `?month=YYYY-MM` and `?view=month|agenda`
-  drive state.
+  drive state. The agenda groups the month's huddlz by day, one entry per
+  huddl, and always draws today as the anchor between what has passed and
+  what is next.
   """
   use HuddlzWeb, :live_view
 
@@ -21,7 +23,7 @@ defmodule HuddlzWeb.CalendarLive do
     defstruct [:key, :label, :variant, :rank]
   end
 
-  @card_loads [:status, :group]
+  @card_loads [:status, :group, :display_image_url]
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -393,11 +395,6 @@ defmodule HuddlzWeb.CalendarLive do
 
   defp legend_swatch_class(%{variant: variant}), do: ["cal-legend-swatch", variant]
 
-  defp format_agenda_when(%{starts_at: %DateTime{}} = huddl) do
-    local = HuddlCardHelpers.local_starts_at(huddl)
-    Calendar.strftime(local, "%a %b %-d · %-I:%M %p %Z")
-  end
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -593,21 +590,12 @@ defmodule HuddlzWeb.CalendarLive do
           <p class="cal-touch-agenda-kicker">Calendar details</p>
           <h2 id="calendar-touch-agenda-title">Huddlz shown above</h2>
         </div>
-        <div class="cal-touch-agenda-list">
-          <.link
-            :for={entry <- @entries}
-            id={"calendar-touch-entry-#{entry.huddl.id}"}
-            navigate={huddl_path(entry)}
-            class="cal-touch-entry"
-            data-status={entry_status(entry, @today).key}
-          >
-            <time datetime={DateTime.to_iso8601(entry.huddl.starts_at)}>
-              {format_agenda_when(entry.huddl)}
-            </time>
-            <span class="cal-touch-entry-title">{entry.huddl.title}</span>
-            <span class="cal-touch-entry-status">{entry_status(entry, @today).label}</span>
-          </.link>
-        </div>
+        <.agenda_list
+          id="calendar-touch-agenda-list"
+          entry_prefix="calendar-touch-entry"
+          days={agenda_days(@entries, @focus_month, @today, anchor_today: false)}
+          today={@today}
+        />
       </section>
     </div>
     """
@@ -659,40 +647,173 @@ defmodule HuddlzWeb.CalendarLive do
   attr :first_run?, :boolean, default: false
 
   defp agenda_view(assigns) do
-    sorted = agenda_entries(assigns.entries, assigns.focus_month)
-    assigns = assign(assigns, :sorted, sorted)
+    days =
+      assigns.entries
+      |> agenda_entries(assigns.focus_month)
+      |> agenda_days(assigns.focus_month, assigns.today, anchor_today: true)
+
+    assigns = assign(assigns, :days, days)
 
     ~H"""
     <%= if @first_run? do %>
       <.first_run_empty />
     <% else %>
-      <%= if @sorted == [] do %>
+      <%= if Enum.all?(@days, &(&1.entries == [])) do %>
         <.empty_state id="calendar-agenda-empty" icon="hero-calendar" title="Nothing this month">
           Nothing on the calendar this month.
         </.empty_state>
       <% else %>
-        <div class="cal-agenda-panel">
-          <div class="row-list cal-agenda-list">
-            <.link
-              :for={entry <- @sorted}
-              id={"calendar-entry-#{entry.huddl.id}"}
-              navigate={huddl_path(entry)}
-              class="row cal-agenda-row"
-            >
-              <span class="meta">{format_agenda_when(entry.huddl)}</span>
-              <span class="row-title">{entry.huddl.title}</span>
-              <.pill
-                variant={entry_status(entry, @today).variant}
-                class="cal-entry-status"
-                data-status={entry_status(entry, @today).key}
-              >
-                {entry_status(entry, @today).label}
-              </.pill>
-            </.link>
-          </div>
-        </div>
+        <.agenda_list
+          id="calendar-agenda"
+          entry_prefix="calendar-entry"
+          days={@days}
+          today={@today}
+        />
       <% end %>
     <% end %>
     """
   end
+
+  # The agenda list: one group per day with a date rail on the left and
+  # the day's huddlz on the right, in time order. Today is always drawn
+  # when it falls in the month, with or without a huddl on it, so the
+  # list reads as "what has passed, today, what is next".
+  attr :id, :string, required: true
+  attr :entry_prefix, :string, required: true
+  attr :days, :list, required: true
+  attr :today, Date, required: true
+
+  defp agenda_list(assigns) do
+    ~H"""
+    <div id={@id} class="cal-agenda">
+      <div
+        :for={day <- @days}
+        id={"#{@id}-day-#{Date.to_iso8601(day.date)}"}
+        class="cal-agenda-day"
+        data-today={day.today? || nil}
+        data-past={day.past? || nil}
+      >
+        <div class="cal-agenda-rail">
+          <span class="cal-agenda-weekday" aria-hidden="true">
+            {Calendar.strftime(day.date, "%a")}
+          </span>
+          <time
+            datetime={Date.to_iso8601(day.date)}
+            class={["cal-agenda-daynum", day.today? && "is-today"]}
+            aria-label={format_full_date(day.date)}
+          >
+            {day.date.day}
+          </time>
+          <span :if={day.today?} class="cal-agenda-day-context">Today</span>
+          <span :if={day.other_month?} class="cal-agenda-day-context">
+            {Calendar.strftime(day.date, "%b")}
+          </span>
+        </div>
+        <div class="cal-agenda-entries">
+          <.agenda_entry
+            :for={entry <- day.entries}
+            id={"#{@entry_prefix}-#{entry.huddl.id}"}
+            entry={entry}
+            today={@today}
+          />
+          <div :if={day.entries == []} class="cal-agenda-quiet">
+            <p>
+              Nothing today.
+              <%= if day.next_up do %>
+                Next up is <.link navigate={huddl_path(day.next_up)}>{day.next_up.huddl.title}</.link>
+                on {Calendar.strftime(day.next_up.calendar_date, "%A")}.
+              <% else %>
+                Nothing else this month.
+              <% end %>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :entry, :map, required: true
+  attr :today, Date, required: true
+
+  defp agenda_entry(assigns) do
+    assigns = assign(assigns, :status, entry_status(assigns.entry, assigns.today))
+
+    ~H"""
+    <.link
+      id={@id}
+      navigate={huddl_path(@entry)}
+      class="cal-agenda-entry"
+      data-status={@status.key}
+    >
+      <div class="cal-agenda-thumb">
+        <%= if @entry.huddl.display_image_url do %>
+          <.cover_image
+            id={"#{@id}-cover"}
+            class="cal-agenda-thumb-img"
+            image_url={@entry.huddl.display_image_url}
+          />
+        <% else %>
+          <.cover_fallback name={@entry.huddl.group.name} />
+        <% end %>
+      </div>
+      <div class="cal-agenda-body">
+        <time class="cal-agenda-time" datetime={DateTime.to_iso8601(@entry.huddl.starts_at)}>
+          {format_pill_time(@entry)}
+        </time>
+        <span class="cal-agenda-title">{@entry.huddl.title}</span>
+        <span class="cal-agenda-meta">
+          <span>{@entry.huddl.group.name}</span>
+          <span class="dot" aria-hidden="true"></span>
+          <span>{place_label(@entry.huddl)}</span>
+        </span>
+      </div>
+      <div class="cal-agenda-side">
+        <.pill variant={@status.variant} class="cal-entry-status" data-status={@status.key}>
+          {@status.label}
+        </.pill>
+        <span :if={@status.variant != :muted} class="cal-agenda-relative">
+          {HuddlCardHelpers.relative_time(@entry.huddl.starts_at)}
+        </span>
+      </div>
+    </.link>
+    """
+  end
+
+  # Groups entries by calendar day, in date order. With `anchor_today: true`
+  # the focused month always gets a row for today, carrying the next huddl
+  # after it so an empty today still points somewhere.
+  defp agenda_days(entries, focus_month, today, anchor_today: anchor?) do
+    grouped = Enum.group_by(entries, & &1.calendar_date)
+
+    dates =
+      if anchor? and day_in_focus?(today, focus_month),
+        do: Enum.uniq([today | Map.keys(grouped)]),
+        else: Map.keys(grouped)
+
+    dates
+    |> Enum.sort(Date)
+    |> Enum.map(fn date ->
+      %{
+        date: date,
+        entries: Map.get(grouped, date, []),
+        today?: Date.compare(date, today) == :eq,
+        past?: Date.compare(date, today) == :lt,
+        other_month?: !day_in_focus?(date, focus_month),
+        next_up: next_up(entries, date)
+      }
+    end)
+  end
+
+  defp next_up(entries, date) do
+    Enum.find(entries, &(Date.compare(&1.calendar_date, date) == :gt))
+  end
+
+  defp place_label(%{event_type: :virtual}), do: "Online"
+
+  defp place_label(%{physical_location: place}) when is_binary(place) and place != "",
+    do: place
+
+  defp place_label(%{event_type: type}), do: HuddlCardHelpers.tag_label(type)
 end

--- a/lib/huddlz_web/live/helpers/huddl_card_helpers.ex
+++ b/lib/huddlz_web/live/helpers/huddl_card_helpers.ex
@@ -1,7 +1,8 @@
 defmodule HuddlzWeb.Live.Helpers.HuddlCardHelpers do
   @moduledoc """
   Shared formatting helpers for huddl card listings (discover, my huddlz,
-  group show): date block, `event_type` tag, and RSVP count labels.
+  group show, calendar): date block, `event_type` tag, RSVP count labels,
+  and relative times.
   """
 
   def tag_variant(:in_person), do: :in_person
@@ -33,4 +34,38 @@ defmodule HuddlzWeb.Live.Helpers.HuddlCardHelpers do
 
   def rsvp_label(%{rsvp_count: 1}), do: "1 RSVP"
   def rsvp_label(%{rsvp_count: count}), do: "#{count} RSVPs"
+
+  @doc """
+  How far a moment is from now, in the words a card foot or agenda entry
+  uses: "tomorrow", "3 days away", "2 weeks ago", or the date once it is
+  more than a month out.
+  """
+  def relative_time(%DateTime{} = dt) do
+    diff_seconds = DateTime.diff(dt, DateTime.utc_now(), :second)
+    abs_seconds = abs(diff_seconds)
+    future? = diff_seconds >= 0
+
+    cond do
+      abs_seconds < 3600 -> if future?, do: "starting soon", else: "just ended"
+      abs_seconds < 86_400 -> format_hours(div(abs_seconds, 3600), future?)
+      abs_seconds < 7 * 86_400 -> format_days(div(abs_seconds, 86_400), future?)
+      abs_seconds < 30 * 86_400 -> format_weeks(div(abs_seconds, 7 * 86_400), future?)
+      true -> Calendar.strftime(dt, "%b %d, %Y")
+    end
+  end
+
+  defp format_hours(1, true), do: "1 hour away"
+  defp format_hours(n, true), do: "#{n} hours away"
+  defp format_hours(1, false), do: "1 hour ago"
+  defp format_hours(n, false), do: "#{n} hours ago"
+
+  defp format_days(1, true), do: "tomorrow"
+  defp format_days(n, true), do: "#{n} days away"
+  defp format_days(1, false), do: "yesterday"
+  defp format_days(n, false), do: "#{n} days ago"
+
+  defp format_weeks(1, true), do: "1 week away"
+  defp format_weeks(n, true), do: "#{n} weeks away"
+  defp format_weeks(1, false), do: "1 week ago"
+  defp format_weeks(n, false), do: "#{n} weeks ago"
 end

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -314,33 +314,4 @@ defmodule HuddlzWeb.MyHuddlzLive do
   defp filter_pill_label(:upcoming), do: "Going"
   defp filter_pill_label(:waitlisted), do: "Waitlist"
   defp filter_pill_label(:past), do: "Attended"
-
-  defp relative_time(%DateTime{} = dt) do
-    diff_seconds = DateTime.diff(dt, DateTime.utc_now(), :second)
-    abs_seconds = abs(diff_seconds)
-    future? = diff_seconds >= 0
-
-    cond do
-      abs_seconds < 3600 -> if future?, do: "starting soon", else: "just ended"
-      abs_seconds < 86_400 -> format_hours(div(abs_seconds, 3600), future?)
-      abs_seconds < 7 * 86_400 -> format_days(div(abs_seconds, 86_400), future?)
-      abs_seconds < 30 * 86_400 -> format_weeks(div(abs_seconds, 7 * 86_400), future?)
-      true -> Calendar.strftime(dt, "%b %d, %Y")
-    end
-  end
-
-  defp format_hours(1, true), do: "1 hour away"
-  defp format_hours(n, true), do: "#{n} hours away"
-  defp format_hours(1, false), do: "1 hour ago"
-  defp format_hours(n, false), do: "#{n} hours ago"
-
-  defp format_days(1, true), do: "tomorrow"
-  defp format_days(n, true), do: "#{n} days away"
-  defp format_days(1, false), do: "yesterday"
-  defp format_days(n, false), do: "#{n} days ago"
-
-  defp format_weeks(1, true), do: "1 week away"
-  defp format_weeks(n, true), do: "#{n} weeks away"
-  defp format_weeks(1, false), do: "1 week ago"
-  defp format_weeks(n, false), do: "#{n} weeks ago"
 end

--- a/test/features/calendar_agenda.feature
+++ b/test/features/calendar_agenda.feature
@@ -1,0 +1,25 @@
+@database @conn
+Feature: Calendar agenda grouped by day
+  As someone with RSVPs
+  I want the agenda to read as days rather than as rows
+  So that I can see what each day holds and how the month flows
+
+  Background:
+    Given the following users exist:
+      | email                | display_name | role    |
+      | attendee@example.com | Agenda User  | regular |
+    And I am signed in as "attendee@example.com"
+
+  Scenario: The month's huddlz are grouped by day in time order
+    Given I am going to "Async Rust reading group" on day 16 of next month at "19:00"
+    And I am going to "Hands-on with Ash Framework" on day 17 of next month at "18:30"
+    And I am going to "Elixir office hours" on day 17 of next month at "12:00"
+    When I open next month's agenda
+    Then the agenda shows day 16 with "Async Rust reading group"
+    And the agenda shows day 17 with "Elixir office hours" then "Hands-on with Ash Framework"
+    And each agenda huddl shows its group and my status
+
+  Scenario: Today anchors the agenda even when nothing is on
+    Given I have huddlz on the days either side of today
+    When I open this month's agenda
+    Then the agenda marks today as having nothing on

--- a/test/features/calendar_agenda.feature
+++ b/test/features/calendar_agenda.feature
@@ -1,8 +1,8 @@
 @database @conn
 Feature: Calendar agenda grouped by day
   As someone with RSVPs
-  I want the agenda to read as days rather than as rows
-  So that I can see what each day holds and how the month flows
+  I want the agenda to start at today and read as days rather than as rows
+  So that I can see what is next without scrolling past what has been
 
   Background:
     Given the following users exist:
@@ -14,12 +14,19 @@ Feature: Calendar agenda grouped by day
     Given I am going to "Async Rust reading group" on day 16 of next month at "19:00"
     And I am going to "Hands-on with Ash Framework" on day 17 of next month at "18:30"
     And I am going to "Elixir office hours" on day 17 of next month at "12:00"
-    When I open next month's agenda
+    When I open the agenda
     Then the agenda shows day 16 with "Async Rust reading group"
     And the agenda shows day 17 with "Elixir office hours" then "Hands-on with Ash Framework"
     And each agenda huddl shows its group and my status
 
-  Scenario: Today anchors the agenda even when nothing is on
+  Scenario: Today anchors the agenda and the past stays in the month view
     Given I have huddlz on the days either side of today
-    When I open this month's agenda
+    When I open the agenda
     Then the agenda marks today as having nothing on
+    And the agenda does not list "Yesterday's huddl"
+
+  Scenario: The agenda stops after a week of days with huddlz
+    Given I am going to a huddl on each of the next 9 days
+    When I open the agenda
+    Then the agenda lists 7 days of huddlz
+    And I am pointed at the month view for the rest

--- a/test/features/current_navigation.feature
+++ b/test/features/current_navigation.feature
@@ -13,7 +13,7 @@ Feature: Current navigation for assistive technology
   Scenario: Current destination and view follow navigation
     When I visit "/calendar"
     Then navigation should identify "My calendar" as the current destination
-    And view choices should identify "Month" as current
+    And view choices should identify "Agenda" as current
     When I click link "Agenda"
     Then view choices should identify "Agenda" as current
     When I click link "Discover"

--- a/test/features/step_definitions/calendar_accessibility_steps.exs
+++ b/test/features/step_definitions/calendar_accessibility_steps.exs
@@ -34,7 +34,7 @@ defmodule CalendarAccessibilitySteps do
        %{conn: conn, calendar_huddl: huddl} = context do
     date = DateTime.to_date(huddl.starts_at)
     month = :io_lib.format("~4..0B-~2..0B", [date.year, date.month]) |> IO.iodata_to_binary()
-    session = visit(conn, "/calendar?month=#{month}")
+    session = visit(conn, "/calendar?month=#{month}&view=month")
 
     Map.merge(context, %{conn: session, session: session})
   end

--- a/test/features/step_definitions/calendar_agenda_steps.exs
+++ b/test/features/step_definitions/calendar_agenda_steps.exs
@@ -78,17 +78,48 @@ defmodule CalendarAgendaSteps do
     context
   end
 
-  step "I open next month's agenda", %{conn: conn} = context do
-    open_agenda(context, conn, next_month())
+  step "I am going to a huddl on each of the next {int} days",
+       %{args: [count], current_user: attendee} = context do
+    host = generate(user(role: :user))
+    group = generate(group(owner_id: host.id, is_public: true, actor: host))
+
+    huddlz =
+      for offset <- 1..count do
+        huddl =
+          generate(
+            huddl(
+              group_id: group.id,
+              creator_id: host.id,
+              is_private: false,
+              title: "Day #{offset}",
+              date: Date.add(eastern_today(), offset),
+              actor: host
+            )
+          )
+
+        huddl
+        |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+        |> Ash.update!()
+
+        huddl
+      end
+
+    Map.put(context, :agenda_huddlz, huddlz)
   end
 
-  step "I open this month's agenda", %{conn: conn} = context do
-    open_agenda(context, conn, eastern_today())
+  step "I open the agenda", %{conn: conn} = context do
+    session = visit(conn, "/calendar?view=agenda")
+    Map.merge(context, %{conn: session, session: session})
   end
 
   step "the agenda shows day {int} with {string}",
        %{args: [day, title], session: session} = context do
-    assert_has(session, "#{day_selector(day)} .cal-agenda-title", text: title)
+    session
+    |> assert_has("#{day_selector(day)} .cal-agenda-title", text: title)
+    |> assert_has("#{day_selector(day)} .cal-agenda-day-context",
+      text: Calendar.strftime(next_month(), "%b")
+    )
+
     context
   end
 
@@ -126,10 +157,22 @@ defmodule CalendarAgendaSteps do
     context
   end
 
-  defp open_agenda(context, conn, %Date{year: year, month: month}) do
-    month_param = "#{year}-#{String.pad_leading(to_string(month), 2, "0")}"
-    session = visit(conn, "/calendar?month=#{month_param}&view=agenda")
-    Map.merge(context, %{conn: session, session: session})
+  step "the agenda does not list {string}", %{args: [title], session: session} = context do
+    refute_has(session, "#calendar-agenda .cal-agenda-title", text: title)
+    context
+  end
+
+  step "the agenda lists {int} days of huddlz", %{args: [count], session: session} = context do
+    session
+    |> assert_has("#calendar-agenda .cal-agenda-day .cal-agenda-entry", count: count)
+    |> refute_has("#calendar-agenda .cal-agenda-title", text: "Day #{count + 1}")
+
+    context
+  end
+
+  step "I am pointed at the month view for the rest", %{session: session} = context do
+    assert_has(session, "#calendar-agenda-more a", text: "in the month view")
+    context
   end
 
   defp next_month do

--- a/test/features/step_definitions/calendar_agenda_steps.exs
+++ b/test/features/step_definitions/calendar_agenda_steps.exs
@@ -1,0 +1,154 @@
+defmodule CalendarAgendaSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import PhoenixTest
+
+  step "I am going to {string} on day {int} of next month at {string}",
+       %{args: [title, day, time], current_user: attendee} = context do
+    host = context[:agenda_host] || generate(user(role: :user))
+
+    group =
+      context[:agenda_group] ||
+        generate(group(name: "Portland Elixir", owner_id: host.id, is_public: true, actor: host))
+
+    {:ok, start_time} = Time.from_iso8601(time <> ":00")
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          title: title,
+          date: %{next_month() | day: day},
+          start_time: start_time,
+          actor: host
+        )
+      )
+
+    huddl
+    |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+    |> Ash.update!()
+
+    context
+    |> Map.put(:agenda_host, host)
+    |> Map.put(:agenda_group, group)
+    |> Map.update(:agenda_huddlz, [huddl], &[huddl | &1])
+  end
+
+  # One of the two always lands in the current month, whatever today's date.
+  step "I have huddlz on the days either side of today", %{current_user: attendee} = context do
+    host = generate(user(role: :user))
+    group = generate(group(owner_id: host.id, is_public: true, actor: host))
+    yesterday = DateTime.utc_now() |> DateTime.add(-1, :day) |> DateTime.truncate(:second)
+
+    past =
+      generate(
+        past_huddl(
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          title: "Yesterday's huddl",
+          starts_at: yesterday,
+          ends_at: DateTime.add(yesterday, 1, :hour),
+          actor: host
+        )
+      )
+
+    upcoming =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          title: "Tomorrow's huddl",
+          date: Date.add(eastern_today(), 1),
+          actor: host
+        )
+      )
+
+    for huddl <- [past, upcoming] do
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+    end
+
+    context
+  end
+
+  step "I open next month's agenda", %{conn: conn} = context do
+    open_agenda(context, conn, next_month())
+  end
+
+  step "I open this month's agenda", %{conn: conn} = context do
+    open_agenda(context, conn, eastern_today())
+  end
+
+  step "the agenda shows day {int} with {string}",
+       %{args: [day, title], session: session} = context do
+    assert_has(session, "#{day_selector(day)} .cal-agenda-title", text: title)
+    context
+  end
+
+  step "the agenda shows day {int} with {string} then {string}",
+       %{args: [day, first, second], session: session} = context do
+    titles =
+      session
+      |> assert_has(day_selector(day))
+      |> render_titles(day_selector(day))
+
+    assert titles == [first, second]
+    context
+  end
+
+  step "each agenda huddl shows its group and my status", %{session: session} = context do
+    session
+    |> assert_has(".cal-agenda-entry .cal-agenda-meta", text: "Portland Elixir", count: 3)
+    |> assert_has(".cal-agenda-entry .cal-entry-status[data-status=going]",
+      text: "Going",
+      count: 3
+    )
+
+    context
+  end
+
+  step "the agenda marks today as having nothing on", %{session: session} = context do
+    session
+    |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-day-context",
+      text: "Today"
+    )
+    |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-quiet",
+      text: "Nothing today"
+    )
+
+    context
+  end
+
+  defp open_agenda(context, conn, %Date{year: year, month: month}) do
+    month_param = "#{year}-#{String.pad_leading(to_string(month), 2, "0")}"
+    session = visit(conn, "/calendar?month=#{month_param}&view=agenda")
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  defp next_month do
+    today = eastern_today()
+    total = today.year * 12 + today.month
+    Date.new!(div(total, 12), rem(total, 12) + 1, 1)
+  end
+
+  defp day_selector(day) do
+    %Date{year: year, month: month} = next_month()
+    date = Date.new!(year, month, day)
+    "#calendar-agenda-day-#{Date.to_iso8601(date)}"
+  end
+
+  defp render_titles(session, selector) do
+    session.view
+    |> Phoenix.LiveViewTest.render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("#{selector} .cal-agenda-title")
+    |> Enum.map(&(&1 |> LazyHTML.text() |> String.trim()))
+  end
+end

--- a/test/features/step_definitions/calendar_agenda_steps.exs
+++ b/test/features/step_definitions/calendar_agenda_steps.exs
@@ -108,7 +108,7 @@ defmodule CalendarAgendaSteps do
   end
 
   step "I open the agenda", %{conn: conn} = context do
-    session = visit(conn, "/calendar?view=agenda")
+    session = visit(conn, "/calendar")
     Map.merge(context, %{conn: session, session: session})
   end
 

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -54,7 +54,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
   describe "anonymous access" do
     test "redirects to sign-in", %{conn: conn} do
       conn
-      |> visit("/calendar")
+      |> visit("/calendar?view=month")
       |> assert_path("/sign-in")
     end
   end
@@ -66,7 +66,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
     } do
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit("/calendar?view=month")
       |> assert_has("h1", text: "My calendar")
       |> assert_has("aside.sidebar")
       |> assert_has(".sb-item.active[aria-current='page']", text: "My calendar")
@@ -84,7 +84,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
     } do
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit("/calendar?view=month")
       |> assert_has(".cal-month-name", text: current_month_name())
       |> assert_has(".cal-month-count", text: "0 huddlz")
     end
@@ -93,7 +93,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
       session =
         conn
         |> login(attendee)
-        |> visit("/calendar")
+        |> visit("/calendar?view=month")
 
       for day <- ~w(Sun Mon Tue Wed Thu Fri Sat) do
         assert_has(session, "#month-calendar th[scope='col']", text: day)
@@ -109,7 +109,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
+      |> visit("/calendar?view=month")
       |> assert_has("#month-calendar caption", text: current_month_name())
       |> assert_has("#month-calendar thead")
       |> assert_has("#month-calendar tbody tr", count: 6)
@@ -123,7 +123,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
       session =
         conn
         |> login(attendee)
-        |> visit("/calendar")
+        |> visit("/calendar?view=month")
 
       document =
         session.view
@@ -137,13 +137,31 @@ defmodule HuddlzWeb.CalendarLiveTest do
       assert overflow |> LazyHTML.query(".cal-day-context") |> Enum.any?()
     end
 
-    test "only the selected calendar view is marked current", %{
+    test "the agenda is the default view and comes first in the toggle", %{
       conn: conn,
       attendee: attendee
     } do
       conn
       |> login(attendee)
       |> visit("/calendar")
+      |> assert_has(".cal-month-name", text: "What's next")
+      |> assert_has(".cal-view-tabs .scope-tab:first-child.is-active[aria-current='page']",
+        text: "Agenda"
+      )
+      |> assert_has(".cal-view-tabs .scope-tab:last-child[href='/calendar?view=month']",
+        text: "Month"
+      )
+      |> assert_has(".cal-view-tabs .scope-tab.is-active[href='/calendar']", text: "Agenda")
+      |> refute_has("#month-calendar")
+    end
+
+    test "only the selected calendar view is marked current", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=month")
       |> assert_has(".cal-view-tabs a[aria-current='page']", text: "Month")
       |> refute_has(".cal-view-tabs a[aria-current]", text: "Agenda")
       |> visit("/calendar?view=agenda")
@@ -437,8 +455,8 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar")
-      |> assert_has(~s(a.cal-nav-btn[href="/calendar?month=#{next}"]))
+      |> visit("/calendar?view=month")
+      |> assert_has(~s(a.cal-nav-btn[href="/calendar?month=#{next}&view=month"]))
     end
 
     test "Today link returns to current month from a navigated state", %{
@@ -449,14 +467,14 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar?month=#{next}")
-      |> assert_has(~s(a.cal-nav-today[href="/calendar"]))
+      |> visit("/calendar?month=#{next}&view=month")
+      |> assert_has(~s(a.cal-nav-today[href="/calendar?view=month"]))
     end
 
     test "invalid ?month= falls back to current month", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/calendar?month=not-a-month")
+      |> visit("/calendar?month=not-a-month&view=month")
       |> assert_has(".cal-month-name", text: current_month_name())
     end
   end
@@ -595,7 +613,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
         |> refute_has("#calendar-agenda-empty")
 
       session
-      |> visit("/calendar")
+      |> visit("/calendar?view=month")
       |> assert_has("#month-calendar")
       |> assert_has("#calendar-first-run.empty-state h3", text: "Your calendar is empty")
     end
@@ -620,6 +638,26 @@ defmodule HuddlzWeb.CalendarLiveTest do
         text: "Nothing today."
       )
       |> refute_has("#calendar-agenda .cal-agenda-day[data-today] a")
+    end
+
+    test "a cancelled huddl stays on its day with a cancelled pill and no countdown", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Called Off", date: tomorrow())
+      rsvp!(huddl, attendee, :rsvp)
+      Communities.cancel_huddl!(huddl, "Venue unavailable", actor: host)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has("#calendar-entry-#{huddl.id} .cal-agenda-title", text: "Called Off")
+      |> assert_has("#calendar-entry-#{huddl.id} .cal-entry-status[data-status=cancelled]",
+        text: "Cancelled"
+      )
+      |> refute_has("#calendar-entry-#{huddl.id} .cal-agenda-relative")
     end
 
     test "the agenda ignores the month param and shows what's next", %{
@@ -758,10 +796,8 @@ defmodule HuddlzWeb.CalendarLiveTest do
   # filtering and for past dates that may slip outside the default grid).
   defp calendar_path_for(date, opts \\ []) do
     month = "#{date.year}-#{String.pad_leading(to_string(date.month), 2, "0")}"
-    view = Keyword.get(opts, :view)
-
-    params =
-      if view, do: "?month=#{month}&view=#{view}", else: "?month=#{month}"
+    view = Keyword.get(opts, :view, "month")
+    params = "?month=#{month}&view=#{view}"
 
     "/calendar" <> params
   end

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -272,12 +272,10 @@ defmodule HuddlzWeb.CalendarLiveTest do
           text: "Hosting · Past"
         )
 
+      # The agenda starts at today, so the past hosted huddl stays in the grid.
       session
-      |> visit(calendar_path_for(DateTime.to_date(local_starts_at), view: "agenda"))
-      |> assert_has(
-        "#calendar-entry-#{past.id} .cal-entry-status[data-status=past-hosting]",
-        text: "Hosting · Past"
-      )
+      |> visit("/calendar?view=agenda")
+      |> refute_has("#calendar-entry-#{past.id}")
     end
 
     test "hosting (creator) appears even without an RSVP", %{
@@ -534,7 +532,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> assert_has("#calendar-legend [data-status=hosting]", text: "Hosting")
     end
 
-    test "agenda represents waitlisted and past statuses with text", %{
+    test "agenda represents waitlisted with text and leaves the past to the month view", %{
       conn: conn,
       attendee: attendee,
       host: host,
@@ -549,28 +547,21 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       waitlisted = Ash.reload!(waitlisted)
       rsvp!(waitlisted, attendee, :join_waitlist)
-
-      conn
-      |> login(attendee)
-      |> visit(calendar_path_for(tomorrow(), view: "agenda"))
-      |> assert_has(
-        "#calendar-entry-#{waitlisted.id} .cal-entry-status[data-status=waitlist]",
-        text: "Waitlist"
-      )
-
       past = create_past_huddl(host, public_group, title: "Agenda Past")
       rsvp!(past, attendee, :rsvp)
 
       conn
       |> login(attendee)
-      |> visit(calendar_path_for(Date.add(Huddlz.Generator.eastern_today(), -2), view: "agenda"))
+      |> visit("/calendar?view=agenda")
       |> assert_has(
-        "#calendar-entry-#{past.id} .cal-entry-status[data-status=past-attended]",
-        text: "Attended · Past"
+        "#calendar-entry-#{waitlisted.id} .cal-entry-status[data-status=waitlist]",
+        text: "Waitlist"
       )
+      |> refute_has("#calendar-entry-#{past.id}")
+      |> refute_has("#calendar-legend [data-status=past-attended]")
     end
 
-    test "empty agenda shows helpful copy", %{
+    test "an agenda with nothing coming up says so quietly", %{
       conn: conn,
       host: host,
       attendee: attendee,
@@ -581,9 +572,12 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit(calendar_path_for(Date.add(Huddlz.Generator.eastern_today(), 400), view: "agenda"))
-      |> assert_has("#calendar-agenda-empty.empty-state h3", text: "Nothing this month")
-      |> assert_has("p", text: "Nothing on the calendar this month.")
+      |> visit("/calendar?view=agenda")
+      |> assert_has("#calendar-agenda-empty.empty-state h3", text: "Nothing coming up")
+      |> assert_has("#calendar-agenda-empty p", text: "Your next RSVP will land here.")
+      |> assert_has("#calendar-agenda-empty a.btn-secondary[href='/discover']",
+        text: "Browse huddlz"
+      )
       |> refute_has(".cal-agenda")
       |> refute_has("#calendar-first-run")
     end
@@ -628,7 +622,63 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> refute_has("#calendar-agenda .cal-agenda-day[data-today] a")
     end
 
-    test "past days go quiet and drop the countdown", %{
+    test "the agenda ignores the month param and shows what's next", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      soon = create_huddl(host, public_group, title: "Soon Enough", date: tomorrow())
+      rsvp!(soon, attendee, :rsvp)
+      far = Date.add(Huddlz.Generator.eastern_today(), 400)
+
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(far, view: "agenda"))
+      |> assert_has(".cal-month-name", text: "What's next")
+      |> assert_has(".cal-month-count", text: "1 huddl")
+      |> refute_has(".cal-nav")
+      |> assert_has("#calendar-entry-#{soon.id} .cal-agenda-title", text: "Soon Enough")
+      |> refute_has("#calendar-agenda-more")
+    end
+
+    test "the agenda stops after seven days with huddlz and points at the month view", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      today = Huddlz.Generator.eastern_today()
+
+      huddlz =
+        for offset <- [1, 1, 2, 3, 5, 8, 13, 21, 34] do
+          huddl =
+            create_huddl(host, public_group,
+              title: "Day #{offset}",
+              date: Date.add(today, offset)
+            )
+
+          rsvp!(huddl, attendee, :rsvp)
+          huddl
+        end
+
+      # Eight distinct days; the window keeps the first seven and points at
+      # the month holding the eighth.
+      beyond = List.last(huddlz)
+      eighth = Date.add(today, 34)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=agenda")
+      |> assert_has("#calendar-agenda .cal-agenda-entry", count: 8)
+      |> assert_has(".cal-month-count", text: "8 huddlz")
+      |> refute_has("#calendar-entry-#{beyond.id}")
+      |> assert_has("#calendar-agenda-more a[href='#{calendar_path_for(eighth)}']",
+        text: "Open #{Calendar.strftime(eighth, "%B %Y")} in the month view"
+      )
+    end
+
+    test "past days in the touch list go quiet and drop the countdown", %{
       conn: conn,
       attendee: attendee,
       host: host,
@@ -640,11 +690,12 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit(calendar_path_for(day, view: "agenda"))
-      |> assert_has("#calendar-agenda-day-#{Date.to_iso8601(day)}[data-past] .cal-agenda-title",
+      |> visit(calendar_path_for(day))
+      |> assert_has(
+        "#calendar-touch-agenda-list-day-#{Date.to_iso8601(day)}[data-past] .cal-agenda-title",
         text: "Agenda Gone By"
       )
-      |> refute_has("#calendar-entry-#{past.id} .cal-agenda-relative")
+      |> refute_has("#calendar-touch-entry-#{past.id} .cal-agenda-relative")
     end
 
     test "an entry shows the group's initials, its place and how far off it is", %{

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -606,7 +606,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> assert_has("#calendar-first-run.empty-state h3", text: "Your calendar is empty")
     end
 
-    test "today is drawn as the anchor and points at the next huddl", %{
+    test "today is drawn as the anchor even with nothing on", %{
       conn: conn,
       attendee: attendee,
       host: host,
@@ -616,26 +616,16 @@ defmodule HuddlzWeb.CalendarLiveTest do
       rsvp!(next, attendee, :rsvp)
       today = Huddlz.Generator.eastern_today()
 
-      session =
-        conn
-        |> login(attendee)
-        |> visit(calendar_path_for(today, view: "agenda"))
-        |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-day-context",
-          text: "Today"
-        )
-        |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-quiet",
-          text: "Nothing today."
-        )
-
-      # Tomorrow is only "next up" while it shares the month; on the last day
-      # of a month the today row says the month is done instead.
-      if tomorrow().month == today.month do
-        assert_has(session, ".cal-agenda-day[data-today] .cal-agenda-quiet a", text: "Next Thing")
-      else
-        assert_has(session, ".cal-agenda-day[data-today] .cal-agenda-quiet",
-          text: "Nothing else this month."
-        )
-      end
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(today, view: "agenda"))
+      |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-day-context",
+        text: "Today"
+      )
+      |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-quiet",
+        text: "Nothing today."
+      )
+      |> refute_has("#calendar-agenda .cal-agenda-day[data-today] a")
     end
 
     test "past days go quiet and drop the countdown", %{

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -2,6 +2,8 @@ defmodule HuddlzWeb.CalendarLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
   alias Huddlz.Communities
+  alias HuddlzWeb.Components.Card
+  alias HuddlzWeb.Live.Helpers.HuddlCardHelpers
 
   setup do
     host = generate(user(role: :user))
@@ -483,8 +485,8 @@ defmodule HuddlzWeb.CalendarLiveTest do
       conn
       |> login(attendee)
       |> visit(calendar_path_for(tomorrow(), view: "agenda"))
-      |> assert_has(".cal-agenda-panel .cal-agenda-row .row-title", text: "Agenda Item")
-      |> assert_has("#calendar-entry-#{huddl.id}.cal-agenda-row .meta")
+      |> assert_has(".cal-agenda .cal-agenda-entry .cal-agenda-title", text: "Agenda Item")
+      |> assert_has("#calendar-entry-#{huddl.id}.cal-agenda-entry .cal-agenda-time")
       |> assert_has(
         "#calendar-entry-#{huddl.id} .cal-entry-status[data-status=going]",
         text: "Going"
@@ -582,7 +584,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> visit(calendar_path_for(Date.add(Huddlz.Generator.eastern_today(), 400), view: "agenda"))
       |> assert_has("#calendar-agenda-empty.empty-state h3", text: "Nothing this month")
       |> assert_has("p", text: "Nothing on the calendar this month.")
-      |> refute_has(".cal-agenda-panel")
+      |> refute_has(".cal-agenda")
       |> refute_has("#calendar-first-run")
     end
 
@@ -602,6 +604,109 @@ defmodule HuddlzWeb.CalendarLiveTest do
       |> visit("/calendar")
       |> assert_has("#month-calendar")
       |> assert_has("#calendar-first-run.empty-state h3", text: "Your calendar is empty")
+    end
+
+    test "today is drawn as the anchor and points at the next huddl", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      next = create_huddl(host, public_group, title: "Next Thing", date: tomorrow())
+      rsvp!(next, attendee, :rsvp)
+      today = Huddlz.Generator.eastern_today()
+
+      session =
+        conn
+        |> login(attendee)
+        |> visit(calendar_path_for(today, view: "agenda"))
+        |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-day-context",
+          text: "Today"
+        )
+        |> assert_has("#calendar-agenda .cal-agenda-day[data-today] .cal-agenda-quiet",
+          text: "Nothing today."
+        )
+
+      # Tomorrow is only "next up" while it shares the month; on the last day
+      # of a month the today row says the month is done instead.
+      if tomorrow().month == today.month do
+        assert_has(session, ".cal-agenda-day[data-today] .cal-agenda-quiet a", text: "Next Thing")
+      else
+        assert_has(session, ".cal-agenda-day[data-today] .cal-agenda-quiet",
+          text: "Nothing else this month."
+        )
+      end
+    end
+
+    test "past days go quiet and drop the countdown", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      past = create_past_huddl(host, public_group, title: "Agenda Gone By")
+      rsvp!(past, attendee, :rsvp)
+      day = DateTime.to_date(HuddlCardHelpers.local_starts_at(past))
+
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(day, view: "agenda"))
+      |> assert_has("#calendar-agenda-day-#{Date.to_iso8601(day)}[data-past] .cal-agenda-title",
+        text: "Agenda Gone By"
+      )
+      |> refute_has("#calendar-entry-#{past.id} .cal-agenda-relative")
+    end
+
+    test "an entry shows the group's initials, its place and how far off it is", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      in_person = create_huddl(host, public_group, title: "Somewhere", date: tomorrow())
+
+      online =
+        create_huddl(host, public_group,
+          title: "Nowhere",
+          date: tomorrow(),
+          event_type: :virtual,
+          virtual_link: "https://meet.example.com/nowhere"
+        )
+
+      rsvp!(in_person, attendee, :rsvp)
+      rsvp!(online, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(tomorrow(), view: "agenda"))
+      |> assert_has("#calendar-entry-#{in_person.id} .cal-agenda-thumb .card-cover-fallback span",
+        text: Card.group_initials(public_group.name)
+      )
+      |> assert_has("#calendar-entry-#{in_person.id} .cal-agenda-meta",
+        text: in_person.physical_location
+      )
+      |> assert_has("#calendar-entry-#{online.id} .cal-agenda-meta", text: "Online")
+      |> assert_has("#calendar-entry-#{in_person.id} .cal-agenda-relative", text: "tomorrow")
+    end
+
+    test "the touch list under the month grid uses the same day groups", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      huddl = create_huddl(host, public_group, title: "Touch Me", date: tomorrow())
+      rsvp!(huddl, attendee, :rsvp)
+      day = Date.to_iso8601(DateTime.to_date(HuddlCardHelpers.local_starts_at(huddl)))
+
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(tomorrow()))
+      |> assert_has("#calendar-touch-agenda-list-day-#{day} .cal-agenda-daynum")
+      |> assert_has("#calendar-touch-entry-#{huddl.id}.cal-agenda-entry .cal-agenda-title",
+        text: "Touch Me"
+      )
+      |> refute_has("#calendar-touch-agenda-list .cal-agenda-day[data-today] .cal-agenda-quiet")
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #481.

The calendar's agenda was a table of rows: date, title, pill. It carried less than a huddl card, gave no sense of time passing between entries, and was scoped to the month, so late in a month it was mostly history. Direction chosen on the design canvas (My calendar · Agenda, plus the phone board): a forward-looking, day-grouped list rather than a card grid, because a grid reads left to right and loses the time order an agenda exists for.

- **The agenda is the default.** `/calendar` opens on it and it comes first in the view toggle. The month grid lives behind `?view=month`, where `?month=YYYY-MM` still drives it.
- **Starts at today.** The agenda ignores the month. It always draws today, then the next 7 days that have huddlz, across month boundaries, with the month named on the rail when a day is outside this one. If more lie beyond, a line under the list points at the month view for the month that holds the next one. The past lives in the month grid.
- **Day groups.** Each day gets a date rail on the left (weekday, day number) and one horizontal card per huddl on the right: a 16:9 cover thumb with the group's initials as the fallback, the time in the huddl's zone, the title, group and place, the status pill, and how far off it is. An empty today says "Nothing today." and no more, since the next row is the next thing. A cancelled huddl stays on its day with the cancelled pill and no countdown.
- **Toolbar.** In agenda mode the month arrows and month title give way to "What's next" and the count of what is listed. The Month tab returns to the month you were on.
- **Empty.** With nothing coming up, the quiet state reads "Nothing coming up" with a secondary "Browse huddlz". The first-run state is unchanged.
- **Phones.** The rail becomes a heading strip above the entries, the thumb shrinks to 96px, and group and place stack. The touch list under the month grid renders through the same component, so the two lists no longer differ; there, past days go quiet.
- `relative_time/1` moves from My huddlz to `HuddlCardHelpers` so both pages say "3 days away" the same way.

## Verification

- Feature `calendar_agenda.feature`, written first and failing before the change: next month's huddlz are grouped by day in time order with the month named on the rail; today is drawn with nothing on it and yesterday's huddl is not listed; nine days of huddlz are cut to seven with a pointer at the month view.
- LiveView tests cover the agenda being the default and first in the toggle, the empty today row, the month param being ignored in agenda mode, the seven-day cap and its month-view link, the cancelled pill without a countdown, the quiet empty state, past days in the touch list, the initials fallback, the online place label and the countdown. Existing month-grid tests now visit `?view=month`.
- `mix precommit` clean, exit code checked directly. No JS changed, so the Playwright suite was not rerun.

Screenshots in the comments.
