### PR TITLE
feat(ui): show everything my groups have on in the calendar

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2355,6 +2355,8 @@ body .cal-toolbar {
   margin-bottom: 24px;
 }
 
+body .cal-scope { margin-bottom: 16px; }
+
 body .cal-nav { display: flex; gap: 4px; }
 
 body .cal-nav-btn {
@@ -2566,6 +2568,11 @@ body .cal-pill-status {
 }
 
 body .cal-pill.hosting { background: var(--pink-soft); color: var(--pink); }
+body .cal-pill.open {
+  border: 1px dashed var(--line-strong);
+  background: transparent;
+  color: var(--soft);
+}
 body .cal-pill.tentative { background: var(--warn-soft); color: var(--warn); }
 body .cal-pill.past { background: var(--panel-2); color: var(--muted); }
 body .cal-pill.past:hover { color: var(--soft); }
@@ -2904,6 +2911,10 @@ body .cal-legend-swatch.cyan { background: var(--accent); }
 body .cal-legend-swatch.magenta { background: var(--pink); }
 body .cal-legend-swatch.warn { background: var(--warn); }
 body .cal-legend-swatch.muted { background: var(--line-strong); }
+body .cal-legend-swatch.outline {
+  border: 1px dashed var(--line-strong);
+  background: transparent;
+}
 
 body .cal-legend-note { margin-left: auto; font-size: 12px; }
 

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -414,12 +414,13 @@ defmodule Huddlz.Communities.Huddl do
       argument :relationship, :atom do
         description """
         Restrict results to huddlz the actor hosts (creator), is attending
-        (confirmed RSVP), or is on the waitlist for. :attending excludes
+        (confirmed RSVP), is on the waitlist for, or that belong to a group
+        the actor owns or has joined (:member). :attending excludes
         waitlisted rows; use :waitlisted to find those instead.
         """
 
         allow_nil? true
-        constraints one_of: [:hosting, :attending, :waitlisted]
+        constraints one_of: [:hosting, :attending, :waitlisted, :member]
       end
 
       argument :search_time_zone, :string do

--- a/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
+++ b/lib/huddlz/communities/huddl/preparations/apply_search_filters.ex
@@ -140,7 +140,7 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
     # rather than ignoring the relationship filter (which would silently broaden
     # the query and leak unrelated huddlz to API consumers).
     case Ash.Query.get_argument(query, :relationship) do
-      relationship when relationship in [:hosting, :attending, :waitlisted] ->
+      relationship when relationship in [:hosting, :attending, :waitlisted, :member] ->
         Ash.Query.filter(query, false)
 
       _ ->
@@ -163,6 +163,12 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFilters do
         Ash.Query.filter(
           query,
           exists(attendees, user_id == ^actor.id and not is_nil(waitlisted_at))
+        )
+
+      :member ->
+        Ash.Query.filter(
+          query,
+          group.owner_id == ^actor.id or exists(group.group_members, user_id == ^actor.id)
         )
 
       _ ->

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -5,7 +5,8 @@ defmodule HuddlzWeb.CalendarLive do
   with a month grid behind `?view=month`; `?month=YYYY-MM` drives the grid.
   The agenda ignores the month: it starts at today and runs
   forward through the next few days that have huddlz, one entry per huddl,
-  leaving the past to the month grid.
+  leaving the past to the month grid. `?scope=groups` widens both views
+  from the person's own RSVPs to everything their groups have scheduled.
   """
   use HuddlzWeb, :live_view
 
@@ -52,8 +53,11 @@ defmodule HuddlzWeb.CalendarLive do
     {grid_start, grid_end} = month_grid_window(focus_month)
     user = socket.assigns.current_user
 
+    scope = parse_scope(params["scope"])
     today = socket.assigns.today
-    all = load_entries(user, socket.assigns.time_zone)
+    own = load_entries(user, socket.assigns.time_zone)
+    group_extras = load_group_extras(user, socket.assigns.time_zone, own, today)
+    all = if scope == :groups, do: merge_entries(own, group_extras), else: own
     entries = grid_entries(all, grid_start, grid_end, socket.assigns.time_zone)
     {agenda_days, agenda_more} = agenda_window(all, today)
     agenda_entries = Enum.flat_map(agenda_days, & &1.entries)
@@ -67,6 +71,8 @@ defmodule HuddlzWeb.CalendarLive do
      socket
      |> assign(:focus_month, focus_month)
      |> assign(:view_mode, view_mode)
+     |> assign(:scope, scope)
+     |> assign(:counts, scope_counts(own, group_extras, today))
      |> assign(:grid_start, grid_start)
      |> assign(:grid_end, grid_end)
      |> assign(:entries, entries)
@@ -103,6 +109,9 @@ defmodule HuddlzWeb.CalendarLive do
   defp parse_view("month"), do: :month
   defp parse_view(_), do: :agenda
 
+  defp parse_scope("groups"), do: :groups
+  defp parse_scope(_), do: :mine
+
   defp first_of_month(date), do: %{date | day: 1}
 
   defp month_grid_window(month_first) do
@@ -124,6 +133,30 @@ defmodule HuddlzWeb.CalendarLive do
     |> Enum.filter(& &1.huddl.starts_at)
     |> Enum.map(&put_calendar_time(&1, time_zone))
     |> Enum.sort_by(& &1.huddl.starts_at, DateTime)
+  end
+
+  # Upcoming huddlz from groups the person owns or has joined that they have
+  # not responded to. Their own entries win on overlap, and the past is left
+  # out: a huddl they did not attend is not a calendar fact.
+  defp load_group_extras(user, time_zone, own, today) do
+    own_ids = MapSet.new(own, & &1.huddl.id)
+
+    user
+    |> fetch(:member)
+    |> Enum.reject(&MapSet.member?(own_ids, &1.huddl.id))
+    |> Enum.filter(& &1.huddl.starts_at)
+    |> Enum.map(&%{huddl: &1.huddl, roles: MapSet.new([:member])})
+    |> Enum.map(&put_calendar_time(&1, time_zone))
+    |> Enum.filter(&(Date.compare(&1.calendar_date, today) != :lt))
+  end
+
+  defp merge_entries(own, extras) do
+    Enum.sort_by(own ++ extras, & &1.huddl.starts_at, DateTime)
+  end
+
+  defp scope_counts(own, extras, today) do
+    mine = Enum.count(own, &(Date.compare(&1.calendar_date, today) != :lt))
+    %{mine: mine, groups: mine + length(extras)}
   end
 
   defp grid_entries(entries, grid_start, grid_end, time_zone) do
@@ -192,16 +225,18 @@ defmodule HuddlzWeb.CalendarLive do
     Date.new!(Integer.floor_div(total, 12), Integer.mod(total, 12) + 1, 1)
   end
 
-  defp month_path(month, view, today) do
-    base = month_param(month, today)
-    view_str = if view == :month, do: "month"
+  # The calendar's own URL: the month only matters to the month view, the
+  # default view and scope are left out, and today's month is the default.
+  defp calendar_path(month, view, today, scope) do
+    params =
+      [
+        month: view == :month && month_param(month, today),
+        view: view == :month && "month",
+        scope: scope == :groups && "groups"
+      ]
+      |> Enum.filter(fn {_key, value} -> value end)
 
-    cond do
-      base && view_str -> ~p"/calendar?#{[month: base, view: view_str]}"
-      base -> ~p"/calendar?#{[month: base]}"
-      view_str -> ~p"/calendar?#{[view: view_str]}"
-      true -> ~p"/calendar"
-    end
+    if params == [], do: ~p"/calendar", else: ~p"/calendar?#{params}"
   end
 
   defp month_param(month, today) do
@@ -258,6 +293,7 @@ defmodule HuddlzWeb.CalendarLive do
       :warn -> "cal-pill tentative waitlisted"
       :magenta -> "cal-pill hosting"
       :cyan -> "cal-pill going"
+      :outline -> "cal-pill open"
     end
   end
 
@@ -328,6 +364,9 @@ defmodule HuddlzWeb.CalendarLive do
 
       attending? ->
         %EntryStatus{key: "going", label: "Going", variant: :cyan, rank: 2}
+
+      true ->
+        %EntryStatus{key: "open", label: "No RSVP", variant: :outline, rank: 9}
     end
   end
 
@@ -417,20 +456,20 @@ defmodule HuddlzWeb.CalendarLive do
         <%= if @view_mode == :month do %>
           <div class="cal-nav">
             <.link
-              patch={month_path(shift_month(@focus_month, -1), @view_mode, @today)}
+              patch={calendar_path(shift_month(@focus_month, -1), @view_mode, @today, @scope)}
               class="cal-nav-btn"
               aria-label="Previous month"
             >
               <.icon name="hero-chevron-left" class="size-4" />
             </.link>
             <.link
-              patch={month_path(first_of_month(@today), @view_mode, @today)}
+              patch={calendar_path(first_of_month(@today), @view_mode, @today, @scope)}
               class="cal-nav-today"
             >
               Today
             </.link>
             <.link
-              patch={month_path(shift_month(@focus_month, 1), @view_mode, @today)}
+              patch={calendar_path(shift_month(@focus_month, 1), @view_mode, @today, @scope)}
               class="cal-nav-btn"
               aria-label="Next month"
             >
@@ -452,7 +491,7 @@ defmodule HuddlzWeb.CalendarLive do
         <div class="cal-view-tabs">
           <.link
             id="calendar-view-agenda"
-            patch={~p"/calendar"}
+            patch={calendar_path(@focus_month, :agenda, @today, @scope)}
             class={["scope-tab", @view_mode == :agenda && "is-active"]}
             aria-current={if @view_mode == :agenda, do: "page"}
           >
@@ -460,13 +499,32 @@ defmodule HuddlzWeb.CalendarLive do
           </.link>
           <.link
             id="calendar-view-month"
-            patch={month_path(@focus_month, :month, @today)}
+            patch={calendar_path(@focus_month, :month, @today, @scope)}
             class={["scope-tab", @view_mode == :month && "is-active"]}
             aria-current={if @view_mode == :month, do: "page"}
           >
             Month
           </.link>
         </div>
+      </div>
+
+      <div class="chip-group cal-scope" aria-label="Whose huddlz to show">
+        <.chip
+          id="calendar-scope-mine"
+          patch={calendar_path(@focus_month, @view_mode, @today, :mine)}
+          active={@scope == :mine}
+          count={@counts.mine}
+        >
+          My RSVPs
+        </.chip>
+        <.chip
+          id="calendar-scope-groups"
+          patch={calendar_path(@focus_month, @view_mode, @today, :groups)}
+          active={@scope == :groups}
+          count={@counts.groups}
+        >
+          My groups
+        </.chip>
       </div>
 
       <%= if @view_mode == :month do %>
@@ -483,6 +541,7 @@ defmodule HuddlzWeb.CalendarLive do
           days={@agenda_days}
           more={@agenda_more}
           today={@today}
+          scope={@scope}
           first_run?={@first_run?}
         />
       <% end %>
@@ -650,6 +709,7 @@ defmodule HuddlzWeb.CalendarLive do
   attr :days, :list, required: true
   attr :more, :any, required: true, doc: "first day with huddlz beyond the window, or nil"
   attr :today, Date, required: true
+  attr :scope, :atom, required: true
   attr :first_run?, :boolean, default: false
 
   defp agenda_view(assigns) do
@@ -673,7 +733,7 @@ defmodule HuddlzWeb.CalendarLive do
         />
         <p :if={@more} id="calendar-agenda-more" class="cal-agenda-more">
           More after {Calendar.strftime(List.last(@days).date, "%A, %B %-d")}.
-          <.link patch={month_path(first_of_month(@more), :month, @today)}>
+          <.link patch={calendar_path(first_of_month(@more), :month, @today, @scope)}>
             Open {format_month(@more)} in the month view
           </.link>
         </p>
@@ -767,7 +827,12 @@ defmodule HuddlzWeb.CalendarLive do
         </span>
       </div>
       <div class="cal-agenda-side">
-        <.pill variant={@status.variant} class="cal-entry-status" data-status={@status.key}>
+        <.pill
+          :if={@status.variant != :outline}
+          variant={@status.variant}
+          class="cal-entry-status"
+          data-status={@status.key}
+        >
           {@status.label}
         </.pill>
         <span :if={countdown?(@status)} class="cal-agenda-relative">

--- a/test/features/calendar_group_scope.feature
+++ b/test/features/calendar_group_scope.feature
@@ -1,0 +1,28 @@
+@database @conn
+Feature: Calendar scope: my RSVPs or everything my groups have on
+  As a member of active groups
+  I want the calendar to show everything my groups have scheduled, not only what I have responded to
+  So that I can see what to join next without opening each group
+
+  Background:
+    Given the following users exist:
+      | email               | display_name | role    |
+      | member@example.com  | Member User  | regular |
+    And I am signed in as "member@example.com"
+
+  Scenario: The calendar starts with what I have responded to
+    Given I belong to "Portland Elixir", which has scheduled "Hands-on with Ash Framework"
+    And I am going to "Async Rust reading group" with another group
+    When I open the agenda
+    Then the agenda lists "Async Rust reading group" as going
+    And the agenda does not list "Hands-on with Ash Framework"
+
+  Scenario: Everything my groups have on
+    Given I belong to "Portland Elixir", which has scheduled "Hands-on with Ash Framework"
+    And I am going to "Async Rust reading group" with another group
+    And a group I have not joined has scheduled "Not for me"
+    When I open the agenda
+    And I switch to everything from my groups
+    Then the agenda lists "Hands-on with Ash Framework" without an RSVP status
+    And the agenda lists "Async Rust reading group" as going
+    And the agenda does not list "Not for me"

--- a/test/features/step_definitions/calendar_group_scope_steps.exs
+++ b/test/features/step_definitions/calendar_group_scope_steps.exs
@@ -1,0 +1,72 @@
+defmodule CalendarGroupScopeSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import PhoenixTest
+
+  step "I belong to {string}, which has scheduled {string}",
+       %{args: [group_name, title], current_user: member} = context do
+    host = generate(user(role: :user))
+    group = generate(group(name: group_name, owner_id: host.id, is_public: true, actor: host))
+    generate(group_member(group_id: group.id, user_id: member.id, role: "member", actor: host))
+    schedule(group, host, title, 3)
+    context
+  end
+
+  step "I am going to {string} with another group",
+       %{args: [title], current_user: attendee} = context do
+    host = generate(user(role: :user))
+    group = generate(group(name: "PDX Rust", owner_id: host.id, is_public: true, actor: host))
+
+    group
+    |> schedule(host, title, 5)
+    |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+    |> Ash.update!()
+
+    context
+  end
+
+  step "a group I have not joined has scheduled {string}", %{args: [title]} = context do
+    host = generate(user(role: :user))
+    group = generate(group(name: "Strangers", owner_id: host.id, is_public: true, actor: host))
+    schedule(group, host, title, 4)
+    context
+  end
+
+  step "I switch to everything from my groups", %{session: session} = context do
+    session = click_link(session, "#calendar-scope-groups", "My groups")
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "the agenda lists {string} as going", %{args: [title], session: session} = context do
+    assert_has(session, "#calendar-agenda .cal-agenda-entry[data-status=going] .cal-agenda-title",
+      text: title
+    )
+
+    context
+  end
+
+  step "the agenda lists {string} without an RSVP status",
+       %{args: [title], session: session} = context do
+    session
+    |> assert_has("#calendar-agenda .cal-agenda-entry[data-status=open] .cal-agenda-title",
+      text: title
+    )
+    |> refute_has("#calendar-agenda .cal-agenda-entry[data-status=open] .cal-entry-status")
+
+    context
+  end
+
+  defp schedule(group, host, title, days_ahead) do
+    generate(
+      huddl(
+        group_id: group.id,
+        creator_id: host.id,
+        is_private: false,
+        title: title,
+        date: Date.add(eastern_today(), days_ahead),
+        actor: host
+      )
+    )
+  end
+end

--- a/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
+++ b/test/huddlz/communities/huddl/preparations/apply_search_filters_test.exs
@@ -276,6 +276,38 @@ defmodule Huddlz.Communities.Huddl.Preparations.ApplySearchFiltersTest do
       assert hosted.id in Enum.map(results, & &1.id)
     end
 
+    test ":member returns huddlz from groups the actor owns or has joined", %{
+      group: host_group,
+      owner: owner,
+      attendee: attendee,
+      hosted_by_owner: in_my_group,
+      hosted_by_stranger: elsewhere
+    } do
+      generate(group_member(group_id: host_group.id, user_id: attendee.id, actor: owner))
+
+      for actor <- [attendee, owner] do
+        {:ok, %{results: results}} =
+          Huddlz.Communities.Huddl
+          |> Ash.Query.for_read(:search, %{relationship: :member, date_filter: :all},
+            actor: actor
+          )
+          |> Ash.read(actor: actor, page: [limit: 50, count: true])
+
+        ids = Enum.map(results, & &1.id)
+        assert in_my_group.id in ids
+        refute elsewhere.id in ids
+      end
+    end
+
+    test "anonymous actor with :member returns []", %{} do
+      {:ok, %{results: results}} =
+        Huddlz.Communities.Huddl
+        |> Ash.Query.for_read(:search, %{relationship: :member, date_filter: :all}, actor: nil)
+        |> Ash.read(actor: nil, page: [limit: 50, count: true])
+
+      assert results == []
+    end
+
     test "anonymous actor with relationship filter returns []", %{} do
       {:ok, %{results: results}} =
         Huddlz.Communities.Huddl

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -789,6 +789,111 @@ defmodule HuddlzWeb.CalendarLiveTest do
     end
   end
 
+  describe "scope: my RSVPs or my groups" do
+    setup %{attendee: attendee, host: host, public_group: public_group} do
+      generate(group_member(group_id: public_group.id, user_id: attendee.id, actor: host))
+      %{}
+    end
+
+    test "the chips carry upcoming counts and default to my RSVPs", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      mine = create_huddl(host, public_group, title: "Mine", date: tomorrow())
+      rsvp!(mine, attendee, :rsvp)
+      create_huddl(host, public_group, title: "Theirs", date: Date.add(tomorrow(), 1))
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has("#calendar-scope-mine.chip.is-active[aria-current='page']", text: "My RSVPs")
+      |> assert_has("#calendar-scope-mine .chip-count", text: "1")
+      |> assert_has("#calendar-scope-groups.chip:not(.is-active)[href='/calendar?scope=groups']",
+        text: "My groups"
+      )
+      |> assert_has("#calendar-scope-groups .chip-count", text: "2")
+      |> refute_has(".cal-agenda-title", text: "Theirs")
+    end
+
+    test "my groups adds unanswered huddlz with an outlined pill in the grid and a legend entry",
+         %{conn: conn, attendee: attendee, host: host, public_group: public_group} do
+      theirs = create_huddl(host, public_group, title: "Theirs", date: tomorrow())
+
+      conn
+      |> login(attendee)
+      |> visit(calendar_path_for(tomorrow()) <> "&scope=groups")
+      |> assert_has("#calendar-entry-#{theirs.id}.cal-pill.open[data-status=open]",
+        text: "Theirs"
+      )
+      |> assert_has("#calendar-legend [data-status=open] .cal-legend-swatch.outline")
+      |> assert_has("#calendar-legend [data-status=open]", text: "No RSVP")
+      |> assert_has("#calendar-scope-groups.chip.is-active")
+    end
+
+    test "the scope survives switching views and paging months", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      next = next_month_param(Huddlz.Generator.eastern_today())
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?scope=groups")
+      |> assert_has("#calendar-view-month[href='/calendar?view=month&scope=groups']")
+      |> visit("/calendar?view=month&scope=groups")
+      |> assert_has("#calendar-view-agenda[href='/calendar?scope=groups']")
+      |> assert_has(~s(a.cal-nav-btn[href="/calendar?month=#{next}&view=month&scope=groups"]))
+      |> assert_has("#calendar-scope-mine[href='/calendar?view=month']")
+    end
+
+    test "my groups leaves out the past and cancelled huddlz nobody answered", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      gone = create_past_huddl(host, public_group, title: "Missed It")
+      off = create_huddl(host, public_group, title: "Called Off", date: tomorrow())
+      Communities.cancel_huddl!(off, "Venue unavailable", actor: host)
+      answered = create_huddl(host, public_group, title: "Answered", date: tomorrow())
+      Communities.cancel_huddl!(answered, "Venue unavailable", actor: host)
+      rsvp_before_cancel = create_huddl(host, public_group, title: "Was Going", date: tomorrow())
+      rsvp!(rsvp_before_cancel, attendee, :rsvp)
+      Communities.cancel_huddl!(rsvp_before_cancel, "Venue unavailable", actor: host)
+      gone_day = DateTime.to_date(HuddlCardHelpers.local_starts_at(gone))
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?scope=groups")
+      |> refute_has("#calendar-entry-#{off.id}")
+      |> refute_has("#calendar-entry-#{answered.id}")
+      |> assert_has("#calendar-entry-#{rsvp_before_cancel.id} [data-status=cancelled]")
+      |> visit(calendar_path_for(gone_day) <> "&scope=groups")
+      |> refute_has("#calendar-entry-#{gone.id}")
+    end
+
+    test "a newcomer's groups still show what they have on", %{
+      conn: conn,
+      attendee: attendee,
+      host: host,
+      public_group: public_group
+    } do
+      theirs = create_huddl(host, public_group, title: "Theirs", date: tomorrow())
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar")
+      |> assert_has("#calendar-first-run")
+      |> visit("/calendar?scope=groups")
+      |> refute_has("#calendar-first-run")
+      |> assert_has("#calendar-entry-#{theirs.id} .cal-agenda-title", text: "Theirs")
+      |> refute_has("#calendar-entry-#{theirs.id} .cal-entry-status")
+      |> assert_has("#calendar-entry-#{theirs.id} .cal-agenda-relative", text: "tomorrow")
+    end
+  end
+
   defp tomorrow, do: Date.add(Huddlz.Generator.eastern_today(), 1)
 
   # Build a /calendar URL pinned to the month containing `date`, so the focus


### PR DESCRIPTION
## Summary

The calendar only ever showed what you were hosting, going to, or waitlisted for. Members of an active group had no view of what that group had scheduled without opening the group page. Follows #490.

- **Scope chips.** Above both views: **My RSVPs** (default) and **My groups**, each with a count of what is upcoming. `?scope=groups` carries through the view toggle, the month arrows and the agenda's month-view pointer.
- **My groups** adds every upcoming huddl from a group you own or have joined that you have not responded to. Your own entries win on overlap. Past huddlz you did not attend and cancelled huddlz nobody answered stay out; a cancelled huddl you had RSVP'd to keeps its cancelled pill as before.
- **Unanswered huddlz** carry no status pill in the agenda, so the ones you are committed to still stand out, and a dashed outline pill in the month grid. The legend gains a "No RSVP" entry with a hollow swatch when any are on screen.
- **A newcomer** with no RSVPs still sees the first-run state on My RSVPs, and switching to My groups shows what their groups have on.
- **Search action.** The huddl search's `relationship` argument gains `:member`: huddlz whose group the actor owns or has joined. The calendar reads through it, and the API and GraphQL get the same filter for free. An anonymous actor gets an empty result, as with the other relationships.

## Verification

- Feature `calendar_group_scope.feature`, written first: the calendar starts with what you have responded to; switching to My groups lists an unanswered group huddl without a status, keeps what you are going to, and leaves out a group you have not joined.
- Preparation tests cover `:member` for a joined member and for the owner, and the anonymous case.
- LiveView tests cover the chip counts and default, the outlined grid pill and legend entry, the scope surviving view and month navigation, the past and cancelled exclusions, and the newcomer case.
- `mix precommit` clean, exit code checked directly. No JS changed, so the Playwright suite was not rerun.

Screenshots in the first comment.
