### PR TITLE
Drop “my” from Groups and Huddlz labels and URLs

### DIFF
--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -20,7 +20,7 @@ defmodule Huddlz.Communities.Group do
       list :list_groups, :read
       list :search_groups, :search
       # `myGroups` mirrors the `Communities.my_groups/1` Elixir interface and
-      # the `/my-groups` LiveView: returns groups the actor owns or has joined.
+      # the `/groups` LiveView: returns groups the actor owns or has joined.
       # Pass `relationship: hosting | joined | all` to scope the result.
       list :my_groups, :my_groups
       list :archived_groups, :archived

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -25,7 +25,7 @@ defmodule HuddlzWeb.Layouts do
 
   attr :active, :string,
     default: nil,
-    doc: "active surface key for nav highlighting (e.g. \"discover\", \"my-huddlz\")"
+    doc: "active surface key for nav highlighting (e.g. \"discover\", \"huddlz\")"
 
   attr :active_group_slug, :string,
     default: nil,
@@ -87,20 +87,20 @@ defmodule HuddlzWeb.Layouts do
             <span class="label">Discover</span>
           </.link>
           <.link
-            class={["sb-item", @active == "my-huddlz" && "active"]}
-            navigate={~p"/my-huddlz"}
-            aria-current={@active == "my-huddlz" && "page"}
+            class={["sb-item", @active == "huddlz" && "active"]}
+            navigate={~p"/huddlz"}
+            aria-current={@active == "huddlz" && "page"}
           >
             <.nav_icon name="ticket" />
-            <span class="label">My huddlz</span>
+            <span class="label">Huddlz</span>
           </.link>
           <.link
-            class={["sb-item", @active == "my-groups" && "active"]}
-            navigate={~p"/my-groups"}
-            aria-current={@active == "my-groups" && "page"}
+            class={["sb-item", @active == "groups" && "active"]}
+            navigate={~p"/groups"}
+            aria-current={@active == "groups" && "page"}
           >
             <.nav_icon name="users" />
-            <span class="label">My groups</span>
+            <span class="label">Groups</span>
           </.link>
           <.link
             class={["sb-item", @active == "calendar" && "active"]}

--- a/lib/huddlz_web/controllers/error_html.ex
+++ b/lib/huddlz_web/controllers/error_html.ex
@@ -126,7 +126,7 @@ defmodule HuddlzWeb.ErrorHTML do
   end
 
   defp home_destination(nil), do: {~p"/", "huddlz home"}
-  defp home_destination(_current_user), do: {~p"/my-huddlz", "Back to My huddlz"}
+  defp home_destination(_current_user), do: {~p"/huddlz", "Back to Huddlz"}
 
   defp safe_retry_path("//" <> _path), do: ~p"/"
   defp safe_retry_path("/\\" <> _path), do: ~p"/"

--- a/lib/huddlz_web/live/group_invitation_live.ex
+++ b/lib/huddlz_web/live/group_invitation_live.ex
@@ -256,11 +256,11 @@ defmodule HuddlzWeb.GroupInvitationLive do
   defp invitation_status_label(:expired), do: "Expired"
 
   defp invitation_status_description(:pending) do
-    "This private group stays hidden until you accept. Accepting adds it to My groups and gives you access to its roster and huddlz."
+    "This private group stays hidden until you accept. Accepting adds it to Groups and gives you access to its roster and huddlz."
   end
 
   defp invitation_status_description(:accepted) do
-    "You accepted this invitation. This private group is now available in My groups."
+    "You accepted this invitation. This private group is now available in Groups."
   end
 
   defp invitation_status_description(:declined) do

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -187,7 +187,7 @@ defmodule HuddlzWeb.GroupLive.New do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-groups"
+      active="groups"
     >
       <div class="page-head">
         <div>
@@ -363,7 +363,7 @@ defmodule HuddlzWeb.GroupLive.New do
           <.button variant={:primary} type="submit" phx-disable-with="Creating…">
             Create group
           </.button>
-          <.button variant={:secondary} navigate={~p"/my-groups"}>Cancel</.button>
+          <.button variant={:secondary} navigate={~p"/groups"}>Cancel</.button>
         </div>
       </.form>
     </Layouts.app>

--- a/lib/huddlz_web/live/group_live/show.ex
+++ b/lib/huddlz_web/live/group_live/show.ex
@@ -450,7 +450,7 @@ defmodule HuddlzWeb.GroupLive.Show do
               </li>
               <li>
                 <.icon name="hero-rectangle-stack" class="size-4" />
-                <span>Remove this group from <strong>My groups</strong></span>
+                <span>Remove this group from <strong>Groups</strong></span>
               </li>
               <li>
                 <.icon name="hero-bell-slash" class="size-4" />

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -5,7 +5,7 @@ defmodule HuddlzWeb.HuddlLive do
   (defaults to `huddlz`). The legacy `?yours=hosting|attending` param scopes
   the huddl results to the actor's relationship; it is huddl-only and ignored
   under `scope=groups`. Personal sections live on the dedicated routes
-  (`/my-huddlz`, `/my-groups`); this view is shared by anonymous and
+  (`/huddlz`, `/groups`); this view is shared by anonymous and
   signed-in users.
   """
   use HuddlzWeb, :live_view

--- a/lib/huddlz_web/live/my_groups_live.ex
+++ b/lib/huddlz_web/live/my_groups_live.ex
@@ -1,6 +1,6 @@
 defmodule HuddlzWeb.MyGroupsLive do
   @moduledoc """
-  LiveView at `/my-groups`. Personal feed of groups the signed-in user
+  LiveView at `/groups`. Personal feed of groups the signed-in user
   organizes (Hosting) or has joined (Joined). Filter chips drive a
   `?filter=` URL param: default `all` is no param, `hosting` and `joined`
   scope the grid. `?page=N` paginates the active filter.
@@ -27,7 +27,7 @@ defmodule HuddlzWeb.MyGroupsLive do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(:page_title, "My groups")
+     |> assign(:page_title, "Groups")
      |> assign(:groups, [])
      |> assign(:counts, %{all: 0, hosting: 0, joined: 0})
      |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})}
@@ -127,13 +127,13 @@ defmodule HuddlzWeb.MyGroupsLive do
     end
   end
 
-  defp filter_path(:all, page) when page > 1, do: ~p"/my-groups?#{[page: page]}"
-  defp filter_path(:all, _page), do: ~p"/my-groups"
+  defp filter_path(:all, page) when page > 1, do: ~p"/groups?#{[page: page]}"
+  defp filter_path(:all, _page), do: ~p"/groups"
 
   defp filter_path(filter, page) when page > 1,
-    do: ~p"/my-groups?#{[filter: filter, page: page]}"
+    do: ~p"/groups?#{[filter: filter, page: page]}"
 
-  defp filter_path(filter, _page), do: ~p"/my-groups?#{[filter: filter]}"
+  defp filter_path(filter, _page), do: ~p"/groups?#{[filter: filter]}"
 
   @impl true
   def render(assigns) do
@@ -143,11 +143,11 @@ defmodule HuddlzWeb.MyGroupsLive do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-groups"
+      active="groups"
     >
       <div class="page-head">
         <div>
-          <h1>My groups</h1>
+          <h1>Groups</h1>
           <p>{filter_blurb(@filter)}</p>
         </div>
         <.button

--- a/lib/huddlz_web/live/my_huddlz_live.ex
+++ b/lib/huddlz_web/live/my_huddlz_live.ex
@@ -1,6 +1,6 @@
 defmodule HuddlzWeb.MyHuddlzLive do
   @moduledoc """
-  LiveView at `/my-huddlz`. Personal feed of huddlz the signed-in user is
+  LiveView at `/huddlz`. Personal feed of huddlz the signed-in user is
   attending, waitlisted on, or has already attended. Filter chips
   (Upcoming N / Waitlisted N / Past N) drive a `?filter=` URL param;
   `?page=N` paginates the active filter.
@@ -35,7 +35,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(:page_title, "My huddlz")
+     |> assign(:page_title, "Huddlz")
      |> assign(:huddls, [])
      |> assign(:counts, %{upcoming: 0, waitlisted: 0, past: 0})
      |> assign(:page_info, %{total_pages: 1, current_page: 1, total_count: 0})}
@@ -134,13 +134,13 @@ defmodule HuddlzWeb.MyHuddlzLive do
     )
   end
 
-  defp filter_path(:upcoming, page) when page > 1, do: ~p"/my-huddlz?#{[page: page]}"
-  defp filter_path(:upcoming, _page), do: ~p"/my-huddlz"
+  defp filter_path(:upcoming, page) when page > 1, do: ~p"/huddlz?#{[page: page]}"
+  defp filter_path(:upcoming, _page), do: ~p"/huddlz"
 
   defp filter_path(filter, page) when page > 1,
-    do: ~p"/my-huddlz?#{[filter: filter, page: page]}"
+    do: ~p"/huddlz?#{[filter: filter, page: page]}"
 
-  defp filter_path(filter, _page), do: ~p"/my-huddlz?#{[filter: filter]}"
+  defp filter_path(filter, _page), do: ~p"/huddlz?#{[filter: filter]}"
 
   @impl true
   def render(assigns) do
@@ -150,11 +150,11 @@ defmodule HuddlzWeb.MyHuddlzLive do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="my-huddlz"
+      active="huddlz"
     >
       <div class="page-head">
         <div>
-          <h1>My huddlz</h1>
+          <h1>Huddlz</h1>
           <p>{filter_blurb(@filter)}</p>
         </div>
         <.button

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -45,7 +45,7 @@ defmodule HuddlzWeb.LiveUserAuth do
 
   def on_mount(:redirect_to_me_if_authenticated, _params, _session, socket) do
     if socket.assigns[:current_user] do
-      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/my-huddlz")}
+      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/huddlz")}
     else
       {:cont, assign(socket, :current_user, nil)}
     end
@@ -119,7 +119,7 @@ defmodule HuddlzWeb.LiveUserAuth do
       {:halt,
        socket
        |> Phoenix.LiveView.put_flash(:error, "You don't have access to the admin area.")
-       |> Phoenix.LiveView.redirect(to: ~p"/my-huddlz")}
+       |> Phoenix.LiveView.redirect(to: ~p"/huddlz")}
     end
   end
 

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -112,8 +112,8 @@ defmodule HuddlzWeb.Router do
       live "/terms", LegalLive, :terms
       live "/code-of-conduct", LegalLive, :conduct
       live "/privacy", LegalLive, :privacy
-      live "/my-huddlz", MyHuddlzLive, :index
-      live "/my-groups", MyGroupsLive, :index
+      live "/huddlz", MyHuddlzLive, :index
+      live "/groups", MyGroupsLive, :index
       live "/calendar", CalendarLive, :index
       live "/notifications", NotificationsLive, :index
       live "/notifications/:id/open", NotificationsLive, :open

--- a/test/browser/features/mobile_navigation.feature
+++ b/test/browser/features/mobile_navigation.feature
@@ -6,5 +6,5 @@ Feature: Mobile navigation in a narrow browser
     Then the drawer contains focus and the page behind it is inert
     When I close mobile navigation with Escape
     Then focus returns to the navigation trigger and the page is usable
-    When I reopen mobile navigation and visit My groups
-    Then My groups loads with the drawer closed and can reopen navigation
+    When I reopen mobile navigation and visit Groups
+    Then Groups loads with the drawer closed and can reopen navigation

--- a/test/browser/steps/discover_navigation_steps.exs
+++ b/test/browser/steps/discover_navigation_steps.exs
@@ -30,9 +30,9 @@ defmodule BrowserDiscoverNavigationSteps do
     conn =
       context.conn
       |> sign_in(member)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".phx-connected")
-      |> assert_has("h1", text: "My huddlz")
+      |> assert_has("h1", text: "Huddlz")
 
     Map.merge(context, %{conn: conn, member: member})
   end

--- a/test/browser/steps/mobile_navigation_steps.exs
+++ b/test/browser/steps/mobile_navigation_steps.exs
@@ -53,19 +53,19 @@ defmodule BrowserNavigationSteps do
     Map.put(context, :conn, conn)
   end
 
-  step "I reopen mobile navigation and visit My groups", context do
+  step "I reopen mobile navigation and visit Groups", context do
     conn =
       context.conn
       |> press("#mobile-nav-trigger", "Enter")
-      |> click_link("#mobile-navigation-drawer a", "My groups")
+      |> click_link("#mobile-navigation-drawer a", "Groups")
 
     Map.put(context, :conn, conn)
   end
 
-  step "My groups loads with the drawer closed and can reopen navigation", context do
+  step "Groups loads with the drawer closed and can reopen navigation", context do
     conn =
       context.conn
-      |> assert_has("h1", text: "My groups")
+      |> assert_has("h1", text: "Groups")
       |> assert_has(".phx-connected")
       |> assert_browser("document.querySelector('#mobile-navigation-drawer').inert")
       |> refute_has("[data-mobile-nav-background][inert]")

--- a/test/features/create_huddl.feature
+++ b/test/features/create_huddl.feature
@@ -70,7 +70,7 @@ Feature: Create Huddl
       | Huddl Type        | Virtual                      |
       | Virtual Link      | https://example.com/creator  |
     And I submit the form
-    And I visit "/my-huddlz"
+    And I visit "/huddlz"
     Then I should see "Creator Attendance"
 
     When I visit the "Creator Attendance" huddl page
@@ -80,7 +80,7 @@ Feature: Create Huddl
 
     When I click "Cancel RSVP"
     Then I should see "RSVP cancelled successfully"
-    When I visit "/my-huddlz"
+    When I visit "/huddlz"
     Then I should not see "Creator Attendance"
 
   Scenario: Owner creates a monthly recurring huddl

--- a/test/features/current_navigation.feature
+++ b/test/features/current_navigation.feature
@@ -19,5 +19,5 @@ Feature: Current navigation for assistive technology
     When I click link "Discover"
     Then navigation should identify "Discover" as the current destination
     And view choices should identify "Huddlz" as current
-    When I click link "Groups"
+    When I choose the "Groups" view
     Then view choices should identify "Groups" as current

--- a/test/features/first_run_empty_states.feature
+++ b/test/features/first_run_empty_states.feature
@@ -11,15 +11,15 @@ Feature: First-run empty states
       | newcomer@example.com | Ada Park     | user |
     And I am signed in as "newcomer@example.com"
 
-  Scenario: A newcomer's My huddlz sends them to find a huddl
-    When I visit "/my-huddlz"
+  Scenario: A newcomer's Huddlz sends them to find a huddl
+    When I visit "/huddlz"
     Then I should see "No upcoming RSVPs yet"
     And I should see "Find a huddl worth showing up to and it will land here."
     When I click link "Find a huddl"
     Then I should see "Browse huddlz"
 
-  Scenario: A newcomer's My groups offers both ways in
-    When I visit "/my-groups"
+  Scenario: A newcomer's Groups offers both ways in
+    When I visit "/groups"
     Then I should see "No groups yet"
     And I should see "Groups are where huddlz come from."
     And I am offered "Browse groups" and "Start your own"
@@ -33,9 +33,9 @@ Feature: First-run empty states
     When I click link "Find a huddl"
     Then I should see "Browse huddlz"
 
-  Scenario: Someone who has attended before sees a quieter My huddlz
+  Scenario: Someone who has attended before sees a quieter Huddlz
     Given I attended a huddl last month
-    When I visit "/my-huddlz"
+    When I visit "/huddlz"
     Then I should see "Nothing coming up"
     And I should not see "No upcoming RSVPs yet"
     And I should see "Browse huddlz"

--- a/test/features/group_archival.feature
+++ b/test/features/group_archival.feature
@@ -13,7 +13,7 @@ Feature: Group archival
     Then I should see "Members keep access to the group's history"
     When I click "Yes, archive group"
     Then I should see "Group archived"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then I should not see "Seasonal Club"
     When I click "Archived"
     Then I should see "Seasonal Club"
@@ -22,7 +22,7 @@ Feature: Group archival
     When I click "Group settings"
     And I click "Restore group"
     Then I should see "Group restored"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then I should see "Seasonal Club"
 
   Scenario: Members retain read-only history while outsiders lose access

--- a/test/features/group_image.feature
+++ b/test/features/group_image.feature
@@ -113,7 +113,7 @@ Feature: Group Image Management
     When I visit the group page for "Remove Image Group"
     Then I should not see the group image
     And I should see the group name "Remove Image Group" in the placeholder
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then I should not see the group image
     When I visit the huddl "Group Image Huddl" page
     Then I should not see an image on the huddl page
@@ -187,5 +187,5 @@ Feature: Group Image Management
     When I visit "/groups/new"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then there should be an orphaned pending image

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -117,7 +117,7 @@ Feature: Group Management
     Then the "Leave Group" button should not be visible
     And the "Join Group" button should be visible
     And the group member count should be 1
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then I should not see "Book Club"
 
   Scenario: Group name is required

--- a/test/features/group_role_labels.feature
+++ b/test/features/group_role_labels.feature
@@ -19,12 +19,12 @@ Feature: Actual group role labels
     When I visit the group page for "Role Labels"
     Then my group role should be "Organizer"
     And my navigation role for "Role Labels" should be "Organizer"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then my card role for "Role Labels" should be "Organizer"
 
-  Scenario: A mounted My groups card follows promotion and demotion
+  Scenario: A mounted Groups card follows promotion and demotion
     Given I am signed in as "member315@example.com"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then my card role for "Role Labels" should be "Member"
     When the owner promotes me in "Role Labels" in another session
     Then my card role for "Role Labels" should be "Organizer"
@@ -36,7 +36,7 @@ Feature: Actual group role labels
     Given I am signed in as "<email>"
     When I visit the group page for "Role Labels"
     Then my group role should be "<role>"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then my card role for "Role Labels" should be "<role>"
 
     Examples:
@@ -73,11 +73,11 @@ Feature: Actual group role labels
     When I visit the edit page for "Role Labels"
     Then I should see "You don't have permission to edit this group"
 
-  Scenario: Accepting an invitation adds a mounted My groups card
+  Scenario: Accepting an invitation adds a mounted Groups card
     Given a private group "Invitation Roles" exists with owner "owner315@example.com"
     And "visitor315@example.com" has an organizer invitation to "Invitation Roles"
     And I am signed in as "visitor315@example.com"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then I should not see "Invitation Roles"
     When I accept my invitation to "Invitation Roles" in another session
     Then my card role for "Invitation Roles" should be "Organizer"

--- a/test/features/landing_surface.feature
+++ b/test/features/landing_surface.feature
@@ -28,8 +28,8 @@ Feature: Landing surface
     Then I should see "Sign in"
     And I should see "Sign up"
 
-  Scenario: Authenticated user is redirected from / to /my-huddlz
+  Scenario: Authenticated user is redirected from / to /huddlz
     Given I am signed in as "regular@example.com"
     When I visit "/"
-    Then I should see "My huddlz"
+    Then I should see "Huddlz"
     And I should see "Upcoming"

--- a/test/features/private_group_invitations.feature
+++ b/test/features/private_group_invitations.feature
@@ -34,7 +34,7 @@ Feature: Private group invitations
     When I click "Back to invitations"
     Then I should see "Invites 0"
     And I should see "No pending invitations"
-    When I visit "/my-groups"
+    When I visit "/groups"
     Then I should see "Quiet Makers"
 
   Scenario: A new recipient registers from their email and accepts the intended invitation

--- a/test/features/step_definitions/current_navigation_steps.exs
+++ b/test/features/step_definitions/current_navigation_steps.exs
@@ -3,6 +3,10 @@ defmodule CurrentNavigationSteps do
 
   import PhoenixTest
 
+  step "I choose the {string} view", %{args: [label], session: session} = context do
+    Map.put(context, :session, click_link(session, ".scope-tab", label))
+  end
+
   step "navigation should identify {string} as the current destination",
        %{args: [label], session: session} = context do
     session

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -142,7 +142,7 @@ defmodule GroupManagementSteps do
     |> assert_has("#leave-group-dialog [role='dialog']")
     |> assert_has("#leave-group-dialog-title", text: "Leave #{group_name}?")
     |> assert_has("#leave-group-dialog", text: "member roster")
-    |> assert_has("#leave-group-dialog", text: "My groups")
+    |> assert_has("#leave-group-dialog", text: "Groups")
     |> assert_has("#leave-group-dialog", text: "notifications")
 
     context

--- a/test/huddlz_web/controllers/error_html_test.exs
+++ b/test/huddlz_web/controllers/error_html_test.exs
@@ -31,8 +31,8 @@ defmodule HuddlzWeb.ErrorHTMLTest do
       html =
         render_to_string(HuddlzWeb.ErrorHTML, "404", "html", current_user: %{id: "person-id"})
 
-      assert html =~ ~s(href="/my-huddlz")
-      assert html =~ "Back to My huddlz"
+      assert html =~ ~s(href="/huddlz")
+      assert html =~ "Back to Huddlz"
       refute html =~ "huddlz home"
     end
   end
@@ -90,7 +90,7 @@ defmodule HuddlzWeb.ErrorHTMLTest do
         |> login(user)
         |> get("/another-route-that-does-not-exist")
 
-      assert html_response(conn, 404) =~ "Back to My huddlz"
+      assert html_response(conn, 404) =~ "Back to Huddlz"
       refute response(conn, 404) =~ "huddlz home"
     end
 
@@ -114,7 +114,7 @@ defmodule HuddlzWeb.ErrorHTMLTest do
                  |> get(~p"/groups/missing-group/huddlz/#{Ash.UUID.generate()}")
                end)
 
-      assert body =~ "Back to My huddlz"
+      assert body =~ "Back to Huddlz"
       refute body =~ "huddlz home"
     end
 
@@ -142,7 +142,7 @@ defmodule HuddlzWeb.ErrorHTMLTest do
                  |> get("/__test__/errors/500")
                end)
 
-      assert body =~ "Back to My huddlz"
+      assert body =~ "Back to Huddlz"
       refute body =~ "huddlz home"
     end
   end

--- a/test/huddlz_web/live/admin_live_test.exs
+++ b/test/huddlz_web/live/admin_live_test.exs
@@ -52,7 +52,7 @@ defmodule HuddlzWeb.AdminLiveTest do
       assert {:error,
               {:redirect,
                %{
-                 to: "/my-huddlz",
+                 to: "/huddlz",
                  flash: %{"error" => "You don't have access to the admin area."}
                }}} = live(conn, ~p"/admin")
 
@@ -64,7 +64,7 @@ defmodule HuddlzWeb.AdminLiveTest do
       conn
       |> login(verified_user)
       |> visit(~p"/admin")
-      |> assert_path(~p"/my-huddlz")
+      |> assert_path(~p"/huddlz")
       |> assert_has("div[role='alert']", text: "You don't have access to the admin area.")
     end
 

--- a/test/huddlz_web/live/group_live/show_test.exs
+++ b/test/huddlz_web/live/group_live/show_test.exs
@@ -220,7 +220,7 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
         |> assert_has("#leave-group-dialog [role='dialog']")
         |> assert_has("#leave-group-dialog-title", text: "Leave Membership Test Group?")
         |> assert_has("#leave-group-dialog", text: "member roster")
-        |> assert_has("#leave-group-dialog", text: "My groups")
+        |> assert_has("#leave-group-dialog", text: "Groups")
         |> assert_has("#leave-group-dialog", text: "notifications")
         |> assert_has(
           "#leave-group-dialog-container[phx-key='escape'][phx-window-keydown][phx-click-away]"
@@ -235,7 +235,7 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> assert_has("button", text: "Leave Group")
     end
 
-    test "confirming leave updates the group page and My groups", %{
+    test "confirming leave updates the group page and Groups", %{
       conn: conn,
       owner: owner,
       group: group
@@ -263,7 +263,7 @@ defmodule HuddlzWeb.GroupLive.ShowTest do
       |> assert_has(".facts li", text: "Members 1")
       |> refute_has("button", text: "Leave Group")
       |> assert_has("button", text: "Join Group")
-      |> visit(~p"/my-groups")
+      |> visit(~p"/groups")
       |> refute_has("*", text: "Membership Test Group")
     end
 

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -176,7 +176,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> assert_has("#huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("#group-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
-      |> visit(~p"/my-huddlz")
+      |> visit(~p"/huddlz")
       |> assert_has("#my-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
     end
 

--- a/test/huddlz_web/live/huddl_live_test.exs
+++ b/test/huddlz_web/live/huddl_live_test.exs
@@ -621,7 +621,7 @@ defmodule HuddlzWeb.HuddlLiveTest do
 
   defp live_navigate(conn, path) do
     conn
-    |> put_connect_params(%{"_live_referer" => "http://localhost/my-huddlz"})
+    |> put_connect_params(%{"_live_referer" => "http://localhost/huddlz"})
     |> live(path)
   end
 end

--- a/test/huddlz_web/live/my_groups_live_test.exs
+++ b/test/huddlz_web/live/my_groups_live_test.exs
@@ -10,25 +10,25 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
   describe "anonymous access" do
     test "redirects to sign-in", %{conn: conn} do
       conn
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_path("/sign-in")
     end
   end
 
   describe "page chrome" do
-    test "renders v3 sidebar with My groups active", %{conn: conn, member: member} do
+    test "renders v3 sidebar with Groups active", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups")
-      |> assert_has("h1", text: "My groups")
+      |> visit("/groups")
+      |> assert_has("h1", text: "Groups")
       |> assert_has("aside.sidebar")
-      |> assert_has(".sb-item.active", text: "My groups")
+      |> assert_has(".sb-item.active", text: "Groups")
     end
 
     test "shows three filter chips with counts", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".filters .chip", text: "All")
       |> assert_has(".filters .chip", text: "Hosting")
       |> assert_has(".filters .chip", text: "Joined")
@@ -37,14 +37,14 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "All chip is active by default", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".filters .chip.is-active", text: "All")
     end
 
     test "Start a group CTA links to /groups/new", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".page-head a[href='/groups/new']", text: "Start a group")
     end
   end
@@ -61,7 +61,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".grid .card .card-title", text: "Hosted Crew")
       |> assert_has(".grid .card .card-title", text: "Joined Crew")
       |> assert_has(".filters .chip", text: "All 2")
@@ -72,7 +72,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "empty state copy", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".empty-state[data-first-run] h3", text: "No groups yet")
       |> assert_has(".empty-state p",
         text:
@@ -101,7 +101,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups?filter=hosting")
+      |> visit("/groups?filter=hosting")
       |> assert_has(".filters .chip.is-active", text: "Hosting")
       |> assert_has(".grid .card .card-title", text: "Owned One")
       |> refute_has(".grid .card .card-title", text: "Joined One")
@@ -111,7 +111,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "empty state copy", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups?filter=hosting")
+      |> visit("/groups?filter=hosting")
       |> assert_has(".empty-state p", text: "Start a group and its huddlz will show up here.")
       |> refute_has(".empty-state a")
     end
@@ -133,7 +133,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups?filter=joined")
+      |> visit("/groups?filter=joined")
       |> assert_has(".filters .chip.is-active", text: "Joined")
       |> assert_has(".grid .card .card-title", text: "Joined One")
       |> refute_has(".grid .card .card-title", text: "Owned One")
@@ -143,7 +143,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "empty state copy", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups?filter=joined")
+      |> visit("/groups?filter=joined")
       |> assert_has(".empty-state p", text: "Join a group to follow its huddlz here.")
       |> assert_has(".empty-state a[href='/discover?scope=groups']", text: "Browse groups")
       |> refute_has(".empty-state a", text: "Start your own")
@@ -154,7 +154,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "unknown filter falls back to All", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups?filter=garbage")
+      |> visit("/groups?filter=garbage")
       |> assert_has(".filters .chip.is-active", text: "All")
     end
   end
@@ -170,7 +170,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> refute_has(".grid .card .card-title", text: "Strangers Only")
       |> assert_has(".filters .chip", text: "All 0")
     end
@@ -183,7 +183,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(~s(.grid .card[href="/groups/#{group.slug}"]))
     end
   end
@@ -200,7 +200,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has("#my-group-cover-#{group.id}[data-testid='group-cover']")
       |> assert_has("#my-group-cover-#{group.id} .group-cover-signal", text: "FC", exact: true)
       |> refute_has("#my-group-cover-#{group.id} img")
@@ -217,7 +217,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
 
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".grid .card .card-meta", text: "3 members")
     end
   end
@@ -234,7 +234,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       session =
         conn
         |> login(member)
-        |> visit("/my-groups")
+        |> visit("/groups")
 
       html = Phoenix.LiveViewTest.render(session.view)
 
@@ -269,7 +269,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "shows pagination when more than 20 groups", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups")
+      |> visit("/groups")
       |> assert_has(".grid .card .card-title", text: "Group 001")
       |> assert_has(".grid .card .card-title", text: "Group 020")
       |> refute_has(".grid .card .card-title", text: "Group 021")
@@ -279,7 +279,7 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "page=2 shows the next 20", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups?page=2")
+      |> visit("/groups?page=2")
       |> assert_has(".grid .card .card-title", text: "Group 021")
       |> assert_has(".grid .card .card-title", text: "Group 022")
       |> refute_has(".grid .card .card-title", text: "Group 001")
@@ -288,8 +288,8 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
     test "out-of-range ?page= clamps to last valid page", %{conn: conn, member: member} do
       conn
       |> login(member)
-      |> visit("/my-groups?page=999")
-      |> assert_path("/my-groups", query_params: %{"page" => "2"})
+      |> visit("/groups?page=999")
+      |> assert_path("/groups", query_params: %{"page" => "2"})
     end
   end
 end

--- a/test/huddlz_web/live/my_huddlz_live_test.exs
+++ b/test/huddlz_web/live/my_huddlz_live_test.exs
@@ -66,17 +66,17 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
   describe "anonymous access" do
     test "redirects to sign-in", %{conn: conn} do
       conn
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_path("/sign-in")
     end
   end
 
   describe "page chrome" do
-    test "renders v3 sidebar with My huddlz active", %{conn: conn, attendee: attendee} do
+    test "renders v3 sidebar with Huddlz active", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
-      |> assert_has("h1", text: "My huddlz")
+      |> visit("/huddlz")
+      |> assert_has("h1", text: "Huddlz")
       |> assert_has(
         "button#mobile-nav-trigger[aria-controls='mobile-navigation-drawer'][aria-expanded='false']"
       )
@@ -85,7 +85,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       )
       |> assert_has("button#mobile-nav-close[aria-label='Close navigation']")
       |> assert_has("button.nav-scrim[aria-hidden='true'][tabindex='-1']")
-      |> assert_has(".sb-item.active[aria-current='page']", text: "My huddlz")
+      |> assert_has(".sb-item.active[aria-current='page']", text: "Huddlz")
       |> refute_has("input.nav-toggle")
       |> refute_has(".sb-item:not(.active)[aria-current]")
     end
@@ -93,7 +93,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "shows three filter chips with counts", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".filters .chip", text: "Upcoming")
       |> assert_has(".filters .chip", text: "Waitlisted")
       |> assert_has(".filters .chip", text: "Past")
@@ -102,7 +102,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "Upcoming chip is active by default", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".filters .chip.is-active[aria-current='page']", text: "Upcoming")
       |> refute_has(".filters .chip:not(.is-active)[aria-current]")
     end
@@ -122,7 +122,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has("h3.card-title", text: "Going Show")
       |> refute_has("h3.card-title", text: "Skipped Show")
       |> assert_has(".pill", text: "Going")
@@ -140,7 +140,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has("h3.card-title", text: "Cancelled Workshop")
       |> assert_has(".pill", text: "Cancelled")
     end
@@ -151,7 +151,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     } do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".empty-state[data-first-run] h3", text: "No upcoming RSVPs yet")
       |> assert_has(".empty-state p",
         text: "Find a huddl worth showing up to and it will land here."
@@ -174,7 +174,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".empty-state:not([data-first-run]) h3", text: "Nothing coming up")
       |> assert_has(".empty-state p", text: "Your next RSVP will land here.")
       |> assert_has(".empty-state a.btn-secondary[href=\"/discover\"]", text: "Browse huddlz")
@@ -193,7 +193,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".filters .chip", text: "Upcoming 1")
     end
 
@@ -206,7 +206,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(host)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has("h3.card-title", text: "Creator RSVP")
       |> assert_has(".filters .chip", text: "Upcoming 1")
 
@@ -214,7 +214,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(host)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> refute_has("h3.card-title", text: "Creator RSVP")
       |> assert_has(".filters .chip", text: "Upcoming 0")
     end
@@ -247,7 +247,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?filter=waitlisted")
+      |> visit("/huddlz?filter=waitlisted")
       |> assert_has(".filters .chip.is-active", text: "Waitlisted")
       |> assert_has("h3.card-title", text: "Sold Out Show")
       |> assert_has(".pill", text: "Waitlist")
@@ -256,7 +256,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "empty state copy", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?filter=waitlisted")
+      |> visit("/huddlz?filter=waitlisted")
       |> assert_has(".empty-state p", text: "You're not on a waitlist right now.")
       |> refute_has(".empty-state a")
     end
@@ -274,7 +274,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?filter=past")
+      |> visit("/huddlz?filter=past")
       |> assert_has(".filters .chip.is-active", text: "Past")
       |> assert_has("h3.card-title", text: "Old Workshop")
       |> assert_has(".pill", text: "Attended")
@@ -283,7 +283,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "empty state copy", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?filter=past")
+      |> visit("/huddlz?filter=past")
       |> assert_has(".empty-state p", text: "No past attendance yet.")
     end
 
@@ -297,7 +297,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(host)
-      |> visit("/my-huddlz?filter=past")
+      |> visit("/huddlz?filter=past")
       |> assert_has("h3.card-title", text: "Creator Attended")
       |> assert_has(".filters .chip", text: "Past 1")
       |> assert_has(".pill", text: "Attended")
@@ -308,7 +308,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "unknown filter falls back to Upcoming", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?filter=garbage")
+      |> visit("/huddlz?filter=garbage")
       |> assert_has(".filters .chip.is-active", text: "Upcoming")
     end
   end
@@ -330,7 +330,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has("h3.card-title", text: "I Am Going")
       |> refute_has("h3.card-title", text: "They Are Going")
       |> assert_has(".filters .chip", text: "Upcoming 1")
@@ -349,7 +349,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(~s(.grid .card[href="/groups/#{public_group.slug}/huddlz/#{huddl.id}"]))
     end
   end
@@ -375,7 +375,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has("#{bare_card} .card-cover-fallback", text: "PE", exact: true)
       |> refute_has("#{bare_card} .cover-image")
       |> assert_has("#{pictured_card} #my-huddl-card-cover-#{pictured.id}.cover-image")
@@ -410,7 +410,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       session =
         conn
         |> login(attendee)
-        |> visit("/my-huddlz?filter=past")
+        |> visit("/huddlz?filter=past")
 
       html = Phoenix.LiveViewTest.render(session.view)
 
@@ -446,7 +446,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "shows pagination when more than 20 results", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has(".filters .chip", text: "Upcoming 22")
       |> assert_has(".pagination .page-num", text: "2")
     end
@@ -454,7 +454,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "page 1 shows the soonest 20", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz")
+      |> visit("/huddlz")
       |> assert_has("h3.card-title", text: "Huddl 001")
       |> refute_has("h3.card-title", text: "Huddl 021")
     end
@@ -462,7 +462,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "page=2 shows the remaining 2", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?page=2")
+      |> visit("/huddlz?page=2")
       |> assert_has("h3.card-title", text: "Huddl 021")
       |> assert_has("h3.card-title", text: "Huddl 022")
       |> refute_has("h3.card-title", text: "Huddl 001")
@@ -471,8 +471,8 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
     test "out-of-range ?page= clamps to last valid page", %{conn: conn, attendee: attendee} do
       conn
       |> login(attendee)
-      |> visit("/my-huddlz?page=999")
-      |> assert_path("/my-huddlz", query_params: %{"page" => "2"})
+      |> visit("/huddlz?page=999")
+      |> assert_path("/huddlz", query_params: %{"page" => "2"})
     end
   end
 end


### PR DESCRIPTION
Replace the signed-in list URLs with `/groups` and `/huddlz`, and shorten their navigation labels and page headings to “Groups” and “Huddlz.” Update related links, copy, and acceptance tests; remove the old web routes without redirects.

This change is scoped to the Groups and Huddlz web pages. The API endpoint and “My calendar” retain their existing names.

Closes #484
