### PR TITLE
feat(ui): rebuild the organizer huddlz page around rows and series

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -236,7 +236,7 @@ jobs:
       # Playwright dependency install refreshes even though only Chromium is
       # wanted; when that mirror's index is inconsistent the whole step fails.
       run: |
-        sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+        sudo grep -rl "dl.google.com" /etc/apt/sources.list.d | xargs -r sudo rm -f
         assets/node_modules/.bin/playwright install --with-deps chromium --only-shell
     - name: Run browser scenarios
       timeout-minutes: 2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -232,7 +232,12 @@ jobs:
     - name: Install Chromium and system dependencies
       env:
         PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/_build/browser/browsers
-      run: assets/node_modules/.bin/playwright install --with-deps chromium --only-shell
+      # The runner image carries Google's Chrome apt source, which the
+      # Playwright dependency install refreshes even though only Chromium is
+      # wanted; when that mirror's index is inconsistent the whole step fails.
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+        assets/node_modules/.bin/playwright install --with-deps chromium --only-shell
     - name: Run browser scenarios
       timeout-minutes: 2
       run: mix test.browser

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2651,6 +2651,166 @@ body .cal-cell:last-child .cal-pill-tooltip::after {
   left: auto;
 }
 
+/* Organizer huddlz: management rows, and a recurring series folded into
+   one entry with its dates. */
+body .org-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  overflow: hidden;
+}
+
+body .org-huddl,
+body .org-series-head,
+body .org-instance {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr) 168px auto;
+  gap: 16px;
+  align-items: center;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+body .org-series-head { grid-template-columns: 96px minmax(0, 1fr) auto; }
+body .org-list > :last-child { border-bottom: 0; }
+body .org-series { display: flex; flex-direction: column; border-bottom: 1px solid var(--line); }
+body .org-series > :last-child { border-bottom: 0; }
+
+body .org-huddl-thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  overflow: hidden;
+}
+
+body .org-huddl-thumb-img {
+  position: absolute;
+  inset: 0;
+  background-position: center;
+  background-size: cover;
+}
+
+body .org-huddl-thumb .card-cover-fallback span {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  font-size: 11px;
+}
+
+body .org-huddl-body { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+
+body .org-huddl-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+body .org-huddl-title a { color: inherit; text-decoration: none; transition: color 120ms ease; }
+body .org-huddl-title a:hover { color: var(--accent-ink); }
+
+body .org-huddl-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body .org-huddl-meta .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--line-strong); }
+
+body .org-series-cadence { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 6px; color: var(--soft); font-weight: 500; }
+body .org-series-cadence .icon { color: var(--accent-ink); }
+
+body .org-huddl-rsvps { display: flex; flex-direction: column; gap: 6px; }
+body .org-huddl-rsvps .n { color: var(--soft); font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
+
+body .org-instance { padding: 10px 20px; }
+
+body .org-instance-date {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  color: inherit;
+  text-decoration: none;
+}
+
+body .org-instance-date .d { color: var(--text); font-size: 13px; font-weight: 700; }
+body .org-instance-date .t { color: var(--muted); font-size: 11px; font-weight: 500; }
+body .org-instance-date:hover .d { color: var(--accent-ink); }
+
+body .org-instance-body {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 28px;
+  padding-left: 14px;
+  border-left: 2px solid var(--line);
+  color: var(--soft);
+  font-size: 13px;
+}
+
+body .org-instance[data-next] .org-instance-body { border-left-color: var(--accent); }
+
+body .org-instance-next {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+body .org-series[data-collapsed="true"] .org-instance-extra { display: none; }
+body .org-series[data-collapsed="true"] .when-open { display: none; }
+body .org-series:not([data-collapsed="true"]) .when-collapsed { display: none; }
+
+body .org-series-more {
+  align-self: flex-start;
+  margin: 0 0 0 132px;
+  padding: 10px 0 12px;
+  border: 0;
+  background: none;
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+body .org-series-more:hover { text-decoration: underline; }
+
+body .btn-sm { height: 32px; padding: 0 12px; font-size: 13px; }
+
+@media (max-width: 760px) {
+  body .org-huddl,
+  body .org-series-head,
+  body .org-instance {
+    grid-template-columns: 80px minmax(0, 1fr);
+    gap: 8px 12px;
+    padding: 12px 14px;
+  }
+  body .org-huddl .org-huddl-rsvps,
+  body .org-instance .org-huddl-rsvps,
+  body .org-huddl .org-huddl-edit,
+  body .org-series-head .org-huddl-edit { grid-column: 2; justify-self: start; }
+  body .org-instance .org-huddl-edit { display: none; }
+  body .org-instance-date { grid-column: 1; align-items: flex-start; }
+  body .org-series-more { margin-left: 14px; }
+}
+
 /* Agenda: the month's huddlz grouped by day. A date rail on the left, one
    horizontal card per huddl on the right. Today is always drawn as the
    anchor between what has passed and what is next; past days go quiet. */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2662,9 +2662,7 @@ body .org-list {
   overflow: hidden;
 }
 
-body .org-huddl,
-body .org-series-head,
-body .org-instance {
+body .org-huddl {
   display: grid;
   grid-template-columns: 96px minmax(0, 1fr) 168px auto;
   gap: 16px;
@@ -2673,10 +2671,7 @@ body .org-instance {
   border-bottom: 1px solid var(--line);
 }
 
-body .org-series-head { grid-template-columns: 96px minmax(0, 1fr) auto; }
-body .org-list > :last-child { border-bottom: 0; }
-body .org-series { display: flex; flex-direction: column; border-bottom: 1px solid var(--line); }
-body .org-series > :last-child { border-bottom: 0; }
+body .cal-agenda-entries > .org-huddl:last-child { border-bottom: 0; }
 
 body .org-huddl-thumb {
   position: relative;
@@ -2730,85 +2725,57 @@ body .org-huddl-meta {
 
 body .org-huddl-meta .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--line-strong); }
 
-body .org-series-cadence { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 6px; color: var(--soft); font-weight: 500; }
-body .org-series-cadence .icon { color: var(--accent-ink); }
-
 body .org-huddl-rsvps { display: flex; flex-direction: column; gap: 6px; }
 body .org-huddl-rsvps .n { color: var(--soft); font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
 
-body .org-instance { padding: 10px 20px; }
+body .org-huddl-series {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--soft);
+  font-weight: 500;
+}
 
-body .org-instance-date {
+body .org-huddl-series .icon { color: var(--accent-ink); }
+
+body .org-huddl-actions {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 1px;
-  color: inherit;
-  text-decoration: none;
+  gap: 4px;
 }
 
-body .org-instance-date .d { color: var(--text); font-size: 13px; font-weight: 700; }
-body .org-instance-date .t { color: var(--muted); font-size: 11px; font-weight: 500; }
-body .org-instance-date:hover .d { color: var(--accent-ink); }
-
-body .org-instance-body {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-height: 28px;
-  padding-left: 14px;
-  border-left: 2px solid var(--line);
-  color: var(--soft);
-  font-size: 13px;
-}
-
-body .org-instance[data-next] .org-instance-body { border-left-color: var(--accent); }
-
-body .org-instance-next {
-  padding: 2px 8px;
-  border-radius: var(--radius-pill);
-  background: var(--accent-soft);
+body .org-huddl-edit-series {
   color: var(--accent-ink);
-  font-size: 11px;
-  font-weight: 700;
-}
-
-body .org-series[data-collapsed="true"] .org-instance-extra { display: none; }
-body .org-series[data-collapsed="true"] .when-open { display: none; }
-body .org-series:not([data-collapsed="true"]) .when-collapsed { display: none; }
-
-body .org-series-more {
-  align-self: flex-start;
-  margin: 0 0 0 132px;
-  padding: 10px 0 12px;
-  border: 0;
-  background: none;
-  color: var(--accent-ink);
-  font: inherit;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
-body .org-series-more:hover { text-decoration: underline; }
+body .org-huddl-edit-series:hover { text-decoration: underline; }
+
+body .org-list-more {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+body .org-list-more .muted { font-size: 13px; }
 
 body .btn-sm { height: 32px; padding: 0 12px; font-size: 13px; }
 
 @media (max-width: 760px) {
-  body .org-huddl,
-  body .org-series-head,
-  body .org-instance {
+  body .org-huddl {
     grid-template-columns: 80px minmax(0, 1fr);
     gap: 8px 12px;
     padding: 12px 14px;
   }
   body .org-huddl .org-huddl-rsvps,
-  body .org-instance .org-huddl-rsvps,
-  body .org-huddl .org-huddl-edit,
-  body .org-series-head .org-huddl-edit { grid-column: 2; justify-self: start; }
-  body .org-instance .org-huddl-edit { display: none; }
-  body .org-instance-date { grid-column: 1; align-items: flex-start; }
-  body .org-series-more { margin-left: 14px; }
+  body .org-huddl .org-huddl-actions { grid-column: 2; justify-self: start; }
+  body .org-huddl-actions { flex-direction: row; align-items: center; gap: 12px; }
 }
 
 /* Agenda: the month's huddlz grouped by day. A date rail on the left, one

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -26,12 +26,34 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   end
 
   @impl true
-  def handle_params(%{"group_slug" => group_slug, "id" => id}, _, socket) do
+  def handle_params(%{"group_slug" => group_slug, "id" => id} = params, _, socket) do
     if socket.assigns[:huddl] && socket.assigns.huddl.id == id do
       {:noreply, apply_modal_state(socket)}
     else
-      load_huddl(socket, group_slug, id)
+      {:noreply, socket} = load_huddl(socket, group_slug, id)
+      {:noreply, preset_edit_type(socket, params["edit_type"])}
     end
+  end
+
+  # `?edit_type=all` opens a recurring huddl on "Whole series", the way the
+  # organizer's series entry links here.
+  defp preset_edit_type(%{assigns: %{huddl: %{huddl_template_id: id}}} = socket, "all")
+       when not is_nil(id),
+       do: apply_edit_type(socket, "all")
+
+  defp preset_edit_type(socket, _edit_type), do: socket
+
+  defp apply_edit_type(socket, type) do
+    current_params = socket.assigns.form.source.params || %{}
+    updated_params = Map.put(current_params, "edit_type", type)
+
+    socket =
+      socket
+      |> update_event_type_visibility(updated_params)
+      |> update_calculated_end_time(updated_params)
+
+    form = AshPhoenix.Form.validate(socket.assigns.form, updated_params)
+    assign(socket, :form, to_form(form))
   end
 
   defp load_huddl(socket, group_slug, id) do
@@ -401,16 +423,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
   @impl true
   def handle_event("set_edit_type", %{"type" => type}, socket) when type in ["instance", "all"] do
-    current_params = socket.assigns.form.source.params || %{}
-    updated_params = Map.put(current_params, "edit_type", type)
-
-    socket =
-      socket
-      |> update_event_type_visibility(updated_params)
-      |> update_calculated_end_time(updated_params)
-
-    form = AshPhoenix.Form.validate(socket.assigns.form, updated_params)
-    {:noreply, assign(socket, :form, to_form(form))}
+    {:noreply, apply_edit_type(socket, type)}
   end
 
   @impl true

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -18,16 +18,17 @@ defmodule HuddlzWeb.OrganizeLive do
   alias Huddlz.Communities.MembershipEvents
   alias HuddlzWeb.HuddlStatus
   alias HuddlzWeb.Layouts
+  alias HuddlzWeb.Live.Helpers.BrowserTimeZone
   alias HuddlzWeb.Live.Helpers.HuddlCardHelpers
-  alias Phoenix.LiveView.JS
 
   require Ash.Query
 
   @group_loads [:current_image_url, :member_count]
   @huddl_loads [:rsvp_count, :status, :group, :display_image_url, :huddl_template]
   @huddlz_filters [:published, :draft, :past, :cancelled]
-  # How many dates of a series show before the rest fold behind a toggle.
-  @series_preview 3
+  # Rows shown before "Show more". A weekly series alone can run to a
+  # hundred dates, so the list pages rather than folding anything.
+  @huddlz_page 20
   @upcoming_loads [:rsvp_count, :group]
   @upcoming_preview_limit 5
 
@@ -36,9 +37,12 @@ defmodule HuddlzWeb.OrganizeLive do
 
   @impl true
   def mount(_params, _session, socket) do
+    time_zone = BrowserTimeZone.for_socket(socket)
+
     {:ok,
      socket
      |> assign(:page_title, "Organizer workspace")
+     |> assign(:today, DateTime.now!(time_zone) |> DateTime.to_date())
      |> assign(:group, nil)
      |> assign(:owned_groups, [])
      |> assign(:huddlz_list, [])
@@ -118,7 +122,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
     socket
     |> assign(:huddlz_list, huddlz)
-    |> assign(:huddlz_entries, organizer_entries(huddlz))
+    |> assign(:huddlz_limit, @huddlz_page)
     |> assign(:huddlz_counts, counts)
   end
 
@@ -173,28 +177,6 @@ defmodule HuddlzWeb.OrganizeLive do
     |> Ash.Query.for_read(:huddlz_for_organizer, %{state: state}, actor: user)
     |> Ash.Query.filter(group_id == ^group.id)
     |> Ash.count!(actor: user)
-  end
-
-  # Rows in schedule order, with the instances of a recurring series folded
-  # into one entry at the position of its first instance.
-  defp organizer_entries(huddlz) do
-    {entries, series} =
-      Enum.reduce(huddlz, {[], %{}}, fn
-        %{huddl_template_id: nil} = huddl, {entries, series} ->
-          {[{:single, huddl} | entries], series}
-
-        %{huddl_template_id: template_id} = huddl, {entries, series} ->
-          if Map.has_key?(series, template_id),
-            do: {entries, Map.update!(series, template_id, &[huddl | &1])},
-            else: {[{:series, template_id} | entries], Map.put(series, template_id, [huddl])}
-      end)
-
-    entries
-    |> Enum.reverse()
-    |> Enum.map(fn
-      {:single, huddl} -> {:single, huddl}
-      {:series, template_id} -> {:series, template_id, Enum.reverse(series[template_id])}
-    end)
   end
 
   defp list_group_members(group, user) do
@@ -319,9 +301,11 @@ defmodule HuddlzWeb.OrganizeLive do
         <% :huddlz -> %>
           <.huddlz_view
             group={@group}
-            entries={@huddlz_entries}
+            huddlz={@huddlz_list}
+            limit={@huddlz_limit}
             counts={@huddlz_counts}
             filter={@huddlz_filter}
+            today={@today}
           />
         <% :members -> %>
           <.members_view
@@ -520,18 +504,33 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # ─────────────────────────────────────────  HUDDLZ  ───
   attr :group, :map, required: true
-  attr :entries, :list, required: true
+  attr :huddlz, :list, required: true
+  attr :limit, :integer, required: true
   attr :counts, :map, required: true
   attr :filter, :atom, required: true
+  attr :today, Date, required: true
 
   defp huddlz_view(assigns) do
+    shown = Enum.take(assigns.huddlz, assigns.limit)
+
+    assigns =
+      assigns
+      |> assign(:days, organizer_days(shown, assigns.today))
+      |> assign(:remaining, length(assigns.huddlz) - length(shown))
+      |> assign(:page, @huddlz_page)
+
     ~H"""
     <div class="page-head">
       <div>
         <h1>Huddlz</h1>
-        <p>Every huddl in {@group.name}. A recurring series shows as one entry with its dates.</p>
+        <p>
+          Every huddl in {@group.name}, in date order. A repeat mark means it is part of a series.
+        </p>
       </div>
       <div class="actions">
+        <.link class="btn-secondary" navigate={~p"/calendar?view=month"}>
+          <.icon name="hero-calendar" class="size-4" /> Month view
+        </.link>
         <a
           :if={is_nil(@group.archived_at)}
           class="btn-primary"
@@ -553,7 +552,7 @@ defmodule HuddlzWeb.OrganizeLive do
       </.chip>
     </div>
 
-    <%= if @entries == [] do %>
+    <%= if @huddlz == [] do %>
       <div class="panel">
         <div class="panel-head">
           <h2>{empty_huddlz_heading(@filter)}</h2>
@@ -570,20 +569,39 @@ defmodule HuddlzWeb.OrganizeLive do
         </div>
       </div>
     <% else %>
-      <div id="organize-huddlz-list" class="org-list">
-        <%= for entry <- @entries do %>
-          <%= case entry do %>
-            <% {:single, huddl} -> %>
-              <.organizer_huddl_row group={@group} huddl={huddl} />
-            <% {:series, template_id, instances} -> %>
-              <.organizer_series
-                group={@group}
-                template_id={template_id}
-                instances={instances}
-                filter={@filter}
-              />
-          <% end %>
-        <% end %>
+      <div id="organize-huddlz-list" class="cal-agenda org-list">
+        <div
+          :for={day <- @days}
+          id={"organize-day-#{Date.to_iso8601(day.date)}"}
+          class="cal-agenda-day"
+          data-today={day.today? || nil}
+        >
+          <div class="cal-agenda-rail">
+            <span class="cal-agenda-weekday" aria-hidden="true">
+              {Calendar.strftime(day.date, "%a")}
+            </span>
+            <time
+              datetime={Date.to_iso8601(day.date)}
+              class={["cal-agenda-daynum", day.today? && "is-today"]}
+              aria-label={Calendar.strftime(day.date, "%A, %B %-d, %Y")}
+            >
+              {day.date.day}
+            </time>
+            <span :if={day.today?} class="cal-agenda-day-context">Today</span>
+            <span :if={day.other_month?} class="cal-agenda-day-context">
+              {Calendar.strftime(day.date, "%b %Y")}
+            </span>
+          </div>
+          <div class="cal-agenda-entries">
+            <.organizer_huddl_row :for={huddl <- day.huddlz} group={@group} huddl={huddl} />
+          </div>
+        </div>
+      </div>
+      <div :if={@remaining > 0} class="org-list-more">
+        <button type="button" class="btn-secondary" phx-click="show_more_huddlz">
+          Show {min(@remaining, @page)} more
+        </button>
+        <span class="muted">{@remaining} more {if @remaining == 1, do: "huddl", else: "huddlz"} after these</span>
       </div>
     <% end %>
     """
@@ -594,7 +612,12 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp organizer_huddl_row(assigns) do
     ~H"""
-    <div id={"organize-huddl-#{@huddl.id}"} class="org-huddl" data-status={@huddl.status}>
+    <div
+      id={"organize-huddl-#{@huddl.id}"}
+      class="org-huddl"
+      data-status={@huddl.status}
+      data-series={@huddl.huddl_template_id}
+    >
       <.organizer_thumb huddl={@huddl} group={@group} />
       <div class="org-huddl-body">
         <h3 class="org-huddl-title">
@@ -604,78 +627,29 @@ defmodule HuddlzWeb.OrganizeLive do
           <.organizer_status huddl={@huddl} />
         </h3>
         <div class="org-huddl-meta">
-          <span>{format_organizer_when(@huddl)}</span>
+          <span>{format_organizer_time(@huddl)}</span>
           <span class="dot" aria-hidden="true"></span>
           <span>{organizer_place(@huddl)}</span>
+          <%= if @huddl.huddl_template do %>
+            <span class="dot" aria-hidden="true"></span>
+            <span class="org-huddl-series">
+              <.icon name="hero-arrow-path" class="size-3.5" />
+              {series_cadence(@huddl)} · until {series_until(@huddl)}
+            </span>
+          <% end %>
         </div>
       </div>
       <.organizer_rsvps huddl={@huddl} />
-      <.organizer_edit_link group={@group} huddl={@huddl} label="Edit" />
-    </div>
-    """
-  end
-
-  attr :group, :map, required: true
-  attr :template_id, :string, required: true
-  attr :instances, :list, required: true
-  attr :filter, :atom, required: true
-
-  defp organizer_series(assigns) do
-    [first | _] = assigns.instances
-    hidden = max(length(assigns.instances) - @series_preview, 0)
-
-    assigns =
-      assigns
-      |> assign(:first, first)
-      |> assign(:hidden, hidden)
-      |> assign(:preview, @series_preview)
-      |> assign(:cadence_line, series_cadence_line(first, length(assigns.instances)))
-      |> assign(:dom_id, "organize-series-#{assigns.template_id}")
-
-    ~H"""
-    <div id={@dom_id} class="org-series" data-collapsed={if @hidden > 0, do: "true"}>
-      <div class="org-series-head">
-        <.organizer_thumb huddl={@first} group={@group} />
-        <div class="org-huddl-body">
-          <h3 class="org-huddl-title">
-            <.link navigate={huddl_show_path(@group, @first)}>{@first.title}</.link>
-          </h3>
-          <div class="org-huddl-meta">
-            <span class="org-series-cadence">
-              <.icon name="hero-arrow-path" class="size-3.5" />
-              {@cadence_line}
-            </span>
-          </div>
-        </div>
-        <.organizer_edit_link group={@group} huddl={@first} label="Edit series" scope="all" />
-      </div>
-      <div
-        :for={{huddl, index} <- Enum.with_index(@instances)}
-        id={"organize-huddl-#{huddl.id}"}
-        class={["org-instance", index >= @preview && "org-instance-extra"]}
-        data-status={huddl.status}
-        data-next={if index == 0 and @filter == :published, do: "true"}
-      >
-        <.link navigate={huddl_show_path(@group, huddl)} class="org-instance-date">
-          <span class="d">{format_organizer_date(huddl)}</span>
-          <span class="t">{format_organizer_time(huddl)}</span>
+      <div class="org-huddl-actions">
+        <.organizer_edit_link group={@group} huddl={@huddl} label="Edit" />
+        <.link
+          :if={@huddl.huddl_template && @huddl.status not in [:cancelled, :completed]}
+          navigate={huddl_edit_path(@group, @huddl, "all")}
+          class="org-huddl-edit-series"
+        >
+          Edit series
         </.link>
-        <div class="org-instance-body">
-          <span :if={index == 0 and @filter == :published} class="org-instance-next">Next</span>
-          <.organizer_status huddl={huddl} />
-        </div>
-        <.organizer_rsvps huddl={huddl} />
-        <.organizer_edit_link group={@group} huddl={huddl} label="Edit" />
       </div>
-      <button
-        :if={@hidden > 0}
-        type="button"
-        class="org-series-more"
-        phx-click={JS.toggle_attribute({"data-collapsed", "true", "false"}, to: "##{@dom_id}")}
-      >
-        <span class="when-collapsed">Show {@hidden} more dates</span>
-        <span class="when-open">Show fewer dates</span>
-      </button>
     </div>
     """
   end
@@ -747,6 +721,26 @@ defmodule HuddlzWeb.OrganizeLive do
     """
   end
 
+  # Rows grouped by the day they start, in the list's own order (soonest
+  # first for what is ahead, most recent first for the past).
+  defp organizer_days(huddlz, today) do
+    huddlz
+    |> Enum.chunk_by(&organizer_date/1)
+    |> Enum.map(fn [first | _] = day ->
+      date = organizer_date(first)
+
+      %{
+        date: date,
+        huddlz: day,
+        today?: Date.compare(date, today) == :eq,
+        other_month?: {date.year, date.month} != {today.year, today.month}
+      }
+    end)
+  end
+
+  defp organizer_date(huddl),
+    do: huddl |> HuddlCardHelpers.local_starts_at() |> DateTime.to_date()
+
   defp huddlz_filters, do: @huddlz_filters
 
   defp huddlz_filter_label(:published), do: "Upcoming"
@@ -765,12 +759,6 @@ defmodule HuddlzWeb.OrganizeLive do
   defp capacity_percent(%{rsvp_count: count, max_attendees: max}),
     do: min(100, div(count * 100, max))
 
-  defp format_organizer_when(huddl),
-    do: format_organizer_date(huddl) <> " · " <> format_organizer_time(huddl)
-
-  defp format_organizer_date(huddl),
-    do: huddl |> HuddlCardHelpers.local_starts_at() |> Calendar.strftime("%a %b %-d")
-
   defp format_organizer_time(huddl) do
     local = HuddlCardHelpers.local_starts_at(huddl)
     Calendar.strftime(local, "%-I:%M %p") <> " " <> local.zone_abbr
@@ -783,28 +771,14 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp organizer_place(%{event_type: type}), do: HuddlCardHelpers.tag_label(type)
 
-  defp series_cadence_line(first, count) do
-    Enum.join(
-      [
-        series_cadence(first),
-        format_organizer_time(first),
-        "until " <> series_until(first),
-        "#{count} #{if count == 1, do: "date", else: "dates"}"
-      ],
-      " · "
-    )
-  end
-
-  # "Weekly on Thursdays", "Every two weeks on Thursdays", "Monthly on the 17th".
-  defp series_cadence(%{huddl_template: %{interval: interval, unit: unit}} = huddl) do
-    local = HuddlCardHelpers.local_starts_at(huddl)
-
+  # "Weekly", "Every two weeks", "Monthly": the day is already on the rail.
+  defp series_cadence(%{huddl_template: %{interval: interval, unit: unit}}) do
     case {interval, unit} do
-      {1, :week} -> "Weekly on #{Calendar.strftime(local, "%A")}s"
-      {2, :week} -> "Every two weeks on #{Calendar.strftime(local, "%A")}s"
-      {n, :week} -> "Every #{n} weeks on #{Calendar.strftime(local, "%A")}s"
-      {1, :month} -> "Monthly on the #{ordinal(local.day)}"
-      {n, :month} -> "Every #{n} months on the #{ordinal(local.day)}"
+      {1, :week} -> "Weekly"
+      {2, :week} -> "Every two weeks"
+      {n, :week} -> "Every #{n} weeks"
+      {1, :month} -> "Monthly"
+      {n, :month} -> "Every #{n} months"
     end
   end
 
@@ -812,20 +786,6 @@ defmodule HuddlzWeb.OrganizeLive do
   # the organizer picked is its UTC date, not a zone-shifted one.
   defp series_until(%{huddl_template: %{repeat_until: until}}),
     do: until |> DateTime.to_date() |> Calendar.strftime("%b %-d")
-
-  defp ordinal(day) when day in [11, 12, 13], do: "#{day}th"
-
-  defp ordinal(day) do
-    suffix =
-      case rem(day, 10) do
-        1 -> "st"
-        2 -> "nd"
-        3 -> "rd"
-        _ -> "th"
-      end
-
-    "#{day}#{suffix}"
-  end
 
   defp huddlz_filter_path(group, :published), do: ~p"/organize/#{group.slug}/huddlz"
 
@@ -1206,6 +1166,10 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   @impl true
+  def handle_event("show_more_huddlz", _params, socket) do
+    {:noreply, update(socket, :huddlz_limit, &(&1 + @huddlz_page))}
+  end
+
   def handle_event("invite", %{"invitation" => params}, socket) do
     group = socket.assigns.group
     user = socket.assigns.current_user

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -18,9 +18,16 @@ defmodule HuddlzWeb.OrganizeLive do
   alias Huddlz.Communities.MembershipEvents
   alias HuddlzWeb.HuddlStatus
   alias HuddlzWeb.Layouts
+  alias HuddlzWeb.Live.Helpers.HuddlCardHelpers
+  alias Phoenix.LiveView.JS
+
+  require Ash.Query
 
   @group_loads [:current_image_url, :member_count]
-  @huddl_loads [:rsvp_count, :status, :group]
+  @huddl_loads [:rsvp_count, :status, :group, :display_image_url, :huddl_template]
+  @huddlz_filters [:published, :draft, :past, :cancelled]
+  # How many dates of a series show before the rest fold behind a toggle.
+  @series_preview 3
   @upcoming_loads [:rsvp_count, :group]
   @upcoming_preview_limit 5
 
@@ -107,7 +114,12 @@ defmodule HuddlzWeb.OrganizeLive do
   defp load_section(socket, :huddlz, group, user) do
     state = socket.assigns.huddlz_filter
     huddlz = list_group_huddlz(group, state, user)
-    assign(socket, :huddlz_list, huddlz)
+    counts = Map.new(@huddlz_filters, &{&1, count_group_huddlz(group, &1, user)})
+
+    socket
+    |> assign(:huddlz_list, huddlz)
+    |> assign(:huddlz_entries, organizer_entries(huddlz))
+    |> assign(:huddlz_counts, counts)
   end
 
   defp load_section(socket, :members, group, user) do
@@ -154,6 +166,35 @@ defmodule HuddlzWeb.OrganizeLive do
         sort: [starts_at: state_sort_dir(state)]
       ]
     )
+  end
+
+  defp count_group_huddlz(group, state, user) do
+    Huddlz.Communities.Huddl
+    |> Ash.Query.for_read(:huddlz_for_organizer, %{state: state}, actor: user)
+    |> Ash.Query.filter(group_id == ^group.id)
+    |> Ash.count!(actor: user)
+  end
+
+  # Rows in schedule order, with the instances of a recurring series folded
+  # into one entry at the position of its first instance.
+  defp organizer_entries(huddlz) do
+    {entries, series} =
+      Enum.reduce(huddlz, {[], %{}}, fn
+        %{huddl_template_id: nil} = huddl, {entries, series} ->
+          {[{:single, huddl} | entries], series}
+
+        %{huddl_template_id: template_id} = huddl, {entries, series} ->
+          if Map.has_key?(series, template_id),
+            do: {entries, Map.update!(series, template_id, &[huddl | &1])},
+            else: {[{:series, template_id} | entries], Map.put(series, template_id, [huddl])}
+      end)
+
+    entries
+    |> Enum.reverse()
+    |> Enum.map(fn
+      {:single, huddl} -> {:single, huddl}
+      {:series, template_id} -> {:series, template_id, Enum.reverse(series[template_id])}
+    end)
   end
 
   defp list_group_members(group, user) do
@@ -276,7 +317,12 @@ defmodule HuddlzWeb.OrganizeLive do
             open_rsvps={@open_rsvps}
           />
         <% :huddlz -> %>
-          <.huddlz_view group={@group} huddlz={@huddlz_list} filter={@huddlz_filter} />
+          <.huddlz_view
+            group={@group}
+            entries={@huddlz_entries}
+            counts={@huddlz_counts}
+            filter={@huddlz_filter}
+          />
         <% :members -> %>
           <.members_view
             group={@group}
@@ -474,7 +520,8 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # ─────────────────────────────────────────  HUDDLZ  ───
   attr :group, :map, required: true
-  attr :huddlz, :list, required: true
+  attr :entries, :list, required: true
+  attr :counts, :map, required: true
   attr :filter, :atom, required: true
 
   defp huddlz_view(assigns) do
@@ -482,7 +529,7 @@ defmodule HuddlzWeb.OrganizeLive do
     <div class="page-head">
       <div>
         <h1>Huddlz</h1>
-        <p>Every huddl in {@group.name}. Click one to manage it.</p>
+        <p>Every huddl in {@group.name}. A recurring series shows as one entry with its dates.</p>
       </div>
       <div class="actions">
         <a
@@ -496,21 +543,17 @@ defmodule HuddlzWeb.OrganizeLive do
     </div>
 
     <div class="filters" id="organize-huddlz-filters">
-      <.chip patch={huddlz_filter_path(@group, :draft)} active={@filter == :draft}>
-        Draft
-      </.chip>
-      <.chip patch={huddlz_filter_path(@group, :published)} active={@filter == :published}>
-        Published
-      </.chip>
-      <.chip patch={huddlz_filter_path(@group, :cancelled)} active={@filter == :cancelled}>
-        Cancelled
-      </.chip>
-      <.chip patch={huddlz_filter_path(@group, :past)} active={@filter == :past}>
-        Past
+      <.chip
+        :for={filter <- huddlz_filters()}
+        patch={huddlz_filter_path(@group, filter)}
+        active={@filter == filter}
+        count={@counts[filter]}
+      >
+        {huddlz_filter_label(filter)}
       </.chip>
     </div>
 
-    <%= if @huddlz == [] do %>
+    <%= if @entries == [] do %>
       <div class="panel">
         <div class="panel-head">
           <h2>{empty_huddlz_heading(@filter)}</h2>
@@ -527,55 +570,267 @@ defmodule HuddlzWeb.OrganizeLive do
         </div>
       </div>
     <% else %>
-      <div class="panel">
-        <div class="panel-head">
-          <h2>{filter_heading(@filter)}</h2>
-          <span class="panel-sub">{length(@huddlz)} total</span>
-        </div>
-        <div class="row-list">
-          <div
-            :for={huddl <- @huddlz}
-            id={"organize-huddl-#{huddl.id}"}
-            class="row row-split-two"
-          >
-            <div>
-              <div class="row-title">
-                <.link
-                  id={"organize-huddl-link-#{huddl.id}"}
-                  navigate={organizer_huddl_path(@group, huddl)}
-                >
-                  {huddl.title}
-                </.link>
-              </div>
-              <div class="meta">{format_starts_at(huddl)}</div>
-            </div>
-            <span class="pill">{rsvp_label(huddl.rsvp_count)}</span>
-            <span class={["pill", HuddlStatus.pill_class(huddl.status)]}>
-              {HuddlStatus.label(huddl.status)}
-            </span>
-          </div>
-        </div>
+      <div id="organize-huddlz-list" class="org-list">
+        <%= for entry <- @entries do %>
+          <%= case entry do %>
+            <% {:single, huddl} -> %>
+              <.organizer_huddl_row group={@group} huddl={huddl} />
+            <% {:series, template_id, instances} -> %>
+              <.organizer_series
+                group={@group}
+                template_id={template_id}
+                instances={instances}
+                filter={@filter}
+              />
+          <% end %>
+        <% end %>
       </div>
     <% end %>
     """
+  end
+
+  attr :group, :map, required: true
+  attr :huddl, :map, required: true
+
+  defp organizer_huddl_row(assigns) do
+    ~H"""
+    <div id={"organize-huddl-#{@huddl.id}"} class="org-huddl" data-status={@huddl.status}>
+      <.organizer_thumb huddl={@huddl} group={@group} />
+      <div class="org-huddl-body">
+        <h3 class="org-huddl-title">
+          <.link id={"organize-huddl-link-#{@huddl.id}"} navigate={huddl_show_path(@group, @huddl)}>
+            {@huddl.title}
+          </.link>
+          <.organizer_status huddl={@huddl} />
+        </h3>
+        <div class="org-huddl-meta">
+          <span>{format_organizer_when(@huddl)}</span>
+          <span class="dot" aria-hidden="true"></span>
+          <span>{organizer_place(@huddl)}</span>
+        </div>
+      </div>
+      <.organizer_rsvps huddl={@huddl} />
+      <.organizer_edit_link group={@group} huddl={@huddl} label="Edit" />
+    </div>
+    """
+  end
+
+  attr :group, :map, required: true
+  attr :template_id, :string, required: true
+  attr :instances, :list, required: true
+  attr :filter, :atom, required: true
+
+  defp organizer_series(assigns) do
+    [first | _] = assigns.instances
+    hidden = max(length(assigns.instances) - @series_preview, 0)
+
+    assigns =
+      assigns
+      |> assign(:first, first)
+      |> assign(:hidden, hidden)
+      |> assign(:preview, @series_preview)
+      |> assign(:cadence_line, series_cadence_line(first, length(assigns.instances)))
+      |> assign(:dom_id, "organize-series-#{assigns.template_id}")
+
+    ~H"""
+    <div id={@dom_id} class="org-series" data-collapsed={if @hidden > 0, do: "true"}>
+      <div class="org-series-head">
+        <.organizer_thumb huddl={@first} group={@group} />
+        <div class="org-huddl-body">
+          <h3 class="org-huddl-title">
+            <.link navigate={huddl_show_path(@group, @first)}>{@first.title}</.link>
+          </h3>
+          <div class="org-huddl-meta">
+            <span class="org-series-cadence">
+              <.icon name="hero-arrow-path" class="size-3.5" />
+              {@cadence_line}
+            </span>
+          </div>
+        </div>
+        <.organizer_edit_link group={@group} huddl={@first} label="Edit series" scope="all" />
+      </div>
+      <div
+        :for={{huddl, index} <- Enum.with_index(@instances)}
+        id={"organize-huddl-#{huddl.id}"}
+        class={["org-instance", index >= @preview && "org-instance-extra"]}
+        data-status={huddl.status}
+        data-next={if index == 0 and @filter == :published, do: "true"}
+      >
+        <.link navigate={huddl_show_path(@group, huddl)} class="org-instance-date">
+          <span class="d">{format_organizer_date(huddl)}</span>
+          <span class="t">{format_organizer_time(huddl)}</span>
+        </.link>
+        <div class="org-instance-body">
+          <span :if={index == 0 and @filter == :published} class="org-instance-next">Next</span>
+          <.organizer_status huddl={huddl} />
+        </div>
+        <.organizer_rsvps huddl={huddl} />
+        <.organizer_edit_link group={@group} huddl={huddl} label="Edit" />
+      </div>
+      <button
+        :if={@hidden > 0}
+        type="button"
+        class="org-series-more"
+        phx-click={JS.toggle_attribute({"data-collapsed", "true", "false"}, to: "##{@dom_id}")}
+      >
+        <span class="when-collapsed">Show {@hidden} more dates</span>
+        <span class="when-open">Show fewer dates</span>
+      </button>
+    </div>
+    """
+  end
+
+  attr :huddl, :map, required: true
+  attr :group, :map, required: true
+
+  defp organizer_thumb(assigns) do
+    ~H"""
+    <div class="org-huddl-thumb">
+      <%= if @huddl.display_image_url do %>
+        <.cover_image
+          id={"organize-huddl-cover-#{@huddl.id}"}
+          class="org-huddl-thumb-img"
+          image_url={@huddl.display_image_url}
+        />
+      <% else %>
+        <.cover_fallback name={@group.name} />
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :huddl, :map, required: true
+
+  defp organizer_status(assigns) do
+    ~H"""
+    <.pill
+      :if={@huddl.status != :upcoming}
+      variant={HuddlStatus.variant(@huddl.status)}
+      class="org-huddl-status"
+    >
+      {HuddlStatus.label(@huddl.status)}
+    </.pill>
+    """
+  end
+
+  attr :huddl, :map, required: true
+
+  defp organizer_rsvps(assigns) do
+    ~H"""
+    <div class="org-huddl-rsvps">
+      <span class="n">{HuddlCardHelpers.rsvp_label(@huddl)}</span>
+      <div
+        :if={is_integer(@huddl.max_attendees) and @huddl.max_attendees > 0}
+        class={["bar", @huddl.rsvp_count >= @huddl.max_attendees && "warn"]}
+        aria-hidden="true"
+      >
+        <span style={"width: #{capacity_percent(@huddl)}%"}></span>
+      </div>
+    </div>
+    """
+  end
+
+  attr :group, :map, required: true
+  attr :huddl, :map, required: true
+  attr :label, :string, required: true
+  attr :scope, :string, default: nil
+
+  defp organizer_edit_link(assigns) do
+    ~H"""
+    <.link
+      :if={@huddl.status not in [:cancelled, :completed]}
+      navigate={huddl_edit_path(@group, @huddl, @scope)}
+      class="btn-secondary btn-sm org-huddl-edit"
+    >
+      {@label}
+    </.link>
+    """
+  end
+
+  defp huddlz_filters, do: @huddlz_filters
+
+  defp huddlz_filter_label(:published), do: "Upcoming"
+  defp huddlz_filter_label(:draft), do: "Drafts"
+  defp huddlz_filter_label(:past), do: "Past"
+  defp huddlz_filter_label(:cancelled), do: "Cancelled"
+
+  defp huddl_show_path(group, huddl), do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}"
+
+  defp huddl_edit_path(group, huddl, "all"),
+    do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit?edit_type=all"
+
+  defp huddl_edit_path(group, huddl, _scope),
+    do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit"
+
+  defp capacity_percent(%{rsvp_count: count, max_attendees: max}),
+    do: min(100, div(count * 100, max))
+
+  defp format_organizer_when(huddl),
+    do: format_organizer_date(huddl) <> " · " <> format_organizer_time(huddl)
+
+  defp format_organizer_date(huddl),
+    do: huddl |> HuddlCardHelpers.local_starts_at() |> Calendar.strftime("%a %b %-d")
+
+  defp format_organizer_time(huddl) do
+    local = HuddlCardHelpers.local_starts_at(huddl)
+    Calendar.strftime(local, "%-I:%M %p") <> " " <> local.zone_abbr
+  end
+
+  defp organizer_place(%{event_type: :virtual}), do: "Online"
+
+  defp organizer_place(%{physical_location: place}) when is_binary(place) and place != "",
+    do: place
+
+  defp organizer_place(%{event_type: type}), do: HuddlCardHelpers.tag_label(type)
+
+  defp series_cadence_line(first, count) do
+    Enum.join(
+      [
+        series_cadence(first),
+        format_organizer_time(first),
+        "until " <> series_until(first),
+        "#{count} #{if count == 1, do: "date", else: "dates"}"
+      ],
+      " · "
+    )
+  end
+
+  # "Weekly on Thursdays", "Every two weeks on Thursdays", "Monthly on the 17th".
+  defp series_cadence(%{huddl_template: %{interval: interval, unit: unit}} = huddl) do
+    local = HuddlCardHelpers.local_starts_at(huddl)
+
+    case {interval, unit} do
+      {1, :week} -> "Weekly on #{Calendar.strftime(local, "%A")}s"
+      {2, :week} -> "Every two weeks on #{Calendar.strftime(local, "%A")}s"
+      {n, :week} -> "Every #{n} weeks on #{Calendar.strftime(local, "%A")}s"
+      {1, :month} -> "Monthly on the #{ordinal(local.day)}"
+      {n, :month} -> "Every #{n} months on the #{ordinal(local.day)}"
+    end
+  end
+
+  # The template stores the chosen end date at midnight UTC, so the date
+  # the organizer picked is its UTC date, not a zone-shifted one.
+  defp series_until(%{huddl_template: %{repeat_until: until}}),
+    do: until |> DateTime.to_date() |> Calendar.strftime("%b %-d")
+
+  defp ordinal(day) when day in [11, 12, 13], do: "#{day}th"
+
+  defp ordinal(day) do
+    suffix =
+      case rem(day, 10) do
+        1 -> "st"
+        2 -> "nd"
+        3 -> "rd"
+        _ -> "th"
+      end
+
+    "#{day}#{suffix}"
   end
 
   defp huddlz_filter_path(group, :published), do: ~p"/organize/#{group.slug}/huddlz"
 
   defp huddlz_filter_path(group, filter),
     do: ~p"/organize/#{group.slug}/huddlz?filter=#{filter}"
-
-  defp organizer_huddl_path(group, %{status: status} = huddl)
-       when status in [:cancelled, :completed],
-       do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}"
-
-  defp organizer_huddl_path(group, huddl),
-    do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit"
-
-  defp filter_heading(:draft), do: "Draft huddlz"
-  defp filter_heading(:cancelled), do: "Cancelled huddlz"
-  defp filter_heading(:past), do: "Past huddlz"
-  defp filter_heading(_), do: "Published huddlz"
 
   defp empty_huddlz_heading(:draft), do: "No draft huddlz"
   defp empty_huddlz_heading(:cancelled), do: "No cancelled huddlz"

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -153,8 +153,7 @@ Feature: Organizer workspace
     And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
     And I am signed in as "host@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
-    Then I should see "Published huddlz"
-    And I should see "Synthwave Night"
+    Then I should see "Synthwave Night"
 
   Scenario: Huddlz tab Past filter lists wrapped huddlz
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
@@ -162,8 +161,7 @@ Feature: Organizer workspace
     And I am signed in as "host@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
     And I click "Past"
-    Then I should see "Past huddlz"
-    And I should see "Last Year's Demoday"
+    Then I should see "Last Year's Demoday"
     And I should not see "Create your first huddl"
 
   Scenario: Huddlz tab does not list huddlz from other groups
@@ -175,12 +173,12 @@ Feature: Organizer workspace
     Then I should see "No huddlz scheduled"
     And I should not see "Modular Jam"
 
-  Scenario: Huddlz rows link to the huddl edit page
+  Scenario: Huddlz rows link to the huddl page and offer Edit
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
     And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
     And I am signed in as "host@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
-    Then the page should link "Synthwave Night" to its huddl edit screen
+    Then the organizer row for "Synthwave Night" links to the huddl and offers "Edit"
 
   Scenario: Members tab shows the roster grouped by role
     Given a public group "Cyberpunk Builders" exists with owner "host@example.com"

--- a/test/features/organizer_huddlz.feature
+++ b/test/features/organizer_huddlz.feature
@@ -1,7 +1,7 @@
 @database @conn
 Feature: Organizer huddlz page
   As an organizer
-  I want the group's huddlz laid out for managing, with a recurring series shown as one entry
+  I want the group's huddlz laid out for managing, in date order, with series dates marked
   So that I can see at a glance what is scheduled, how full it is, and edit the right thing
 
   Background:
@@ -20,10 +20,10 @@ Feature: Organizer huddlz page
     And the filter chips read "Upcoming 1", "Drafts 1", "Past 0" and "Cancelled 0"
     And I should not see "Modular Jam"
 
-  Scenario: A recurring series is one entry with its dates
+  Scenario: A recurring series keeps its dates in order, each marked as part of it
     Given a weekly series "Office hours" exists in group "Cyberpunk Builders" for the next 5 weeks
+    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" with room for 20 and 5 RSVPs
     When I visit "/organize/cyberpunk-builders/huddlz"
-    Then the series "Office hours" is one entry reading "Weekly on" with 5 dates
-    And the first date of "Office hours" is marked as next
-    And only 3 dates of "Office hours" show until I ask for the rest
-    And "Edit series" for "Office hours" opens the edit page on the whole series
+    Then the huddlz are listed day by day in date order
+    And every date of "Office hours" is marked "Weekly"
+    And "Edit series" on a date of "Office hours" opens the edit page on the whole series

--- a/test/features/organizer_huddlz.feature
+++ b/test/features/organizer_huddlz.feature
@@ -1,0 +1,29 @@
+@database @conn
+Feature: Organizer huddlz page
+  As an organizer
+  I want the group's huddlz laid out for managing, with a recurring series shown as one entry
+  So that I can see at a glance what is scheduled, how full it is, and edit the right thing
+
+  Background:
+    Given the following users exist:
+      | email            | display_name | role    |
+      | host@example.com | Host User    | regular |
+    And a public group "Cyberpunk Builders" exists with owner "host@example.com"
+    And I am signed in as "host@example.com"
+
+  Scenario: Upcoming huddlz show their schedule, capacity and an edit action
+    Given the huddl "Synthwave Night" exists in group "Cyberpunk Builders" with room for 20 and 5 RSVPs
+    And the draft huddl "Modular Jam" exists in group "Cyberpunk Builders"
+    When I visit "/organize/cyberpunk-builders/huddlz"
+    Then the organizer row for "Synthwave Night" shows when it is and "5 / 20 RSVPs"
+    And the organizer row for "Synthwave Night" links to the huddl and offers "Edit"
+    And the filter chips read "Upcoming 1", "Drafts 1", "Past 0" and "Cancelled 0"
+    And I should not see "Modular Jam"
+
+  Scenario: A recurring series is one entry with its dates
+    Given a weekly series "Office hours" exists in group "Cyberpunk Builders" for the next 5 weeks
+    When I visit "/organize/cyberpunk-builders/huddlz"
+    Then the series "Office hours" is one entry reading "Weekly on" with 5 dates
+    And the first date of "Office hours" is marked as next
+    And only 3 dates of "Office hours" show until I ask for the rest
+    And "Edit series" for "Office hours" opens the edit page on the whole series

--- a/test/features/step_definitions/organizer_huddlz_steps.exs
+++ b/test/features/step_definitions/organizer_huddlz_steps.exs
@@ -1,0 +1,198 @@
+defmodule OrganizerHuddlzSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import PhoenixTest
+
+  require Ash.Query
+
+  step "the huddl {string} exists in group {string} with room for {int} and {int} RSVPs",
+       %{args: [title, group_name, capacity, rsvps]} = context do
+    group = lookup_group(group_name)
+    host = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
+
+    huddl =
+      generate(
+        huddl(
+          title: title,
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          max_attendees: capacity,
+          date: Date.add(eastern_today(), 3),
+          actor: host
+        )
+      )
+
+    # The host's own RSVP is counted, so top up with other people.
+    for _ <- 1..(rsvps - 1)//1 do
+      attendee = generate(user(role: :user))
+
+      huddl
+      |> Ash.Changeset.for_update(:rsvp, %{}, actor: attendee)
+      |> Ash.update!()
+    end
+
+    Map.update(context, :huddls, [huddl], &[huddl | &1])
+  end
+
+  step "the draft huddl {string} exists in group {string}",
+       %{args: [title, group_name]} = context do
+    group = lookup_group(group_name)
+    host = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
+
+    huddl =
+      generate(
+        huddl(
+          title: title,
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          lifecycle_state: :draft,
+          date: Date.add(eastern_today(), 4),
+          actor: host
+        )
+      )
+
+    Map.update(context, :huddls, [huddl], &[huddl | &1])
+  end
+
+  step "a weekly series {string} exists in group {string} for the next {int} weeks",
+       %{args: [title, group_name, weeks]} = context do
+    group = lookup_group(group_name)
+    host = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
+
+    source =
+      generate(
+        huddl(
+          title: title,
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          date: Date.add(eastern_today(), 2),
+          is_recurring: true,
+          frequency: "weekly",
+          # The end date is stored at midnight UTC, so the last date only
+          # generates when the cutoff sits the day after it.
+          repeat_until: Date.add(eastern_today(), 2 + 7 * (weeks - 1) + 1),
+          actor: host
+        )
+      )
+
+    Oban.drain_queue(queue: :default)
+    Map.put(context, :series_source, source)
+  end
+
+  step "the organizer row for {string} shows when it is and {string}",
+       %{args: [title, rsvps], session: session} = context do
+    huddl = lookup_huddl(title)
+    local = DateTime.shift_zone!(huddl.starts_at, huddl.time_zone)
+
+    session
+    |> assert_has("#organize-huddl-#{huddl.id} .org-huddl-meta",
+      text: Calendar.strftime(local, "%a %b %-d · %-I:%M %p")
+    )
+    |> assert_has("#organize-huddl-#{huddl.id} .org-huddl-rsvps", text: rsvps)
+    |> assert_has("#organize-huddl-#{huddl.id} .org-huddl-rsvps .bar")
+
+    context
+  end
+
+  step "the organizer row for {string} links to the huddl and offers {string}",
+       %{args: [title, action], session: session} = context do
+    huddl = lookup_huddl(title)
+    base = "/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"
+
+    session
+    |> assert_has("#organize-huddl-#{huddl.id} a[href='#{base}']", text: title)
+    |> assert_has("#organize-huddl-#{huddl.id} a[href='#{base}/edit']", text: action)
+
+    context
+  end
+
+  step "the filter chips read {string}, {string}, {string} and {string}",
+       %{args: labels, session: session} = context do
+    Enum.reduce(labels, session, fn label, session ->
+      [name, count] = String.split(label, " ", parts: 2)
+      assert_has(session, "#organize-huddlz-filters .chip", text: name, count: 1)
+      assert_has(session, "#organize-huddlz-filters .chip .chip-count", text: count)
+    end)
+
+    context
+  end
+
+  step "the series {string} is one entry reading {string} with {int} dates",
+       %{args: [title, cadence, count], session: session, series_source: source} = context do
+    session
+    |> assert_has("#organize-series-#{source.huddl_template_id} .org-huddl-title", text: title)
+    |> assert_has("#organize-series-#{source.huddl_template_id} .org-series-cadence",
+      text: cadence
+    )
+    |> assert_has("#organize-series-#{source.huddl_template_id} .org-series-cadence",
+      text: "#{count} dates"
+    )
+    |> assert_has("#organize-series-#{source.huddl_template_id} .org-instance", count: count)
+    |> assert_has(".org-huddl-title", text: title, count: 1)
+
+    context
+  end
+
+  step "the first date of {string} is marked as next",
+       %{args: [_title], session: session, series_source: source} = context do
+    session
+    |> assert_has("#organize-huddl-#{source.id}.org-instance[data-next] .org-instance-next",
+      text: "Next"
+    )
+    |> assert_has(".org-instance[data-next]", count: 1)
+
+    context
+  end
+
+  step "only {int} dates of {string} show until I ask for the rest",
+       %{args: [shown, _title], session: session, series_source: source} = context do
+    selector = "#organize-series-#{source.huddl_template_id}"
+    total = session |> instance_count(selector)
+    hidden = total - shown
+
+    session
+    |> assert_has("#{selector}[data-collapsed='true']")
+    |> assert_has("#{selector} .org-instance:not(.org-instance-extra)", count: shown)
+    |> assert_has("#{selector} .org-instance.org-instance-extra", count: hidden)
+    |> assert_has("#{selector} button .when-collapsed", text: "Show #{hidden} more dates")
+
+    context
+  end
+
+  step "{string} for {string} opens the edit page on the whole series",
+       %{args: [action, _title], session: session, series_source: source} = context do
+    session =
+      session
+      |> click_link("#organize-series-#{source.huddl_template_id} a", action)
+      |> assert_has("h1", text: "Editing")
+      |> assert_has(".edit-scope-row .chip.is-active", text: "Whole series")
+
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  defp instance_count(session, selector) do
+    session.view
+    |> Phoenix.LiveViewTest.render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("#{selector} .org-instance")
+    |> Enum.count()
+  end
+
+  defp lookup_group(name) do
+    Huddlz.Communities.Group
+    |> Ash.Query.filter(name == ^name)
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp lookup_huddl(title) do
+    Huddlz.Communities.Huddl
+    |> Ash.Query.filter(title == ^title)
+    |> Ash.Query.load(:group)
+    |> Ash.read_one!(authorize?: false)
+  end
+end

--- a/test/features/step_definitions/organizer_huddlz_steps.exs
+++ b/test/features/step_definitions/organizer_huddlz_steps.exs
@@ -89,9 +89,12 @@ defmodule OrganizerHuddlzSteps do
     huddl = lookup_huddl(title)
     local = DateTime.shift_zone!(huddl.starts_at, huddl.time_zone)
 
+    day = Date.to_iso8601(DateTime.to_date(local))
+
     session
-    |> assert_has("#organize-huddl-#{huddl.id} .org-huddl-meta",
-      text: Calendar.strftime(local, "%a %b %-d · %-I:%M %p")
+    |> assert_has("#organize-day-#{day} .cal-agenda-daynum", text: to_string(local.day))
+    |> assert_has("#organize-day-#{day} #organize-huddl-#{huddl.id} .org-huddl-meta",
+      text: Calendar.strftime(local, "%-I:%M %p")
     )
     |> assert_has("#organize-huddl-#{huddl.id} .org-huddl-rsvps", text: rsvps)
     |> assert_has("#organize-huddl-#{huddl.id} .org-huddl-rsvps .bar")
@@ -122,65 +125,49 @@ defmodule OrganizerHuddlzSteps do
     context
   end
 
-  step "the series {string} is one entry reading {string} with {int} dates",
-       %{args: [title, cadence, count], session: session, series_source: source} = context do
+  step "the huddlz are listed day by day in date order", %{session: session} = context do
+    days =
+      session.view
+      |> Phoenix.LiveViewTest.render()
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query("#organize-huddlz-list .cal-agenda-day")
+      |> Enum.map(&(&1 |> LazyHTML.attribute("id") |> hd()))
+
+    assert length(days) >= 2
+    assert days == Enum.sort(days)
+
     session
-    |> assert_has("#organize-series-#{source.huddl_template_id} .org-huddl-title", text: title)
-    |> assert_has("#organize-series-#{source.huddl_template_id} .org-series-cadence",
-      text: cadence
+    |> assert_has("#organize-huddlz-list .cal-agenda-rail .cal-agenda-daynum")
+    |> assert_has("#organize-huddlz-list .org-huddl .org-huddl-title", text: "Synthwave Night")
+
+    Map.put(context, :listed_days, days)
+  end
+
+  step "every date of {string} is marked {string}",
+       %{args: [title, cadence], session: session, series_source: source} = context do
+    session
+    |> assert_has(".org-huddl[data-series='#{source.huddl_template_id}'] .org-huddl-title",
+      text: title,
+      count: 5
     )
-    |> assert_has("#organize-series-#{source.huddl_template_id} .org-series-cadence",
-      text: "#{count} dates"
+    |> assert_has(".org-huddl[data-series='#{source.huddl_template_id}'] .org-huddl-series",
+      text: cadence,
+      count: 5
     )
-    |> assert_has("#organize-series-#{source.huddl_template_id} .org-instance", count: count)
-    |> assert_has(".org-huddl-title", text: title, count: 1)
+    |> refute_has(".org-huddl:not([data-series]) .org-huddl-series")
 
     context
   end
 
-  step "the first date of {string} is marked as next",
-       %{args: [_title], session: session, series_source: source} = context do
-    session
-    |> assert_has("#organize-huddl-#{source.id}.org-instance[data-next] .org-instance-next",
-      text: "Next"
-    )
-    |> assert_has(".org-instance[data-next]", count: 1)
-
-    context
-  end
-
-  step "only {int} dates of {string} show until I ask for the rest",
-       %{args: [shown, _title], session: session, series_source: source} = context do
-    selector = "#organize-series-#{source.huddl_template_id}"
-    total = session |> instance_count(selector)
-    hidden = total - shown
-
-    session
-    |> assert_has("#{selector}[data-collapsed='true']")
-    |> assert_has("#{selector} .org-instance:not(.org-instance-extra)", count: shown)
-    |> assert_has("#{selector} .org-instance.org-instance-extra", count: hidden)
-    |> assert_has("#{selector} button .when-collapsed", text: "Show #{hidden} more dates")
-
-    context
-  end
-
-  step "{string} for {string} opens the edit page on the whole series",
+  step "{string} on a date of {string} opens the edit page on the whole series",
        %{args: [action, _title], session: session, series_source: source} = context do
     session =
       session
-      |> click_link("#organize-series-#{source.huddl_template_id} a", action)
+      |> click_link("#organize-huddl-#{source.id} a", action)
       |> assert_has("h1", text: "Editing")
       |> assert_has(".edit-scope-row .chip.is-active", text: "Whole series")
 
     Map.merge(context, %{conn: session, session: session})
-  end
-
-  defp instance_count(session, selector) do
-    session.view
-    |> Phoenix.LiveViewTest.render()
-    |> LazyHTML.from_fragment()
-    |> LazyHTML.query("#{selector} .org-instance")
-    |> Enum.count()
   end
 
   defp lookup_group(name) do

--- a/test/huddlz_web/live/huddl_live/edit_test.exs
+++ b/test/huddlz_web/live/huddl_live/edit_test.exs
@@ -284,6 +284,24 @@ defmodule HuddlzWeb.HuddlLive.EditTest do
       refute_has(session, "input[name='form[repeat_until]']")
     end
 
+    test "?edit_type=all opens on the whole series, the way the organizer's series entry links",
+         %{
+           conn: conn,
+           owner: owner,
+           group: group,
+           huddl: huddl
+         } do
+      session =
+        conn
+        |> login(owner)
+        |> visit(~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit?edit_type=all")
+
+      assert_has(session, "*", text: "Editing every upcoming date")
+      assert_has(session, ".edit-scope-row .chip.is-active", text: "Whole series")
+      assert_has(session, "input[type='hidden'][name='form[edit_type]'][value='all']")
+      assert_has(session, "select[name='form[frequency]']")
+    end
+
     test "clicking 'Whole series' flips scope and reveals series fields", %{
       conn: conn,
       owner: owner,

--- a/test/huddlz_web/live/organize_live_huddlz_test.exs
+++ b/test/huddlz_web/live/organize_live_huddlz_test.exs
@@ -26,6 +26,39 @@ defmodule HuddlzWeb.OrganizeLiveHuddlzTest do
     end)
   end
 
+  test "a long list pages twenty at a time", %{conn: conn, group: group, owner: owner} do
+    today = Huddlz.Generator.eastern_today()
+
+    source =
+      generate(
+        huddl(
+          title: "Long Running",
+          group_id: group.id,
+          creator_id: owner.id,
+          actor: owner,
+          date: Date.add(today, 1),
+          is_recurring: true,
+          frequency: "weekly",
+          # 25 weekly dates; the cutoff sits the day after the last one.
+          repeat_until: Date.add(today, 1 + 7 * 24 + 1)
+        )
+      )
+
+    Oban.drain_queue(queue: :default)
+
+    conn
+    |> login(owner)
+    |> visit(~p"/organize/#{group.slug}/huddlz")
+    |> assert_has("#organize-huddlz-filters .chip .chip-count", text: "25")
+    |> assert_has("#organize-huddlz-list .org-huddl", count: 20)
+    |> assert_has("#organize-huddl-#{source.id} .org-huddl-series", text: "Weekly")
+    |> assert_has(".org-list-more button", text: "Show 5 more")
+    |> assert_has(".org-list-more", text: "5 more huddlz after these")
+    |> click_button(".org-list-more button", "Show 5 more")
+    |> assert_has("#organize-huddlz-list .org-huddl", count: 25)
+    |> refute_has(".org-list-more")
+  end
+
   test "cancelled huddlz link directly to their detail page", %{
     conn: conn,
     group: group,

--- a/test/huddlz_web/live/organize_live_huddlz_test.exs
+++ b/test/huddlz_web/live/organize_live_huddlz_test.exs
@@ -15,10 +15,10 @@ defmodule HuddlzWeb.OrganizeLiveHuddlzTest do
       conn
       |> login(owner)
       |> visit(~p"/organize/#{group.slug}/huddlz")
-      |> assert_has("#organize-huddlz-filters .is-active[aria-current='page']", text: "Published")
+      |> assert_has("#organize-huddlz-filters .is-active[aria-current='page']", text: "Upcoming")
       |> refute_has("#organize-huddlz-filters .chip:not(.is-active)[aria-current]")
 
-    Enum.reduce(["Draft", "Cancelled", "Past", "Published"], session, fn label, session ->
+    Enum.reduce(["Drafts", "Cancelled", "Past", "Upcoming"], session, fn label, session ->
       session
       |> click_link("#organize-huddlz-filters a", label)
       |> assert_has("#organize-huddlz-filters .is-active[aria-current='page']", text: label)


### PR DESCRIPTION
## Summary

Closes #482.

The organizer's huddlz page was a plain list: title, date, two pills. It had none of the treatment the huddl card has elsewhere, and nothing showed that a row belonged to a recurring series. Direction chosen on the design canvas (Organize · Huddlz, plus the phone board): management rows in date order, grouped by day on the same rail as the calendar's agenda. A series is not a container, since folding its dates would break the date order the page exists for; each date carries a repeat mark instead.

- **Rows.** Each huddl gets a cover thumb with the group's initials as the fallback, the title linking to the huddl page, a status pill only when it is not plainly upcoming (draft, happening now, cancelled, completed), the time in the huddl's zone, the place, RSVPs against capacity as a bar that turns amber when full, and an Edit button. Cancelled and completed huddlz have no Edit, as before.
- **Day rail.** Rows group under the day they start, soonest first for what is ahead and most recent first for the past, with the month named when it differs from this one and today marked.
- **Series.** A date that belongs to a series shows a repeat mark with its cadence and end date ("Weekly · until Nov 4") and an **Edit series** link that opens the edit page with "Whole series" preselected, via `?edit_type=all`. Edit opens "Just this huddl".
- **Paging.** The list shows twenty rows and a "Show 20 more" button with the count left, so a two-year weekly series stays readable.
- **Filters** read Upcoming, Drafts, Past and Cancelled, each with a count. A **Month view** button links across to the calendar.
- **Phones.** Rows stack under the thumb and the rail becomes a heading strip, as on the agenda.

Duplicate is not offered: there is no duplicate action in the domain yet.

## Verification

- Feature `organizer_huddlz.feature`, written first: upcoming huddlz show their day, time, capacity and Edit with the chip counts right; a weekly series keeps its five dates in order under their days, each marked Weekly, and Edit series on one of them lands on the whole-series edit.
- LiveView tests cover paging a 25-date series twenty at a time and the edit-page URL preset. Existing organizer scenarios and tests updated for the chip labels and the row linking to the huddl page.
- `mix precommit` clean, exit code checked directly. No JS changed, so the Playwright suite was not rerun.

Found on the way and filed as #495: a series whose end date equals its last date drops that date, because `repeat_until` is stored at midnight UTC. The new steps work around it.

Screenshots in the comments; the earlier comment shows the folded direction this PR moved away from.
