### PR TITLE
Finish personal-label cleanup across UI and APIs

### DIFF
--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -66,7 +66,7 @@ defmodule Huddlz.Communities do
       define :get_by_owner, action: :get_by_owner
       define :get_organizable_groups, action: :get_organizable
       define :get_joined_groups, action: :get_joined
-      define :my_groups, action: :my_groups, args: [{:optional, :relationship}]
+      define :groups_for_actor, action: :groups_for_actor, args: [{:optional, :relationship}]
       define :get_by_slug, action: :get_by_slug, args: [:slug]
       define :get_group_for_organize, action: :get_for_organize, args: [:slug], get?: true
 
@@ -141,9 +141,9 @@ defmodule Huddlz.Communities do
         args: [:group_id, :email, {:optional, :role}]
 
       define :open_email_group_invitation, action: :open_email_invitation, args: [:token]
-      define :list_my_group_invitations, action: :mine
+      define :group_invitations_for_actor, action: :mine
       define :get_group_invitation, action: :read, get_by: [:id]
-      define :get_my_group_invitation, action: :get_mine, args: [:id], get?: true
+      define :get_group_invitation_for_actor, action: :get_mine, args: [:id], get?: true
       define :list_group_invitations, action: :for_group, args: [:group_id]
       define :accept_group_invitation, action: :accept
       define :decline_group_invitation, action: :decline

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -19,10 +19,10 @@ defmodule Huddlz.Communities.Group do
       read_one :get_group, :get_by_slug
       list :list_groups, :read
       list :search_groups, :search
-      # `myGroups` mirrors the `Communities.my_groups/1` Elixir interface and
+      # `viewerGroups` mirrors the `Communities.groups_for_actor/1` Elixir interface and
       # the `/groups` LiveView: returns groups the actor owns or has joined.
       # Pass `relationship: hosting | joined | all` to scope the result.
-      list :my_groups, :my_groups
+      list :viewer_groups, :groups_for_actor
       list :archived_groups, :archived
       read_one :get_group_history, :get_visible_by_slug
     end
@@ -45,7 +45,7 @@ defmodule Huddlz.Communities.Group do
       get :read
       index :read
       index :search, route: "/search"
-      index :my_groups, route: "/my-groups"
+      index :groups_for_actor, route: "/mine"
       get :get_by_slug, route: "/by_slug/:slug"
       post :create_group
       patch :update_details
@@ -198,7 +198,7 @@ defmodule Huddlz.Communities.Group do
       prepare Huddlz.Communities.Group.Preparations.ApplyTrigramSearch
     end
 
-    read :my_groups do
+    read :groups_for_actor do
       description """
       Groups the actor either owns or has joined. The `:relationship` arg
       scopes the result: `:hosting` (owned), `:joined` (member but not
@@ -213,7 +213,7 @@ defmodule Huddlz.Communities.Group do
 
       pagination offset?: true, countable: true, required?: false, default_limit: 20
 
-      prepare Huddlz.Communities.Group.Preparations.ApplyMyGroupsFilter
+      prepare Huddlz.Communities.Group.Preparations.ApplyGroupRelationshipFilter
       prepare Huddlz.Communities.Group.Preparations.ApplyTrigramSearch
     end
 

--- a/lib/huddlz/communities/group/preparations/apply_group_relationship_filter.ex
+++ b/lib/huddlz/communities/group/preparations/apply_group_relationship_filter.ex
@@ -1,4 +1,4 @@
-defmodule Huddlz.Communities.Group.Preparations.ApplyMyGroupsFilter do
+defmodule Huddlz.Communities.Group.Preparations.ApplyGroupRelationshipFilter do
   @moduledoc """
   Filters a Group read down to the actor's relationship with the result rows.
 

--- a/lib/huddlz/communities/group_invitation/open_email_invitation.ex
+++ b/lib/huddlz/communities/group_invitation/open_email_invitation.ex
@@ -23,6 +23,6 @@ defmodule Huddlz.Communities.GroupInvitation.OpenEmailInvitation do
   end
 
   defp open(invitation, _token, actor) do
-    Communities.get_my_group_invitation(invitation.id, actor: actor)
+    Communities.get_group_invitation_for_actor(invitation.id, actor: actor)
   end
 end

--- a/lib/huddlz/communities/group_member.ex
+++ b/lib/huddlz/communities/group_member.ex
@@ -16,7 +16,7 @@ defmodule Huddlz.Communities.GroupMember do
 
     queries do
       list :group_members, :get_by_group
-      list :my_memberships, :get_by_user
+      list :viewer_memberships, :get_by_user
     end
 
     mutations do

--- a/lib/huddlz/communities/huddl_attendee.ex
+++ b/lib/huddlz/communities/huddl_attendee.ex
@@ -15,7 +15,7 @@ defmodule Huddlz.Communities.HuddlAttendee do
 
     queries do
       list :huddl_attendees, :by_huddl
-      list :my_rsvps, :by_user
+      list :viewer_rsvps, :by_user
     end
   end
 

--- a/lib/huddlz/notifications/target.ex
+++ b/lib/huddlz/notifications/target.ex
@@ -37,7 +37,7 @@ defmodule Huddlz.Notifications.Target do
         %User{} = user
       )
       when is_binary(id) do
-    case Communities.get_my_group_invitation(id, actor: user) do
+    case Communities.get_group_invitation_for_actor(id, actor: user) do
       {:ok, _invitation} -> {:available, "/invitations/#{id}"}
       _ -> :resolved
     end

--- a/lib/huddlz/notifications/triggers.ex
+++ b/lib/huddlz/notifications/triggers.ex
@@ -68,7 +68,7 @@ defmodule Huddlz.Notifications.Triggers do
       category: :activity,
       sender: Senders.GroupRoleChanged,
       default: true,
-      label: "My role in a group changed"
+      label: "Your group role changed"
     },
     group_archived: %{
       category: :transactional,

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -108,7 +108,7 @@ defmodule HuddlzWeb.Layouts do
             aria-current={@active == "calendar" && "page"}
           >
             <.nav_icon name="calendar" />
-            <span class="label">My calendar</span>
+            <span class="label">Calendar</span>
           </.link>
 
           <div class="sb-orgs">

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -40,7 +40,7 @@ defmodule HuddlzWeb.CalendarLive do
 
     {:ok,
      socket
-     |> assign(:page_title, "My calendar")
+     |> assign(:page_title, "Calendar")
      |> assign(:time_zone, time_zone)
      |> assign(:today, today)
      |> stream_configure(:legend_items, dom_id: &"calendar-legend-item-#{&1.key}")}
@@ -445,7 +445,7 @@ defmodule HuddlzWeb.CalendarLive do
     >
       <div class="page-head">
         <div>
-          <h1>My calendar</h1>
+          <h1>Calendar</h1>
           <p>
             huddlz you're hosting, attending, or watching from the waitlist. Calendar dates use <strong id="calendar-time-zone">{@time_zone}</strong>.
           </p>
@@ -515,7 +515,7 @@ defmodule HuddlzWeb.CalendarLive do
           active={@scope == :mine}
           count={@counts.mine}
         >
-          My RSVPs
+          RSVPs
         </.chip>
         <.chip
           id="calendar-scope-groups"
@@ -523,7 +523,7 @@ defmodule HuddlzWeb.CalendarLive do
           active={@scope == :groups}
           count={@counts.groups}
         >
-          My groups
+          Groups
         </.chip>
       </div>
 

--- a/lib/huddlz_web/live/group_invitation_live.ex
+++ b/lib/huddlz_web/live/group_invitation_live.ex
@@ -149,7 +149,7 @@ defmodule HuddlzWeb.GroupInvitationLive do
 
   defp load_invitation(id, user) do
     with {:ok, %GroupInvitation{} = invitation} <-
-           Communities.get_my_group_invitation(id, actor: user) do
+           Communities.get_group_invitation_for_actor(id, actor: user) do
       {:ok, Communities.load_group_invitation_details!(invitation)}
     end
   end

--- a/lib/huddlz_web/live/groups_live.ex
+++ b/lib/huddlz_web/live/groups_live.ex
@@ -1,11 +1,11 @@
-defmodule HuddlzWeb.MyGroupsLive do
+defmodule HuddlzWeb.GroupsLive do
   @moduledoc """
   LiveView at `/groups`. Personal feed of groups the signed-in user
   organizes (Hosting) or has joined (Joined). Filter chips drive a
   `?filter=` URL param: default `all` is no param, `hosting` and `joined`
   scope the grid. `?page=N` paginates the active filter.
 
-  All sorting and pagination happens in postgres via the `:my_groups` read
+  All sorting and pagination happens in postgres via the `:groups_for_actor` read
   action — we do not sort in code.
   """
   use HuddlzWeb, :live_view
@@ -87,7 +87,7 @@ defmodule HuddlzWeb.MyGroupsLive do
   end
 
   defp count_for(user, relationship) do
-    case Communities.my_groups(relationship,
+    case Communities.groups_for_actor(relationship,
            actor: user,
            page: [limit: 1, offset: 0, count: true]
          ) do
@@ -97,7 +97,7 @@ defmodule HuddlzWeb.MyGroupsLive do
   end
 
   defp list_groups(:archived, opts), do: Communities.archived_groups(opts)
-  defp list_groups(filter, opts), do: Communities.my_groups(filter, opts)
+  defp list_groups(filter, opts), do: Communities.groups_for_actor(filter, opts)
 
   defp load_results(socket, filter, page, user) do
     offset = (page - 1) * @page_size
@@ -119,7 +119,7 @@ defmodule HuddlzWeb.MyGroupsLive do
         })
 
       {:error, reason} ->
-        Logger.warning("MyGroupsLive load failed: #{inspect(reason)}")
+        Logger.warning("GroupsLive load failed: #{inspect(reason)}")
 
         socket
         |> assign(:groups, [])
@@ -196,7 +196,7 @@ defmodule HuddlzWeb.MyGroupsLive do
         </.empty_state>
       <% else %>
         <div class="grid">
-          <.my_group_card :for={group <- @groups} group={group} role={group.viewer_role} />
+          <.group_card :for={group <- @groups} group={group} role={group.viewer_role} />
         </div>
         <.pagination
           :if={@page_info.total_pages > 1}
@@ -212,11 +212,11 @@ defmodule HuddlzWeb.MyGroupsLive do
   attr :group, :map, required: true
   attr :role, :atom, required: true
 
-  defp my_group_card(assigns) do
+  defp group_card(assigns) do
     ~H"""
     <.card navigate={~p"/groups/#{@group.slug}"}>
       <:cover>
-        <.group_cover id={"my-group-cover-#{@group.id}"} group={@group} />
+        <.group_cover id={"group-list-cover-#{@group.id}"} group={@group} />
         <span class={["card-tag", role_class(@role)]}>{HuddlzWeb.GroupRole.label(@role)}</span>
       </:cover>
       <:body>

--- a/lib/huddlz_web/live/helpers/huddl_card_helpers.ex
+++ b/lib/huddlz_web/live/helpers/huddl_card_helpers.ex
@@ -1,6 +1,6 @@
 defmodule HuddlzWeb.Live.Helpers.HuddlCardHelpers do
   @moduledoc """
-  Shared formatting helpers for huddl card listings (discover, my huddlz,
+  Shared formatting helpers for huddl card listings (discover, huddlz,
   group show, calendar): date block, `event_type` tag, RSVP count labels,
   and relative times.
   """

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -1249,20 +1249,20 @@ defmodule HuddlzWeb.HuddlLive.Show do
       {:ok, [%{waitlisted_at: nil} | _]} ->
         {:attending, nil}
 
-      {:ok, [%{waitlisted_at: %DateTime{} = my_at} | _]} ->
-        {:waitlisted, waitlist_position(huddl, my_at)}
+      {:ok, [%{waitlisted_at: %DateTime{} = waitlisted_at} | _]} ->
+        {:waitlisted, waitlist_position(huddl, waitlisted_at)}
 
       _ ->
         {:none, nil}
     end
   end
 
-  defp waitlist_position(huddl, %DateTime{} = my_at) do
+  defp waitlist_position(huddl, %DateTime{} = waitlisted_at) do
     require Ash.Query
 
     Huddlz.Communities.HuddlAttendee
     |> Ash.Query.filter(
-      huddl_id == ^huddl.id and not is_nil(waitlisted_at) and waitlisted_at <= ^my_at
+      huddl_id == ^huddl.id and not is_nil(waitlisted_at) and waitlisted_at <= ^waitlisted_at
     )
     |> Ash.count!(authorize?: false)
   end

--- a/lib/huddlz_web/live/huddlz_live.ex
+++ b/lib/huddlz_web/live/huddlz_live.ex
@@ -1,4 +1,4 @@
-defmodule HuddlzWeb.MyHuddlzLive do
+defmodule HuddlzWeb.HuddlzLive do
   @moduledoc """
   LiveView at `/huddlz`. Personal feed of huddlz the signed-in user is
   attending, waitlisted on, or has already attended. Filter chips
@@ -106,7 +106,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
         })
 
       {:error, reason} ->
-        Logger.warning("MyHuddlzLive search failed: #{inspect(reason)}")
+        Logger.warning("HuddlzLive search failed: #{inspect(reason)}")
 
         socket
         |> assign(:huddls, [])
@@ -203,7 +203,7 @@ defmodule HuddlzWeb.MyHuddlzLive do
         </.empty_state>
       <% else %>
         <div class="grid">
-          <.my_huddl_card :for={huddl <- @huddls} huddl={huddl} filter={@filter} />
+          <.huddl_card :for={huddl <- @huddls} huddl={huddl} filter={@filter} />
         </div>
         <.pagination
           :if={@page_info.total_pages > 1}
@@ -219,13 +219,13 @@ defmodule HuddlzWeb.MyHuddlzLive do
   attr :huddl, :map, required: true
   attr :filter, :atom, required: true
 
-  defp my_huddl_card(assigns) do
+  defp huddl_card(assigns) do
     ~H"""
     <.card navigate={~p"/groups/#{@huddl.group.slug}/huddlz/#{@huddl.id}"}>
       <:cover>
         <%= if @huddl.display_image_url do %>
           <.cover_image
-            id={"my-huddl-card-cover-#{@huddl.id}"}
+            id={"huddl-list-cover-#{@huddl.id}"}
             class="card-cover-img"
             image_url={@huddl.display_image_url}
           />

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -201,7 +201,7 @@ defmodule HuddlzWeb.LiveUserAuth do
 
   defp refresh_organizer_access(_message, socket), do: {:cont, socket}
 
-  defp organizer_access_result(%{view: HuddlzWeb.MyGroupsLive} = socket), do: {:cont, socket}
+  defp organizer_access_result(%{view: HuddlzWeb.GroupsLive} = socket), do: {:cont, socket}
   defp organizer_access_result(socket), do: {:halt, socket}
 
   defp maybe_assign_picker_groups(%{assigns: %{owned_groups: _}} = socket, groups) do

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -112,8 +112,8 @@ defmodule HuddlzWeb.Router do
       live "/terms", LegalLive, :terms
       live "/code-of-conduct", LegalLive, :conduct
       live "/privacy", LegalLive, :privacy
-      live "/huddlz", MyHuddlzLive, :index
-      live "/groups", MyGroupsLive, :index
+      live "/huddlz", HuddlzLive, :index
+      live "/groups", GroupsLive, :index
       live "/calendar", CalendarLive, :index
       live "/notifications", NotificationsLive, :index
       live "/notifications/:id/open", NotificationsLive, :open

--- a/test/features/account_role_changed_notification.feature
+++ b/test/features/account_role_changed_notification.feature
@@ -6,24 +6,24 @@ Feature: Account role changed notification email
 
   Scenario: A notification email is sent when an admin promotes a user
     Given the following users exist:
-      | email             | display_name | role  |
-      | adm@example.com   | Adm          | admin |
-      | regular@example.com | Reggie     | user  |
-    When the admin "adm@example.com" updates "regular@example.com" to role "admin"
-    Then a role-change notification should be sent to "regular@example.com" naming role "admin"
+      | email                                                 | display_name | role  |
+      | adm@example.com                                       | Adm          | admin |
+      | regular+account-role-changed-notification@example.com | Reggie       | user  |
+    When the admin "adm@example.com" updates "regular+account-role-changed-notification@example.com" to role "admin"
+    Then a role-change notification should be sent to "regular+account-role-changed-notification@example.com" naming role "admin"
 
   Scenario: No email is sent when the role does not actually change
     Given the following users exist:
-      | email             | display_name | role  |
-      | adm@example.com   | Adm          | admin |
-      | already@example.com | Al         | admin |
+      | email               | display_name | role  |
+      | adm@example.com     | Adm          | admin |
+      | already@example.com | Al           | admin |
     When the admin "adm@example.com" updates "already@example.com" to role "admin"
     Then no role-change notification should be sent
 
   Scenario: An admin cannot change their own role
     Given the following users exist:
-      | email             | display_name | role  |
-      | self@example.com  | Solo         | admin |
+      | email            | display_name | role  |
+      | self@example.com | Solo         | admin |
     When the admin "self@example.com" tries to update "self@example.com" to role "user"
     Then the role update should be rejected
     And no role-change notification should be sent

--- a/test/features/calendar_accessibility.feature
+++ b/test/features/calendar_accessibility.feature
@@ -6,9 +6,9 @@ Feature: Accessible personal calendar
 
   Background:
     Given the following users exist:
-      | email                | display_name | role    |
-      | attendee@example.com | Calendar User | regular |
-    And I am signed in as "attendee@example.com"
+      | email                                       | display_name  | role    |
+      | attendee+calendar-accessibility@example.com | Calendar User | regular |
+    And I am signed in as "attendee+calendar-accessibility@example.com"
 
   Scenario: A past attended huddl keeps its attendance context
     Given I attended a past huddl named "Retrospective"

--- a/test/features/calendar_group_scope.feature
+++ b/test/features/calendar_group_scope.feature
@@ -14,7 +14,8 @@ Feature: Calendar scope: my RSVPs or everything my groups have on
     Given I belong to "Portland Elixir", which has scheduled "Hands-on with Ash Framework"
     And I am going to "Async Rust reading group" with another group
     When I open the agenda
-    Then the agenda lists "Async Rust reading group" as going
+    Then the calendar offers "RSVPs" and "Groups" scopes
+    And the agenda lists "Async Rust reading group" as going
     And the agenda does not list "Hands-on with Ash Framework"
 
   Scenario: Everything my groups have on

--- a/test/features/create_huddl.feature
+++ b/test/features/create_huddl.feature
@@ -6,69 +6,69 @@ Feature: Create Huddl
 
   Background:
     Given the following users exist:
-      | email                 | role     | display_name |
-      | owner@example.com     | verified | Group Owner  |
-      | organizer@example.com | verified | Organizer    |
-      | member@example.com    | verified | Member       |
-      | regular@example.com   | regular  | Regular User |
+      | email                              | role     | display_name |
+      | owner+create-huddl@example.com     | verified | Group Owner  |
+      | organizer+create-huddl@example.com | verified | Organizer    |
+      | member+create-huddl@example.com    | verified | Member       |
+      | regular+create-huddl@example.com   | regular  | Regular User |
     And the following groups exist:
-      | name           | owner_email       | is_public |
-      | Tech Meetup    | owner@example.com | true      |
-      | Private Group  | owner@example.com | false     |
+      | name                     | owner_email                    | is_public |
+      | Scheduling Tech Meetup | owner+create-huddl@example.com | true      |
+      | Private Group            | owner+create-huddl@example.com | false     |
     And the following group memberships exist:
-      | group_name   | user_email            | role      |
-      | Tech Meetup  | organizer@example.com | organizer |
-      | Tech Meetup  | member@example.com    | member    |
+      | group_name               | user_email                         | role      |
+      | Scheduling Tech Meetup | organizer+create-huddl@example.com | organizer |
+      | Scheduling Tech Meetup | member+create-huddl@example.com    | member    |
 
   Scenario: Owner creates an in-person huddl
-    Given I am signed in as "owner@example.com"
-    When I visit the "Tech Meetup" group page
+    Given I am signed in as "owner+create-huddl@example.com"
+    When I visit the "Scheduling Tech Meetup" group page
     Then I should see a "Create Huddl" button
     When I click "Create Huddl"
-    Then I should be on the new huddl page for "Tech Meetup"
+    Then I should be on the new huddl page for "Scheduling Tech Meetup"
     When I fill in the huddl form with:
-      | Field             | Value                        |
-      | Title             | Monthly Tech Talk            |
-      | Description       | Discussion about new tech    |
-      | Start Date & Time | tomorrow at 6:00 PM         |
-      | End Date & Time   | tomorrow at 8:00 PM         |
-      | Huddl Type        | In-Person                   |
-      | Physical Location | 123 Main St, Tech City      |
+      | Field             | Value                     |
+      | Title             | Monthly Tech Talk         |
+      | Description       | Discussion about new tech |
+      | Start Date & Time | tomorrow at 6:00 PM       |
+      | End Date & Time   | tomorrow at 8:00 PM       |
+      | Huddl Type        | In-Person                 |
+      | Physical Location | 123 Main St, Tech City    |
     And I submit the form
-    Then I should be redirected to the "Tech Meetup" group page
+    Then I should be redirected to the "Scheduling Tech Meetup" group page
     And I should see "Huddl created successfully!"
     And the huddl "Monthly Tech Talk" should have coordinates 30.27, -97.74
 
   Scenario: Organizer creates a virtual huddl
-    Given I am signed in as "organizer@example.com"
-    When I visit the "Tech Meetup" group page
+    Given I am signed in as "organizer+create-huddl@example.com"
+    When I visit the "Scheduling Tech Meetup" group page
     Then I should see a "Create Huddl" button
     When I click "Create Huddl"
-    Then I should be on the new huddl page for "Tech Meetup"
+    Then I should be on the new huddl page for "Scheduling Tech Meetup"
     When I fill in the huddl form with:
-      | Field             | Value                        |
-      | Title             | Virtual Code Review          |
-      | Description       | Remote code review session   |
-      | Start Date & Time | tomorrow at 3:00 PM         |
-      | End Date & Time   | tomorrow at 4:00 PM         |
-      | Huddl Type        | Virtual                     |
-      | Virtual Link      | https://zoom.us/j/123456    |
+      | Field             | Value                      |
+      | Title             | Virtual Code Review        |
+      | Description       | Remote code review session |
+      | Start Date & Time | tomorrow at 3:00 PM        |
+      | End Date & Time   | tomorrow at 4:00 PM        |
+      | Huddl Type        | Virtual                    |
+      | Virtual Link      | https://zoom.us/j/123456   |
     And I submit the form
-    Then I should be redirected to the "Tech Meetup" group page
+    Then I should be redirected to the "Scheduling Tech Meetup" group page
     And I should see "Huddl created successfully!"
 
   @creator_attendance
   Scenario: Creator automatically attends and can later cancel their RSVP
-    Given I am signed in as "owner@example.com"
-    When I visit the new huddl page for "Tech Meetup"
+    Given I am signed in as "owner+create-huddl@example.com"
+    When I visit the new huddl page for "Scheduling Tech Meetup"
     And I fill in the huddl form with:
-      | Field             | Value                         |
-      | Title             | Creator Attendance            |
-      | Description       | The creator initially hosts   |
-      | Start Date & Time | tomorrow at 6:00 PM          |
-      | End Date & Time   | tomorrow at 8:00 PM          |
-      | Huddl Type        | Virtual                      |
-      | Virtual Link      | https://example.com/creator  |
+      | Field             | Value                       |
+      | Title             | Creator Attendance          |
+      | Description       | The creator initially hosts |
+      | Start Date & Time | tomorrow at 6:00 PM         |
+      | End Date & Time   | tomorrow at 8:00 PM         |
+      | Huddl Type        | Virtual                     |
+      | Virtual Link      | https://example.com/creator |
     And I submit the form
     And I visit "/huddlz"
     Then I should see "Creator Attendance"
@@ -84,48 +84,48 @@ Feature: Create Huddl
     Then I should not see "Creator Attendance"
 
   Scenario: Owner creates a monthly recurring huddl
-    Given I am signed in as "owner@example.com"
-    When I visit the "Tech Meetup" group page
+    Given I am signed in as "owner+create-huddl@example.com"
+    When I visit the "Scheduling Tech Meetup" group page
     Then I should see a "Create Huddl" button
     When I click "Create Huddl"
-    Then I should be on the new huddl page for "Tech Meetup"
+    Then I should be on the new huddl page for "Scheduling Tech Meetup"
     When I check "Recurring huddl"
     When I fill in the huddl form with:
-      | Field             | Value                       |
-      | Title             | Monthly Tech Talk           |
-      | Description       | Discussion about new tech   |
-      | Start Date & Time | tomorrow at 6:00 PM         |
-      | End Date & Time   | tomorrow at 8:00 PM         |
-      | Huddl Type        | In-Person                   |
-      | Physical Location | 123 Main St, Tech City      |
-      | Frequency         | Monthly                     |
-      | Repeat Until      | two months                  |
+      | Field             | Value                     |
+      | Title             | Monthly Tech Talk         |
+      | Description       | Discussion about new tech |
+      | Start Date & Time | tomorrow at 6:00 PM       |
+      | End Date & Time   | tomorrow at 8:00 PM       |
+      | Huddl Type        | In-Person                 |
+      | Physical Location | 123 Main St, Tech City    |
+      | Frequency         | Monthly                   |
+      | Repeat Until      | two months                |
     And I submit the form
     Then the huddl "Monthly Tech Talk" should be created 2 times
 
   Scenario: Owner creates a weekly recurring huddl
-    Given I am signed in as "owner@example.com"
-    When I visit the "Tech Meetup" group page
+    Given I am signed in as "owner+create-huddl@example.com"
+    When I visit the "Scheduling Tech Meetup" group page
     Then I should see a "Create Huddl" button
     When I click "Create Huddl"
-    Then I should be on the new huddl page for "Tech Meetup"
+    Then I should be on the new huddl page for "Scheduling Tech Meetup"
     When I check "Recurring huddl"
     When I fill in the huddl form with:
-      | Field             | Value                       |
-      | Title             | Weekly Tech Talk            |
-      | Description       | Discussion about new tech   |
-      | Start Date & Time | tomorrow at 6:00 PM         |
-      | End Date & Time   | tomorrow at 8:00 PM         |
-      | Huddl Type        | In-Person                   |
-      | Physical Location | 123 Main St, Tech City      |
-      | Frequency         | Weekly                      |
-      | Repeat Until      | two months                  |
+      | Field             | Value                     |
+      | Title             | Weekly Tech Talk          |
+      | Description       | Discussion about new tech |
+      | Start Date & Time | tomorrow at 6:00 PM       |
+      | End Date & Time   | tomorrow at 8:00 PM       |
+      | Huddl Type        | In-Person                 |
+      | Physical Location | 123 Main St, Tech City    |
+      | Frequency         | Weekly                    |
+      | Repeat Until      | two months                |
     And I submit the form
     Then the huddl "Weekly Tech Talk" should be created 9 times
 
   Scenario: Creating a hybrid huddl shows both location fields
-    Given I am signed in as "owner@example.com"
-    When I visit the new huddl page for "Tech Meetup"
+    Given I am signed in as "owner+create-huddl@example.com"
+    When I visit the new huddl page for "Scheduling Tech Meetup"
     Then I should see "Physical Location" field
     And I should not see "Online link" field
     When I choose "Hybrid"
@@ -133,32 +133,32 @@ Feature: Create Huddl
     And I should see "Online link" field
 
   Scenario: Private groups create private huddls only
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "owner+create-huddl@example.com"
     When I visit the new huddl page for "Private Group"
     Then I should not see a checkbox for "Members only"
     And I should see "This will be a private huddl"
     When I fill in the huddl form with:
-      | Field             | Value                        |
-      | Title             | Private Meeting              |
-      | Description       | Members only                 |
-      | Start Date & Time | tomorrow at 2:00 PM         |
-      | End Date & Time   | tomorrow at 3:00 PM         |
-      | Huddl Type        | In-Person                   |
-      | Physical Location | Secret Location              |
+      | Field             | Value               |
+      | Title             | Private Meeting     |
+      | Description       | Members only        |
+      | Start Date & Time | tomorrow at 2:00 PM |
+      | End Date & Time   | tomorrow at 3:00 PM |
+      | Huddl Type        | In-Person           |
+      | Physical Location | Secret Location     |
     And I submit the form
     Then the huddl should be created as private
 
   Scenario: Regular member cannot create huddl
-    Given I am signed in as "member@example.com"
-    When I visit the "Tech Meetup" group page
+    Given I am signed in as "member+create-huddl@example.com"
+    When I visit the "Scheduling Tech Meetup" group page
     Then I should not see a "Create Huddl" button
-    When I try to visit the new huddl page for "Tech Meetup"
-    Then I should be redirected to the "Tech Meetup" group page
+    When I try to visit the new huddl page for "Scheduling Tech Meetup"
+    Then I should be redirected to the "Scheduling Tech Meetup" group page
     And I should see "You don't have permission to create huddlz for this group"
 
   Scenario: Form validation shows errors
-    Given I am signed in as "owner@example.com"
-    When I visit the new huddl page for "Tech Meetup"
+    Given I am signed in as "owner+create-huddl@example.com"
+    When I visit the new huddl page for "Scheduling Tech Meetup"
     And I submit the form without filling it
     Then I should see validation errors for required fields
     And I should remain on the new huddl page

--- a/test/features/current_navigation.feature
+++ b/test/features/current_navigation.feature
@@ -12,7 +12,7 @@ Feature: Current navigation for assistive technology
 
   Scenario: Current destination and view follow navigation
     When I visit "/calendar"
-    Then navigation should identify "My calendar" as the current destination
+    Then navigation should identify "Calendar" as the current destination
     And view choices should identify "Agenda" as current
     When I click link "Agenda"
     Then view choices should identify "Agenda" as current

--- a/test/features/current_navigation.feature
+++ b/test/features/current_navigation.feature
@@ -6,9 +6,9 @@ Feature: Current navigation for assistive technology
 
   Background:
     Given the following users exist:
-      | email                | display_name    | role    |
-      | attendee@example.com | Navigation User | regular |
-    And I am signed in as "attendee@example.com"
+      | email                                   | display_name    | role    |
+      | attendee+current-navigation@example.com | Navigation User | regular |
+    And I am signed in as "attendee+current-navigation@example.com"
 
   Scenario: Current destination and view follow navigation
     When I visit "/calendar"

--- a/test/features/delete_huddl.feature
+++ b/test/features/delete_huddl.feature
@@ -6,15 +6,15 @@ Feature: Cancel Huddl
 
   Background:
     Given the following users exist:
-      | email                 | role     | display_name |
-      | owner@example.com     | verified | Group Owner  |
-      | non_owner@example.com | verified | Other User   |
+      | email                              | role     | display_name |
+      | owner+delete-huddl@example.com     | verified | Group Owner  |
+      | non_owner+delete-huddl@example.com | verified | Other User   |
     Given the following huddlz exist:
-      | name            | creator_name | group_name
-      | Future Workshop | Group Owner  | Tech Meetup
+      | name            | creator_name | group_name               |
+      | Future Workshop | Group Owner  | Delete Huddl Tech Meetup |
 
   Scenario: Owner cancels an in-person huddl
-    Given I am signed in as "owner@example.com"
+    Given I am signed in as "owner+delete-huddl@example.com"
     When I visit the "Future Workshop" huddl page
     Then I should see "Cancel huddl"
     When I click "Cancel huddl"
@@ -24,6 +24,6 @@ Feature: Cancel Huddl
     And I should see "Huddl cancelled. Attendees have been notified."
 
   Scenario: Non-owner cannot cancel a huddl
-    Given I am signed in as "non_owner@example.com"
+    Given I am signed in as "non_owner+delete-huddl@example.com"
     When I visit the "Future Workshop" huddl page
     Then I should not see "Cancel huddl"

--- a/test/features/discover_combined.feature
+++ b/test/features/discover_combined.feature
@@ -6,8 +6,8 @@ Feature: Combined search on /discover
 
   Background:
     Given the following users exist:
-      | email             | role     | display_name |
-      | host@example.com  | verified | Group Host   |
+      | email                              | role     | display_name |
+      | host+discover-combined@example.com | verified | Group Host   |
 
   Scenario: Default scope shows both scope chips
     When I visit "/discover"
@@ -15,13 +15,13 @@ Feature: Combined search on /discover
     And I should see "Groups"
 
   Scenario: scope=groups shows the groups section
-    Given a group named "Tampa Tech Talks" is owned by "host@example.com"
+    Given a group named "Tampa Tech Talks" is owned by "host+discover-combined@example.com"
     When I visit "/discover?scope=groups"
     Then I should see "Browse groups"
     And I should see "Tampa Tech Talks"
 
   Scenario: scope=groups hides huddlz
-    Given a group named "Tampa Tech Talks" is owned by "host@example.com"
+    Given a group named "Tampa Tech Talks" is owned by "host+discover-combined@example.com"
     And the group "Tampa Tech Talks" has an upcoming huddl titled "Builders Night"
     When I visit "/discover?scope=groups"
     Then I should see "Tampa Tech Talks"

--- a/test/features/edit_huddl.feature
+++ b/test/features/edit_huddl.feature
@@ -6,14 +6,14 @@ Feature: Edit Huddl Location
 
   Background:
     Given the following users exist:
-      | email             | role | display_name |
-      | owner@example.com | user | Group Owner  |
-    And a public group "Tech Meetup" exists with owner "owner@example.com"
+      | email                           | role | display_name |
+      | edit-location-owner@example.com | user | Group Owner  |
+    And a public group "Edit Location Crew" exists with owner "edit-location-owner@example.com"
 
   Scenario: Saving a huddl whose location matches a saved one persists those coordinates
-    Given the group "Tech Meetup" has a saved location "Convention Center" at "500 E Cesar Chavez St" with coordinates 30.27, -97.74
-    And the group "Tech Meetup" has a huddl "Existing" at "500 E Cesar Chavez St"
-    And I am signed in as "owner@example.com"
+    Given the group "Edit Location Crew" has a saved location "Convention Center" at "500 E Cesar Chavez St" with coordinates 30.27, -97.74
+    And the group "Edit Location Crew" has a huddl "Existing" at "500 E Cesar Chavez St"
+    And I am signed in as "edit-location-owner@example.com"
     When I visit the edit page for huddl "Existing"
     Then the saved location "Convention Center" should be preselected
     When I click the "Save changes" button
@@ -21,10 +21,10 @@ Feature: Edit Huddl Location
     And the huddl "Existing" should have coordinates 30.27, -97.74
 
   Scenario: Switching to a different saved location persists the new coordinates
-    Given the group "Tech Meetup" has a saved location "Original" at "Original Address, Austin, TX" with coordinates 30.27, -97.74
-    And the group "Tech Meetup" has a saved location "Houston Hub" at "Houston Address, Houston, TX" with coordinates 29.76, -95.37
-    And the group "Tech Meetup" has a huddl "Movable" at "Original Address, Austin, TX"
-    And I am signed in as "owner@example.com"
+    Given the group "Edit Location Crew" has a saved location "Original" at "Original Address, Austin, TX" with coordinates 30.27, -97.74
+    And the group "Edit Location Crew" has a saved location "Houston Hub" at "Houston Address, Houston, TX" with coordinates 29.76, -95.37
+    And the group "Edit Location Crew" has a huddl "Movable" at "Original Address, Austin, TX"
+    And I am signed in as "edit-location-owner@example.com"
     When I visit the edit page for huddl "Movable"
     And I switch the saved location to "Houston Hub"
     And I click the "Save changes" button
@@ -32,8 +32,8 @@ Feature: Edit Huddl Location
     And the huddl "Movable" should have coordinates 29.76, -95.37
 
   Scenario: Adding a brand-new address via the modal updates the huddl coordinates
-    Given the group "Tech Meetup" has a huddl "Relocating" at "Old Address, Austin, TX"
-    And I am signed in as "owner@example.com"
+    Given the group "Edit Location Crew" has a huddl "Relocating" at "Old Address, Austin, TX"
+    And I am signed in as "edit-location-owner@example.com"
     When I visit the edit page for huddl "Relocating"
     And I add a new saved address "Saint Augustine, FL, USA" with coordinates 29.89, -81.31 via the modal
     And I click the "Save changes" button
@@ -41,9 +41,9 @@ Feature: Edit Huddl Location
     And the huddl "Relocating" should have coordinates 29.89, -81.31
 
   Scenario: Adding another address while a saved location is preselected persists the modal coordinates
-    Given the group "Tech Meetup" has a saved location "Convention Center" at "500 E Cesar Chavez St" with coordinates 30.27, -97.74
-    And the group "Tech Meetup" has a huddl "Movable Pre" at "500 E Cesar Chavez St"
-    And I am signed in as "owner@example.com"
+    Given the group "Edit Location Crew" has a saved location "Convention Center" at "500 E Cesar Chavez St" with coordinates 30.27, -97.74
+    And the group "Edit Location Crew" has a huddl "Movable Pre" at "500 E Cesar Chavez St"
+    And I am signed in as "edit-location-owner@example.com"
     When I visit the edit page for huddl "Movable Pre"
     Then the saved location "Convention Center" should be preselected
     When I add a new saved address "Saint Augustine, FL, USA" with coordinates 29.89, -81.31 via the modal

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -6,18 +6,18 @@ Feature: Group Management
 
   Background:
     Given the following users exist:
-      | email                    | role     | display_name |
-      | admin@example.com        | admin    | Admin User   |
-      | verified@example.com     | verified | Verified User|
-      | regular@example.com      | regular  | Regular User |
+      | email                                | role     | display_name  |
+      | admin+group-management@example.com   | admin    | Admin User    |
+      | verified@example.com                 | verified | Verified User |
+      | regular+group-management@example.com | regular  | Regular User  |
 
   Scenario: Creating a public group as a verified user
     Given I am signed in as "verified@example.com"
     When I visit "/groups/new"
     Then I should see "Create a group"
     When I fill in the following:
-      | Group name  | Tech Enthusiasts           |
-      | Description | A group for tech lovers    |
+      | Group name  | Tech Enthusiasts        |
+      | Description | A group for tech lovers |
     And I select "San Francisco, CA, USA" as the group city in "America/Los_Angeles"
     And I check "Public group"
     And I click "Create group"
@@ -26,7 +26,7 @@ Feature: Group Management
     And I should see "A group for tech lovers"
 
   Scenario: Creating a private group as an admin
-    Given I am signed in as "admin@example.com"
+    Given I am signed in as "admin+group-management@example.com"
     When I visit "/groups/new"
     When I fill in the following:
       | Group name  | Secret Society |
@@ -39,40 +39,40 @@ Feature: Group Management
     And I should see "Private"
 
   Scenario: Regular users can create groups
-    Given I am signed in as "regular@example.com"
+    Given I am signed in as "regular+group-management@example.com"
     When I visit "/groups/new"
     Then I should see "Create a group"
 
   Scenario: Viewing a public group as a visitor
-    Given a public group "Book Club" exists with owner "verified@example.com"
-    When I visit the group page for "Book Club"
-    Then I should see "Book Club"
+    Given a public group "Management Book Club" exists with owner "verified@example.com"
+    When I visit the group page for "Management Book Club"
+    Then I should see "Management Book Club"
     And the group member count should be 1
 
   Scenario: Cannot view private group as non-member
-    Given a private group "VIP Club" exists with owner "admin@example.com"
-    And I am signed in as "regular@example.com"
+    Given a private group "VIP Club" exists with owner "admin+group-management@example.com"
+    And I am signed in as "regular+group-management@example.com"
     When I try to visit the group page for "VIP Club"
     Then I should see the branded not found recovery page
 
   Scenario: Owner can edit group details
-    Given a public group "Book Club" exists with owner "verified@example.com"
+    Given a public group "Management Book Club" exists with owner "verified@example.com"
     And I am signed in as "verified@example.com"
-    When I visit the group page for "Book Club"
+    When I visit the group page for "Management Book Club"
     And I click "Edit Group"
     Then I should see "Edit Group"
     When I fill in the following:
-      | Group Name  | Updated Book Club       |
-      | Description | Updated description     |
+      | Group Name  | Updated Management Book Club |
+      | Description | Updated description                |
     And I select "Austin, TX, USA" as the group city in "America/Chicago"
     And I click "Save Changes"
     Then I should see "Group updated successfully"
-    And I should see "Updated Book Club"
+    And I should see "Updated Management Book Club"
 
   Scenario: Owner understands making a public group private
-    Given a public group "Book Club" exists with owner "verified@example.com"
+    Given a public group "Management Book Club" exists with owner "verified@example.com"
     And I am signed in as "verified@example.com"
-    When I visit the edit page for "Book Club"
+    When I visit the edit page for "Management Book Club"
     Then I should see "Current visibility"
     And I should see "Public"
     When I uncheck "Public group"
@@ -84,9 +84,9 @@ Feature: Group Management
     Then I should see "Visibility is now private"
 
   Scenario: Owner understands making a private group public
-    Given a private group "Book Club" exists with owner "verified@example.com"
+    Given a private group "Management Book Club" exists with owner "verified@example.com"
     And I am signed in as "verified@example.com"
-    When I visit the edit page for "Book Club"
+    When I visit the edit page for "Management Book Club"
     Then I should see "Current visibility"
     And I should see "Private"
     When I check "Public group"
@@ -97,19 +97,19 @@ Feature: Group Management
     Then I should see "Visibility is now public"
 
   Scenario: Non-owner cannot edit group
-    Given a public group "Book Club" exists with owner "verified@example.com"
-    And I am signed in as "regular@example.com"
-    When I visit the edit page for "Book Club"
+    Given a public group "Management Book Club" exists with owner "verified@example.com"
+    And I am signed in as "regular+group-management@example.com"
+    When I visit the edit page for "Management Book Club"
     Then I should see "You don't have permission to edit this group"
 
   Scenario: Member confirms before leaving a group
-    Given a public group "Book Club" exists with owner "verified@example.com"
-    And "regular@example.com" is a member of "Book Club"
-    And I am signed in as "regular@example.com"
-    When I visit the group page for "Book Club"
+    Given a public group "Management Book Club" exists with owner "verified@example.com"
+    And "regular+group-management@example.com" is a member of "Management Book Club"
+    And I am signed in as "regular+group-management@example.com"
+    When I visit the group page for "Management Book Club"
     Then the group member count should be 2
     When I click "Leave Group"
-    Then I should see the leave dialog for "Book Club"
+    Then I should see the leave dialog for "Management Book Club"
     When I click "Cancel"
     Then the "Leave Group" button should be visible
     When I click "Leave Group"
@@ -118,7 +118,7 @@ Feature: Group Management
     And the "Join Group" button should be visible
     And the group member count should be 1
     When I visit "/groups"
-    Then I should not see "Book Club"
+    Then I should not see "Management Book Club"
 
   Scenario: Group name is required
     Given I am signed in as "verified@example.com"

--- a/test/features/huddl_cover_image.feature
+++ b/test/features/huddl_cover_image.feature
@@ -6,25 +6,25 @@ Feature: Huddl Image Management
 
   Background:
     Given the following users exist:
-      | email                | role     | display_name    |
-      | owner@example.com    | user     | Group Owner     |
-      | organizer@example.com| user     | Organizer       |
-      | member@example.com   | user     | Group Member    |
+      | email                                   | role | display_name |
+      | owner+huddl-cover-image@example.com     | user | Group Owner  |
+      | organizer+huddl-cover-image@example.com | user | Organizer    |
+      | member+huddl-cover-image@example.com    | user | Group Member |
 
   # ===== Huddl Creation with Image =====
 
   Scenario: Owner can see image upload area when creating a huddl
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And I am signed in as "owner@example.com"
-    When I visit the new huddl page for group "Tech Meetup"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And I am signed in as "owner+huddl-cover-image@example.com"
+    When I visit the new huddl page for group "Cover Image Tech Meetup"
     Then I should see "Cover image"
     And I should see "Drop a 16:9 image"
 
   Scenario: Creating a huddl without an image falls back to group image
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the group "Tech Meetup" has an image
-    And I am signed in as "owner@example.com"
-    When I visit the new huddl page for group "Tech Meetup"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the group "Cover Image Tech Meetup" has an image
+    And I am signed in as "owner+huddl-cover-image@example.com"
+    When I visit the new huddl page for group "Cover Image Tech Meetup"
     And I fill in the huddl form with:
       | Field             | Value                |
       | Title             | Code Review Session  |
@@ -39,20 +39,20 @@ Feature: Huddl Image Management
     And the huddl "Code Review Session" should use the group image
 
   Scenario: Creating a huddl with its own image
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the group "Tech Meetup" has an image
-    And I am signed in as "owner@example.com"
-    When I visit the new huddl page for group "Tech Meetup"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the group "Cover Image Tech Meetup" has an image
+    And I am signed in as "owner+huddl-cover-image@example.com"
+    When I visit the new huddl page for group "Cover Image Tech Meetup"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
     When I fill in the huddl form with:
-      | Field             | Value                |
-      | Title             | Workshop             |
-      | Description       | Hands-on workshop    |
-      | Huddl Type        | In-Person            |
-      | Physical Location | Lab                  |
-      | Start Date & Time | tomorrow at 2:00 PM  |
-      | End Date & Time   | tomorrow at 4:00 PM  |
+      | Field             | Value               |
+      | Title             | Workshop            |
+      | Description       | Hands-on workshop   |
+      | Huddl Type        | In-Person           |
+      | Physical Location | Lab                 |
+      | Start Date & Time | tomorrow at 2:00 PM |
+      | End Date & Time   | tomorrow at 4:00 PM |
     And I submit the form
     Then I should see "Huddl created successfully"
     And the huddl "Workshop" should have its own image
@@ -60,21 +60,21 @@ Feature: Huddl Image Management
   # ===== Huddl Editing with Image =====
 
   Scenario: Owner can see image upload area when editing a huddl
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the following huddl exists in "Tech Meetup":
-      | title          | description | event_type | physical_location | creator              |
-      | Existing Huddl | Test desc   | in_person  | Test Location     | owner@example.com    |
-    And I am signed in as "owner@example.com"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the following huddl exists in "Cover Image Tech Meetup":
+      | title          | description | event_type | physical_location | creator                             |
+      | Existing Huddl | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
+    And I am signed in as "owner+huddl-cover-image@example.com"
     When I visit the edit page for huddl "Existing Huddl"
     Then I should see "Cover image"
     And I should see "Drop a 16:9 image"
 
   Scenario: Owner can upload a new image for existing huddl
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the following huddl exists in "Tech Meetup":
-      | title        | description | event_type | physical_location | creator              |
-      | Add Image    | Test desc   | in_person  | Test Location     | owner@example.com    |
-    And I am signed in as "owner@example.com"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the following huddl exists in "Cover Image Tech Meetup":
+      | title     | description | event_type | physical_location | creator                             |
+      | Add Image | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
+    And I am signed in as "owner+huddl-cover-image@example.com"
     When I visit the edit page for huddl "Add Image"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "New image uploaded. Save to apply."
@@ -83,13 +83,13 @@ Feature: Huddl Image Management
     And the huddl "Add Image" should have its own image
 
   Scenario: Owner can remove existing huddl image to fallback to group
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the group "Tech Meetup" has an image
-    And the following huddl exists in "Tech Meetup":
-      | title            | description | event_type | physical_location | creator              |
-      | Remove Image     | Test desc   | in_person  | Test Location     | owner@example.com    |
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the group "Cover Image Tech Meetup" has an image
+    And the following huddl exists in "Cover Image Tech Meetup":
+      | title        | description | event_type | physical_location | creator                             |
+      | Remove Image | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
     And the huddl "Remove Image" has an image
-    And I am signed in as "owner@example.com"
+    And I am signed in as "owner+huddl-cover-image@example.com"
     When I visit the edit page for huddl "Remove Image"
     Then I should see "Current image"
     When I click the "Remove" button
@@ -99,10 +99,10 @@ Feature: Huddl Image Management
   # ===== Organizer Permissions =====
 
   Scenario: Organizer can upload images for huddl
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And "organizer@example.com" is an organizer of "Tech Meetup"
-    And I am signed in as "organizer@example.com"
-    When I visit the new huddl page for group "Tech Meetup"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And "organizer+huddl-cover-image@example.com" is an organizer of "Cover Image Tech Meetup"
+    And I am signed in as "organizer+huddl-cover-image@example.com"
+    When I visit the new huddl page for group "Cover Image Tech Meetup"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"
     When I fill in the huddl form with:
@@ -120,40 +120,40 @@ Feature: Huddl Image Management
   # ===== Image Display Fallback =====
 
   Scenario: Huddl without image displays group image on show page
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the group "Tech Meetup" has an image
-    And the following huddl exists in "Tech Meetup":
-      | title          | description | event_type | physical_location | creator              |
-      | No Image Huddl | Test desc   | in_person  | Test Location     | owner@example.com    |
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the group "Cover Image Tech Meetup" has an image
+    And the following huddl exists in "Cover Image Tech Meetup":
+      | title          | description | event_type | physical_location | creator                             |
+      | No Image Huddl | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
     When I visit the huddl page for "No Image Huddl"
     Then I should see the group fallback image
 
   Scenario: Huddl with image displays its own image
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And the group "Tech Meetup" has an image
-    And the following huddl exists in "Tech Meetup":
-      | title          | description | event_type | physical_location | creator              |
-      | Has Image      | Test desc   | in_person  | Test Location     | owner@example.com    |
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And the group "Cover Image Tech Meetup" has an image
+    And the following huddl exists in "Cover Image Tech Meetup":
+      | title     | description | event_type | physical_location | creator                             |
+      | Has Image | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
     And the huddl "Has Image" has an image
     When I visit the huddl page for "Has Image"
     Then I should see the huddl image
 
   Scenario: Huddl without image and no group image shows placeholder
-    Given a public group "No Images Group" exists with owner "owner@example.com"
+    Given a public group "No Images Group" exists with owner "owner+huddl-cover-image@example.com"
     And the following huddl exists in "No Images Group":
-      | title          | description | event_type | physical_location | creator              |
-      | Placeholder    | Test desc   | in_person  | Test Location     | owner@example.com    |
+      | title       | description | event_type | physical_location | creator                             |
+      | Placeholder | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
     When I visit the huddl page for "Placeholder"
     Then I should not see an image on the huddl page
 
   # ===== Member Permissions =====
 
   Scenario: Regular member cannot edit huddl images
-    Given a public group "Tech Meetup" exists with owner "owner@example.com"
-    And "member@example.com" is a member of "Tech Meetup"
-    And the following huddl exists in "Tech Meetup":
-      | title          | description | event_type | physical_location | creator              |
-      | Member Test    | Test desc   | in_person  | Test Location     | owner@example.com    |
-    And I am signed in as "member@example.com"
+    Given a public group "Cover Image Tech Meetup" exists with owner "owner+huddl-cover-image@example.com"
+    And "member+huddl-cover-image@example.com" is a member of "Cover Image Tech Meetup"
+    And the following huddl exists in "Cover Image Tech Meetup":
+      | title       | description | event_type | physical_location | creator                             |
+      | Member Test | Test desc   | in_person  | Test Location     | owner+huddl-cover-image@example.com |
+    And I am signed in as "member+huddl-cover-image@example.com"
     When I visit the edit page for huddl "Member Test"
     Then I should be redirected away from the edit page

--- a/test/features/landing_surface.feature
+++ b/test/features/landing_surface.feature
@@ -6,8 +6,8 @@ Feature: Landing surface
 
   Background:
     Given the following users exist:
-      | email             | role     | display_name |
-      | regular@example.com | verified | Regular User |
+      | email                               | role     | display_name |
+      | regular+landing-surface@example.com | verified | Regular User |
 
   Scenario: Anonymous visitor sees the landing hero and CTAs
     When I visit "/"
@@ -29,7 +29,7 @@ Feature: Landing surface
     And I should see "Sign up"
 
   Scenario: Authenticated user is redirected from / to /huddlz
-    Given I am signed in as "regular@example.com"
+    Given I am signed in as "regular+landing-surface@example.com"
     When I visit "/"
     Then I should see "Huddlz"
     And I should see "Upcoming"

--- a/test/features/location_based_time_zones.feature
+++ b/test/features/location_based_time_zones.feature
@@ -5,9 +5,9 @@ Feature: Location-based time zones
 
   Background:
     Given the following users exist:
-      | email             | role     | display_name |
-      | owner@example.com | verified | Group Owner  |
-    And I am signed in as "owner@example.com"
+      | email                                       | role     | display_name |
+      | owner+location-based-time-zones@example.com | verified | Group Owner  |
+    And I am signed in as "owner+location-based-time-zones@example.com"
 
   Scenario: A group's required city determines its time zone
     When I visit "/groups/new"

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -9,6 +9,7 @@ Feature: Notification preferences settings page
     When I visit "/profile/notifications"
     Then I should see "notification preferences and other knobs"
     And I should see "Activity"
+    And I should see "Your group role changed"
     When I uncheck "Confirmation when I RSVP to a huddl"
     And I click "Save preferences"
     Then I should see "Notification preferences saved"

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -7,17 +7,17 @@ Feature: Organizer workspace
 
   Background:
     Given the following users exist:
-      | email                | role     | display_name |
-      | host@example.com     | verified | Host User    |
-      | attendee@example.com | verified | Attendee     |
-      | stranger@example.com | verified | Stranger     |
+      | email                                   | role     | display_name |
+      | host+organize-workspace@example.com     | verified | Host User    |
+      | attendee+organize-workspace@example.com | verified | Attendee     |
+      | stranger@example.com                    | verified | Stranger     |
 
   Scenario: Anonymous visitor is redirected from /organize to sign-in
     When I visit "/organize"
     Then I should see "Sign in"
 
   Scenario: Signed-in user with no groups sees the empty-state CTA at /organize
-    Given I am signed in as "host@example.com"
+    Given I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize"
     Then I should see "Organizer workspace"
     And I should see "Get started"
@@ -25,9 +25,9 @@ Feature: Organizer workspace
     And I should see "Create your first group"
 
   Scenario: /organize lists owned groups as a picker
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And a private group "Inner Circle" exists with owner "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And a private group "Inner Circle" exists with owner "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize"
     Then I should see "Your groups"
     And I should see "Cyberpunk Builders"
@@ -36,10 +36,10 @@ Feature: Organizer workspace
     And I should see "Private"
 
   Scenario: Organizer views show the complete member count
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And "attendee@example.com" is a member of "Cyberpunk Builders"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And "attendee+organize-workspace@example.com" is a member of "Cyberpunk Builders"
     And "stranger@example.com" is a member of "Cyberpunk Builders"
-    And I am signed in as "host@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize"
     Then I should see "3 members"
     When I visit "/organize/cyberpunk-builders"
@@ -47,22 +47,22 @@ Feature: Organizer workspace
 
   Scenario: /organize picker does not list groups the actor does not own
     Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
-    And I am signed in as "host@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize"
     Then I should see "You don't organize any groups yet."
     And I should not see "Phoenix Devs"
 
   Scenario: /organize picker lists owned groups alphabetically by name
-    Given a public group "Synth Society" exists with owner "host@example.com"
-    And a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Synth Society" exists with owner "host+organize-workspace@example.com"
+    And a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize"
     Then the picker should list "Cyberpunk Builders" before "Synth Society"
 
   Scenario: Sidebar shows each owned group with sub-tabs when active
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And a public group "Synth Society" exists with owner "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And a public group "Synth Society" exists with owner "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Synth Society"
@@ -72,24 +72,24 @@ Feature: Organizer workspace
 
   Scenario: Visiting another organizer's group slug redirects back to the picker
     Given a public group "Phoenix Devs" exists with owner "stranger@example.com"
-    And I am signed in as "host@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/phoenix-devs"
     Then I should see "That group doesn't exist, or you don't organize it."
     And I should see "You don't organize any groups yet."
 
   Scenario: Visiting an unknown group slug redirects back to the picker with the same flash
-    Given I am signed in as "host@example.com"
+    Given I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/no-such-group"
     Then I should see "That group doesn't exist, or you don't organize it."
     And I should see "You don't organize any groups yet."
 
   Scenario: An organizer can open the workspace for a group they help run
     Given the following users exist:
-      | email                  | role     | display_name |
-      | organizer@example.com | verified | Group Organizer |
-    And a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And "organizer@example.com" is an organizer of "Cyberpunk Builders"
-    And I am signed in as "organizer@example.com"
+      | email                                    | role     | display_name    |
+      | organizer+organize-workspace@example.com | verified | Group Organizer |
+    And a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And "organizer+organize-workspace@example.com" is an organizer of "Cyberpunk Builders"
+    And I am signed in as "organizer+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
@@ -97,17 +97,17 @@ Feature: Organizer workspace
 
   Scenario: An admin can open the workspace for any group
     Given the following users exist:
-      | email             | role  | display_name |
-      | admin@example.com | admin | Admin User   |
+      | email                                | role  | display_name |
+      | admin+organize-workspace@example.com | admin | Admin User   |
     And a public group "Phoenix Devs" exists with owner "stranger@example.com"
-    And I am signed in as "admin@example.com"
+    And I am signed in as "admin+organize-workspace@example.com"
     When I visit "/organize/phoenix-devs"
     Then I should see "Phoenix Devs"
     And I should not see "That group doesn't exist, or you don't organize it."
 
   Scenario: Group overview shows zeroed KPIs and empty upcoming list
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
@@ -117,49 +117,49 @@ Feature: Organizer workspace
     And I should see "No upcoming huddlz right now. Create one to get started."
 
   Scenario: Group overview lists the group's upcoming huddl
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Upcoming huddlz"
     And I should see "Synthwave Night"
 
   Scenario: Open RSVPs roll up into the overview KPI tile
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
-    And "attendee@example.com" has RSVPed to "Synthwave Night"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
+    And "attendee+organize-workspace@example.com" has RSVPed to "Synthwave Night"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Open RSVPs"
     And I should see "2 RSVPs"
 
   Scenario: Overview does not show huddlz from groups the actor does not organize
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
     And a public group "Phoenix Devs" exists with owner "stranger@example.com"
     And the huddl "External Meetup" exists in group "Phoenix Devs" hosted by "stranger@example.com"
-    And I am signed in as "host@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
     Then I should not see "External Meetup"
 
   Scenario: Huddlz tab shows the empty state when the group has no live huddlz
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
     Then I should see "No huddlz scheduled"
     And I should see "Create your first huddl"
 
   Scenario: Huddlz tab lists live huddlz for the active group
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
     Then I should see "Published huddlz"
     And I should see "Synthwave Night"
 
   Scenario: Huddlz tab Past filter lists wrapped huddlz
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And the past huddl "Last Year's Demoday" exists in group "Cyberpunk Builders" hosted by "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And the past huddl "Last Year's Demoday" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
     And I click "Past"
     Then I should see "Past huddlz"
@@ -167,25 +167,25 @@ Feature: Organizer workspace
     And I should not see "Create your first huddl"
 
   Scenario: Huddlz tab does not list huddlz from other groups
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And a public group "Synth Society" exists with owner "host@example.com"
-    And the huddl "Modular Jam" exists in group "Synth Society" hosted by "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And a public group "Synth Society" exists with owner "host+organize-workspace@example.com"
+    And the huddl "Modular Jam" exists in group "Synth Society" hosted by "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
     Then I should see "No huddlz scheduled"
     And I should not see "Modular Jam"
 
   Scenario: Huddlz rows link to the huddl edit page
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host@example.com"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders/huddlz"
     Then the page should link "Synthwave Night" to its huddl edit screen
 
   Scenario: Members tab shows the roster grouped by role
-    Given a public group "Cyberpunk Builders" exists with owner "host@example.com"
-    And "attendee@example.com" is a member of "Cyberpunk Builders"
-    And I am signed in as "host@example.com"
+    Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
+    And "attendee+organize-workspace@example.com" is a member of "Cyberpunk Builders"
+    And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders/members"
     Then I should see "Owner"
     And I should see "Members"

--- a/test/features/organizer_navigation.feature
+++ b/test/features/organizer_navigation.feature
@@ -6,11 +6,11 @@ Feature: Organizer pages highlight the group's section
 
   Background:
     Given the following users exist:
-      | email             | display_name | role    |
-      | owner@example.com | Owner User   | regular |
-    And a public group "Portland Elixir" exists with owner "owner@example.com"
-    And a huddl "Ash workshop" exists in "Portland Elixir" created by "owner@example.com"
-    And I am signed in as "owner@example.com"
+      | email                                  | display_name | role    |
+      | owner+organizer-navigation@example.com | Owner User   | regular |
+    And a public group "Portland Elixir" exists with owner "owner+organizer-navigation@example.com"
+    And a huddl "Ash workshop" exists in "Portland Elixir" created by "owner+organizer-navigation@example.com"
+    And I am signed in as "owner+organizer-navigation@example.com"
 
   Scenario: Scheduling a huddl highlights the group's huddlz
     When I visit the new huddl page for group "Portland Elixir"

--- a/test/features/profile_picture.feature
+++ b/test/features/profile_picture.feature
@@ -6,9 +6,9 @@ Feature: Profile Picture Management
 
   Background:
     Given the following users exist:
-      | email                | role     | display_name    |
-      | alice@example.com    | user     | Alice User      |
-    And I am signed in as "alice@example.com"
+      | email                             | role | display_name |
+      | alice+profile-picture@example.com | user | Alice User   |
+    And I am signed in as "alice+profile-picture@example.com"
 
   Scenario: Viewing profile picture section
     When I visit "/profile"
@@ -37,45 +37,45 @@ Feature: Profile Picture Management
     And I should see "Display name"
 
   Scenario: Profile picture appears in navbar when user has one
-    Given a public group "Avatar Group" exists with owner "alice@example.com"
+    Given a public group "Avatar Group" exists with owner "alice+profile-picture@example.com"
     And the following profile pictures exist:
-      | user_email          | storage_path                                      |
-      | alice@example.com   | /uploads/profile_pictures/alice/avatar.jpg        |
+      | user_email                        | storage_path                               |
+      | alice+profile-picture@example.com | /uploads/profile_pictures/alice/avatar.jpg |
     When I visit the locations page for "Avatar Group"
     Then I should see the navbar avatar with image
 
   Scenario: Navbar shows initials when user has no profile picture
-    Given a public group "Initials Group" exists with owner "alice@example.com"
+    Given a public group "Initials Group" exists with owner "alice+profile-picture@example.com"
     When I visit the locations page for "Initials Group"
     Then I should see the navbar avatar with initials "AU"
 
   Scenario: Member section shows member initials on the group page
     Given the following groups exist:
-      | name          | slug          | owner_email       | visibility |
-      | Test Group    | test-group    | alice@example.com | public     |
-    And I am signed in as "alice@example.com"
+      | name       | slug       | owner_email                       | visibility |
+      | Test Group | test-group | alice+profile-picture@example.com | public     |
+    And I am signed in as "alice+profile-picture@example.com"
     When I visit "/groups/test-group"
     Then I should see the member tile with initials "AU"
 
   Scenario: Profile picture appears for huddl creator
     Given the following groups exist:
-      | name          | slug          | owner_email       | visibility |
-      | Test Group    | test-group    | alice@example.com | public     |
-    And a huddl "Test Huddl" exists in "Test Group" created by "alice@example.com"
+      | name       | slug       | owner_email                       | visibility |
+      | Test Group | test-group | alice+profile-picture@example.com | public     |
+    And a huddl "Test Huddl" exists in "Test Group" created by "alice+profile-picture@example.com"
     And the following profile pictures exist:
-      | user_email          | storage_path                                      |
-      | alice@example.com   | /uploads/profile_pictures/alice/avatar.jpg        |
+      | user_email                        | storage_path                               |
+      | alice+profile-picture@example.com | /uploads/profile_pictures/alice/avatar.jpg |
     When I visit the huddl "Test Huddl" page
     Then I should see the creator avatar with image
 
   Scenario: Avatar shows initials after profile picture is removed
     Given the following groups exist:
-      | name       | slug       | owner_email       | visibility |
-      | Test Group | test-group | alice@example.com | public     |
-    And a huddl "Test Huddl" exists in "Test Group" created by "alice@example.com"
+      | name       | slug       | owner_email                       | visibility |
+      | Test Group | test-group | alice+profile-picture@example.com | public     |
+    And a huddl "Test Huddl" exists in "Test Group" created by "alice+profile-picture@example.com"
     And the following profile pictures exist:
-      | user_email          | storage_path                                      |
-      | alice@example.com   | /uploads/profile_pictures/alice/avatar.jpg        |
+      | user_email                        | storage_path                               |
+      | alice+profile-picture@example.com | /uploads/profile_pictures/alice/avatar.jpg |
     When I visit "/profile"
     And I click "Remove"
     Then I should see "Remove your profile picture?"
@@ -89,8 +89,8 @@ Feature: Profile Picture Management
 
   Scenario: Canceling profile picture removal preserves the picture
     Given the following profile pictures exist:
-      | user_email        | storage_path                               |
-      | alice@example.com | /uploads/profile_pictures/alice/avatar.jpg |
+      | user_email                        | storage_path                               |
+      | alice+profile-picture@example.com | /uploads/profile_pictures/alice/avatar.jpg |
     When I visit "/profile"
     And I click "Remove"
     Then I should see "Remove your profile picture?"
@@ -100,11 +100,11 @@ Feature: Profile Picture Management
 
   Scenario: Removing profile picture shows initials not previous picture
     Given the following profile pictures exist:
-      | user_email          | storage_path                                      |
-      | alice@example.com   | /uploads/profile_pictures/alice/first.jpg        |
+      | user_email                        | storage_path                              |
+      | alice+profile-picture@example.com | /uploads/profile_pictures/alice/first.jpg |
     And the following profile pictures exist:
-      | user_email          | storage_path                                      |
-      | alice@example.com   | /uploads/profile_pictures/alice/second.jpg       |
+      | user_email                        | storage_path                               |
+      | alice+profile-picture@example.com | /uploads/profile_pictures/alice/second.jpg |
     When I visit "/profile"
     And I click "Remove"
     Then I should see "Remove your profile picture?"

--- a/test/features/rsvp_cancellation.feature
+++ b/test/features/rsvp_cancellation.feature
@@ -6,20 +6,20 @@ Feature: RSVP Cancellation
 
   Background:
     Given the following users exist:
-      | email                    | display_name | role     |
-      | organizer@example.com    | Organizer    | verified |
-      | member@example.com       | Member       | verified |
+      | email                                   | display_name | role     |
+      | organizer+rsvp-cancellation@example.com | Organizer    | verified |
+      | member+rsvp-cancellation@example.com    | Member       | verified |
     And the following group exists:
-      | name          | description        | is_public | owner_email           |
-      | Tech Meetup   | Local tech group   | true      | organizer@example.com |
-    And "member@example.com" is a member of "Tech Meetup"
-    And the following huddl exists in "Tech Meetup":
-      | title                 | description              | event_type | starts_at    | virtual_link                |
-      | Virtual Code Review   | Let's review some code   | virtual    | tomorrow 2pm | https://zoom.us/j/123456789 |
+      | name                          | description      | is_public | owner_email                             |
+      | Cancellation Tech Meetup | Local tech group | true      | organizer+rsvp-cancellation@example.com |
+    And "member+rsvp-cancellation@example.com" is a member of "Cancellation Tech Meetup"
+    And the following huddl exists in "Cancellation Tech Meetup":
+      | title               | description            | event_type | starts_at    | virtual_link                |
+      | Virtual Code Review | Let's review some code | virtual    | tomorrow 2pm | https://zoom.us/j/123456789 |
 
   Scenario: User cancels their RSVP to a huddl
-    Given I am logged in as "member@example.com"
-    And I am on the "Tech Meetup" group page
+    Given I am logged in as "member+rsvp-cancellation@example.com"
+    And I am on the "Cancellation Tech Meetup" group page
     Then I should see "Virtual Code Review"
     When I click "Virtual Code Review"
     Then I should be on the huddl page for "Virtual Code Review"
@@ -40,7 +40,7 @@ Feature: RSVP Cancellation
     And I should see "1 person attending"
 
   Scenario: User can RSVP again after cancelling
-    Given I am logged in as "member@example.com"
+    Given I am logged in as "member+rsvp-cancellation@example.com"
     And I have RSVPed to "Virtual Code Review"
     When I visit the "Virtual Code Review" huddl page
     And I click "Cancel RSVP"
@@ -52,9 +52,9 @@ Feature: RSVP Cancellation
     And I should see "2 people attending"
 
   Scenario: Multiple users can manage their RSVPs independently
-    Given I am logged in as "organizer@example.com"
+    Given I am logged in as "organizer+rsvp-cancellation@example.com"
     And I have RSVPed to "Virtual Code Review"
-    And "member@example.com" has RSVPed to "Virtual Code Review"
+    And "member+rsvp-cancellation@example.com" has RSVPed to "Virtual Code Review"
     When I visit the "Virtual Code Review" huddl page
     Then I should see "2 people attending"
     
@@ -63,16 +63,16 @@ Feature: RSVP Cancellation
     And I should see "1 person attending"
     
     When I log out
-    And I am logged in as "member@example.com"
+    And I am logged in as "member+rsvp-cancellation@example.com"
     And I visit the "Virtual Code Review" huddl page
     Then I should see "You're attending"
     And I should see "1 person attending"
 
   Scenario: Cannot cancel RSVP for past events
-    Given I am logged in as "member@example.com"
-    And the following huddl exists in "Tech Meetup":
-      | title        | description    | event_type | starts_at      | ends_at        | virtual_link              |
-      | Past Event   | Already done   | virtual    | yesterday 2pm  | yesterday 3pm  | https://zoom.us/j/999999  |
+    Given I am logged in as "member+rsvp-cancellation@example.com"
+    And the following huddl exists in "Cancellation Tech Meetup":
+      | title      | description  | event_type | starts_at     | ends_at       | virtual_link             |
+      | Past Event | Already done | virtual    | yesterday 2pm | yesterday 3pm | https://zoom.us/j/999999 |
     And I have RSVPed to "Past Event"
     When I visit the "Past Event" huddl page
     Then I should not see "Cancel RSVP"

--- a/test/features/saved_location_deletion.feature
+++ b/test/features/saved_location_deletion.feature
@@ -6,14 +6,14 @@ Feature: Safe saved-location deletion
 
   Background:
     Given the following users exist:
-      | email             | role | display_name |
-      | owner@example.com | user | Group Owner  |
-    And a public group "Book Club" exists with owner "owner@example.com"
-    And the group "Book Club" has a saved location "Library" at "100 Main St" with coordinates 30.27, -97.74
-    And I am signed in as "owner@example.com"
+      | email                                     | role | display_name |
+      | owner+saved-location-deletion@example.com | user | Group Owner  |
+    And a public group "Address Removal Book Club" exists with owner "owner+saved-location-deletion@example.com"
+    And the group "Address Removal Book Club" has a saved location "Library" at "100 Main St" with coordinates 30.27, -97.74
+    And I am signed in as "owner+saved-location-deletion@example.com"
 
   Scenario: Deleting an unused saved location requires confirmation
-    When I visit the locations page for "Book Club"
+    When I visit the locations page for "Address Removal Book Club"
     And I click "Delete"
     Then I should see "Delete this saved location?"
     And I should see "It will no longer appear in future venue pickers"
@@ -26,7 +26,7 @@ Feature: Safe saved-location deletion
 
   Scenario: A scheduled huddl blocks saved-location deletion
     Given the saved location "Library" is used by an upcoming huddl
-    When I visit the locations page for "Book Club"
+    When I visit the locations page for "Address Removal Book Club"
     And I click "Delete"
     Then I should see "This location is used by 1 current or upcoming huddl"
     And I should see "Move it to another venue before deleting it"

--- a/test/features/step_definitions/calendar_group_scope_steps.exs
+++ b/test/features/step_definitions/calendar_group_scope_steps.exs
@@ -4,6 +4,16 @@ defmodule CalendarGroupScopeSteps do
   import Huddlz.Generator
   import PhoenixTest
 
+  step "the calendar offers {string} and {string} scopes",
+       %{args: [rsvps, groups], session: session} = context do
+    session
+    |> assert_has("#calendar-scope-mine", text: rsvps)
+    |> assert_has("#calendar-scope-groups", text: groups)
+    |> refute_has(".cal-scope", text: "My")
+
+    context
+  end
+
   step "I belong to {string}, which has scheduled {string}",
        %{args: [group_name, title], current_user: member} = context do
     host = generate(user(role: :user))
@@ -34,7 +44,7 @@ defmodule CalendarGroupScopeSteps do
   end
 
   step "I switch to everything from my groups", %{session: session} = context do
-    session = click_link(session, "#calendar-scope-groups", "My groups")
+    session = click_link(session, "#calendar-scope-groups", "Groups")
     Map.merge(context, %{conn: session, session: session})
   end
 

--- a/test/features/step_definitions/group_membership_visibility_steps.exs
+++ b/test/features/step_definitions/group_membership_visibility_steps.exs
@@ -8,7 +8,7 @@ defmodule GroupMembershipVisibilitySteps do
     group = Enum.find(context.groups, &(to_string(&1.name) == name))
 
     invitation =
-      Huddlz.Communities.list_my_group_invitations!(actor: context.current_user)
+      Huddlz.Communities.group_invitations_for_actor!(actor: context.current_user)
       |> Enum.find(&(&1.group_id == group.id))
 
     Phoenix.ConnTest.build_conn()

--- a/test/features/step_definitions/private_group_invitation_steps.exs
+++ b/test/features/step_definitions/private_group_invitation_steps.exs
@@ -30,7 +30,7 @@ defmodule PrivateGroupInvitationSteps do
     group = find_group(context, group_name)
 
     invitation =
-      Communities.list_my_group_invitations!(actor: context.current_user)
+      Communities.group_invitations_for_actor!(actor: context.current_user)
       |> Enum.find(&(&1.group_id == group.id))
 
     session = context[:session] || context[:conn]

--- a/test/features/unavailable_notification_targets.feature
+++ b/test/features/unavailable_notification_targets.feature
@@ -6,9 +6,9 @@ Feature: Unavailable notification targets
 
   Scenario: A deleted huddl remains visible without an Open action
     Given the following users exist:
-      | email              | display_name | role |
-      | member@example.com | Test Member  | user |
-    And I am signed in as "member@example.com"
+      | email                                               | display_name | role |
+      | member+unavailable-notification-targets@example.com | Test Member  | user |
+    And I am signed in as "member+unavailable-notification-targets@example.com"
     And I have a notification for a deleted huddl named "Boat Drinks"
     When I visit "/notifications"
     Then I should see "Boat Drinks"

--- a/test/features/user_profile.feature
+++ b/test/features/user_profile.feature
@@ -6,15 +6,15 @@ Feature: User Profile Management
 
   Background:
     Given the following users exist:
-      | email                | role     | display_name    |
-      | alice@example.com    | user     | BraveEagle726   |
-    And I am signed in as "alice@example.com"
+      | email                          | role | display_name  |
+      | alice+user-profile@example.com | user | BraveEagle726 |
+    And I am signed in as "alice+user-profile@example.com"
 
   Scenario: Viewing my profile
     When I visit "/profile"
     Then I should see "Profile"
     And I should see my current display name
-    And I should see "alice@example.com"
+    And I should see "alice+user-profile@example.com"
 
   Scenario: Updating my display name
     Given I am on my profile page
@@ -24,36 +24,36 @@ Feature: User Profile Management
     And the display name field should contain "Alice Cooper"
 
   Scenario: Changing my sign-in email securely
-    Given the user "alice@example.com" has password "OldPassword123!"
+    Given the user "alice+user-profile@example.com" has password "OldPassword123!"
     And I am on my profile page
     When I fill in "New email" with "alice.changed@example.com"
     And I fill in "Confirm current password" with "OldPassword123!"
     And I click the "Change email" button
     Then I should see "Email updated successfully"
     And I should see "alice.changed@example.com"
-    And a security notice should be sent to "alice@example.com" naming the new address "alice.changed@example.com"
-    And a confirmation should be sent to "alice.changed@example.com" naming the previous address "alice@example.com"
+    And a security notice should be sent to "alice+user-profile@example.com" naming the new address "alice.changed@example.com"
+    And a confirmation should be sent to "alice.changed@example.com" naming the previous address "alice+user-profile@example.com"
 
   Scenario: Rejecting an invalid sign-in email
-    Given the user "alice@example.com" has password "OldPassword123!"
+    Given the user "alice+user-profile@example.com" has password "OldPassword123!"
     And I am on my profile page
     When I fill in "New email" with "not-an-email"
     And I fill in "Confirm current password" with "OldPassword123!"
     And I click the "Change email" button
     Then I should see "Enter a valid email address."
-    And I should see "alice@example.com"
+    And I should see "alice+user-profile@example.com"
 
   Scenario: Rejecting a sign-in email change with the wrong password
-    Given the user "alice@example.com" has password "OldPassword123!"
+    Given the user "alice+user-profile@example.com" has password "OldPassword123!"
     And I am on my profile page
     When I fill in "New email" with "alice.changed@example.com"
     And I fill in "Confirm current password" with "WrongPassword"
     And I click the "Change email" button
     Then I should see "Email could not be updated"
-    And I should see "alice@example.com"
+    And I should see "alice+user-profile@example.com"
 
   Scenario: Rejecting a sign-in email already used by another person
-    Given the user "alice@example.com" has password "OldPassword123!"
+    Given the user "alice+user-profile@example.com" has password "OldPassword123!"
     And the following users exist:
       | email             | role | display_name |
       | taken@example.com | user | Taken Email  |
@@ -62,7 +62,7 @@ Feature: User Profile Management
     And I fill in "Confirm current password" with "OldPassword123!"
     And I click the "Change email" button
     Then I should see "That email is already in use."
-    And I should see "alice@example.com"
+    And I should see "alice+user-profile@example.com"
 
   Scenario: Display name validation - empty
     Given I am on my profile page

--- a/test/features/view_past_huddlz.feature
+++ b/test/features/view_past_huddlz.feature
@@ -6,9 +6,9 @@ Feature: View Past Huddlz on Group Pages
 
   Background:
     Given the following users exist:
-      | email                | display_name | role     |
-      | member@example.com   | Test Member  | regular  |
-      | nonmember@example.com| Non Member   | regular  |
+      | email                                  | display_name | role    |
+      | member+view-past-huddlz@example.com    | Test Member  | regular |
+      | nonmember+view-past-huddlz@example.com | Non Member   | regular |
     And there are groups with past and future huddlz in the system
 
   Scenario: View past huddlz in public groups
@@ -19,14 +19,14 @@ Feature: View Past Huddlz on Group Pages
     And the past huddlz should be sorted newest first
 
   Scenario: View past huddlz as a group member
-    Given I am signed in as "member@example.com"
+    Given I am signed in as "member+view-past-huddlz@example.com"
     And I am a member of a private group with past huddlz
     When I visit that private group page
     And I click on the "Past" tab
     Then I should see past huddlz from my private group
 
   Scenario: Non-members cannot see private groups
-    Given I am signed in as "nonmember@example.com"
+    Given I am signed in as "nonmember+view-past-huddlz@example.com"
     And there is a private group with past huddlz I'm not a member of
     When I try to visit that private group page
     Then I should see the branded not found recovery page

--- a/test/features/waitlist.feature
+++ b/test/features/waitlist.feature
@@ -6,19 +6,19 @@ Feature: Waitlist
 
   Background:
     Given the following users exist:
-      | email                    | display_name | role     |
-      | organizer@example.com    | Organizer    | verified |
-      | member@example.com       | Member       | verified |
-      | hopeful@example.com      | Hopeful      | verified |
+      | email                          | display_name | role     |
+      | organizer+waitlist@example.com | Organizer    | verified |
+      | member+waitlist@example.com    | Member       | verified |
+      | hopeful@example.com            | Hopeful      | verified |
     And the following group exists:
-      | name          | description        | is_public | owner_email           |
-      | Tech Meetup   | Local tech group   | true      | organizer@example.com |
-    And "member@example.com" is a member of "Tech Meetup"
-    And "hopeful@example.com" is a member of "Tech Meetup"
-    And the following capped huddl exists in "Tech Meetup":
-      | title              | description       | event_type | starts_at    | virtual_link                | max_attendees |
-      | Capped Code Review | Limited seats     | virtual    | tomorrow 2pm | https://zoom.us/j/123456789 | 2             |
-    And "member@example.com" has RSVPed to "Capped Code Review"
+      | name                 | description      | is_public | owner_email                    |
+      | Waitlist Tech Meetup | Local tech group | true      | organizer+waitlist@example.com |
+    And "member+waitlist@example.com" is a member of "Waitlist Tech Meetup"
+    And "hopeful@example.com" is a member of "Waitlist Tech Meetup"
+    And the following capped huddl exists in "Waitlist Tech Meetup":
+      | title              | description   | event_type | starts_at    | virtual_link                | max_attendees |
+      | Capped Code Review | Limited seats | virtual    | tomorrow 2pm | https://zoom.us/j/123456789 | 2             |
+    And "member+waitlist@example.com" has RSVPed to "Capped Code Review"
 
   Scenario: User joins the waitlist when the huddl is full
     Given I am logged in as "hopeful@example.com"
@@ -45,7 +45,7 @@ Feature: Waitlist
   Scenario: User is promoted when an attendee cancels
     Given I am logged in as "hopeful@example.com"
     And I have joined the waitlist for "Capped Code Review"
-    When "member@example.com" cancels their RSVP to "Capped Code Review"
+    When "member+waitlist@example.com" cancels their RSVP to "Capped Code Review"
     And I visit the "Capped Code Review" huddl page
     Then I should see "You're attending"
     And I should not see "On waitlist"

--- a/test/huddlz/communities/confirmed_recipient_worker_test.exs
+++ b/test/huddlz/communities/confirmed_recipient_worker_test.exs
@@ -23,7 +23,7 @@ defmodule Huddlz.Communities.ConfirmedRecipientWorkerTest do
     assert :ok = ConfirmedRecipientWorker.perform(context.job)
     assert :ok = ConfirmedRecipientWorker.perform(context.job)
 
-    assert [invitation] = Communities.list_my_group_invitations!(actor: context.recipient)
+    assert [invitation] = Communities.group_invitations_for_actor!(actor: context.recipient)
     assert invitation.id == context.invitation.id
     assert invitation.status == :pending
     assert [_notification] = Notifications.list_for_user!(actor: context.recipient)
@@ -33,7 +33,7 @@ defmodule Huddlz.Communities.ConfirmedRecipientWorkerTest do
     Communities.revoke_group_invitation!(context.invitation, actor: context.owner)
 
     assert :ok = ConfirmedRecipientWorker.perform(context.job)
-    assert [] = Communities.list_my_group_invitations!(actor: context.recipient)
+    assert [] = Communities.group_invitations_for_actor!(actor: context.recipient)
     assert [] = Notifications.list_for_user!(actor: context.recipient)
   end
 
@@ -41,7 +41,7 @@ defmodule Huddlz.Communities.ConfirmedRecipientWorkerTest do
     job = %{context.job | args: %{context.job.args | "email" => "previous@example.com"}}
 
     assert :ok = ConfirmedRecipientWorker.perform(job)
-    assert [] = Communities.list_my_group_invitations!(actor: context.recipient)
+    assert [] = Communities.group_invitations_for_actor!(actor: context.recipient)
     assert [] = Notifications.list_for_user!(actor: context.recipient)
   end
 end

--- a/test/huddlz/communities/group_invitation_test.exs
+++ b/test/huddlz/communities/group_invitation_test.exs
@@ -204,7 +204,7 @@ defmodule Huddlz.Communities.GroupInvitationTest do
              Communities.accept_group_invitation(invitation, actor: outsider)
 
     assert {:ok, nil} =
-             Communities.get_my_group_invitation(
+             Communities.get_group_invitation_for_actor(
                invitation.id,
                actor: outsider,
                not_found_error?: false

--- a/test/huddlz_web/api/graphql/group_test.exs
+++ b/test/huddlz_web/api/graphql/group_test.exs
@@ -52,7 +52,7 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
     end
   end
 
-  describe "myGroups query" do
+  describe "viewerGroups query" do
     test "returns groups the actor owns or has joined (default :all)", %{conn: conn} do
       member = generate(user())
       stranger = generate(user())
@@ -67,9 +67,9 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
       conn =
         conn
         |> authenticated_conn(member)
-        |> gql_post("{ myGroups { results { id name } } }")
+        |> gql_post("{ viewerGroups { results { id name } } }")
 
-      assert %{"data" => %{"myGroups" => %{"results" => results}}} =
+      assert %{"data" => %{"viewerGroups" => %{"results" => results}}} =
                json_response(conn, 200)
 
       ids = Enum.map(results, & &1["id"])
@@ -88,9 +88,9 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
       conn =
         conn
         |> authenticated_conn(member)
-        |> gql_post(~s|{ myGroups(relationship: "hosting") { results { id } } }|)
+        |> gql_post(~s|{ viewerGroups(relationship: "hosting") { results { id } } }|)
 
-      assert %{"data" => %{"myGroups" => %{"results" => results}}} = json_response(conn, 200)
+      assert %{"data" => %{"viewerGroups" => %{"results" => results}}} = json_response(conn, 200)
 
       ids = Enum.map(results, & &1["id"])
       assert owned.id in ids
@@ -108,9 +108,9 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
       conn =
         conn
         |> authenticated_conn(member)
-        |> gql_post(~s|{ myGroups(relationship: "joined") { results { id } } }|)
+        |> gql_post(~s|{ viewerGroups(relationship: "joined") { results { id } } }|)
 
-      assert %{"data" => %{"myGroups" => %{"results" => results}}} = json_response(conn, 200)
+      assert %{"data" => %{"viewerGroups" => %{"results" => results}}} = json_response(conn, 200)
 
       ids = Enum.map(results, & &1["id"])
       assert joined.id in ids
@@ -123,9 +123,9 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
       conn =
         conn
         |> authenticated_conn(lonely)
-        |> gql_post("{ myGroups { results { id } } }")
+        |> gql_post("{ viewerGroups { results { id } } }")
 
-      assert %{"data" => %{"myGroups" => %{"results" => []}}} = json_response(conn, 200)
+      assert %{"data" => %{"viewerGroups" => %{"results" => []}}} = json_response(conn, 200)
     end
   end
 end

--- a/test/huddlz_web/api/graphql/viewer_test.exs
+++ b/test/huddlz_web/api/graphql/viewer_test.exs
@@ -1,0 +1,56 @@
+defmodule HuddlzWeb.Api.Graphql.ViewerTest do
+  use HuddlzWeb.ApiCase, async: true
+
+  test "the schema exposes viewer queries without the retired personal names", %{conn: conn} do
+    response =
+      conn
+      |> gql_post("{ __schema { queryType { fields { name } } } }")
+      |> json_response(200)
+
+    names = Enum.map(response["data"]["__schema"]["queryType"]["fields"], & &1["name"])
+
+    assert "viewerGroups" in names
+    assert "viewerMemberships" in names
+    assert "viewerRsvps" in names
+    refute "myGroups" in names
+    refute "myMemberships" in names
+    refute "myRsvps" in names
+  end
+
+  test "viewerRsvps returns only the authenticated user's RSVPs", %{conn: conn} do
+    owner = generate(user())
+    viewer = generate(user())
+    group = generate(group(actor: owner, is_public: true))
+    huddl = generate(huddl(group_id: group.id, actor: owner, is_private: false))
+    Huddlz.Communities.rsvp_huddl!(huddl, actor: owner)
+    Huddlz.Communities.rsvp_huddl!(huddl, actor: viewer)
+    [rsvp] = Huddlz.Communities.check_user_rsvp!(huddl.id, actor: viewer)
+
+    response =
+      conn
+      |> authenticated_conn(viewer)
+      |> gql_post("{ viewerRsvps { id } }")
+      |> json_response(200)
+
+    assert response == %{
+             "data" => %{
+               "viewerRsvps" => [%{"id" => rsvp.id}]
+             }
+           }
+  end
+
+  test "viewerMemberships returns only the authenticated user's memberships", %{conn: conn} do
+    owner = generate(user())
+    viewer = generate(user())
+    group = generate(group(actor: owner, is_public: true))
+    membership = generate(group_member(group_id: group.id, user_id: viewer.id, actor: owner))
+
+    response =
+      conn
+      |> authenticated_conn(viewer)
+      |> gql_post("{ viewerMemberships { id } }")
+      |> json_response(200)
+
+    assert response == %{"data" => %{"viewerMemberships" => [%{"id" => membership.id}]}}
+  end
+end

--- a/test/huddlz_web/api/json/group_test.exs
+++ b/test/huddlz_web/api/json/group_test.exs
@@ -181,7 +181,7 @@ defmodule HuddlzWeb.Api.Json.GroupTest do
     end
   end
 
-  describe "GET /api/json/groups/my-groups" do
+  describe "GET /api/json/groups/mine" do
     test "returns groups the actor owns or has joined", %{conn: conn} do
       me = generate(user())
       mine = generate(group(owner_id: me.id, is_public: true, actor: me))
@@ -196,7 +196,7 @@ defmodule HuddlzWeb.Api.Json.GroupTest do
       conn =
         conn
         |> authenticated_conn(me)
-        |> get("/api/json/groups/my-groups")
+        |> get("/api/json/groups/mine")
 
       assert %{"data" => data} = json_response(conn, 200)
       ids = Enum.map(data, & &1["id"])

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -67,9 +67,9 @@ defmodule HuddlzWeb.CalendarLiveTest do
       conn
       |> login(attendee)
       |> visit("/calendar?view=month")
-      |> assert_has("h1", text: "My calendar")
+      |> assert_has("h1", text: "Calendar")
       |> assert_has("aside.sidebar")
-      |> assert_has(".sb-item.active[aria-current='page']", text: "My calendar")
+      |> assert_has(".sb-item.active[aria-current='page']", text: "Calendar")
       |> refute_has(".sb-item:not(.active)[aria-current]")
       |> assert_has(".cal-toolbar")
       |> assert_has(".cal-nav-today", text: "Today")
@@ -808,10 +808,10 @@ defmodule HuddlzWeb.CalendarLiveTest do
       conn
       |> login(attendee)
       |> visit("/calendar")
-      |> assert_has("#calendar-scope-mine.chip.is-active[aria-current='page']", text: "My RSVPs")
+      |> assert_has("#calendar-scope-mine.chip.is-active[aria-current='page']", text: "RSVPs")
       |> assert_has("#calendar-scope-mine .chip-count", text: "1")
       |> assert_has("#calendar-scope-groups.chip:not(.is-active)[href='/calendar?scope=groups']",
-        text: "My groups"
+        text: "Groups"
       )
       |> assert_has("#calendar-scope-groups .chip-count", text: "2")
       |> refute_has(".cal-agenda-title", text: "Theirs")

--- a/test/huddlz_web/live/group_invitation_live_test.exs
+++ b/test/huddlz_web/live/group_invitation_live_test.exs
@@ -40,7 +40,7 @@ defmodule HuddlzWeb.GroupInvitationLiveTest do
     assert has_element?(organizer_view, "#invitation-rows", invitee.display_name)
 
     invitation =
-      Communities.list_my_group_invitations!(actor: invitee)
+      Communities.group_invitations_for_actor!(actor: invitee)
       |> List.first()
 
     {:ok, invitation_view, _html} =
@@ -68,7 +68,7 @@ defmodule HuddlzWeb.GroupInvitationLiveTest do
     refute has_element?(invitation_view, "#accept-invitation")
 
     assert Communities.get_membership_in_group!(group.id, actor: invitee).role == :member
-    assert Enum.any?(Communities.my_groups!(:all, actor: invitee), &(&1.id == group.id))
+    assert Enum.any?(Communities.groups_for_actor!(:all, actor: invitee), &(&1.id == group.id))
   end
 
   test "invitation page keeps the unread notification badge", context do
@@ -200,7 +200,7 @@ defmodule HuddlzWeb.GroupInvitationLiveTest do
     assert has_element?(view, "#group-invitation-form option[value='member']")
     refute has_element?(view, "#group-invitation-form option[value='organizer']")
 
-    assert Communities.list_my_group_invitations!(actor: invitee) == []
+    assert Communities.group_invitations_for_actor!(actor: invitee) == []
   end
 
   test "public groups do not show the invitation form", context do

--- a/test/huddlz_web/live/groups_live_test.exs
+++ b/test/huddlz_web/live/groups_live_test.exs
@@ -1,4 +1,4 @@
-defmodule HuddlzWeb.MyGroupsLiveTest do
+defmodule HuddlzWeb.GroupsLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
   setup do
@@ -201,9 +201,9 @@ defmodule HuddlzWeb.MyGroupsLiveTest do
       conn
       |> login(member)
       |> visit("/groups")
-      |> assert_has("#my-group-cover-#{group.id}[data-testid='group-cover']")
-      |> assert_has("#my-group-cover-#{group.id} .group-cover-signal", text: "FC", exact: true)
-      |> refute_has("#my-group-cover-#{group.id} img")
+      |> assert_has("#group-list-cover-#{group.id}[data-testid='group-cover']")
+      |> assert_has("#group-list-cover-#{group.id} .group-cover-signal", text: "FC", exact: true)
+      |> refute_has("#group-list-cover-#{group.id} img")
     end
 
     test "renders the complete member count", %{conn: conn, member: member} do

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -177,7 +177,7 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
       |> visit(~p"/groups/#{group.slug}")
       |> assert_has("#group-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
       |> visit(~p"/huddlz")
-      |> assert_has("#my-huddl-card-cover-#{huddl.id}#{image_fallback_attributes}")
+      |> assert_has("#huddl-list-cover-#{huddl.id}#{image_fallback_attributes}")
     end
 
     test "renders rich link preview metadata", %{conn: conn, group: group, huddl: huddl} do

--- a/test/huddlz_web/live/huddlz_live_test.exs
+++ b/test/huddlz_web/live/huddlz_live_test.exs
@@ -1,4 +1,4 @@
-defmodule HuddlzWeb.MyHuddlzLiveTest do
+defmodule HuddlzWeb.HuddlzLiveTest do
   use HuddlzWeb.ConnCase, async: true
 
   alias Huddlz.Communities
@@ -378,7 +378,7 @@ defmodule HuddlzWeb.MyHuddlzLiveTest do
       |> visit("/huddlz")
       |> assert_has("#{bare_card} .card-cover-fallback", text: "PE", exact: true)
       |> refute_has("#{bare_card} .cover-image")
-      |> assert_has("#{pictured_card} #my-huddl-card-cover-#{pictured.id}.cover-image")
+      |> assert_has("#{pictured_card} #huddl-list-cover-#{pictured.id}.cover-image")
       |> refute_has("#{pictured_card} .card-cover-fallback")
     end
   end


### PR DESCRIPTION
Finish the personal-label cleanup with “Calendar,” “RSVPs,” and “Groups” in the calendar, plus “Your group role changed” in notification settings. Align related internal names with the pages and actor scope.

Replace the personal API names before launch:

- GraphQL: `myGroups`, `myMemberships`, and `myRsvps` become `viewerGroups`, `viewerMemberships`, and `viewerRsvps`.
- JSON: `/api/json/groups/my-groups` becomes `/api/json/groups/mine`, matching the existing membership and RSVP endpoint convention.

The API renames preserve authenticated-user scoping and intentionally provide no compatibility aliases. Natural first-person test prose and framework examples remain unchanged.

Follow-up to #493 and #484.


CI also exposed shared fixture emails and group slugs blocking concurrent sandbox transactions. Give the affected async features distinct fixture values while preserving their parallel execution.
