### PR TITLE
feat(groups): filter discovery by location and distance

### DIFF
--- a/docs/adr/0002-group-discovery-location.md
+++ b/docs/adr/0002-group-discovery-location.md
@@ -1,0 +1,3 @@
+# Group discovery uses the group home location
+
+For #483, geographic group discovery measures distance from the search location to the group's required home location. Groups have no online-only classification, so even a group organizing only virtual huddlz follows this rule; inferring an exemption from its current huddlz would make its discoverability depend on its schedule. An unrestricted search includes groups at any location, without adding an include-online toggle.

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -2,6 +2,20 @@
 
 Anonymous clients can discover public huddlz with `GET /api/json/huddlz`.
 
+## Group location search
+
+`GET /api/json/groups/search` and GraphQL `searchGroups` accept
+`search_latitude`, `search_longitude`, and `distance_miles` (GraphQL:
+`searchLatitude`, `searchLongitude`, `distanceMiles`). Distance defaults to
+25 miles and accepts 5–100 miles. Supply both coordinates to filter by the
+group's home location; omit them for an unrestricted search. The optional
+`search` text argument combines with the location filter.
+
+Discover groups uses the account's home search location by default. API clients
+can obtain and apply the same profile defaults described below; read actions
+do not implicitly apply them. Groups that organize virtual huddlz follow the
+same home-location rule; see [the decision](adr/0002-group-discovery-location.md).
+
 ## Private profile and home search defaults
 
 Authenticated clients can read their current private profile with

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -138,15 +138,25 @@ defmodule Huddlz.Communities.Group do
     end
 
     read :search do
-      description "Search for groups by name or description. With nil :search arg, returns all groups sorted by name."
+      description "Discover groups by name or description and distance from their home location. Without text search, sorts by name."
 
       argument :search, :string do
         allow_nil? true
       end
 
+      argument :search_latitude, :float, allow_nil?: true, constraints: [min: -90, max: 90]
+      argument :search_longitude, :float, allow_nil?: true, constraints: [min: -180, max: 180]
+
+      argument :distance_miles, :integer do
+        allow_nil? true
+        default 25
+        constraints min: 5, max: 100
+      end
+
       pagination offset?: true, countable: true, required?: false, default_limit: 20
 
       prepare Huddlz.Communities.Group.Preparations.ApplyTrigramSearch
+      prepare Huddlz.Communities.Group.Preparations.FilterByDistance
     end
 
     read :get_by_owner do

--- a/lib/huddlz/communities/group/preparations/filter_by_distance.ex
+++ b/lib/huddlz/communities/group/preparations/filter_by_distance.ex
@@ -1,0 +1,33 @@
+defmodule Huddlz.Communities.Group.Preparations.FilterByDistance do
+  @moduledoc "Filters groups by the distance from a search point to their home location."
+  use Ash.Resource.Preparation
+
+  require Ash.Query
+
+  @meters_per_mile 1609.344
+
+  @impl true
+  def prepare(query, _opts, _context) do
+    latitude = Ash.Query.get_argument(query, :search_latitude)
+    longitude = Ash.Query.get_argument(query, :search_longitude)
+    distance = Ash.Query.get_argument(query, :distance_miles) || 25
+
+    if is_number(latitude) and is_number(longitude) and is_integer(distance) do
+      meters = distance * @meters_per_mile
+
+      Ash.Query.filter(
+        query,
+        fragment(
+          "ST_DWithin(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)",
+          longitude,
+          latitude,
+          ^longitude,
+          ^latitude,
+          ^meters
+        )
+      )
+    else
+      query
+    end
+  end
+end

--- a/lib/huddlz_web/live/huddl_live.ex
+++ b/lib/huddlz_web/live/huddl_live.ex
@@ -429,7 +429,7 @@ defmodule HuddlzWeb.HuddlLive do
   end
 
   defp search_results(%{scope: :groups} = assigns, page) do
-    {groups, total} = list_groups(assigns.search_query, page, assigns[:current_user])
+    {groups, total} = list_groups(assigns, page, assigns[:current_user])
 
     page_info =
       if total > 0 do
@@ -500,8 +500,14 @@ defmodule HuddlzWeb.HuddlLive do
   defp sort_fields(:newest), do: [inserted_at: :desc]
   defp sort_fields(:soonest), do: [starts_at: :asc]
 
-  defp list_groups(query, page, actor) do
-    case Communities.search_groups(query,
+  defp list_groups(assigns, page, actor) do
+    filters = %{
+      search_latitude: if(assigns.location_active, do: assigns.location_lat),
+      search_longitude: if(assigns.location_active, do: assigns.location_lng),
+      distance_miles: assigns.distance_miles
+    }
+
+    case Communities.search_groups(assigns.search_query, filters,
            actor: actor,
            query: [filter: [is_public: true]],
            load: [:current_image_url, :member_count],
@@ -645,7 +651,7 @@ defmodule HuddlzWeb.HuddlLive do
         </.link>
       </div>
 
-      <div :if={@scope == :huddlz} class="filter-bar">
+      <div class="filter-bar">
         <div class="filter-group">
           <span class="filter-label">Within</span>
           <.live_component
@@ -681,7 +687,7 @@ defmodule HuddlzWeb.HuddlLive do
           </form>
         </div>
 
-        <div class="filter-group">
+        <div :if={@scope == :huddlz} class="filter-group">
           <span class="filter-label">Type</span>
           <div class="chip-group">
             <.chip
@@ -705,7 +711,7 @@ defmodule HuddlzWeb.HuddlLive do
           </div>
         </div>
 
-        <div class="filter-group">
+        <div :if={@scope == :huddlz} class="filter-group">
           <span class="filter-label">When</span>
           <div class="chip-group">
             <.chip
@@ -729,7 +735,7 @@ defmodule HuddlzWeb.HuddlLive do
           </div>
         </div>
 
-        <div class="filter-group">
+        <div :if={@scope == :huddlz} class="filter-group">
           <span class="filter-label">Sort</span>
           <div class="chip-group">
             <.chip patch={sort_toggle_url("soonest", assigns)} active={@sort == :soonest}>

--- a/test/features/discover_combined.feature
+++ b/test/features/discover_combined.feature
@@ -6,8 +6,9 @@ Feature: Combined search on /discover
 
   Background:
     Given the following users exist:
-      | email             | role     | display_name |
-      | host@example.com  | verified | Group Host   |
+      | email              | role     | display_name |
+      | host@example.com   | verified | Group Host   |
+      | viewer@example.com | user     | Viewer       |
 
   Scenario: Default scope shows both scope chips
     When I visit "/discover"
@@ -30,3 +31,51 @@ Feature: Combined search on /discover
   Scenario: scope=groups empty state
     When I visit "/discover?scope=groups&q=zzznomatchforanything"
     Then I should see "No groups match this search"
+
+  @group_distance
+  Scenario: Discover groups within the chosen distance
+    Given discover groups are based in Austin and Houston
+    When I visit "/discover?scope=groups&location=Austin&lat=30.2672&lng=-97.7431&time_zone=America%2FChicago&distance=25"
+    Then I should see "Austin Neighbors"
+    And I should not see "Houston Neighbors"
+    And I should see "25 mi"
+
+  @group_distance
+  Scenario: Changing the search location re-filters groups
+    Given discover groups are based in Austin and Houston
+    When I visit "/discover?scope=groups&location=Austin&lat=30.2672&lng=-97.7431&time_zone=America%2FChicago&distance=25"
+    And I change the discover location to Houston
+    Then I should see "Houston Neighbors"
+    And I should not see "Austin Neighbors"
+
+  @group_distance
+  Scenario: Expanding the distance finds more groups
+    Given discover groups are based in Austin and Houston
+    When I visit "/discover?scope=groups&location=Central+Texas&lat=31.0&lng=-97.7431&time_zone=America%2FChicago&distance=25"
+    Then I should see "No groups found"
+    When I expand the discover distance to 100 miles
+    Then I should see "Austin Neighbors"
+    And I should not see "Houston Neighbors"
+    And I should see "100 mi"
+
+  @group_distance
+  Scenario: Clearing a location filter recovers an empty group search
+    Given discover groups are based in Austin and Houston
+    When I visit "/discover?scope=groups&location=London&lat=51.5074&lng=-0.1278&time_zone=Europe%2FLondon&distance=25"
+    Then I should see "No groups found"
+    And I should see "Clear filters"
+    When I click the "Clear filters" button
+    Then I should see "Austin Neighbors"
+    And I should see "Houston Neighbors"
+
+  @group_distance
+  Scenario: Group discovery defaults to the member's home search location
+    Given discover groups are based in Austin and Houston
+    And "viewer@example.com" has Austin as their home search location
+    And I am logged in as "viewer@example.com"
+    When I visit "/discover?scope=groups"
+    Then I should see "Austin Neighbors"
+    And I should not see "Houston Neighbors"
+    And I should see "25 mi"
+    When I click the "Clear filters" button
+    Then I should see "Houston Neighbors"

--- a/test/features/step_definitions/discover_combined_steps.exs
+++ b/test/features/step_definitions/discover_combined_steps.exs
@@ -2,11 +2,88 @@ defmodule DiscoverCombinedSteps do
   use Cucumber.StepDefinition
 
   import Huddlz.Generator
+  import Phoenix.LiveViewTest
+  import Huddlz.Test.MoxHelpers
 
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.Group
 
   require Ash.Query
+
+  step "I expand the discover distance to {int} miles", %{args: [distance]} = context do
+    context.session.view
+    |> form("#distance-filter-form", %{"distance_miles" => Integer.to_string(distance)})
+    |> render_change()
+
+    render_async(context.session.view)
+    context
+  end
+
+  step "{string} has Austin as their home search location", %{args: [email]} = context do
+    member = lookup_user(email)
+
+    Huddlz.Accounts.update_home_location!(
+      member,
+      "Austin, TX",
+      30.2672,
+      -97.7431,
+      "America/Chicago",
+      actor: member
+    )
+
+    context
+  end
+
+  step "I change the discover location to Houston", context do
+    stub_places_autocomplete(%{
+      "Houston" => [
+        %{
+          place_id: "houston",
+          display_text: "Houston, TX, USA",
+          main_text: "Houston",
+          secondary_text: "TX, USA"
+        }
+      ]
+    })
+
+    stub_place_details(%{
+      "houston" => %{latitude: 29.7604, longitude: -95.3698, time_zone: "America/Chicago"}
+    })
+
+    view = context.session.view
+    view |> element("[aria-label='Edit location']") |> render_click()
+
+    view
+    |> element("#location-autocomplete-input")
+    |> render_change(%{"location-autocomplete_search" => "Houston"})
+
+    render_async(view)
+    view |> element("[role='option']", "Houston") |> render_click()
+    render_async(view)
+    context
+  end
+
+  step "discover groups are based in Austin and Houston", context do
+    owner = lookup_user("host@example.com")
+
+    for {name, lat, lng} <- [
+          {"Austin Neighbors", 30.2672, -97.7431},
+          {"Houston Neighbors", 29.7604, -95.3698}
+        ] do
+      generate(
+        group(
+          name: name,
+          location: name,
+          latitude: lat,
+          longitude: lng,
+          time_zone: "America/Chicago",
+          actor: owner
+        )
+      )
+    end
+
+    context
+  end
 
   step "a group named {string} is owned by {string}",
        %{args: [group_name, owner_email]} = context do

--- a/test/huddlz/communities/group_search_distance_test.exs
+++ b/test/huddlz/communities/group_search_distance_test.exs
@@ -1,0 +1,37 @@
+defmodule Huddlz.Communities.GroupSearchDistanceTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Communities
+
+  test "distance limits group home locations and an omitted radius defaults to 25 miles" do
+    actor = generate(user())
+    austin = generate(group(latitude: 30.2672, longitude: -97.7431, actor: actor))
+    # San Marcos is approximately 29 miles from Austin.
+    san_marcos = generate(group(latitude: 29.8833, longitude: -97.9414, actor: actor))
+    houston = generate(group(latitude: 29.7604, longitude: -95.3698, actor: actor))
+    origin = %{search_latitude: 30.2672, search_longitude: -97.7431}
+
+    assert [result] = Communities.search_groups!(nil, origin)
+    assert result.id == austin.id
+
+    assert [result] = Communities.search_groups!(nil, Map.put(origin, :distance_miles, nil))
+    assert result.id == austin.id
+
+    results = Communities.search_groups!(nil, Map.put(origin, :distance_miles, 50))
+    assert MapSet.new(results, & &1.id) == MapSet.new([austin.id, san_marcos.id])
+
+    results = Communities.search_groups!(nil, %{distance_miles: 5})
+    assert MapSet.new(results, & &1.id) == MapSet.new([austin.id, san_marcos.id, houston.id])
+  end
+
+  test "invalid distances return validation errors" do
+    for distance <- [4, 101] do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Communities.search_groups(nil, %{
+                 search_latitude: 30.2672,
+                 search_longitude: -97.7431,
+                 distance_miles: distance
+               })
+    end
+  end
+end

--- a/test/huddlz_web/api/graphql/group_test.exs
+++ b/test/huddlz_web/api/graphql/group_test.exs
@@ -17,6 +17,24 @@ defmodule HuddlzWeb.Api.Graphql.GroupTest do
   end
 
   describe "searchGroups query" do
+    test "accepts location and distance arguments", %{conn: conn} do
+      owner = generate(user())
+      nearby = generate(group(latitude: 30.2672, longitude: -97.7431, actor: owner))
+      generate(group(latitude: 29.7604, longitude: -95.3698, actor: owner))
+
+      conn =
+        gql_post(conn, """
+        { searchGroups(searchLatitude: 30.2672, searchLongitude: -97.7431, distanceMiles: 25) {
+          results { id }
+        } }
+        """)
+
+      assert %{"data" => %{"searchGroups" => %{"results" => [%{"id" => id}]}}} =
+               json_response(conn, 200)
+
+      assert id == nearby.id
+    end
+
     test "matches groups by name via trigram search", %{conn: conn} do
       owner = generate(user())
 

--- a/test/huddlz_web/api/json/group_test.exs
+++ b/test/huddlz_web/api/json/group_test.exs
@@ -2,6 +2,22 @@ defmodule HuddlzWeb.Api.Json.GroupTest do
   use HuddlzWeb.ApiCase, async: true
   require Ash.Query
 
+  test "group search accepts location and distance arguments", %{conn: conn} do
+    owner = generate(user())
+    nearby = generate(group(latitude: 30.2672, longitude: -97.7431, actor: owner))
+    generate(group(latitude: 29.7604, longitude: -95.3698, actor: owner))
+
+    conn =
+      get(conn, "/api/json/groups/search", %{
+        search_latitude: 30.2672,
+        search_longitude: -97.7431,
+        distance_miles: 25
+      })
+
+    assert %{"data" => [%{"id" => id}]} = json_response(conn, 200)
+    assert id == nearby.id
+  end
+
   describe "GET /api/json/groups" do
     test "lists public groups with their attributes", %{conn: conn} do
       owner = generate(user())

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -297,10 +297,13 @@ defmodule HuddlzWeb.HuddlSearchTest do
              )
     end
 
-    test "filter bar is hidden under scope=groups", %{conn: conn} do
+    test "groups expose location filtering without huddl-specific controls", %{conn: conn} do
       conn
       |> visit("/discover?scope=groups")
-      |> refute_has(".filter-bar")
+      |> assert_has(".filter-label", text: "Within")
+      |> refute_has(".filter-label", text: "Type")
+      |> refute_has(".filter-label", text: "When")
+      |> refute_has(".filter-label", text: "Sort")
     end
 
     test "Sort: Newest patches URL and marks chip active", %{conn: conn} do


### PR DESCRIPTION
Discover groups now supports the shared location and distance controls, defaults to the account's home search location, and offers Clear filters when no groups match. The same geographic filters are available through JSON:API and GraphQL.

Groups are filtered by their home location even when they organize only virtual huddlz. The ADR records this choice because groups have no online-only classification.

Closes #483.
