### PR TITLE
fix(ui): make profile picture removal dialog clickable

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2115,7 +2115,6 @@ body .delete-confirm-icon {
   background: var(--warn-soft);
 }
 
-body .delete-confirm-copy h2,
 /* Modal dialog chrome (`HuddlzWeb.Components.Modal`). The open/close
    transitions add Tailwind opacity/translate classes from `Flash.show/hide`. */
 body .modal-backdrop {
@@ -2174,6 +2173,7 @@ body .modal-close:focus-visible { outline: 2px solid var(--accent); outline-offs
 body .avatar-initials { background: var(--accent); color: var(--on-accent); }
 body .avatar-placeholder { background: var(--panel-2); color: var(--muted); }
 
+body .delete-confirm-copy h2,
 body .share-modal-copy h2 {
   margin: 6px 0 8px;
   color: var(--text);

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -32,7 +32,7 @@ The command builds the actual app assets, starts the test endpoint and Chromium,
 | Calendar | Actual `Intl` time-zone detection moves a late Denver huddl to the next New York calendar day |
 | Organizer | Native Tab, arrow keys, Space, visible focus, and switch state survive LiveView patches |
 | Huddl photos | Mixed-batch rejection, corrupt-image feedback, native Tab access to upload, keyboard carousel, dialog focus wrapping and restoration, and mobile gallery placement |
-| Profile picture | Real file upload and image decode; dialog Tab containment, Escape, and focus restoration |
+| Profile picture | Real file upload and image decode; removal button hit testing and pointer confirmation; dialog Tab containment, Escape, and focus restoration |
 | Mobile navigation | 320px drawer, native focus wrapping, inert background, dismissal and navigation |
 | Group cover | Valid, missing, and failed images; long details fit at 320px and on desktop |
 

--- a/test/browser/features/profile_picture.feature
+++ b/test/browser/features/profile_picture.feature
@@ -1,5 +1,13 @@
 @browser_smoke @picture_browser
 Feature: Profile picture browser interaction
+  Scenario: Removing a profile picture through the confirmation dialog
+    Given I have opened my profile in a browser
+    When I upload a profile picture through the file input
+    And I open the remove picture confirmation by clicking Remove
+    Then the Remove picture button is above the backdrop
+    When I confirm picture removal by clicking Remove picture
+    Then my profile picture is replaced by initials
+
   Scenario: A real upload renders and its confirmation dialog contains keyboard focus
     Given I have opened my profile in a browser
     When I upload a profile picture through the file input

--- a/test/browser/steps/location_keyboard_steps.exs
+++ b/test/browser/steps/location_keyboard_steps.exs
@@ -9,7 +9,7 @@ defmodule BrowserLocationKeyboardSteps do
   import PhoenixTest.Playwright, only: [type: 3, press: 3, evaluate: 3]
 
   step "I have opened my profile in a browser", context do
-    member = generate(user(role: :user))
+    member = generate(user(role: :user, display_name: "Browser Member"))
 
     stub_places_autocomplete(%{"saint" => [:saint_augustine]})
     stub_place_details(:defaults)

--- a/test/browser/steps/profile_picture_steps.exs
+++ b/test/browser/steps/profile_picture_steps.exs
@@ -40,6 +40,46 @@ defmodule BrowserPictureSteps do
     Map.put(context, :conn, conn)
   end
 
+  step "I open the remove picture confirmation by clicking Remove", context do
+    conn =
+      context.conn
+      |> click_button("Remove")
+      |> assert_has("#remove-avatar-dialog [role='dialog']")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the Remove picture button is above the backdrop", context do
+    assert_browser(context.conn, """
+    (() => {
+      const button = document.querySelector('#confirm-remove-avatar');
+      if (!button) return false;
+      const rect = button.getBoundingClientRect();
+      const topElement = document.elementFromPoint(
+        rect.left + rect.width / 2, rect.top + rect.height / 2
+      );
+      return rect.width > 0 && rect.height > 0 && button.contains(topElement);
+    })()
+    """)
+
+    context
+  end
+
+  step "I confirm picture removal by clicking Remove picture", context do
+    Map.put(context, :conn, click_button(context.conn, "Remove picture"))
+  end
+
+  step "my profile picture is replaced by initials", context do
+    conn =
+      context.conn
+      |> refute_has("#remove-avatar-dialog")
+      |> assert_has("[role='alert']", text: "Profile picture removed")
+      |> refute_has("img.big-avatar")
+      |> assert_has("main .big-avatar", text: "BM")
+
+    Map.put(context, :conn, conn)
+  end
+
   step "Tab stays inside the confirmation dialog", context do
     conn =
       context.conn


### PR DESCRIPTION
Fix the profile picture confirmation dialog so its buttons remain visible and clickable. The heading accidentally inherited the full-screen blurred backdrop styles; it now uses the intended heading styles.

Adds a browser regression scenario that checks the confirm button is topmost at its center, clicks it, and verifies the picture is replaced by initials.

Validation found two existing calendar assertions expecting “tomorrow” instead of “23 hours away”; both also fail with the original CSS. A mobile navigation page-load timeout passed on recheck.

Closes #487.
