### PR TITLE
feat(calendar): add a week view and a day panel

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2498,6 +2498,24 @@ body .cal-day-num.is-today {
   color: var(--on-accent);
 }
 
+/* The day number opens the day panel. Hover lifts it as a control; the
+   open day's cell tints so the panel reads as belonging to it. */
+body a.cal-day-num {
+  text-decoration: none;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+body a.cal-day-num:hover { background: var(--panel-2); color: var(--accent-ink); }
+body a.cal-day-num.is-today:hover { background: var(--accent); color: var(--on-accent); }
+
+body a.cal-day-num:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+body .cal-cell.is-open { background: var(--accent-soft); }
+body .cal-cell.is-open .cal-day-num:not(.is-today) { box-shadow: inset 0 0 0 1px var(--accent); }
+
 body .cal-day-context {
   color: var(--muted);
   font-size: 11px;
@@ -2974,6 +2992,144 @@ body .cal-agenda-quiet {
   font-size: 14px;
 }
 
+/* Week: the agenda list for one Sunday-to-Saturday week. Every day is
+   drawn; an empty day that is not today is a bare rail row. */
+body .cal-agenda-day[data-blank] .cal-agenda-rail { padding-top: 14px; padding-bottom: 14px; }
+
+/* Day panel: one day's huddlz over the month grid. A side panel from the
+   right on wide screens, a bottom sheet on phones. The scrim sits right of
+   the sidebar rail, as the modal does, so the sidebar stays usable. */
+body .cal-day-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+}
+
+body .cal-day-scrim {
+  position: absolute;
+  inset: 0;
+  background: var(--scrim);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: cal-day-fade 160ms ease-out;
+}
+
+body .cal-day-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  width: min(420px, 100%);
+  border-left: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: var(--shadow);
+  animation: cal-day-slide-in 200ms ease-out;
+}
+
+body .cal-day-head {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 22px 64px 18px 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+body .cal-day-kicker {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+body .cal-day-kicker-today { color: var(--accent-ink); }
+
+body .cal-agenda-day-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+body .cal-day-count {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+body .cal-day-head .modal-close { top: 14px; right: 14px; }
+
+body .cal-day-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+body .cal-day-body .cal-agenda-entry {
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 4px 12px;
+  align-items: start;
+  padding: 14px 24px;
+}
+
+body .cal-day-body .cal-agenda-title { white-space: normal; font-size: 15px; }
+body .cal-day-body .cal-agenda-meta { flex-direction: column; align-items: flex-start; gap: 2px; }
+body .cal-day-body .cal-agenda-meta .dot { display: none; }
+
+body .cal-day-body .cal-agenda-side {
+  grid-column: 2;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+body .cal-day-body .cal-agenda-quiet { min-height: 0; padding: 24px; }
+
+body .cal-day-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 24px;
+  border-top: 1px solid var(--line);
+}
+
+body .cal-day-foot a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+@keyframes cal-day-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes cal-day-slide-in {
+  from { transform: translateX(24px); opacity: 0; }
+  to { transform: none; opacity: 1; }
+}
+
+@keyframes cal-day-rise {
+  from { transform: translateY(32px); opacity: 0; }
+  to { transform: none; opacity: 1; }
+}
+
+@media (min-width: 761px) {
+  body:not(.is-landing):not(.is-auth):not(.is-signed-out) .cal-day-layer { left: var(--rail-w); }
+}
+
 /* Touch agenda: the same list under the month grid, shown where hover
    tooltips don't work (narrow screens and coarse pointers). */
 body .cal-touch-agenda {
@@ -3089,6 +3245,39 @@ body .cal-legend-note { margin-left: auto; font-size: 12px; }
     gap: 10px;
   }
   body .cal-agenda-quiet { min-height: 60px; padding: 12px 14px; }
+
+  /* Cells are too small for titles, so the whole cell opens the day; the
+     pills stay on top of the stretched link and still open their huddl. */
+  body .cal-cell-content { position: relative; }
+  body a.cal-day-num::after { content: ""; position: absolute; inset: 0; }
+
+  /* The day panel becomes a bottom sheet with a grab handle. */
+  body .cal-day-panel {
+    top: auto;
+    right: 0;
+    left: 0;
+    width: auto;
+    max-height: 78%;
+    border-left: 0;
+    border-top: 1px solid var(--line);
+    border-radius: 16px 16px 0 0;
+    animation-name: cal-day-rise;
+  }
+  body .cal-day-panel::before {
+    content: "";
+    flex: 0 0 auto;
+    width: 36px;
+    height: 4px;
+    margin: 10px auto 0;
+    border-radius: var(--radius-pill);
+    background: var(--line-strong);
+  }
+  body .cal-day-head { padding: 12px 56px 14px 16px; }
+  body .cal-day-head .modal-close { top: 6px; right: 10px; }
+  body .cal-agenda-day-title { font-size: 20px; }
+  body .cal-day-body .cal-agenda-entry { padding: 12px 16px; }
+  body .cal-day-body .cal-agenda-quiet { padding: 20px 16px; }
+  body .cal-day-foot { padding: 12px 16px 20px; }
 }
 
 @media (hover: none) and (pointer: coarse) {
@@ -3102,6 +3291,8 @@ body .cal-legend-note { margin-left: auto; font-size: 12px; }
   body .cal-touch-entry {
     transition: none;
   }
+  body .cal-day-scrim,
+  body .cal-day-panel { animation: none; }
 }
 
 

--- a/lib/huddlz_web/live/calendar_live.ex
+++ b/lib/huddlz_web/live/calendar_live.ex
@@ -1,12 +1,20 @@
 defmodule HuddlzWeb.CalendarLive do
   @moduledoc """
   LiveView at `/calendar`. Personal calendar of huddlz the signed-in user
-  is hosting, attending, or watching from the waitlist. Agenda by default
-  with a month grid behind `?view=month`; `?month=YYYY-MM` drives the grid.
-  The agenda ignores the month: it starts at today and runs
-  forward through the next few days that have huddlz, one entry per huddl,
-  leaving the past to the month grid. `?scope=groups` widens both views
-  from the person's own RSVPs to everything their groups have scheduled.
+  is hosting, attending, or watching from the waitlist. Three views:
+
+    * the agenda (default) ignores the month: it starts at today and runs
+      forward through the next few days that have huddlz, leaving the past
+      to the other two;
+    * the week, `?view=week&week=YYYY-MM-DD`, is the same day-by-day list
+      for one Sunday-to-Saturday week, every day drawn, any week;
+    * the month grid, `?view=month&month=YYYY-MM`, is the overview. A day
+      in it opens as a panel, `?day=YYYY-MM-DD`, listing that day's huddlz.
+
+  Every piece of state is in the URL, so closing the panel, the browser's
+  back button and returning from a huddl all land on the same view.
+  `?scope=groups` widens every view from the person's own RSVPs to
+  everything their groups have scheduled.
   """
   use HuddlzWeb, :live_view
 
@@ -15,6 +23,7 @@ defmodule HuddlzWeb.CalendarLive do
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.Live.Helpers.BrowserTimeZone
   alias HuddlzWeb.Live.Helpers.HuddlCardHelpers
+  alias Phoenix.LiveView.JS
   require Logger
 
   defmodule EntryStatus do
@@ -48,30 +57,58 @@ defmodule HuddlzWeb.CalendarLive do
 
   @impl true
   def handle_params(params, _uri, socket) do
-    focus_month = parse_month(params["month"], socket.assigns.today)
+    today = socket.assigns.today
     view_mode = parse_view(params["view"])
+    focus_week = parse_week(params["week"], today)
+
+    focus_month =
+      if view_mode == :week,
+        do: first_of_month(focus_week),
+        else: parse_month(params["month"], today)
+
+    focus_week = if view_mode == :week, do: focus_week, else: week_for_month(focus_month, today)
+    open_day = parse_day(params["day"])
     {grid_start, grid_end} = month_grid_window(focus_month)
     user = socket.assigns.current_user
 
     scope = parse_scope(params["scope"])
-    today = socket.assigns.today
     own = load_entries(user, socket.assigns.time_zone)
     group_extras = load_group_extras(user, socket.assigns.time_zone, own, today)
     all = if scope == :groups, do: merge_entries(own, group_extras), else: own
     entries = grid_entries(all, grid_start, grid_end, socket.assigns.time_zone)
     {agenda_days, agenda_more} = agenda_window(all, today)
     agenda_entries = Enum.flat_map(agenda_days, & &1.entries)
+    week_days = week_days(all, focus_week, today)
+    week_entries = Enum.flat_map(week_days, & &1.entries)
+    day_entries = if open_day, do: Enum.filter(all, &(&1.calendar_date == open_day)), else: []
 
     entries_by_day = group_by_day(entries)
     in_month_count = Enum.count(entries, &in_focus_month?(&1, focus_month))
-    visible = if view_mode == :month, do: entries, else: agenda_entries
+
+    visible =
+      case view_mode do
+        :month -> entries
+        :week -> week_entries
+        :agenda -> agenda_entries
+      end
+
     legend_items = legend_items(visible, today)
 
     {:noreply,
      socket
      |> assign(:focus_month, focus_month)
+     |> assign(:focus_week, focus_week)
      |> assign(:view_mode, view_mode)
      |> assign(:scope, scope)
+     |> assign(:nav, %{
+       view: view_mode,
+       month: focus_month,
+       week: focus_week,
+       scope: scope,
+       today: today
+     })
+     |> assign(:open_day, open_day)
+     |> assign(:day_entries, day_entries)
      |> assign(:counts, scope_counts(own, group_extras, today))
      |> assign(:grid_start, grid_start)
      |> assign(:grid_end, grid_end)
@@ -82,6 +119,8 @@ defmodule HuddlzWeb.CalendarLive do
      |> assign(:agenda_days, agenda_days)
      |> assign(:agenda_more, agenda_more)
      |> assign(:agenda_count, length(agenda_entries))
+     |> assign(:week_days, week_days)
+     |> assign(:week_count, length(week_entries))
      |> assign(:legend_empty?, legend_items == [])
      |> stream(:legend_items, legend_items, reset: true)}
   end
@@ -107,7 +146,36 @@ defmodule HuddlzWeb.CalendarLive do
   defp parse_month(_, today), do: first_of_month(today)
 
   defp parse_view("month"), do: :month
+  defp parse_view("week"), do: :week
   defp parse_view(_), do: :agenda
+
+  # Any date in the week names it; the week runs Sunday to Saturday, like
+  # the month grid. Anything unreadable means this week.
+  defp parse_week(value, today) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> Date.beginning_of_week(date, :sunday)
+      _ -> Date.beginning_of_week(today, :sunday)
+    end
+  end
+
+  defp parse_week(_, today), do: Date.beginning_of_week(today, :sunday)
+
+  defp parse_day(value) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> date
+      _ -> nil
+    end
+  end
+
+  defp parse_day(_), do: nil
+
+  # The week the Week tab opens from a month: this week when today is in
+  # that month, otherwise the month's first week.
+  defp week_for_month(month_first, today) do
+    if day_in_focus?(today, month_first),
+      do: Date.beginning_of_week(today, :sunday),
+      else: Date.beginning_of_week(month_first, :sunday)
+  end
 
   defp parse_scope("groups"), do: :groups
   defp parse_scope(_), do: :mine
@@ -225,14 +293,25 @@ defmodule HuddlzWeb.CalendarLive do
     Date.new!(Integer.floor_div(total, 12), Integer.mod(total, 12) + 1, 1)
   end
 
-  # The calendar's own URL: the month only matters to the month view, the
-  # default view and scope are left out, and today's month is the default.
-  defp calendar_path(month, view, today, scope) do
+  # The calendar's own URL, from the current state (`@nav`) with anything
+  # in `overrides` changed. The month only matters to the month view and
+  # the week to the week view; the defaults (agenda, this month, this
+  # week, own RSVPs, no day open) are left out, so the plain `/calendar`
+  # is the default view and an open day never outlives a view change.
+  defp calendar_path(nav, overrides \\ []) do
+    view = Keyword.get(overrides, :view, nav.view)
+    month = Keyword.get(overrides, :month, nav.month)
+    week = Keyword.get(overrides, :week, nav.week)
+    scope = Keyword.get(overrides, :scope, nav.scope)
+    day = Keyword.get(overrides, :day)
+
     params =
       [
-        month: view == :month && month_param(month, today),
-        view: view == :month && "month",
-        scope: scope == :groups && "groups"
+        month: view == :month && month_param(month, nav.today),
+        week: view == :week && week_param(week, nav.today),
+        view: view != :agenda && Atom.to_string(view),
+        scope: scope == :groups && "groups",
+        day: day && Date.to_iso8601(day)
       ]
       |> Enum.filter(fn {_key, value} -> value end)
 
@@ -242,6 +321,29 @@ defmodule HuddlzWeb.CalendarLive do
   defp month_param(month, today) do
     today_first = first_of_month(today)
     if Date.compare(month, today_first) == :eq, do: nil, else: format_month_param(month)
+  end
+
+  defp week_param(week, today) do
+    if Date.compare(week, Date.beginning_of_week(today, :sunday)) == :eq,
+      do: nil,
+      else: Date.to_iso8601(week)
+  end
+
+  # "Sep 6 – 12, 2026", naming the second month or year only when it
+  # changes across the week.
+  defp format_week(%Date{} = start) do
+    finish = Date.add(start, 6)
+
+    cond do
+      start.year != finish.year ->
+        "#{Calendar.strftime(start, "%b %-d, %Y")} – #{Calendar.strftime(finish, "%b %-d, %Y")}"
+
+      start.month != finish.month ->
+        "#{Calendar.strftime(start, "%b %-d")} – #{Calendar.strftime(finish, "%b %-d, %Y")}"
+
+      true ->
+        "#{Calendar.strftime(start, "%b %-d")} – #{Calendar.strftime(finish, "%-d, %Y")}"
+    end
   end
 
   defp format_month_param(%Date{year: y, month: m}) do
@@ -453,57 +555,45 @@ defmodule HuddlzWeb.CalendarLive do
       </div>
 
       <div class="cal-toolbar">
-        <%= if @view_mode == :month do %>
-          <div class="cal-nav">
-            <.link
-              patch={calendar_path(shift_month(@focus_month, -1), @view_mode, @today, @scope)}
-              class="cal-nav-btn"
-              aria-label="Previous month"
-            >
-              <.icon name="hero-chevron-left" class="size-4" />
-            </.link>
-            <.link
-              patch={calendar_path(first_of_month(@today), @view_mode, @today, @scope)}
-              class="cal-nav-today"
-            >
-              Today
-            </.link>
-            <.link
-              patch={calendar_path(shift_month(@focus_month, 1), @view_mode, @today, @scope)}
-              class="cal-nav-btn"
-              aria-label="Next month"
-            >
-              <.icon name="hero-chevron-right" class="size-4" />
-            </.link>
-          </div>
-
-          <div class="cal-month-title">
-            <span class="cal-month-name">{format_month(@focus_month)}</span>
-            <span class="cal-month-count">{format_count(@in_month_count)}</span>
-          </div>
-        <% else %>
-          <div class="cal-month-title">
-            <span class="cal-month-name">What's next</span>
-            <span class="cal-month-count">{format_count(@agenda_count)}</span>
-          </div>
+        <%= case @view_mode do %>
+          <% :month -> %>
+            <.period_nav
+              previous={calendar_path(@nav, month: shift_month(@focus_month, -1))}
+              today={calendar_path(@nav, month: first_of_month(@today))}
+              next={calendar_path(@nav, month: shift_month(@focus_month, 1))}
+              unit="month"
+            />
+            <div class="cal-month-title">
+              <span class="cal-month-name">{format_month(@focus_month)}</span>
+              <span class="cal-month-count">{format_count(@in_month_count)}</span>
+            </div>
+          <% :week -> %>
+            <.period_nav
+              previous={calendar_path(@nav, week: Date.add(@focus_week, -7))}
+              today={calendar_path(@nav, week: Date.beginning_of_week(@today, :sunday))}
+              next={calendar_path(@nav, week: Date.add(@focus_week, 7))}
+              unit="week"
+            />
+            <div class="cal-month-title">
+              <span class="cal-month-name">{format_week(@focus_week)}</span>
+              <span class="cal-month-count">{format_count(@week_count)}</span>
+            </div>
+          <% :agenda -> %>
+            <div class="cal-month-title">
+              <span class="cal-month-name">What's next</span>
+              <span class="cal-month-count">{format_count(@agenda_count)}</span>
+            </div>
         <% end %>
 
         <div class="cal-view-tabs">
           <.link
-            id="calendar-view-agenda"
-            patch={calendar_path(@focus_month, :agenda, @today, @scope)}
-            class={["scope-tab", @view_mode == :agenda && "is-active"]}
-            aria-current={if @view_mode == :agenda, do: "page"}
+            :for={{view, label} <- [agenda: "Agenda", week: "Week", month: "Month"]}
+            id={"calendar-view-#{view}"}
+            patch={calendar_path(@nav, view: view)}
+            class={["scope-tab", @view_mode == view && "is-active"]}
+            aria-current={if @view_mode == view, do: "page"}
           >
-            Agenda
-          </.link>
-          <.link
-            id="calendar-view-month"
-            patch={calendar_path(@focus_month, :month, @today, @scope)}
-            class={["scope-tab", @view_mode == :month && "is-active"]}
-            aria-current={if @view_mode == :month, do: "page"}
-          >
-            Month
+            {label}
           </.link>
         </div>
       </div>
@@ -511,7 +601,7 @@ defmodule HuddlzWeb.CalendarLive do
       <div class="chip-group cal-scope" aria-label="Whose huddlz to show">
         <.chip
           id="calendar-scope-mine"
-          patch={calendar_path(@focus_month, @view_mode, @today, :mine)}
+          patch={calendar_path(@nav, scope: :mine)}
           active={@scope == :mine}
           count={@counts.mine}
         >
@@ -519,7 +609,7 @@ defmodule HuddlzWeb.CalendarLive do
         </.chip>
         <.chip
           id="calendar-scope-groups"
-          patch={calendar_path(@focus_month, @view_mode, @today, :groups)}
+          patch={calendar_path(@nav, scope: :groups)}
           active={@scope == :groups}
           count={@counts.groups}
         >
@@ -527,24 +617,37 @@ defmodule HuddlzWeb.CalendarLive do
         </.chip>
       </div>
 
-      <%= if @view_mode == :month do %>
-        <.month_grid
-          entries={@entries}
-          focus_month={@focus_month}
-          grid_start={@grid_start}
-          entries_by_day={@entries_by_day}
-          today={@today}
-        />
-        <.first_run_empty :if={@first_run?} />
-      <% else %>
-        <.agenda_view
-          days={@agenda_days}
-          more={@agenda_more}
-          today={@today}
-          scope={@scope}
-          first_run?={@first_run?}
-        />
+      <%= case @view_mode do %>
+        <% :month -> %>
+          <.month_grid
+            entries={@entries}
+            focus_month={@focus_month}
+            grid_start={@grid_start}
+            entries_by_day={@entries_by_day}
+            today={@today}
+            nav={@nav}
+            open_day={@open_day}
+          />
+          <.first_run_empty :if={@first_run?} />
+        <% :week -> %>
+          <.week_view days={@week_days} today={@today} first_run?={@first_run?} />
+        <% :agenda -> %>
+          <.agenda_view
+            days={@agenda_days}
+            more={@agenda_more}
+            today={@today}
+            nav={@nav}
+            first_run?={@first_run?}
+          />
       <% end %>
+
+      <.day_panel
+        :if={@open_day}
+        day={@open_day}
+        entries={@day_entries}
+        today={@today}
+        nav={@nav}
+      />
 
       <div
         :if={!@legend_empty?}
@@ -567,11 +670,39 @@ defmodule HuddlzWeb.CalendarLive do
     """
   end
 
+  # Previous / Today / Next for the month and week views. The labels are
+  # visually hidden text rather than aria-labels so a test can click them
+  # by name the way a person reads them.
+  attr :previous, :string, required: true
+  attr :today, :string, required: true
+  attr :next, :string, required: true
+  attr :unit, :string, required: true
+
+  defp period_nav(assigns) do
+    ~H"""
+    <div class="cal-nav">
+      <.link patch={@previous} class="cal-nav-btn">
+        <.icon name="hero-chevron-left" class="size-4" />
+        <span class="sr-only">Previous {@unit}</span>
+      </.link>
+      <.link patch={@today} class="cal-nav-today">
+        Today
+      </.link>
+      <.link patch={@next} class="cal-nav-btn">
+        <.icon name="hero-chevron-right" class="size-4" />
+        <span class="sr-only">Next {@unit}</span>
+      </.link>
+    </div>
+    """
+  end
+
   attr :focus_month, Date, required: true
   attr :grid_start, Date, required: true
   attr :entries, :list, required: true
   attr :entries_by_day, :map, required: true
   attr :today, Date, required: true
+  attr :nav, :map, required: true
+  attr :open_day, :any, required: true
 
   defp month_grid(assigns) do
     ~H"""
@@ -592,19 +723,32 @@ defmodule HuddlzWeb.CalendarLive do
             <tr :for={week <- weeks_in_grid(@grid_start)}>
               <td
                 :for={day <- week}
-                class={cell_class(day, @focus_month)}
+                class={cell_class(day, @focus_month, @open_day)}
                 aria-label={day_accessible_label(day, @focus_month, @today)}
                 aria-current={if Date.compare(day, @today) == :eq, do: "date"}
               >
                 <div class="cal-cell-content">
-                  <div class="cal-day-heading" aria-hidden="true">
-                    <time datetime={Date.to_iso8601(day)} class={day_num_class(day, @today)}>
+                  <div class="cal-day-heading">
+                    <.link
+                      id={"calendar-day-link-#{Date.to_iso8601(day)}"}
+                      patch={calendar_path(@nav, day: day)}
+                      class={day_num_class(day, @today)}
+                      aria-label={"Open " <> format_full_date(day)}
+                    >
                       {day.day}
-                    </time>
-                    <span :if={Date.compare(day, @today) == :eq} class="cal-day-context">
+                    </.link>
+                    <span
+                      :if={Date.compare(day, @today) == :eq}
+                      class="cal-day-context"
+                      aria-hidden="true"
+                    >
                       Today
                     </span>
-                    <span :if={!day_in_focus?(day, @focus_month)} class="cal-day-context">
+                    <span
+                      :if={!day_in_focus?(day, @focus_month)}
+                      class="cal-day-context"
+                      aria-hidden="true"
+                    >
                       {Calendar.strftime(day, "%b")}
                     </span>
                   </div>
@@ -678,8 +822,12 @@ defmodule HuddlzWeb.CalendarLive do
     ]
   end
 
-  defp cell_class(day, focus_month) do
-    if day_in_focus?(day, focus_month), do: "cal-cell", else: "cal-cell out-of-month"
+  defp cell_class(day, focus_month, open_day) do
+    [
+      "cal-cell",
+      !day_in_focus?(day, focus_month) && "out-of-month",
+      open_day && Date.compare(day, open_day) == :eq && "is-open"
+    ]
   end
 
   defp day_num_class(day, today) do
@@ -706,10 +854,102 @@ defmodule HuddlzWeb.CalendarLive do
     """
   end
 
+  # One calendar week as the agenda list: every day drawn, empty days as a
+  # bare rail row, so the shape of the week reads at a glance.
+  attr :days, :list, required: true
+  attr :today, Date, required: true
+  attr :first_run?, :boolean, default: false
+
+  defp week_view(assigns) do
+    ~H"""
+    <.agenda_list id="calendar-week" entry_prefix="calendar-entry" days={@days} today={@today} />
+    <.first_run_empty :if={@first_run?} />
+    """
+  end
+
+  # One day's huddlz over the month grid: a side panel on wide screens and
+  # a bottom sheet on phones. Everything about it is in the URL (`?day=`),
+  # so closing it is a patch, Escape and the scrim do the same, and the
+  # browser's back button reopens it after a visit to a huddl.
+  attr :day, Date, required: true
+  attr :entries, :list, required: true
+  attr :today, Date, required: true
+  attr :nav, :map, required: true
+
+  defp day_panel(assigns) do
+    assigns =
+      assigns
+      |> assign(:close, calendar_path(assigns.nav))
+      |> assign(:return_focus, "#calendar-day-link-#{Date.to_iso8601(assigns.day)}")
+      |> assign(:today?, Date.compare(assigns.day, assigns.today) == :eq)
+
+    ~H"""
+    <div
+      id="calendar-day-layer"
+      class="cal-day-layer"
+      phx-window-keydown={close_day(@close, @return_focus)}
+      phx-key="escape"
+      phx-mounted={JS.focus_first(to: "#calendar-day-panel")}
+    >
+      <div class="cal-day-scrim" phx-click={close_day(@close, @return_focus)} aria-hidden="true">
+      </div>
+      <.focus_wrap
+        id="calendar-day-panel"
+        class="cal-day-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="calendar-day-panel-title"
+        data-today={@today? || nil}
+      >
+        <div class="cal-day-head">
+          <span class="cal-day-kicker">
+            {Calendar.strftime(@day, "%A")}
+            <span :if={@today?} class="cal-day-kicker-today">· Today</span>
+          </span>
+          <h2 id="calendar-day-panel-title" class="cal-agenda-day-title">
+            {Calendar.strftime(@day, "%B %-d")}
+          </h2>
+          <span class="cal-day-count">{format_count(length(@entries))}</span>
+          <.link
+            id="calendar-day-close"
+            patch={@close}
+            phx-click={JS.focus(to: @return_focus)}
+            class="modal-close"
+          >
+            <.icon name="hero-x-mark" class="size-5" />
+            <span class="sr-only">Close</span>
+          </.link>
+        </div>
+        <div class="cal-day-body">
+          <.agenda_entry
+            :for={entry <- @entries}
+            id={"calendar-day-entry-#{entry.huddl.id}"}
+            entry={entry}
+            today={@today}
+          />
+          <p :if={@entries == []} class="cal-agenda-quiet">Nothing on this day.</p>
+        </div>
+        <div class="cal-day-foot">
+          <.link
+            id="calendar-day-week"
+            patch={calendar_path(@nav, view: :week, week: Date.beginning_of_week(@day, :sunday))}
+          >
+            Open this week <.icon name="hero-arrow-right" class="size-4" />
+          </.link>
+        </div>
+      </.focus_wrap>
+    </div>
+    """
+  end
+
+  defp close_day(path, return_focus) do
+    JS.patch(path) |> JS.focus(to: return_focus)
+  end
+
   attr :days, :list, required: true
   attr :more, :any, required: true, doc: "first day with huddlz beyond the window, or nil"
   attr :today, Date, required: true
-  attr :scope, :atom, required: true
+  attr :nav, :map, required: true
   attr :first_run?, :boolean, default: false
 
   defp agenda_view(assigns) do
@@ -733,7 +973,7 @@ defmodule HuddlzWeb.CalendarLive do
         />
         <p :if={@more} id="calendar-agenda-more" class="cal-agenda-more">
           More after {Calendar.strftime(List.last(@days).date, "%A, %B %-d")}.
-          <.link patch={calendar_path(first_of_month(@more), :month, @today, @scope)}>
+          <.link patch={calendar_path(@nav, view: :month, month: first_of_month(@more))}>
             Open {format_month(@more)} in the month view
           </.link>
         </p>
@@ -759,6 +999,7 @@ defmodule HuddlzWeb.CalendarLive do
         class="cal-agenda-day"
         data-today={day.today? || nil}
         data-past={day.past? || nil}
+        data-blank={day.blank? || nil}
       >
         <div class="cal-agenda-rail">
           <span class="cal-agenda-weekday" aria-hidden="true">
@@ -783,7 +1024,7 @@ defmodule HuddlzWeb.CalendarLive do
             entry={entry}
             today={@today}
           />
-          <p :if={day.entries == []} class="cal-agenda-quiet">Nothing today.</p>
+          <p :if={day.entries == [] && !day.blank?} class="cal-agenda-quiet">Nothing today.</p>
         </div>
       </div>
     </div>
@@ -876,7 +1117,34 @@ defmodule HuddlzWeb.CalendarLive do
         entries: Map.get(grouped, date, []),
         today?: Date.compare(date, today) == :eq,
         past?: Date.compare(date, today) == :lt,
-        other_month?: !day_in_focus?(date, reference_month)
+        other_month?: !day_in_focus?(date, reference_month),
+        blank?: false
+      }
+    end)
+  end
+
+  # The seven days of the week starting on `week_start`, every one drawn.
+  # An empty day that is not today is blank: a rail with nothing beside
+  # it. The rail names the month only where it changes mid-week; the
+  # toolbar already names the week.
+  defp week_days(entries, week_start, today) do
+    grouped =
+      entries
+      |> Enum.filter(&(Date.diff(&1.calendar_date, week_start) in 0..6))
+      |> Enum.group_by(& &1.calendar_date)
+
+    Enum.map(0..6, fn offset ->
+      date = Date.add(week_start, offset)
+      day_entries = Map.get(grouped, date, [])
+      today? = Date.compare(date, today) == :eq
+
+      %{
+        date: date,
+        entries: day_entries,
+        today?: today?,
+        past?: Date.compare(date, today) == :lt,
+        other_month?: offset > 0 && date.day == 1,
+        blank?: day_entries == [] && !today?
       }
     end)
   end

--- a/test/browser/features/calendar_day_sheet.feature
+++ b/test/browser/features/calendar_day_sheet.feature
@@ -1,0 +1,13 @@
+@browser_smoke @mobile @calendar_day_browser
+Feature: Day sheet on a phone
+  On a narrow screen the month grid has no room for titles, so a day opens
+  as a bottom sheet. The open day lives in the address, so the browser's
+  back button returns to the sheet, and to where the page was scrolled.
+
+  Scenario: A day opens as a bottom sheet and the back button returns to it
+    Given I am going to "Elixir office hours" on the 17th of next month
+    And I have opened next month's calendar in a narrow browser
+    When I tap the 17th
+    Then the day sheet is docked to the bottom edge and lists "Elixir office hours"
+    When I open "Elixir office hours" from the sheet and go back
+    Then the calendar returns with the sheet open on the 17th where I left it

--- a/test/browser/steps/calendar_day_sheet_steps.exs
+++ b/test/browser/steps/calendar_day_sheet_steps.exs
@@ -1,0 +1,119 @@
+defmodule BrowserCalendarDaySheetSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+
+  step "I am going to {string} on the 17th of next month", %{args: [title]} = context do
+    attendee = generate(user(role: :user))
+    host = generate(user(role: :user))
+    group = generate(group(name: "Portland Elixir", owner_id: host.id, actor: host))
+    date = day_of_next_month(17)
+
+    huddl =
+      generate(
+        huddl(
+          title: title,
+          date: date,
+          start_time: ~T[12:00:00],
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          actor: host
+        )
+      )
+
+    Huddlz.Communities.rsvp_huddl!(huddl, actor: attendee)
+
+    Map.merge(context, %{conn: sign_in(context.conn, attendee), huddl: huddl, day: date})
+  end
+
+  step "I have opened next month's calendar in a narrow browser", context do
+    %Date{year: y, month: m} = context.day
+    month = "#{y}-#{String.pad_leading(to_string(m), 2, "0")}"
+
+    conn =
+      context.conn
+      |> visit("/calendar?view=month&month=#{month}")
+      |> assert_has(".phx-connected")
+      |> assert_browser("innerWidth === 320 && !document.querySelector('#calendar-day-panel')")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I tap the 17th", context do
+    link = day_link(context.day)
+
+    # Bring the day into the middle of the screen first, so there is a scroll
+    # position to come back to.
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const link = document.querySelector('#{link}');
+        if (!link) return false;
+        link.scrollIntoView({ block: 'center' });
+        sessionStorage.setItem('calendar-scroll', String(Math.round(scrollY)));
+        return scrollY > 0;
+      })()
+      """)
+
+    Map.put(context, :conn, click_link(conn, link, "17"))
+  end
+
+  step "the day sheet is docked to the bottom edge and lists {string}",
+       %{args: [title]} = context do
+    conn =
+      context.conn
+      |> assert_has("#calendar-day-panel .cal-agenda-title", text: title)
+      |> assert_browser("""
+      (() => {
+        const sheet = document.querySelector('#calendar-day-panel');
+        if (!sheet) return false;
+        const rect = sheet.getBoundingClientRect();
+        return Math.abs(rect.bottom - innerHeight) < 1 &&
+          rect.left === 0 && Math.abs(rect.right - innerWidth) < 1 &&
+          rect.top > 0 &&
+          document.documentElement.scrollWidth <= innerWidth;
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I open {string} from the sheet and go back", %{args: [title]} = context do
+    conn =
+      context.conn
+      |> click_link("#calendar-day-panel .cal-agenda-entry", title)
+      |> assert_has("h1", text: title)
+      |> assert_browser("(() => { history.back(); return true; })()")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the calendar returns with the sheet open on the 17th where I left it", context do
+    conn =
+      context.conn
+      |> assert_has("#calendar-day-panel .cal-agenda-day-title",
+        text: Calendar.strftime(context.day, "%B %-d")
+      )
+      |> assert_browser("""
+      (() => {
+        const expected = Number(sessionStorage.getItem('calendar-scroll'));
+        return location.search.includes('day=#{Date.to_iso8601(context.day)}') &&
+          document.querySelector('#month-calendar') &&
+          Math.abs(scrollY - expected) < 2;
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  defp day_of_next_month(day) do
+    today = eastern_today()
+    total = today.year * 12 + today.month
+    Date.new!(div(total, 12), rem(total, 12) + 1, day)
+  end
+
+  defp day_link(date), do: "#calendar-day-link-#{Date.to_iso8601(date)}"
+end

--- a/test/features/calendar_week.feature
+++ b/test/features/calendar_week.feature
@@ -1,0 +1,41 @@
+@database @conn
+Feature: Calendar week view and day panel
+  As someone with RSVPs
+  I want to page through my calendar a week at a time and open any day of the month
+  So that I can see the shape of a week and get back to where I was in one step
+
+  Background:
+    Given the following users exist:
+      | email              | display_name | role    |
+      | weekly@example.com | Weekly User  | regular |
+    And I am signed in as "weekly@example.com"
+
+  Scenario: The week view draws one week, every day of it
+    Given I am going to "Founder Coffee planning call" on day 17 of next month at "08:00"
+    And I am going to "Async Rust reading group" on day 24 of next month at "19:00"
+    When I open the week of day 17 of next month
+    Then every day of that week is drawn
+    And the week shows "Founder Coffee planning call" on day 17
+    And the week does not list "Async Rust reading group"
+    When I move to the next week
+    Then the week shows "Async Rust reading group" on day 24
+    And the week does not list "Founder Coffee planning call"
+
+  Scenario: A day in the month grid opens its huddlz
+    Given I am going to "Elixir office hours" on day 17 of next month at "12:00"
+    And I am going to "Hands-on with Ash Framework" on day 17 of next month at "18:30"
+    And I am going to "Async Rust reading group" on day 16 of next month at "19:00"
+    When I open next month in the month view
+    And I open day 17
+    Then the day panel lists "Elixir office hours" then "Hands-on with Ash Framework" with their times and places
+    And the day panel does not list "Async Rust reading group"
+    When I open "Hands-on with Ash Framework" from the day panel
+    Then I am on the huddl page for "Hands-on with Ash Framework"
+
+  Scenario: Closing the day panel lands back on the same month
+    Given I am going to "Elixir office hours" on day 17 of next month at "12:00"
+    When I open next month in the month view
+    And I open day 17
+    Then the open day is part of the address
+    When I close the day panel
+    Then I am back on next month in the month view with no day open

--- a/test/features/step_definitions/calendar_week_steps.exs
+++ b/test/features/step_definitions/calendar_week_steps.exs
@@ -1,0 +1,139 @@
+defmodule CalendarWeekSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import PhoenixTest
+
+  step "I open the week of day {int} of next month", %{args: [day], conn: conn} = context do
+    week = day |> next_month_date() |> Date.beginning_of_week(:sunday)
+    session = visit(conn, "/calendar?view=week&week=#{Date.to_iso8601(week)}")
+    Map.merge(context, %{conn: session, session: session, week_start: week})
+  end
+
+  step "every day of that week is drawn", %{session: session, week_start: start} = context do
+    session = assert_has(session, "#calendar-week .cal-agenda-day", count: 7)
+
+    for offset <- 0..6 do
+      date = Date.add(start, offset)
+      assert_has(session, "#calendar-week-day-#{Date.to_iso8601(date)} .cal-agenda-daynum")
+    end
+
+    context
+  end
+
+  step "the week shows {string} on day {int}",
+       %{args: [title, day], session: session} = context do
+    date = next_month_date(day)
+
+    assert_has(session, "#calendar-week-day-#{Date.to_iso8601(date)} .cal-agenda-title",
+      text: title
+    )
+
+    context
+  end
+
+  step "the week does not list {string}", %{args: [title], session: session} = context do
+    refute_has(session, "#calendar-week .cal-agenda-title", text: title)
+    context
+  end
+
+  step "I move to the next week", %{session: session} = context do
+    session = click_link(session, ".cal-nav-btn", "Next week")
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "I open next month in the month view", %{conn: conn} = context do
+    session = visit(conn, "/calendar?view=month&month=#{month_param()}")
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "I open day {int}", %{args: [day], session: session} = context do
+    session = click_link(session, day_link_selector(day), to_string(day))
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "the day panel lists {string} then {string} with their times and places",
+       %{args: [first, second], session: session} = context do
+    session = assert_has(session, "#calendar-day-panel")
+
+    assert render_texts(session, "#calendar-day-panel .cal-agenda-title") == [first, second]
+
+    assert [noon, evening] = render_texts(session, "#calendar-day-panel .cal-agenda-time")
+    assert String.starts_with?(noon, "12:00 PM")
+    assert String.starts_with?(evening, "6:30 PM")
+
+    session
+    |> assert_has("#calendar-day-panel .cal-agenda-meta", text: "Portland Elixir", count: 2)
+    |> assert_has("#calendar-day-panel .cal-agenda-day-title", text: day_heading(17))
+
+    context
+  end
+
+  step "the day panel does not list {string}", %{args: [title], session: session} = context do
+    refute_has(session, "#calendar-day-panel .cal-agenda-title", text: title)
+    context
+  end
+
+  step "I open {string} from the day panel", %{args: [title], session: session} = context do
+    session = click_link(session, "#calendar-day-panel .cal-agenda-entry", title)
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "I am on the huddl page for {string}", %{args: [title], session: session} = context do
+    assert_has(session, "h1", text: title)
+    context
+  end
+
+  step "the open day is part of the address", %{session: session} = context do
+    assert_path(session, "/calendar",
+      query_params: %{
+        "view" => "month",
+        "month" => month_param(),
+        "day" => Date.to_iso8601(next_month_date(17))
+      }
+    )
+
+    context
+  end
+
+  step "I close the day panel", %{session: session} = context do
+    session = click_link(session, "#calendar-day-close", "Close")
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "I am back on next month in the month view with no day open",
+       %{session: session} = context do
+    session
+    |> assert_path("/calendar", query_params: %{"view" => "month", "month" => month_param()})
+    |> refute_has("#calendar-day-panel")
+    |> assert_has("#month-calendar")
+
+    context
+  end
+
+  defp next_month do
+    today = eastern_today()
+    total = today.year * 12 + today.month
+    Date.new!(div(total, 12), rem(total, 12) + 1, 1)
+  end
+
+  defp next_month_date(day), do: %{next_month() | day: day}
+
+  defp month_param do
+    %Date{year: y, month: m} = next_month()
+    "#{y}-#{String.pad_leading(to_string(m), 2, "0")}"
+  end
+
+  defp day_link_selector(day), do: "#calendar-day-link-#{Date.to_iso8601(next_month_date(day))}"
+
+  defp day_heading(day), do: Calendar.strftime(next_month_date(day), "%B %-d")
+
+  defp render_texts(session, selector) do
+    session.view
+    |> Phoenix.LiveViewTest.render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query(selector)
+    |> Enum.map(&(&1 |> LazyHTML.text() |> String.trim()))
+  end
+end

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -742,12 +742,16 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      in_person = create_huddl(host, public_group, title: "Somewhere", date: tomorrow())
+      {date, start_time} = thirty_hours_out()
+
+      in_person =
+        create_huddl(host, public_group, title: "Somewhere", date: date, start_time: start_time)
 
       online =
         create_huddl(host, public_group,
           title: "Nowhere",
-          date: tomorrow(),
+          date: date,
+          start_time: start_time,
           event_type: :virtual,
           virtual_link: "https://meet.example.com/nowhere"
         )
@@ -819,7 +823,10 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
     test "my groups adds unanswered huddlz with an outlined pill in the grid and a legend entry",
          %{conn: conn, attendee: attendee, host: host, public_group: public_group} do
-      theirs = create_huddl(host, public_group, title: "Theirs", date: tomorrow())
+      {date, start_time} = thirty_hours_out()
+
+      theirs =
+        create_huddl(host, public_group, title: "Theirs", date: date, start_time: start_time)
 
       conn
       |> login(attendee)
@@ -880,7 +887,10 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      theirs = create_huddl(host, public_group, title: "Theirs", date: tomorrow())
+      {date, start_time} = thirty_hours_out()
+
+      theirs =
+        create_huddl(host, public_group, title: "Theirs", date: date, start_time: start_time)
 
       conn
       |> login(attendee)
@@ -895,6 +905,15 @@ defmodule HuddlzWeb.CalendarLiveTest do
   end
 
   defp tomorrow, do: Date.add(Huddlz.Generator.eastern_today(), 1)
+
+  # A start that reads as "tomorrow" (24 to 48 hours away) whatever the
+  # time of day the suite runs, as a date and time in the huddl's zone.
+  defp thirty_hours_out do
+    local =
+      DateTime.utc_now() |> DateTime.add(30, :hour) |> DateTime.shift_zone!("America/New_York")
+
+    {DateTime.to_date(local), local |> DateTime.to_time() |> Time.truncate(:second)}
+  end
 
   # Build a /calendar URL pinned to the month containing `date`, so the focus
   # month always matches where the huddl actually lives (matters for agenda

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -904,6 +904,162 @@ defmodule HuddlzWeb.CalendarLiveTest do
     end
   end
 
+  describe "week view" do
+    test "the Week tab opens this week from this month and the first week of another month", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      today = Huddlz.Generator.eastern_today()
+      next = shift(today, 1)
+      first_week = Date.beginning_of_week(next, :sunday)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=month")
+      |> assert_has("#calendar-view-week[href='/calendar?view=week']", text: "Week")
+      |> visit("/calendar?month=#{next_month_param(today)}&view=month")
+      |> assert_has("#calendar-view-week[href='/calendar?week=#{first_week}&view=week']")
+    end
+
+    test "draws every day of the week, blank where nothing is on, and today says so", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      today = Huddlz.Generator.eastern_today()
+      start = Date.beginning_of_week(today, :sunday)
+
+      session =
+        conn
+        |> login(attendee)
+        |> visit("/calendar?view=week")
+        |> assert_has(".cal-view-tabs .scope-tab.is-active[aria-current='page']", text: "Week")
+        |> assert_has(".cal-month-name", text: Calendar.strftime(start, "%b %-d"))
+        |> assert_has(".cal-month-count", text: "0 huddlz")
+        |> assert_has("#calendar-week .cal-agenda-day", count: 7)
+        |> assert_has("#calendar-week .cal-agenda-day[data-blank]", count: 6)
+        |> assert_has("#calendar-week .cal-agenda-day[data-today] .cal-agenda-quiet",
+          text: "Nothing today."
+        )
+        |> refute_has("#calendar-week .cal-agenda-day[data-blank] .cal-agenda-quiet")
+        |> refute_has("#calendar-legend")
+
+      for offset <- 0..6 do
+        assert_has(session, "#calendar-week-day-#{Date.add(start, offset)}")
+      end
+    end
+
+    test "any date names its week, the rail marks a month change, and nonsense means this week",
+         %{conn: conn, attendee: attendee} do
+      this_week = Date.beginning_of_week(Huddlz.Generator.eastern_today(), :sunday)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=week&week=2030-10-02")
+      |> assert_has(".cal-month-name", text: "Sep 29 – Oct 5, 2030")
+      |> assert_has("#calendar-week-day-2030-09-29")
+      |> assert_has("#calendar-week-day-2030-10-01 .cal-agenda-day-context", text: "Oct")
+      |> refute_has("#calendar-week-day-2030-09-30 .cal-agenda-day-context")
+      |> assert_has("a.cal-nav-btn[href='/calendar?week=2030-09-22&view=week']",
+        text: "Previous week"
+      )
+      |> assert_has("a.cal-nav-btn[href='/calendar?week=2030-10-06&view=week']",
+        text: "Next week"
+      )
+      |> assert_has("a.cal-nav-today[href='/calendar?view=week']", text: "Today")
+      |> assert_has("#calendar-view-month[href='/calendar?month=2030-09&view=month']")
+      |> visit("/calendar?view=week&week=someday")
+      |> assert_has("#calendar-week-day-#{this_week}")
+      |> assert_has("a.cal-nav-today[href='/calendar?view=week']")
+    end
+
+    test "lists the week's huddlz with the legend for them and keeps the scope", %{
+      conn: conn,
+      host: host,
+      attendee: attendee,
+      public_group: group
+    } do
+      in_week = ~D[2030-10-02]
+      hosted = create_huddl(host, group, title: "In the week", date: in_week)
+      rsvp!(hosted, attendee, :rsvp)
+      after_week = create_huddl(host, group, title: "The week after", date: ~D[2030-10-09])
+      rsvp!(after_week, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=week&week=2030-09-29&scope=groups")
+      |> assert_has("#calendar-week-day-2030-10-02 .cal-agenda-title", text: "In the week")
+      |> refute_has("#calendar-week .cal-agenda-title", text: "The week after")
+      |> assert_has(".cal-month-count", text: "1 huddl")
+      |> assert_has("#calendar-legend .cal-legend-item", count: 1)
+      |> assert_has("a.cal-nav-btn[href='/calendar?week=2030-10-06&view=week&scope=groups']")
+      |> assert_has("#calendar-scope-mine[href='/calendar?week=2030-09-29&view=week']")
+    end
+  end
+
+  describe "day panel" do
+    test "opens from a day number with that day's huddlz and closes back to the month", %{
+      conn: conn,
+      host: host,
+      attendee: attendee,
+      public_group: group
+    } do
+      day = ~D[2030-10-17]
+      huddl = create_huddl(host, group, title: "Elixir office hours", date: day)
+      rsvp!(huddl, attendee, :rsvp)
+      other = create_huddl(host, group, title: "The day before", date: ~D[2030-10-16])
+      rsvp!(other, attendee, :rsvp)
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?month=2030-10&view=month")
+      |> refute_has("#calendar-day-panel")
+      |> assert_has(
+        "#calendar-day-link-2030-10-17[href='/calendar?month=2030-10&view=month&day=2030-10-17']"
+      )
+      |> click_link("#calendar-day-link-2030-10-17", "17")
+      |> assert_has("td.cal-cell.is-open #calendar-day-link-2030-10-17")
+      |> assert_has("#calendar-day-panel[role=dialog][aria-modal=true]")
+      |> assert_has("#calendar-day-panel .cal-day-kicker", text: "Thursday")
+      |> assert_has("#calendar-day-panel-title", text: "October 17")
+      |> assert_has("#calendar-day-panel .cal-day-count", text: "1 huddl")
+      |> assert_has("#calendar-day-entry-#{huddl.id} .cal-agenda-title",
+        text: "Elixir office hours"
+      )
+      |> refute_has("#calendar-day-panel .cal-agenda-title", text: "The day before")
+      |> assert_has("#calendar-day-week[href='/calendar?week=2030-10-13&view=week']",
+        text: "Open this week"
+      )
+      |> assert_has("#calendar-day-layer[phx-key=escape]")
+      |> click_link("#calendar-day-close", "Close")
+      |> assert_path("/calendar", query_params: %{"month" => "2030-10", "view" => "month"})
+      |> refute_has("#calendar-day-panel")
+      |> refute_has("td.cal-cell.is-open")
+    end
+
+    test "an empty day says so and the scope survives opening it", %{
+      conn: conn,
+      attendee: attendee
+    } do
+      conn
+      |> login(attendee)
+      |> visit("/calendar?month=2030-10&view=month&scope=groups&day=2030-10-03")
+      |> assert_has("#calendar-day-panel .cal-agenda-quiet", text: "Nothing on this day.")
+      |> assert_has("#calendar-day-panel .cal-day-count", text: "0 huddlz")
+      |> assert_has("#calendar-day-close[href='/calendar?month=2030-10&view=month&scope=groups']")
+      |> visit("/calendar?month=2030-10&view=month&day=not-a-day")
+      |> refute_has("#calendar-day-panel")
+    end
+
+    test "marks today in the panel", %{conn: conn, attendee: attendee} do
+      today = Huddlz.Generator.eastern_today()
+
+      conn
+      |> login(attendee)
+      |> visit("/calendar?view=month&day=#{today}")
+      |> assert_has("#calendar-day-panel[data-today] .cal-day-kicker-today", text: "Today")
+    end
+  end
+
   defp tomorrow, do: Date.add(Huddlz.Generator.eastern_today(), 1)
 
   # A start that reads as "tomorrow" (24 to 48 hours away) whatever the


### PR DESCRIPTION
## Summary

Closes #485.

The calendar had an agenda and a month grid, and clicking a day did nothing. Direction chosen on the design canvas (My calendar · Week, My calendar · Day panel, plus the two phone boards), after asking what a week grid would add once the agenda exists: not much. A seven-column grid for a calendar that holds a few things a week is mostly empty air, and the agenda already answers "what's next". What neither view gives is the shape of one week, or any past week, in readable form.

- **Week view.** The agenda's day rail for one Sunday-to-Saturday week, every day drawn. A day with nothing on is a bare rail row; today still says "Nothing today."; past days dim as they do elsewhere. Previous, Today and Next move a week at a time, the title reads "Sep 6 – 12, 2026" (naming the second month or year only when it changes), and the rail names a month where it changes mid-week. `?view=week&week=YYYY-MM-DD`; any date names its week, and an unreadable one means this week. The Week tab opens this week from this month and the first week of any other month.
- **Day panel.** Clicking a day number in the month grid opens that day's huddlz: a side panel on wide screens, a bottom sheet with a grab handle on phones, listing time, title, group, place, status and how far off, each opening the huddl. An empty day says so. The panel ends with **Open this week**. Escape, the scrim and the close button all close it and hand focus back to the day number. The open day tints its cell. On phones the whole cell opens the day, with the pills still opening their huddl.
- **Everything in the URL.** The open day is `?day=YYYY-MM-DD` on top of the month, so closing the panel, the browser's back button and returning from a huddl all land on the same view, and LiveView puts the scroll position back on the way back.
- The view toggle reads Agenda, Week, Month. Every calendar URL now comes from one `calendar_path(@nav, overrides)`, which leaves out the defaults and never carries an open day across a view change. The previous and next arrows use visually hidden labels rather than `aria-label`, so they read the same to a screen reader and to a test.

## Verification

- Feature `calendar_week.feature`, written first and failing before the change: the week draws all seven days and lists only that week's huddlz until the next arrow; a day in the month grid opens its two huddlz in order with times and places and not the day before's, and a huddl opens from the panel; closing the panel lands on the same month with the day gone from the address.
- Browser scenario `calendar_day_sheet.feature` at 320px: the sheet is docked to the bottom edge with no horizontal overflow, opening a huddl from it and pressing back returns with the sheet open on the same day and the page at the same scroll position.
- LiveView tests cover the Week tab's target from this and other months, blank days and today's quiet row, the week title across a month boundary and the rail's month mark, nonsense week params, the legend and scope in week view, the panel's contents and close link, the empty day, a bad day param, and today's mark in the panel.
- Two agenda tests that asserted "tomorrow" on a huddl 14:00 tomorrow read "23 hours away" after 14:00 local; they now place the huddl 30 hours out.
- `mix precommit` clean, exit code checked directly.

Screenshots in the comments.
