### PR TITLE
fix(groups): require nonblank descriptions

### DIFF
--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -126,6 +126,8 @@ defmodule Huddlz.Communities.Group do
       description "Create a new group; the owner is always the current actor."
       accept [:name, :description, :location, :latitude, :longitude, :time_zone, :is_public]
 
+      validate present(:description), message: "is required"
+
       argument :slug, :string, allow_nil?: true
       argument :provided_latitude, :float, allow_nil?: true, public?: false
       argument :provided_longitude, :float, allow_nil?: true, public?: false
@@ -274,6 +276,10 @@ defmodule Huddlz.Communities.Group do
 
       argument :provided_latitude, :float, allow_nil?: true, public?: false
       argument :provided_longitude, :float, allow_nil?: true, public?: false
+
+      validate present(:description),
+        where: [changing(:description, touching?: true)],
+        message: "is required"
 
       change Huddlz.Geocoding.ApplyProvidedCoordinates
       change {Huddlz.Geocoding.GeocodeChange, field: :location}

--- a/test/features/group_image.feature
+++ b/test/features/group_image.feature
@@ -48,6 +48,7 @@ Feature: Group Image Management
     Given I am signed in as "group-image-owner@example.com"
     When I visit "/groups/new"
     And I fill in "Group name" with "Cancel Image Group"
+    And I fill in "Description" with "A community choosing its cover image"
     And I select "Saint Augustine, FL, USA" as the group city in "America/New_York"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
     Then I should see "Image uploaded"

--- a/test/features/group_management.feature
+++ b/test/features/group_management.feature
@@ -125,3 +125,43 @@ Feature: Group Management
     When I visit "/groups/new"
     And I click "Create group"
     Then I should see an error on the "Group name" field
+
+  Scenario: Creating a group requires a description
+    Given I am signed in as "verified@example.com"
+    When I visit "/groups/new"
+    And I fill in the following:
+      | Group name | Description Required Club |
+    And I select "San Francisco, CA, USA" as the group city in "America/Los_Angeles"
+    And I click "Create group"
+    Then I should not see "Group created successfully"
+    And the group description should show a required error
+
+  Scenario: Whitespace does not count as a group description
+    Given I am signed in as "verified@example.com"
+    When I visit "/groups/new"
+    And I fill in the following:
+      | Group name | Whitespace Description Club |
+    And I fill the group description with "whitespace-only" text
+    And I select "San Francisco, CA, USA" as the group city in "America/Los_Angeles"
+    And I click "Create group"
+    Then the group description should show a required error
+    When I fill in the following:
+      | Description | A community for local readers |
+    And I click "Create group"
+    Then I should see "Group created successfully"
+    And I should see "A community for local readers"
+
+  Scenario Outline: An owner cannot clear the group description
+    Given a public group "Management Book Club" exists with owner "verified@example.com"
+    And I am signed in as "verified@example.com"
+    When I visit the edit page for "Management Book Club"
+    And I fill the group description with "<description>" text
+    And I click "Save Changes"
+    Then the group description should show a required error
+    When I visit the group page for "Management Book Club"
+    Then I should see "Management Book Club description"
+
+    Examples:
+      | description     |
+      | empty           |
+      | whitespace-only |

--- a/test/features/location_based_time_zones.feature
+++ b/test/features/location_based_time_zones.feature
@@ -12,6 +12,7 @@ Feature: Location-based time zones
   Scenario: A group's required city determines its time zone
     When I visit "/groups/new"
     And I fill in "Group name" with "Saint Augustine Neighbors"
+    And I fill in "Description" with "A community for Saint Augustine neighbors"
     And I select "Saint Augustine, FL, USA" as the group city in "America/New_York"
     And I click "Create group"
     Then I should see "Group created successfully"
@@ -20,6 +21,7 @@ Feature: Location-based time zones
   Scenario: A group cannot be created without a city
     When I visit "/groups/new"
     And I fill in "Group name" with "Locationless Neighbors"
+    And I fill in "Description" with "A community still choosing its home city"
     And I click "Create group"
     Then I should see an error on the "Location" field
     And the group "Locationless Neighbors" should not exist

--- a/test/features/step_definitions/group_management_steps.exs
+++ b/test/features/step_definitions/group_management_steps.exs
@@ -61,6 +61,12 @@ defmodule GroupManagementSteps do
   end
 
   # Form interaction steps
+  step "I fill the group description with {string} text", %{args: [kind]} = context do
+    text = description_text(kind)
+    session = fill_in(context[:session] || context[:conn], "Description", with: text)
+    Map.merge(context, %{session: session, conn: session})
+  end
+
   step "I fill in the following:", context do
     # For 2-column tables without headers, Cucumber treats them as key-value pairs
     # Access the raw table data instead
@@ -122,6 +128,12 @@ defmodule GroupManagementSteps do
   end
 
   # Assertions specific to groups
+  step "the group description should show a required error", context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "#form_description-error-0", text: "is required")
+    context
+  end
+
   step "I should be redirected to {string}", %{args: [_path]} = context do
     # PhoenixTest handles redirects automatically, so we just check we're on the expected page
     # We can check the path by looking for unique content on that page
@@ -153,4 +165,7 @@ defmodule GroupManagementSteps do
     assert_has(session, ".facts li", text: "Members #{count}")
     context
   end
+
+  defp description_text("empty"), do: ""
+  defp description_text("whitespace-only"), do: " \t\n\u00A0 "
 end

--- a/test/huddlz/communities/group_live_functionality_test.exs
+++ b/test/huddlz/communities/group_live_functionality_test.exs
@@ -135,6 +135,7 @@ defmodule Huddlz.Communities.GroupLiveFunctionalityTest do
         Group
         |> Ash.Changeset.for_create(:create_group, %{
           name: "Unique Name Test",
+          description: "A community with a unique name",
           location: "Saint Augustine, FL",
           latitude: 29.9012,
           longitude: -81.3124,
@@ -148,6 +149,7 @@ defmodule Huddlz.Communities.GroupLiveFunctionalityTest do
                Group
                |> Ash.Changeset.for_create(:create_group, %{
                  name: "Unique Name Test",
+                 description: "Another community using the same name",
                  location: "Saint Augustine, FL",
                  latitude: 29.9012,
                  longitude: -81.3124,
@@ -162,6 +164,7 @@ defmodule Huddlz.Communities.GroupLiveFunctionalityTest do
         Group
         |> Ash.Changeset.for_create(:create_group, %{
           name: "Default Public Test",
+          description: "A community with default visibility",
           location: "Saint Augustine, FL",
           latitude: 29.9012,
           longitude: -81.3124,

--- a/test/huddlz_web/api/json/group_test.exs
+++ b/test/huddlz_web/api/json/group_test.exs
@@ -99,6 +99,58 @@ defmodule HuddlzWeb.Api.Json.GroupTest do
   end
 
   describe "PATCH /api/json/groups/:id" do
+    test "rejects blank descriptions and preserves the existing description", %{conn: conn} do
+      owner = generate(user())
+      group = generate(group(description: "A community for readers", actor: owner))
+
+      for description <- [nil, "", " \t\n\u00A0 "] do
+        response =
+          conn
+          |> authenticated_conn(owner)
+          |> put_req_header("content-type", "application/vnd.api+json")
+          |> patch("/api/json/groups/#{group.id}", %{
+            "data" => %{"type" => "group", "attributes" => %{"description" => description}}
+          })
+
+        assert %{"errors" => [error]} = json_response(response, 400)
+        assert error["source"]["pointer"] == "/data/attributes/description"
+        assert error["detail"] =~ "is required"
+      end
+
+      response = get(conn, "/api/json/groups/#{group.id}")
+      assert %{"data" => %{"attributes" => attributes}} = json_response(response, 200)
+      assert attributes["description"] == "A community for readers"
+    end
+
+    test "legacy groups allow unrelated edits but reject resubmitting a missing description", %{
+      conn: conn
+    } do
+      owner = generate(user())
+      group = generate(group(actor: owner)) |> Ash.Seed.update!(%{description: nil})
+      conn = authenticated_conn(conn, owner)
+
+      response =
+        conn
+        |> put_req_header("content-type", "application/vnd.api+json")
+        |> patch("/api/json/groups/#{group.id}", %{
+          "data" => %{"type" => "group", "attributes" => %{"name" => "Renamed Reading Club"}}
+        })
+
+      assert %{"data" => %{"attributes" => attributes}} = json_response(response, 200)
+      assert attributes["name"] == "Renamed Reading Club"
+      assert attributes["description"] == nil
+
+      response =
+        conn
+        |> put_req_header("content-type", "application/vnd.api+json")
+        |> patch("/api/json/groups/#{group.id}", %{
+          "data" => %{"type" => "group", "attributes" => %{"description" => nil}}
+        })
+
+      assert %{"errors" => [error]} = json_response(response, 400)
+      assert error["source"]["pointer"] == "/data/attributes/description"
+    end
+
     test "owner can update group details", %{conn: conn} do
       owner = generate(user())
       g = generate(group(owner_id: owner.id, is_public: true, actor: owner))
@@ -142,6 +194,41 @@ defmodule HuddlzWeb.Api.Json.GroupTest do
   end
 
   describe "POST /api/json/groups" do
+    test "requires a nonblank description", %{conn: conn} do
+      owner = generate(user())
+
+      for description <- [
+            %{},
+            %{"description" => nil},
+            %{"description" => ""},
+            %{"description" => " \t\n\u00A0 "}
+          ] do
+        attributes =
+          Map.merge(
+            %{
+              "name" => "Reading Club",
+              "location" => "Tucson",
+              "latitude" => 32.2226,
+              "longitude" => -110.9747,
+              "time_zone" => "America/Phoenix"
+            },
+            description
+          )
+
+        response =
+          conn
+          |> authenticated_conn(owner)
+          |> put_req_header("content-type", "application/vnd.api+json")
+          |> post("/api/json/groups", %{
+            "data" => %{"type" => "group", "attributes" => attributes}
+          })
+
+        assert %{"errors" => [error]} = json_response(response, 400)
+        assert error["source"]["pointer"] == "/data/attributes/description"
+        assert error["detail"] =~ "is required"
+      end
+    end
+
     test "creates a group and auto-generates slug from name when omitted", %{conn: conn} do
       me = generate(user())
 

--- a/test/huddlz_web/live/group_live/show_tabs_test.exs
+++ b/test/huddlz_web/live/group_live/show_tabs_test.exs
@@ -159,7 +159,9 @@ defmodule HuddlzWeb.GroupLive.ShowTabsTest do
     end
 
     test "renders fallback description metadata", %{conn: conn, user: user} do
-      group = generate(group(owner_id: user.id, is_public: true, actor: user, description: nil))
+      group =
+        generate(group(owner_id: user.id, is_public: true, actor: user))
+        |> Ash.Seed.update!(%{description: nil})
 
       html =
         conn


### PR DESCRIPTION
Require a nonblank description when creating a group or submitting a description change, with feedback on the description field. Empty, whitespace-only, and null values are rejected.

Existing descriptions are preserved after rejected edits. Older groups with missing descriptions can still receive unrelated updates; no existing data is rewritten and no migration is required.

Local validation found two pre-existing calendar tests expecting “tomorrow” instead of “23 hours away”; both also failed with the original code. The description regression tests, compilation, and Credo pass.

Closes #491.
