### PR TITLE
fix(huddlz): include the recurrence end date

### DIFF
--- a/lib/huddlz/communities/huddl/recurrence_helper.ex
+++ b/lib/huddlz/communities/huddl/recurrence_helper.ex
@@ -195,7 +195,7 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelper do
     ends_at_local = NaiveDateTime.add(starts_at_local, duration, :second)
 
     cond do
-      not Date.before?(NaiveDateTime.to_date(starts_at_local), repeat_until_date(template)) ->
+      Date.after?(NaiveDateTime.to_date(starts_at_local), repeat_until_date(template)) ->
         :done
 
       starting_after && not NaiveDateTime.after?(starts_at_local, starting_after) ->

--- a/test/features/organizer_huddlz.feature
+++ b/test/features/organizer_huddlz.feature
@@ -20,10 +20,12 @@ Feature: Organizer huddlz page
     And the filter chips read "Upcoming 1", "Drafts 1", "Past 0" and "Cancelled 0"
     And I should not see "Modular Jam"
 
-  Scenario: A recurring series keeps its dates in order, each marked as part of it
+  Scenario: A weekly series includes its fifth date when recurrence ends on that date
     Given a weekly series "Office hours" exists in group "Cyberpunk Builders" for the next 5 weeks
     And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" with room for 20 and 5 RSVPs
     When I visit "/organize/cyberpunk-builders/huddlz"
     Then the huddlz are listed day by day in date order
     And every date of "Office hours" is marked "Weekly"
+    And the organizer dates of "Office hours" show the selected series end date
     And "Edit series" on a date of "Office hours" opens the edit page on the whole series
+    And the series edit form shows the selected end date

--- a/test/features/step_definitions/organizer_huddlz_steps.exs
+++ b/test/features/step_definitions/organizer_huddlz_steps.exs
@@ -63,6 +63,8 @@ defmodule OrganizerHuddlzSteps do
     group = lookup_group(group_name)
     host = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
 
+    end_date = Date.add(eastern_today(), 2 + 7 * (weeks - 1))
+
     source =
       generate(
         huddl(
@@ -73,15 +75,15 @@ defmodule OrganizerHuddlzSteps do
           date: Date.add(eastern_today(), 2),
           is_recurring: true,
           frequency: "weekly",
-          # The end date is stored at midnight UTC, so the last date only
-          # generates when the cutoff sits the day after it.
-          repeat_until: Date.add(eastern_today(), 2 + 7 * (weeks - 1) + 1),
+          repeat_until: end_date,
+          start_time: ~T[23:30:00],
+          end_time: ~T[23:45:00],
           actor: host
         )
       )
 
     Oban.drain_queue(queue: :default)
-    Map.put(context, :series_source, source)
+    Map.merge(context, %{series_source: source, series_end_date: end_date})
   end
 
   step "the organizer row for {string} shows when it is and {string}",
@@ -168,6 +170,27 @@ defmodule OrganizerHuddlzSteps do
       |> assert_has(".edit-scope-row .chip.is-active", text: "Whole series")
 
     Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "the organizer dates of {string} show the selected series end date",
+       %{args: [_title], session: session, series_source: source, series_end_date: end_date} =
+         context do
+    assert_has(session, ".org-huddl[data-series='#{source.huddl_template_id}'] .org-huddl-series",
+      text: "until #{Calendar.strftime(end_date, "%b %-d")}",
+      count: 5
+    )
+
+    assert_has(session, "#organize-day-#{Date.to_iso8601(end_date)} .org-huddl-title",
+      text: source.title
+    )
+
+    context
+  end
+
+  step "the series edit form shows the selected end date",
+       %{session: session, series_end_date: end_date} = context do
+    assert_has(session, "input[name='form[repeat_until]'][value='#{Date.to_iso8601(end_date)}']")
+    context
   end
 
   defp lookup_group(name) do

--- a/test/features/step_definitions/recurring_huddl_generation_steps.exs
+++ b/test/features/step_definitions/recurring_huddl_generation_steps.exs
@@ -208,7 +208,7 @@ defmodule RecurringHuddlGenerationSteps do
               date: Date.add(Date.utc_today(), 1),
               is_recurring: true,
               frequency: "weekly",
-              repeat_until: Date.add(Date.utc_today(), 22)
+              repeat_until: Date.add(Date.utc_today(), 15)
             ],
             opts
           )

--- a/test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs
+++ b/test/huddlz/communities/huddl/edit_recurring_huddlz_test.exs
@@ -41,7 +41,7 @@ defmodule Huddlz.Communities.Huddl.Changes.EditRecurringHuddlzTest do
       )
       |> Ash.update!()
 
-    repeat_until = opts[:repeat_until] || Date.add(Huddlz.Generator.eastern_today(), 22)
+    repeat_until = opts[:repeat_until] || Date.add(Huddlz.Generator.eastern_today(), 15)
 
     template =
       HuddlTemplate

--- a/test/huddlz/communities/huddl/recurrence_helper_test.exs
+++ b/test/huddlz/communities/huddl/recurrence_helper_test.exs
@@ -70,16 +70,17 @@ defmodule Huddlz.Communities.Huddl.RecurrenceHelperTest do
         |> Ash.Query.filter(huddl_template_id == ^template.id)
         |> Ash.read!(authorize?: false)
 
-      # With 22 days ahead: day 8 (week 1), day 15 (week 2) should be generated
-      # day 22 is NOT before repeat_until (it equals it), so only 2
-      assert length(generated) == 2
+      # Include day 22, the selected final local date, along with days 8 and 15.
+      assert length(generated) == 3
 
       dates = generated |> Enum.map(&DateTime.to_date(&1.starts_at)) |> Enum.sort()
 
       expected_first = Date.add(DateTime.to_date(ctx.starts_at), 7)
       expected_second = Date.add(DateTime.to_date(ctx.starts_at), 14)
 
-      assert dates == Enum.sort([expected_first, expected_second])
+      expected_third = Date.add(DateTime.to_date(ctx.starts_at), 21)
+
+      assert dates == Enum.sort([expected_first, expected_second, expected_third])
     end
 
     test "generates no huddlz when repeat_until is before next occurrence", ctx do

--- a/test/huddlz/communities/workers/regenerate_recurring_series_test.exs
+++ b/test/huddlz/communities/workers/regenerate_recurring_series_test.exs
@@ -11,7 +11,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
   alias Huddlz.Storage
 
   # Creates a recurring huddl through the :create action. Pins the start to
-  # "tomorrow" so the weekly cadence is deterministic: with repeat_until 22 days
+  # "tomorrow" so the weekly cadence is deterministic: with repeat_until 15 days
   # out, exactly 2 future instances are generated (days +7 and +14).
   defp create_recurring(opts \\ []) do
     owner = generate(user(role: :user))
@@ -29,7 +29,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
               date: Date.add(Date.utc_today(), 1),
               is_recurring: true,
               frequency: "weekly",
-              repeat_until: Date.add(Date.utc_today(), 22)
+              repeat_until: Date.add(Date.utc_today(), 15)
             ],
             opts
           )
@@ -123,7 +123,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
           group_id: group.id,
           is_recurring: true,
           frequency: "weekly",
-          repeat_until: Date.add(Date.utc_today(), 22)
+          repeat_until: Date.add(Date.utc_today(), 15)
         },
         actor: owner
       )
@@ -275,7 +275,7 @@ defmodule Huddlz.Communities.Workers.RegenerateRecurringSeriesTest do
           group_id: group.id,
           is_recurring: true,
           frequency: "weekly",
-          repeat_until: Date.add(Date.utc_today(), 22)
+          repeat_until: Date.add(Date.utc_today(), 15)
         },
         actor: owner
       )

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -35,6 +35,23 @@ defmodule HuddlzWeb.CalendarLiveTest do
     )
   end
 
+  # Keep the countdown safely within its 24–48 hour "tomorrow" window.
+  defp create_huddl_in_36_hours(host, group, opts) do
+    local_start =
+      DateTime.utc_now()
+      |> DateTime.add(36, :hour)
+      |> DateTime.shift_zone!("America/New_York")
+
+    create_huddl(
+      host,
+      group,
+      Keyword.merge(opts,
+        date: DateTime.to_date(local_start),
+        start_time: DateTime.to_time(local_start)
+      )
+    )
+  end
+
   defp create_past_huddl(host, group, opts) do
     generate(
       past_huddl(
@@ -742,12 +759,11 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      in_person = create_huddl(host, public_group, title: "Somewhere", date: tomorrow())
+      in_person = create_huddl_in_36_hours(host, public_group, title: "Somewhere")
 
       online =
-        create_huddl(host, public_group,
+        create_huddl_in_36_hours(host, public_group,
           title: "Nowhere",
-          date: tomorrow(),
           event_type: :virtual,
           virtual_link: "https://meet.example.com/nowhere"
         )
@@ -757,7 +773,11 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit(calendar_path_for(tomorrow(), view: "agenda"))
+      |> visit(
+        calendar_path_for(DateTime.to_date(HuddlCardHelpers.local_starts_at(in_person)),
+          view: "agenda"
+        )
+      )
       |> assert_has("#calendar-entry-#{in_person.id} .cal-agenda-thumb .card-cover-fallback span",
         text: Card.group_initials(public_group.name)
       )
@@ -880,13 +900,17 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
-      theirs = create_huddl(host, public_group, title: "Theirs", date: tomorrow())
+      theirs = create_huddl_in_36_hours(host, public_group, title: "Theirs")
 
       conn
       |> login(attendee)
       |> visit("/calendar")
       |> assert_has("#calendar-first-run")
-      |> visit("/calendar?scope=groups")
+      |> visit(
+        calendar_path_for(DateTime.to_date(HuddlCardHelpers.local_starts_at(theirs)),
+          view: "agenda"
+        ) <> "&scope=groups"
+      )
       |> refute_has("#calendar-first-run")
       |> assert_has("#calendar-entry-#{theirs.id} .cal-agenda-title", text: "Theirs")
       |> refute_has("#calendar-entry-#{theirs.id} .cal-entry-status")


### PR DESCRIPTION
Recurring huddlz now include the selected end date: a weekly series ending on its fifth date generates all five occurrences. The organizer list and edit form retain the date the organizer selected, including for late-night huddlz.

Closes #495
