### PR TITLE
feat(ui): one cover slot for group and huddl covers

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -4859,7 +4859,6 @@ body .cover-slot-track > span {
   height: 100%;
   border-radius: var(--radius-pill);
   background: var(--accent);
-  transition: width 200ms ease;
 }
 
 body .cover-slot-track.is-busy > span { animation: cover-slot-busy 1.1s ease-in-out infinite alternate; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -4677,7 +4677,8 @@ body .slug-control .form-input:focus { box-shadow: none; }
 
 body .warn-text { color: var(--warn); }
 
-/* Upload zone */
+/* Upload zone: the dashed multi-file dropzone the huddl photos section
+   uses. Covers use the cover slot below. */
 body .upload-zone {
   display: flex;
   flex-direction: column;
@@ -4691,6 +4692,8 @@ body .upload-zone {
   text-align: center;
 }
 
+body .upload-zone.phx-drop-target-active { border-style: solid; border-color: var(--accent); background: var(--accent-soft); }
+
 body .upload-icon {
   width: 44px;
   height: 44px;
@@ -4702,30 +4705,210 @@ body .upload-icon {
 }
 
 body .upload-prompt { color: var(--soft); font-size: 14px; }
-body .upload-link { color: var(--accent-ink); font-weight: 700; cursor: pointer; }
-body .upload-link:hover { text-decoration: underline; }
 body .upload-meta { font-size: 12px; }
 
-body .image-preview .card-cover {
-  border-radius: var(--radius-sm);
+/* Cover slot (`HuddlzWeb.Components.UploadComponents.cover_upload/1`):
+   one 16:9 field that never changes size. Idle it is a dashed prompt;
+   dragging a file over it lights it cyan (LiveView adds
+   `phx-drop-target-active`); uploading, the browser's preview fills it
+   with the progress over its bottom edge; uploaded, the cover as the
+   card and page will show it with the actions over the corner; refused,
+   the message lives inside. */
+body .cover-upload { display: flex; flex-direction: column; gap: 10px; }
+
+body .cover-slot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   width: 100%;
   aspect-ratio: 16 / 9;
-  background-size: cover;
-  background-position: center;
+  padding: 24px;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--bg) 40%, transparent);
+  text-align: center;
+  overflow: hidden;
+  transition: border-color 120ms ease, background 120ms ease;
 }
 
-body .image-preview-foot {
+body .cover-slot.phx-drop-target-active {
+  border-style: solid;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+body .cover-upload[data-state="uploading"] .cover-slot,
+body .cover-upload[data-state="uploaded"] .cover-slot {
+  padding: 0;
+  border-style: solid;
+  border-color: var(--line);
+  background: var(--panel-2);
+}
+
+body .cover-upload[data-state="error"] .cover-slot {
+  border-style: solid;
+  border-color: var(--danger);
+}
+
+body .cover-slot-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+body .cover-slot-icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--panel-2);
+  color: var(--muted);
+}
+
+body .cover-slot.phx-drop-target-active .cover-slot-icon { background: var(--panel); color: var(--accent-ink); }
+
+body .cover-slot-icon.is-error {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+}
+
+body .cover-slot-prompt,
+body .cover-slot-error {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+body .cover-slot-error { color: var(--danger); }
+body .cover-slot-meta, body .cover-slot-hint { margin: 0; color: var(--muted); font-size: 12px; }
+body .cover-slot-prompt, body .cover-slot-hint { cursor: pointer; }
+body .upload-link { color: var(--accent-ink); font-weight: 700; cursor: pointer; }
+body .cover-slot-prompt:hover .upload-link, body .cover-slot-hint:hover .upload-link { text-decoration: underline; }
+
+/* The progress bar over the bottom edge of the preview. */
+body .cover-slot-bar {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 12px;
-  margin-top: 10px;
-  gap: 12px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--line);
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  text-align: left;
 }
 
-body .image-preview-actions { display: flex; gap: 8px; }
-body .image-preview-progress { margin-top: 12px; }
-body .upload-replace { cursor: pointer; }
+body .cover-slot-bar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+body .cover-slot-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body .cover-slot-pct { margin-left: auto; color: var(--accent-ink); font-variant-numeric: tabular-nums; }
+
+body .cover-slot-cancel {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+body .cover-slot-cancel:hover { color: var(--text); background: var(--panel-2); }
+
+body .cover-slot-track {
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--line);
+  overflow: hidden;
+}
+
+body .cover-slot-track > span {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  transition: width 200ms ease;
+}
+
+body .cover-slot-track.is-busy > span { animation: cover-slot-busy 1.1s ease-in-out infinite alternate; }
+
+@keyframes cover-slot-busy {
+  from { margin-left: 0; }
+  to { margin-left: 60%; }
+}
+
+body .cover-slot-spinner {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  border: 2px solid var(--accent-ink);
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: cover-slot-spin 0.8s linear infinite;
+}
+
+@keyframes cover-slot-spin { to { transform: rotate(360deg); } }
+
+/* Replace and the caller's actions over the corner of an uploaded cover. */
+body .cover-slot-actions {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+}
+
+body .cover-slot-actions .btn-secondary,
+body .cover-slot-actions .btn-muted,
+body .cover-slot-actions .btn-primary { background: var(--panel); }
+body .cover-slot-actions .btn-primary { background: var(--accent); }
+body .cover-slot-actions .btn-muted { border-color: var(--line); color: var(--soft); }
+body .cover-slot-actions .btn-muted:hover { color: var(--text); }
+body .cover-slot-replace { cursor: pointer; }
+
+body .cover-slot-caption {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body .cover-slot-track.is-busy > span,
+  body .cover-slot-spinner { animation: none; }
+}
 
 /* Slug-change warning panel */
 body .slug-warn {

--- a/lib/huddlz/storage/group_images.ex
+++ b/lib/huddlz/storage/group_images.ex
@@ -31,7 +31,7 @@ defmodule Huddlz.Storage.GroupImages do
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),
-         {:ok, thumbnail_binary} <- ImageProcessing.create_banner_thumbnail(image_binary),
+         {:ok, thumbnail_binary} <- banner_thumbnail(image_binary),
          storage_path = generate_path(group_id, original_filename),
          thumbnail_path = generate_thumbnail_path(storage_path),
          {:ok, _} <- Storage.put(source_path, storage_path, content_type),
@@ -61,7 +61,7 @@ defmodule Huddlz.Storage.GroupImages do
          {:ok, %{size: size}} <- File.stat(source_path),
          :ok <- validate_file_size(size),
          {:ok, image_binary} <- File.read(source_path),
-         {:ok, thumbnail_binary} <- ImageProcessing.create_banner_thumbnail(image_binary),
+         {:ok, thumbnail_binary} <- banner_thumbnail(image_binary),
          storage_path = generate_pending_path(original_filename),
          thumbnail_path = generate_thumbnail_path(storage_path),
          {:ok, _} <- Storage.put(source_path, storage_path, content_type),
@@ -72,6 +72,15 @@ defmodule Huddlz.Storage.GroupImages do
          thumbnail_path: thumbnail_path,
          size_bytes: size
        }}
+    end
+  end
+
+  # A file the image library cannot decode is one error to the person,
+  # whatever the library says about it.
+  defp banner_thumbnail(image_binary) do
+    case ImageProcessing.create_banner_thumbnail(image_binary) do
+      {:ok, thumbnail} -> {:ok, thumbnail}
+      {:error, _reason} -> {:error, :invalid_image}
     end
   end
 

--- a/lib/huddlz_web/components/upload_components.ex
+++ b/lib/huddlz_web/components/upload_components.ex
@@ -1,95 +1,201 @@
 defmodule HuddlzWeb.Components.UploadComponents do
   @moduledoc """
-  Shared cover-image upload panel used by the huddl create and edit forms.
+  The cover slot: one 16:9 field for a group or huddl cover that never
+  changes size while a picture is chosen, uploaded, prepared, shown or
+  refused. Used by the group and huddl create and edit forms.
 
   ```
-  <.cover_image_panel upload={@uploads.huddl_cover_image} image_error={@image_error}>
-    <:preview>...</:preview>
-  </.cover_image_panel>
+  <.cover_upload
+    id="group-cover-upload"
+    upload={@uploads.group_image}
+    image_url={@pending_preview_url}
+    caption="Image uploaded · ready to publish."
+    processing?={@upload_processing}
+    image_error={@image_error}
+  >
+    <:actions>
+      <.button variant={:muted} type="button" phx-click="cancel_pending_image">Remove</.button>
+    </:actions>
+  </.cover_upload>
   ```
+
+  States, in the order they are checked:
+
+    * uploading: a file is on its way, or has arrived and the server is
+      preparing the 16:9 cover. The browser's own preview of the file
+      fills the slot with the progress over its bottom edge.
+    * error: the file was refused, by the browser rules or by the server.
+      The message lives in the slot with a way to choose another file.
+    * uploaded: `image_url` is set. The cover as the card and page will
+      show it, with Replace and the caller's actions over the corner.
+    * idle: the dashed prompt.
   """
   use Phoenix.Component
 
   import HuddlzWeb.Components.Button, only: [button: 1]
+  import HuddlzWeb.Components.Icon, only: [icon: 1]
   import HuddlzWeb.Live.Helpers.UploadHelpers, only: [upload_error_to_string: 1]
 
-  attr :upload, :any, required: true
-  attr :image_error, :string, default: nil
+  attr :id, :string, required: true
+  attr :upload, :any, required: true, doc: "the `@uploads` config"
+  attr :image_url, :string, default: nil, doc: "the cover to show, pending or current"
+  attr :caption, :string, default: nil, doc: "one line under an uploaded cover"
+  attr :processing?, :boolean, default: false, doc: "the server is preparing the cover"
+  attr :image_error, :string, default: nil, doc: "why the server refused the file"
   attr :optional, :boolean, default: false
 
-  slot :preview do
-    attr :hide_upload_zone, :boolean
+  slot :actions, doc: "controls over the corner of an uploaded cover, after Replace"
+
+  def cover_upload(assigns) do
+    entry = List.first(assigns.upload.entries)
+    errors = slot_errors(assigns.upload, entry, assigns.image_error)
+    state = slot_state(entry, errors, assigns.image_url)
+
+    assigns =
+      assigns
+      |> assign(:entry, entry)
+      |> assign(:errors, errors)
+      |> assign(:state, state)
+
+    ~H"""
+    <div id={@id} class="cover-upload" data-state={@state}>
+      <label for={@upload.ref} class="sr-only">Cover image</label>
+      <.live_file_input upload={@upload} class="hidden" />
+
+      <div class="cover-slot" phx-drop-target={@upload.ref}>
+        <%= case @state do %>
+          <% :uploading -> %>
+            <.live_img_preview entry={@entry} class="cover-slot-img" />
+            <div class="cover-slot-bar" role="status" aria-live="polite">
+              <div class="cover-slot-bar-row">
+                <%= if @entry.done? do %>
+                  <span class="cover-slot-file">
+                    <span class="cover-slot-spinner" aria-hidden="true"></span> Preparing the cover…
+                  </span>
+                  <span class="cover-slot-pct">{@entry.client_name}</span>
+                <% else %>
+                  <span class="cover-slot-file">
+                    {@entry.client_name} · {format_size(@entry.client_size)}
+                  </span>
+                  <span class="cover-slot-pct">{@entry.progress}%</span>
+                  <button
+                    type="button"
+                    class="cover-slot-cancel"
+                    phx-click="cancel_image_upload"
+                    phx-value-ref={@entry.ref}
+                  >
+                    Cancel
+                  </button>
+                <% end %>
+              </div>
+              <div class={["cover-slot-track", @entry.done? && "is-busy"]} aria-hidden="true">
+                <span style={"width: #{if @entry.done?, do: 40, else: @entry.progress}%"}></span>
+              </div>
+            </div>
+          <% :error -> %>
+            <span class="cover-slot-icon is-error" aria-hidden="true">
+              <.icon name="hero-x-circle" class="size-5" />
+            </span>
+            <p :for={message <- @errors} class="cover-slot-error">{message}</p>
+            <label for={@upload.ref} class="cover-slot-hint">
+              Choose another JPG, PNG or WebP · <span class="upload-link">browse</span>
+            </label>
+          <% :uploaded -> %>
+            <img class="cover-slot-img" src={@image_url} alt="" />
+            <div class="cover-slot-actions">
+              <label for={@upload.ref} class="btn-secondary btn-sm cover-slot-replace">
+                Replace
+              </label>
+              {render_slot(@actions)}
+            </div>
+          <% :idle -> %>
+            <span class="cover-slot-icon" aria-hidden="true">
+              <.icon name="hero-photo" class="size-5" />
+            </span>
+            <label for={@upload.ref} class="cover-slot-prompt">
+              Drop a 16:9 image, or <span class="upload-link">browse</span>
+            </label>
+            <p class="cover-slot-meta">
+              JPG, PNG, WebP · 5 MB max{if @optional, do: " · optional", else: ""}
+            </p>
+        <% end %>
+      </div>
+
+      <p :if={@state == :uploaded && @caption} class="cover-slot-caption">{@caption}</p>
+    </div>
+    """
   end
 
-  def cover_image_panel(assigns) do
-    assigns = assign(assigns, :show_upload_zone, show_upload_zone?(assigns.preview))
+  @doc """
+  A form panel headed "Cover image" around the slot, for the huddl forms.
+  Takes the same attributes and slot as `cover_upload/1`.
+  """
+  attr :id, :string, required: true
+  attr :upload, :any, required: true
+  attr :image_url, :string, default: nil
+  attr :caption, :string, default: nil
+  attr :processing?, :boolean, default: false
+  attr :image_error, :string, default: nil
+  attr :optional, :boolean, default: false
+  slot :actions
 
+  def cover_image_panel(assigns) do
     ~H"""
     <div class="panel">
       <div class="panel-head">
         <h2>Cover image</h2>
       </div>
-
-      <label for={@upload.ref} class="sr-only">Cover image</label>
-      <.live_file_input upload={@upload} class="hidden" />
-
-      {render_slot(@preview)}
-
-      <div :if={@show_upload_zone} class="upload-zone" phx-drop-target={@upload.ref}>
-        <div class="upload-icon">
-          <svg
-            width="22"
-            height="22"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.6"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="9" cy="9" r="2" /><path d="m21 15-5-5L5 21" />
-          </svg>
-        </div>
-        <label for={@upload.ref} class="upload-prompt">
-          Drop a 16:9 image, or <span class="upload-link">browse</span>
-        </label>
-        <div class="upload-meta muted">
-          JPG, PNG, WebP · 5 MB max{if @optional, do: " · optional", else: ""}
-        </div>
-      </div>
-
-      <%= for entry <- @upload.entries do %>
-        <div class="image-preview image-preview-progress">
-          <div class="card-cover">
-            <.live_img_preview entry={entry} class="card-cover-img" />
-          </div>
-          <div class="image-preview-foot">
-            <span>{entry.client_name} · {entry.progress}%</span>
-            <.button
-              variant={:muted}
-              type="button"
-              phx-click="cancel_image_upload"
-              phx-value-ref={entry.ref}
-            >
-              Cancel
-            </.button>
-          </div>
-        </div>
-        <p :for={err <- upload_errors(@upload, entry)} class="form-error">
-          {upload_error_to_string(err)}
-        </p>
-      <% end %>
-
-      <p :if={@image_error} class="form-error">{@image_error}</p>
-      <p :for={err <- upload_errors(@upload)} class="form-error">
-        {upload_error_to_string(err)}
-      </p>
+      <.cover_upload
+        id={@id}
+        upload={@upload}
+        image_url={@image_url}
+        caption={@caption}
+        processing?={@processing?}
+        image_error={@image_error}
+        optional={@optional}
+      >
+        <:actions>{render_slot(@actions)}</:actions>
+      </.cover_upload>
     </div>
     """
   end
 
-  defp show_upload_zone?(preview) do
-    Enum.all?(preview, &(not Map.get(&1, :hide_upload_zone, false)))
+  # A muted Remove-style control sized for the slot's corner.
+  attr :rest, :global, include: ~w(phx-click phx-value-ref type id)
+  slot :inner_block, required: true
+
+  def cover_slot_button(assigns) do
+    ~H"""
+    <.button variant={:muted} class="btn-sm cover-slot-action" {@rest}>
+      {render_slot(@inner_block)}
+    </.button>
+    """
   end
+
+  defp slot_state(entry, errors, image_url) do
+    cond do
+      entry && errors == [] -> :uploading
+      errors != [] -> :error
+      image_url -> :uploaded
+      true -> :idle
+    end
+  end
+
+  defp slot_errors(upload, entry, image_error) do
+    entry_errors = if entry, do: upload_errors(upload, entry), else: []
+
+    (upload_errors(upload) ++ entry_errors)
+    |> Enum.uniq()
+    |> Enum.map(&upload_error_to_string/1)
+    |> Kernel.++(List.wrap(image_error))
+  end
+
+  defp format_size(bytes) when is_integer(bytes) and bytes >= 1_000_000,
+    do: "#{Float.round(bytes / 1_000_000, 1)} MB"
+
+  defp format_size(bytes) when is_integer(bytes) and bytes >= 1_000,
+    do: "#{div(bytes, 1_000)} KB"
+
+  defp format_size(bytes) when is_integer(bytes), do: "#{bytes} B"
+  defp format_size(_), do: ""
 end

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -4,12 +4,14 @@ defmodule HuddlzWeb.GroupLive.Edit do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Components.UploadComponents
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
   import HuddlzWeb.HuddlLive.FormHelpers,
     only: [
       inject_group_location_param: 2,
-      apply_group_location_to_form: 2
+      apply_group_location_to_form: 2,
+      mark_untouched_group_location: 2
     ]
 
   alias Huddlz.Communities
@@ -73,14 +75,16 @@ defmodule HuddlzWeb.GroupLive.Edit do
 
   defp handle_upload_progress(:group_image, entry, socket) do
     if entry.done? do
-      {:noreply, process_eager_upload(socket)}
+      {:noreply, ImageUploadPipeline.start_eager_upload(socket, upload_config())}
     else
       {:noreply, socket}
     end
   end
 
-  defp process_eager_upload(socket),
-    do: ImageUploadPipeline.process_eager_upload(socket, upload_config())
+  @impl true
+  def handle_async(:prepare_cover, result, socket) do
+    {:noreply, ImageUploadPipeline.finish_eager_upload(socket, result, upload_config())}
+  end
 
   defp cleanup_pending_image(socket),
     do: ImageUploadPipeline.cleanup_pending_image(socket, upload_config())
@@ -94,7 +98,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
     }
   end
 
-  defp create_pending_group_image(socket, entry, metadata) do
+  defp create_pending_group_image(actor, entry, metadata) do
     Communities.create_pending_group_image(
       %{
         filename: entry.client_name,
@@ -103,7 +107,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
         storage_path: metadata.storage_path,
         thumbnail_path: metadata.thumbnail_path
       },
-      actor: socket.assigns.current_user
+      actor: actor
     )
   end
 
@@ -154,107 +158,53 @@ defmodule HuddlzWeb.GroupLive.Edit do
             <h2>Cover image</h2>
           </div>
 
-          <label for={@uploads.group_image.ref} class="sr-only">Cover image</label>
-          <.live_file_input upload={@uploads.group_image} class="hidden" />
-
           <%= cond do %>
             <% @pending_preview_url -> %>
-              <div class="image-preview" phx-drop-target={@uploads.group_image.ref}>
-                <div
-                  class="card-cover"
-                  style={"background-image: url('#{@pending_preview_url}')"}
-                >
-                </div>
-                <div class="image-preview-foot">
-                  <span class="muted">New image uploaded. Save to apply.</span>
-                  <div class="image-preview-actions">
-                    <.button variant={:primary} type="submit" phx-disable-with="Saving...">
-                      Save
-                    </.button>
-                    <label for={@uploads.group_image.ref} class="btn-secondary upload-replace">
-                      Replace
-                    </label>
-                    <.button variant={:muted} type="button" phx-click="cancel_pending_image">
-                      Remove
-                    </.button>
-                  </div>
-                </div>
-              </div>
-            <% @group.current_image_url && @uploads.group_image.entries == [] -> %>
-              <div class="image-preview" phx-drop-target={@uploads.group_image.ref}>
-                <div
-                  class="card-cover"
-                  style={"background-image: url('#{GroupImages.url(@group.current_image_url)}')"}
-                >
-                </div>
-                <div class="image-preview-foot">
-                  <span class="muted">Current image. Upload a new one to replace it.</span>
-                  <div class="image-preview-actions">
-                    <label for={@uploads.group_image.ref} class="btn-secondary upload-replace">
-                      Replace
-                    </label>
-                    <.button
-                      variant={:muted}
-                      id="open-remove-group-image-dialog"
-                      type="button"
-                      phx-click={JS.push_focus() |> JS.push("open_remove_image_dialog")}
-                    >
-                      Remove
-                    </.button>
-                  </div>
-                </div>
-              </div>
-            <% true -> %>
-              <div class="upload-zone" phx-drop-target={@uploads.group_image.ref}>
-                <div class="upload-icon">
-                  <svg
-                    width="22"
-                    height="22"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.6"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    aria-hidden="true"
+              <.cover_upload
+                id="group-cover-upload"
+                upload={@uploads.group_image}
+                image_url={@pending_preview_url}
+                caption="New image uploaded. Save to apply."
+                processing?={@upload_processing}
+                image_error={@image_error}
+              >
+                <:actions>
+                  <.button
+                    variant={:primary}
+                    type="submit"
+                    class="btn-sm"
+                    phx-disable-with="Saving..."
                   >
-                    <rect x="3" y="3" width="18" height="18" rx="2" />
-                    <circle cx="9" cy="9" r="2" />
-                    <path d="m21 15-5-5L5 21" />
-                  </svg>
-                </div>
-                <label for={@uploads.group_image.ref} class="upload-prompt">
-                  Drop a 16:9 image, or <span class="upload-link">browse</span>
-                </label>
-                <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max</div>
-              </div>
-
-              <%= for entry <- @uploads.group_image.entries do %>
-                <div class="image-preview image-preview-progress">
-                  <.live_img_preview entry={entry} class="card-cover-img" />
-                  <div class="image-preview-foot">
-                    <span class="muted">{entry.client_name} · {entry.progress}%</span>
-                    <.button
-                      variant={:muted}
-                      type="button"
-                      phx-click="cancel_image_upload"
-                      phx-value-ref={entry.ref}
-                    >
-                      Cancel
-                    </.button>
-                  </div>
-                </div>
-
-                <%= for err <- upload_errors(@uploads.group_image, entry) do %>
-                  <p class="form-error">{upload_error_to_string(err)}</p>
-                <% end %>
-              <% end %>
-          <% end %>
-
-          <p :if={@image_error} class="form-error">{@image_error}</p>
-
-          <%= for err <- upload_errors(@uploads.group_image) do %>
-            <p class="form-error">{upload_error_to_string(err)}</p>
+                    Save
+                  </.button>
+                  <.cover_slot_button phx-click="cancel_pending_image">Remove</.cover_slot_button>
+                </:actions>
+              </.cover_upload>
+            <% @group.current_image_url -> %>
+              <.cover_upload
+                id="group-cover-upload"
+                upload={@uploads.group_image}
+                image_url={GroupImages.url(@group.current_image_url)}
+                caption="Current image. Upload a new one to replace it."
+                processing?={@upload_processing}
+                image_error={@image_error}
+              >
+                <:actions>
+                  <.cover_slot_button
+                    id="open-remove-group-image-dialog"
+                    phx-click={JS.push_focus() |> JS.push("open_remove_image_dialog")}
+                  >
+                    Remove
+                  </.cover_slot_button>
+                </:actions>
+              </.cover_upload>
+            <% true -> %>
+              <.cover_upload
+                id="group-cover-upload"
+                upload={@uploads.group_image}
+                processing?={@upload_processing}
+                image_error={@image_error}
+              />
           <% end %>
         </div>
 
@@ -524,6 +474,8 @@ defmodule HuddlzWeb.GroupLive.Edit do
   end
 
   def handle_event("validate", %{"form" => params}, socket) do
+    params = mark_untouched_group_location(params, socket.assigns.selected_location_data)
+
     form =
       socket.assigns.form.source
       |> AshPhoenix.Form.validate(params)
@@ -535,7 +487,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
      socket
      |> assign(:form, form)
      |> assign(:slug_changed, slug_changed)
-     |> assign(:image_error, nil)}
+     |> ImageUploadPipeline.drop_invalid_entries(upload_config())}
   end
 
   @impl true

--- a/lib/huddlz_web/live/group_live/new.ex
+++ b/lib/huddlz_web/live/group_live/new.ex
@@ -4,12 +4,14 @@ defmodule HuddlzWeb.GroupLive.New do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Components.UploadComponents
   import HuddlzWeb.Live.Helpers.UploadHelpers
 
   import HuddlzWeb.HuddlLive.FormHelpers,
     only: [
       inject_group_location_param: 2,
-      apply_group_location_to_form: 2
+      apply_group_location_to_form: 2,
+      mark_untouched_group_location: 2
     ]
 
   alias Huddlz.Communities
@@ -51,14 +53,16 @@ defmodule HuddlzWeb.GroupLive.New do
 
   defp handle_upload_progress(:group_image, entry, socket) do
     if entry.done? do
-      {:noreply, process_eager_upload(socket)}
+      {:noreply, ImageUploadPipeline.start_eager_upload(socket, upload_config())}
     else
       {:noreply, socket}
     end
   end
 
-  defp process_eager_upload(socket),
-    do: ImageUploadPipeline.process_eager_upload(socket, upload_config())
+  @impl true
+  def handle_async(:prepare_cover, result, socket) do
+    {:noreply, ImageUploadPipeline.finish_eager_upload(socket, result, upload_config())}
+  end
 
   defp cleanup_pending_image(socket),
     do: ImageUploadPipeline.cleanup_pending_image(socket, upload_config())
@@ -72,7 +76,7 @@ defmodule HuddlzWeb.GroupLive.New do
     }
   end
 
-  defp create_pending_group_image(socket, entry, metadata) do
+  defp create_pending_group_image(actor, entry, metadata) do
     Communities.create_pending_group_image(
       %{
         filename: entry.client_name,
@@ -81,7 +85,7 @@ defmodule HuddlzWeb.GroupLive.New do
         storage_path: metadata.storage_path,
         thumbnail_path: metadata.thumbnail_path
       },
-      actor: socket.assigns.current_user
+      actor: actor
     )
   end
 
@@ -94,6 +98,8 @@ defmodule HuddlzWeb.GroupLive.New do
 
   @impl true
   def handle_event("validate", %{"form" => params}, socket) do
+    params = mark_untouched_group_location(params, socket.assigns.selected_location_data)
+
     form =
       socket.assigns.form.source
       |> AshPhoenix.Form.validate(params)
@@ -101,7 +107,7 @@ defmodule HuddlzWeb.GroupLive.New do
     {:noreply,
      socket
      |> assign(:form, to_form(form))
-     |> assign(:image_error, nil)}
+     |> ImageUploadPipeline.drop_invalid_entries(upload_config())}
   end
 
   @impl true
@@ -247,89 +253,26 @@ defmodule HuddlzWeb.GroupLive.New do
 
         <div class="panel">
           <div class="panel-head">
-            <h2>Cover image</h2>
+            <div>
+              <h2>Cover image</h2>
+              <div class="panel-sub">
+                Optional. Shown on the group card and at the top of the group page.
+              </div>
+            </div>
           </div>
-
-          <label for={@uploads.group_image.ref} class="sr-only">Cover image</label>
-          <.live_file_input upload={@uploads.group_image} class="hidden" />
-
-          <%= if @pending_preview_url do %>
-            <div class="image-preview" phx-drop-target={@uploads.group_image.ref}>
-              <div
-                class="card-cover"
-                style={"height:140px; background-image: url('#{@pending_preview_url}')"}
-              >
-              </div>
-              <div
-                class="muted"
-                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-              >
-                <span>Image uploaded · ready to publish.</span>
-                <div style="display:flex; gap:8px">
-                  <label for={@uploads.group_image.ref} class="btn-secondary" style="cursor:pointer">
-                    Replace
-                  </label>
-                  <.button variant={:muted} type="button" phx-click="cancel_pending_image">
-                    Remove
-                  </.button>
-                </div>
-              </div>
-            </div>
-          <% else %>
-            <div class="upload-zone" phx-drop-target={@uploads.group_image.ref}>
-              <div class="upload-icon">
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.6"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <rect x="3" y="3" width="18" height="18" rx="2" />
-                  <circle cx="9" cy="9" r="2" />
-                  <path d="m21 15-5-5L5 21" />
-                </svg>
-              </div>
-              <label for={@uploads.group_image.ref} class="upload-prompt">
-                Drop a 16:9 image, or <span class="upload-link">browse</span>
-              </label>
-              <div class="upload-meta muted">JPG, PNG, WebP · 5 MB max</div>
-            </div>
-
-            <%= for entry <- @uploads.group_image.entries do %>
-              <div class="image-preview" style="margin-top:12px">
-                <.live_img_preview entry={entry} class="card-cover-img" />
-                <div
-                  class="muted"
-                  style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-                >
-                  <span>{entry.client_name} · {entry.progress}%</span>
-                  <.button
-                    variant={:muted}
-                    type="button"
-                    phx-click="cancel_image_upload"
-                    phx-value-ref={entry.ref}
-                  >
-                    Cancel
-                  </.button>
-                </div>
-              </div>
-
-              <%= for err <- upload_errors(@uploads.group_image, entry) do %>
-                <p class="form-error">{upload_error_to_string(err)}</p>
-              <% end %>
-            <% end %>
-          <% end %>
-
-          <p :if={@image_error} class="form-error">{@image_error}</p>
-
-          <%= for err <- upload_errors(@uploads.group_image) do %>
-            <p class="form-error">{upload_error_to_string(err)}</p>
-          <% end %>
+          <.cover_upload
+            id="group-cover-upload"
+            upload={@uploads.group_image}
+            image_url={@pending_preview_url}
+            caption="Image uploaded · ready to publish."
+            processing?={@upload_processing}
+            image_error={@image_error}
+            optional
+          >
+            <:actions>
+              <.cover_slot_button phx-click="cancel_pending_image">Remove</.cover_slot_button>
+            </:actions>
+          </.cover_upload>
         </div>
 
         <div class="panel">

--- a/lib/huddlz_web/live/helpers/image_upload_pipeline.ex
+++ b/lib/huddlz_web/live/helpers/image_upload_pipeline.ex
@@ -1,41 +1,104 @@
 defmodule HuddlzWeb.Live.Helpers.ImageUploadPipeline do
   @moduledoc """
   Shared eager-upload pipeline used by the huddl and group new/edit
-  LiveViews. Handles the flow:
+  LiveViews. A chosen file is uploaded at once and prepared as a pending
+  cover before the form is saved:
 
-    1. Consume a just-completed LiveView upload entry
-    2. Copy the file into pending storage
-    3. Create a pending Ash image record
-    4. Assign preview URL / image id to the socket
-    5. On re-upload or cancel, soft-delete the previous pending image
+    1. When the bytes have arrived (`start_eager_upload/2`), the file is
+       copied aside and the entry is kept, so the browser's own preview
+       stays in the slot, and the cover is prepared off the LiveView
+       process with `start_async/3`, so the form stays usable.
+    2. When that finishes (`finish_eager_upload/3`, from `handle_async/3`),
+       the entry is dropped and the pending image id and preview URL are
+       assigned, or the error is.
+    3. On re-upload or cancel, the previous pending image is soft-deleted.
 
   Call sites pass a config map:
 
       %{
         upload_name: :group_image | :huddl_cover_image,
         storage: Huddlz.Storage.GroupImages,   # needs store_pending/3 + url/1
-        create_pending: fn socket, entry, metadata -> {:ok, image} | {:error, reason} end,
+        create_pending: fn actor, entry, metadata -> {:ok, image} | {:error, reason} end,
         cleanup: fn socket, image_id -> :ok end
       }
+
+  The storage module can be swapped per module through the
+  `:image_storage_overrides` application env (a map from module to
+  module), which the browser suite uses to slow preparation down.
   """
 
   import Phoenix.Component, only: [assign: 2, assign: 3]
-  import Phoenix.LiveView, only: [consume_uploaded_entries: 3]
+  import Phoenix.LiveView, only: [cancel_upload: 3, consume_uploaded_entries: 3, start_async: 3]
   import HuddlzWeb.Live.Helpers.UploadHelpers, only: [format_upload_error: 1]
 
-  @doc "Run the eager-upload pipeline and return the updated socket."
-  def process_eager_upload(socket, %{} = config) do
-    socket = cleanup_pending_image(socket, config)
-    socket = assign(socket, :upload_processing, true)
+  @async_name :prepare_cover
 
-    result =
+  @doc "The `handle_async/3` name the pipeline reports back under."
+  def async_name, do: @async_name
+
+  @doc """
+  Copy the finished upload aside, keep its entry for the preview, and
+  prepare the cover off the LiveView process.
+  """
+  def start_eager_upload(socket, %{} = config) do
+    socket = cleanup_pending_image(socket, config)
+    actor = socket.assigns.current_user
+    storage = storage(config)
+
+    copies =
       consume_uploaded_entries(socket, config.upload_name, fn %{path: path}, entry ->
-        store_and_create_pending_image(path, entry, socket, config)
+        copy =
+          Path.join(System.tmp_dir!(), "cover-#{entry.uuid}#{Path.extname(entry.client_name)}")
+
+        File.cp!(path, copy)
+        {:postpone, {copy, entry}}
       end)
 
-    socket
-    |> assign(:upload_processing, false)
-    |> apply_upload_result(result, config)
+    case copies do
+      [{copy, entry}] ->
+        socket
+        |> assign(:upload_processing, true)
+        |> assign(:image_error, nil)
+        |> start_async(@async_name, fn ->
+          prepare(copy, entry, actor, storage, config)
+        end)
+
+      [] ->
+        socket
+    end
+  end
+
+  @doc "Apply the prepared cover, or the error, and drop the kept entry."
+  def finish_eager_upload(socket, result, %{} = config) do
+    consume_uploaded_entries(socket, config.upload_name, fn _meta, _entry -> {:ok, :done} end)
+
+    socket = assign(socket, :upload_processing, false)
+
+    case result do
+      {:ok, {:success, image_id, thumbnail_path}} ->
+        socket
+        |> assign(:pending_image_id, image_id)
+        |> assign(:pending_preview_url, storage(config).url(thumbnail_path))
+        |> assign(:image_error, nil)
+
+      {:ok, {:error, reason}} ->
+        assign(socket, :image_error, format_upload_error(reason))
+
+      {:exit, _reason} ->
+        assign(socket, :image_error, format_upload_error(:failed))
+    end
+  end
+
+  @doc """
+  Cancel entries the browser rules refused, so the slot can take another
+  file. Called from the form's validate event.
+  """
+  def drop_invalid_entries(socket, %{upload_name: name}) do
+    upload = socket.assigns.uploads[name]
+
+    Enum.reduce(upload.entries, socket, fn entry, socket ->
+      if entry.valid?, do: socket, else: cancel_upload(socket, name, entry.ref)
+    end)
   end
 
   @doc "Soft-delete any pending image attached to the socket and clear the preview assigns."
@@ -50,29 +113,23 @@ defmodule HuddlzWeb.Live.Helpers.ImageUploadPipeline do
     end
   end
 
-  defp store_and_create_pending_image(path, entry, socket, config) do
-    with {:ok, metadata} <-
-           config.storage.store_pending(path, entry.client_name, entry.client_type),
-         {:ok, image} <- config.create_pending.(socket, entry, metadata) do
-      {:ok, {:success, image.id, metadata.thumbnail_path}}
-    else
-      {:error, reason} -> {:ok, {:error, reason}}
-    end
+  @doc "The storage module for a config, honouring `:image_storage_overrides`."
+  def storage(%{storage: storage}) do
+    :huddlz
+    |> Application.get_env(:image_storage_overrides, %{})
+    |> Map.get(storage, storage)
   end
 
-  defp apply_upload_result(socket, result, config) do
-    case result do
-      [{:success, image_id, thumbnail_path}] ->
-        socket
-        |> assign(:pending_image_id, image_id)
-        |> assign(:pending_preview_url, config.storage.url(thumbnail_path))
-        |> assign(:image_error, nil)
+  defp prepare(copy, entry, actor, storage, config) do
+    result =
+      with {:ok, metadata} <- storage.store_pending(copy, entry.client_name, entry.client_type),
+           {:ok, image} <- config.create_pending.(actor, entry, metadata) do
+        {:success, image.id, metadata.thumbnail_path}
+      else
+        {:error, reason} -> {:error, reason}
+      end
 
-      [{:error, reason}] ->
-        assign(socket, :image_error, format_upload_error(reason))
-
-      [] ->
-        socket
-    end
+    File.rm(copy)
+    result
   end
 end

--- a/lib/huddlz_web/live/helpers/upload_helpers.ex
+++ b/lib/huddlz_web/live/helpers/upload_helpers.ex
@@ -34,7 +34,7 @@ defmodule HuddlzWeb.Live.Helpers.UploadHelpers do
     do: "Choose a JPG, PNG, or WebP image."
 
   def format_upload_error(:invalid_image),
-    do: "That file could not be read as an image. Choose another JPG, PNG, or WebP image."
+    do: "That file could not be read as an image."
 
   def format_upload_error(msg) when is_binary(msg), do: msg
   def format_upload_error(_), do: "The image could not be uploaded. Please try again."

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -157,30 +157,35 @@ defmodule HuddlzWeb.HuddlLive.Edit do
 
   defp handle_upload_progress(:huddl_cover_image, entry, socket) do
     if entry.done? do
-      {:noreply, process_eager_upload(socket)}
+      {:noreply, ImageUploadPipeline.start_eager_upload(socket, upload_config(socket))}
     else
       {:noreply, socket}
     end
   end
 
-  defp process_eager_upload(socket),
-    do: ImageUploadPipeline.process_eager_upload(socket, upload_config())
+  @impl true
+  def handle_async(:prepare_cover, result, socket) do
+    {:noreply, ImageUploadPipeline.finish_eager_upload(socket, result, upload_config(socket))}
+  end
 
   defp cleanup_pending_image(socket),
-    do: ImageUploadPipeline.cleanup_pending_image(socket, upload_config())
+    do: ImageUploadPipeline.cleanup_pending_image(socket, upload_config(socket))
 
-  defp upload_config do
+  # The pending cover belongs to the group before it belongs to a huddl.
+  defp upload_config(socket) do
+    group_id = socket.assigns.huddl.group.id
+
     %{
       upload_name: :huddl_cover_image,
       storage: HuddlCoverImages,
-      create_pending: &create_pending_huddl_cover_image/3,
+      create_pending: &create_pending_huddl_cover_image(group_id, &1, &2, &3),
       cleanup: &soft_delete_pending_huddl_cover_image/2
     }
   end
 
-  defp create_pending_huddl_cover_image(socket, entry, metadata) do
+  defp create_pending_huddl_cover_image(group_id, actor, entry, metadata) do
     Communities.create_pending_huddl_cover_image(
-      socket.assigns.huddl.group.id,
+      group_id,
       %{
         filename: entry.client_name,
         content_type: entry.client_type,
@@ -188,7 +193,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
         storage_path: metadata.storage_path,
         thumbnail_path: metadata.thumbnail_path
       },
-      actor: socket.assigns.current_user
+      actor: actor
     )
   end
 
@@ -271,14 +276,25 @@ defmodule HuddlzWeb.HuddlLive.Edit do
           </div>
         <% end %>
 
-        <.cover_image_panel upload={@uploads.huddl_cover_image} image_error={@image_error}>
-          <:preview>
-            <.image_preview
-              pending_preview_url={@pending_preview_url}
-              huddl={@huddl}
-              upload_ref={@uploads.huddl_cover_image.ref}
-            />
-          </:preview>
+        <.cover_image_panel
+          id="huddl-cover-upload"
+          upload={@uploads.huddl_cover_image}
+          image_url={cover_url(@pending_preview_url, @huddl)}
+          caption={cover_caption(@pending_preview_url, @huddl)}
+          processing?={@upload_processing}
+          image_error={@image_error}
+        >
+          <:actions>
+            <.cover_slot_button :if={@pending_preview_url} phx-click="cancel_pending_image">
+              Discard
+            </.cover_slot_button>
+            <.cover_slot_button
+              :if={!@pending_preview_url && @huddl.current_image_url}
+              phx-click="remove_current_image"
+            >
+              Remove
+            </.cover_slot_button>
+          </:actions>
         </.cover_image_panel>
 
         <.basics_panel form={@form} />
@@ -348,65 +364,28 @@ defmodule HuddlzWeb.HuddlLive.Edit do
     """
   end
 
-  attr :pending_preview_url, :string, default: nil
-  attr :huddl, :map, required: true
-  attr :upload_ref, :string, required: true
+  # What the slot shows: the new cover, else the huddl's own, else the
+  # group's, which the huddl falls back to.
+  defp cover_url(pending, _huddl) when is_binary(pending), do: pending
 
-  defp image_preview(%{pending_preview_url: url} = assigns) when is_binary(url) do
-    ~H"""
-    <div class="image-preview" phx-drop-target={@upload_ref}>
-      <div class="card-cover" style={"background-image: url('#{@pending_preview_url}')"}></div>
-      <div class="image-preview-foot">
-        <span>New image uploaded. Save to apply.</span>
-        <div class="image-preview-actions">
-          <label for={@upload_ref} class="btn-secondary" style="cursor:pointer">Replace</label>
-          <.button variant={:muted} type="button" phx-click="cancel_pending_image">
-            Discard
-          </.button>
-        </div>
-      </div>
-    </div>
-    """
-  end
+  defp cover_url(_pending, %{current_image_url: url}) when is_binary(url),
+    do: HuddlCoverImages.url(url)
 
-  defp image_preview(%{huddl: %{current_image_url: url}} = assigns) when is_binary(url) do
-    ~H"""
-    <div class="image-preview">
-      <div
-        class="card-cover"
-        style={"background-image: url('#{HuddlCoverImages.url(@huddl.current_image_url)}')"}
-      >
-      </div>
-      <div class="image-preview-foot">
-        <span>Current image.</span>
-        <div class="image-preview-actions">
-          <label for={@upload_ref} class="btn-secondary" style="cursor:pointer">Replace</label>
-          <.button variant={:muted} type="button" phx-click="remove_current_image">
-            Remove
-          </.button>
-        </div>
-      </div>
-    </div>
-    """
-  end
+  defp cover_url(_pending, %{group: %{current_image_url: url}}) when is_binary(url),
+    do: GroupImages.url(url)
 
-  defp image_preview(%{huddl: %{group: %{current_image_url: url}}} = assigns)
-       when is_binary(url) do
-    ~H"""
-    <div class="image-preview">
-      <div
-        class="card-cover"
-        style={"background-image: url('#{GroupImages.url(@huddl.group.current_image_url)}')"}
-      >
-      </div>
-      <div class="image-preview-foot">
-        <span>Using group image — upload one specific to this huddl below.</span>
-      </div>
-    </div>
-    """
-  end
+  defp cover_url(_pending, _huddl), do: nil
 
-  defp image_preview(assigns), do: ~H""
+  defp cover_caption(pending, _huddl) when is_binary(pending),
+    do: "New image uploaded. Save to apply."
+
+  defp cover_caption(_pending, %{current_image_url: url}) when is_binary(url),
+    do: "Current image."
+
+  defp cover_caption(_pending, %{group: %{current_image_url: url}}) when is_binary(url),
+    do: "Using the group's image. Upload one specific to this huddl to replace it here."
+
+  defp cover_caption(_pending, _huddl), do: nil
 
   defp edit_type_value(form) do
     case AshPhoenix.Form.value(form.source, :edit_type) do
@@ -469,7 +448,11 @@ defmodule HuddlzWeb.HuddlLive.Edit do
       |> update_calculated_end_time(params)
 
     form = AshPhoenix.Form.validate(socket.assigns.form, params)
-    {:noreply, assign(socket, :form, to_form(form))}
+
+    {:noreply,
+     socket
+     |> assign(:form, to_form(form))
+     |> ImageUploadPipeline.drop_invalid_entries(upload_config(socket))}
   end
 
   @impl true

--- a/lib/huddlz_web/live/huddl_live/form_helpers.ex
+++ b/lib/huddlz_web/live/huddl_live/form_helpers.ex
@@ -125,6 +125,18 @@ defmodule HuddlzWeb.HuddlLive.FormHelpers do
   end
 
   @doc """
+  Marks the group location as untouched while it is blank and nothing has
+  been picked. Its value travels in a hidden input, which LiveView never
+  reports as unused, so without this the "is required" error would show
+  on the first change to any other field. Submitting sends no marker, so
+  the error still shows then.
+  """
+  def mark_untouched_group_location(%{"location" => ""} = params, nil),
+    do: Map.put(params, "_unused_location", "")
+
+  def mark_untouched_group_location(params, _selected), do: params
+
+  @doc """
   Updates the group form with a resolved home location.
   """
   def apply_group_location_to_form(socket, location) when is_map(location) do

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -102,30 +102,35 @@ defmodule HuddlzWeb.HuddlLive.New do
 
   defp handle_upload_progress(:huddl_cover_image, entry, socket) do
     if entry.done? do
-      {:noreply, process_eager_upload(socket)}
+      {:noreply, ImageUploadPipeline.start_eager_upload(socket, upload_config(socket))}
     else
       {:noreply, socket}
     end
   end
 
-  defp process_eager_upload(socket),
-    do: ImageUploadPipeline.process_eager_upload(socket, upload_config())
+  @impl true
+  def handle_async(:prepare_cover, result, socket) do
+    {:noreply, ImageUploadPipeline.finish_eager_upload(socket, result, upload_config(socket))}
+  end
 
   defp cleanup_pending_image(socket),
-    do: ImageUploadPipeline.cleanup_pending_image(socket, upload_config())
+    do: ImageUploadPipeline.cleanup_pending_image(socket, upload_config(socket))
 
-  defp upload_config do
+  # The pending cover belongs to the group before it belongs to a huddl.
+  defp upload_config(socket) do
+    group_id = socket.assigns.group.id
+
     %{
       upload_name: :huddl_cover_image,
       storage: HuddlCoverImages,
-      create_pending: &create_pending_huddl_cover_image/3,
+      create_pending: &create_pending_huddl_cover_image(group_id, &1, &2, &3),
       cleanup: &soft_delete_pending_huddl_cover_image/2
     }
   end
 
-  defp create_pending_huddl_cover_image(socket, entry, metadata) do
+  defp create_pending_huddl_cover_image(group_id, actor, entry, metadata) do
     Communities.create_pending_huddl_cover_image(
-      socket.assigns.group.id,
+      group_id,
       %{
         filename: entry.client_name,
         content_type: entry.client_type,
@@ -133,7 +138,7 @@ defmodule HuddlzWeb.HuddlLive.New do
         storage_path: metadata.storage_path,
         thumbnail_path: metadata.thumbnail_path
       },
-      actor: socket.assigns.current_user
+      actor: actor
     )
   end
 
@@ -174,34 +179,17 @@ defmodule HuddlzWeb.HuddlLive.New do
 
       <.form for={@form} id="huddl-form" phx-change="validate" phx-submit="save">
         <.cover_image_panel
+          id="huddl-cover-upload"
           upload={@uploads.huddl_cover_image}
+          image_url={@pending_preview_url}
+          caption="Image uploaded · ready to publish."
+          processing?={@upload_processing}
           image_error={@image_error}
           optional
         >
-          <:preview :if={@pending_preview_url} hide_upload_zone>
-            <div class="image-preview" phx-drop-target={@uploads.huddl_cover_image.ref}>
-              <div class="card-cover" style={"background-image: url('#{@pending_preview_url}')"}>
-              </div>
-              <div
-                class="muted"
-                style="display:flex; justify-content:space-between; align-items:center; font-size:12px; margin-top:10px"
-              >
-                <span>Image uploaded · ready to publish.</span>
-                <div style="display:flex; gap:8px">
-                  <label
-                    for={@uploads.huddl_cover_image.ref}
-                    class="btn-secondary"
-                    style="cursor:pointer"
-                  >
-                    Replace
-                  </label>
-                  <.button variant={:muted} type="button" phx-click="cancel_pending_image">
-                    Remove
-                  </.button>
-                </div>
-              </div>
-            </div>
-          </:preview>
+          <:actions>
+            <.cover_slot_button phx-click="cancel_pending_image">Remove</.cover_slot_button>
+          </:actions>
         </.cover_image_panel>
 
         <.basics_panel form={@form} />
@@ -317,7 +305,11 @@ defmodule HuddlzWeb.HuddlLive.New do
       |> update_calculated_end_time(params)
 
     form = AshPhoenix.Form.validate(socket.assigns.form, params)
-    {:noreply, assign(socket, :form, to_form(form))}
+
+    {:noreply,
+     socket
+     |> assign(:form, to_form(form))
+     |> ImageUploadPipeline.drop_invalid_entries(upload_config(socket))}
   end
 
   @impl true

--- a/test/browser/features/cover_upload_progress.feature
+++ b/test/browser/features/cover_upload_progress.feature
@@ -1,0 +1,12 @@
+@browser_smoke @upload_browser
+Feature: Cover upload in progress
+  The cover slot on the group form must hold its place while a picture
+  is chosen, uploaded and prepared, and the rest of the form must stay
+  usable the whole time. That depends on the upload JavaScript, so it is
+  checked in a real browser.
+
+  Scenario: Choosing a picture fills the slot at once and nothing else moves
+    Given I am creating a group in a browser where preparing a cover takes a moment
+    When I choose a picture for the cover
+    Then the slot shows my picture with the upload in progress and the form is still usable
+    And the slot settles on the prepared cover without moving

--- a/test/browser/steps/cover_upload_progress_steps.exs
+++ b/test/browser/steps/cover_upload_progress_steps.exs
@@ -1,0 +1,106 @@
+defmodule BrowserCoverUploadSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+
+  alias Huddlz.Storage.GroupImages
+
+  step "I am creating a group in a browser where preparing a cover takes a moment", context do
+    owner = generate(user(role: :user))
+
+    # Preparing the cover normally takes a few hundred milliseconds; hold it
+    # for a moment so the in-progress state is there to be observed.
+    Application.put_env(:huddlz, :image_storage_overrides, %{
+      GroupImages => Huddlz.Test.SlowGroupImages
+    })
+
+    ExUnit.Callbacks.on_exit(fn ->
+      Application.delete_env(:huddlz, :image_storage_overrides)
+      File.rm_rf!("priv/static/uploads/group_images/pending")
+    end)
+
+    conn =
+      context.conn
+      |> sign_in(owner)
+      |> visit("/groups/new")
+      |> assert_has(".phx-connected")
+      |> assert_has("#group-cover-upload[data-state=idle]")
+
+    # Remember where the slot and the name field sit before anything happens.
+    assert_browser(conn, """
+    (() => {
+      const slot = document.querySelector('#group-cover-upload .cover-slot').getBoundingClientRect();
+      const name = document.querySelector('#group-form input[name="form[name]"]').getBoundingClientRect();
+      window.__coverBefore = {slot: [slot.top, slot.height, slot.width], name: [name.top, name.height]};
+      return slot.height > 100 && Math.abs(slot.width / slot.height - 16 / 9) < 0.02;
+    })()
+    """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I choose a picture for the cover", context do
+    assert {:ok, _} =
+             PlaywrightEx.Frame.set_input_files(context.conn.frame_id,
+               selector: "#group-cover-upload input[type=file]",
+               timeout: 5_000,
+               local_paths: [Path.expand("test/fixtures/test_image.jpg")]
+             )
+
+    context
+  end
+
+  step "the slot shows my picture with the upload in progress and the form is still usable",
+       context do
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const root = document.querySelector('#group-cover-upload');
+        if (!root || root.dataset.state !== 'uploading') return false;
+        const img = root.querySelector('.cover-slot img');
+        const bar = root.querySelector('.cover-slot-bar');
+        const slot = root.querySelector('.cover-slot').getBoundingClientRect();
+        const name = document.querySelector('#group-form input[name="form[name]"]');
+        const before = window.__coverBefore;
+        return img && img.src.startsWith('blob:') && img.complete && img.naturalWidth > 0 &&
+          bar && bar.getBoundingClientRect().bottom <= slot.bottom + 1 &&
+          Math.abs(slot.top - before.slot[0]) < 1 && Math.abs(slot.height - before.slot[1]) < 1 &&
+          !name.disabled && !document.querySelector('#group-form [disabled]') &&
+          Math.abs(name.getBoundingClientRect().top - before.name[0]) < 1;
+      })()
+      """)
+
+    # Typing while the cover is prepared must work.
+    conn =
+      conn
+      |> fill_in("Group name", with: "Typed while uploading")
+      |> assert_has("#group-cover-upload[data-state=uploading]")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the slot settles on the prepared cover without moving", context do
+    conn =
+      context.conn
+      |> assert_has(
+        "#group-cover-upload[data-state=uploaded] .cover-slot img[src*='group_images']"
+      )
+      |> assert_browser("""
+      (() => {
+        const root = document.querySelector('#group-cover-upload');
+        const img = root.querySelector('.cover-slot img');
+        const slot = root.querySelector('.cover-slot').getBoundingClientRect();
+        const before = window.__coverBefore;
+        return img.complete && img.naturalWidth > 0 &&
+          Math.abs(slot.top - before.slot[0]) < 1 && Math.abs(slot.height - before.slot[1]) < 1 &&
+          !root.querySelector('.cover-slot-bar') &&
+          document.querySelector('#group-form input[name="form[name]"]').value === 'Typed while uploading';
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+end

--- a/test/features/group_image.feature
+++ b/test/features/group_image.feature
@@ -38,11 +38,25 @@ Feature: Group Image Management
     And I fill in "Description" with "A group with an image"
     And I select "Saint Augustine, FL, USA" as the group city in "America/New_York"
     And I upload "test/fixtures/test_image.jpg" to "Cover image"
-    Then I should see "Image uploaded"
+    Then the cover slot shows the picture as it will appear on the group
+    And I should see "Image uploaded"
     When I click "Create group"
     Then I should see "Group created successfully"
     And I should see "Image Test Group"
     And the group "Image Test Group" should have an image
+
+  Scenario: A file that is not an image is refused inside the cover slot and the form stays usable
+    Given I am signed in as "group-image-owner@example.com"
+    When I visit "/groups/new"
+    And I upload "test/fixtures/corrupt_image.jpg" to "Cover image"
+    Then the cover slot says "That file could not be read as an image."
+    And the cover slot still offers to browse for another
+    When I fill in "Group name" with "Still Usable Group"
+    And I fill in "Description" with "The form survived a bad file"
+    And I select "Saint Augustine, FL, USA" as the group city in "America/New_York"
+    And I click "Create group"
+    Then I should see "Group created successfully"
+    And the group "Still Usable Group" should not have an image
 
   Scenario: Canceling a pending image before saving group
     Given I am signed in as "group-image-owner@example.com"

--- a/test/features/step_definitions/group_image_steps.exs
+++ b/test/features/step_definitions/group_image_steps.exs
@@ -69,7 +69,7 @@ defmodule GroupImageSteps do
   step "I upload {string} to {string}", %{args: [file_path, label]} = context do
     session = context[:session] || context[:conn]
     session = upload(session, label, file_path, exact: false)
-    Phoenix.LiveViewTest.render_async(session.view)
+    Phoenix.LiveViewTest.render_async(session.view, 5_000)
     Map.merge(context, %{session: session, conn: session})
   end
 

--- a/test/features/step_definitions/group_image_steps.exs
+++ b/test/features/step_definitions/group_image_steps.exs
@@ -64,20 +64,47 @@ defmodule GroupImageSteps do
     |> Map.put(:current_group, group)
   end
 
+  # The bytes arrive synchronously here; the cover is then prepared off the
+  # LiveView process, so wait for that before looking at the slot.
   step "I upload {string} to {string}", %{args: [file_path, label]} = context do
     session = context[:session] || context[:conn]
     session = upload(session, label, file_path, exact: false)
+    Phoenix.LiveViewTest.render_async(session.view)
     Map.merge(context, %{session: session, conn: session})
   end
 
   step "I cancel the pending image", context do
     session = context[:session] || context[:conn]
 
-    # Scope to the pending image preview so we only see its Remove button
+    # Scope to the cover slot so we only see its Remove button
     # (other "Remove" controls may exist elsewhere on the page).
-    session = within(session, ".image-preview", fn scoped -> click_button(scoped, "Remove") end)
+    session = within(session, ".cover-upload", fn scoped -> click_button(scoped, "Remove") end)
 
     Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "the cover slot shows the picture as it will appear on the group", context do
+    session = context[:session] || context[:conn]
+
+    session
+    |> assert_has(".cover-upload[data-state=uploaded] .cover-slot img[src*='group_images']")
+    |> assert_has(".cover-upload[data-state=uploaded] .cover-slot-actions label", text: "Replace")
+    |> assert_has(".cover-upload[data-state=uploaded] .cover-slot-actions button", text: "Remove")
+    |> refute_has(".cover-upload .cover-slot-bar")
+
+    context
+  end
+
+  step "the cover slot says {string}", %{args: [message]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, ".cover-upload[data-state=error] .cover-slot-error", text: message)
+    context
+  end
+
+  step "the cover slot still offers to browse for another", context do
+    session = context[:session] || context[:conn]
+    assert_has(session, ".cover-upload[data-state=error] .cover-slot label", text: "browse")
+    context
   end
 
   # ===== Then Steps =====

--- a/test/huddlz_web/live/group_live/new_test.exs
+++ b/test/huddlz_web/live/group_live/new_test.exs
@@ -1,0 +1,37 @@
+defmodule HuddlzWeb.GroupLive.NewTest do
+  use HuddlzWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  describe "location errors" do
+    setup %{conn: conn} do
+      owner = generate(user(role: :user))
+      %{conn: login(conn, owner)}
+    end
+
+    test "changing another field does not fault the untouched location", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/groups/new")
+
+      # The location travels in a hidden input, so a change to any field
+      # carries it along, blank; the browser marks the untouched textarea
+      # unused, which this does by hand.
+      html =
+        render_change(view, "validate", %{
+          "form" => %{"name" => "Founder Coffee", "location" => "", "_unused_description" => ""}
+        })
+
+      refute html =~ "is required"
+    end
+
+    test "submitting without a location shows the error", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/groups/new")
+
+      html =
+        view
+        |> form("#group-form", form: %{name: "Founder Coffee", description: "Weekly coffee"})
+        |> render_submit()
+
+      assert html =~ "is required"
+    end
+  end
+end

--- a/test/huddlz_web/live/group_live_image_test.exs
+++ b/test/huddlz_web/live/group_live_image_test.exs
@@ -81,7 +81,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("test_banner.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show "Image uploaded" confirmation
       html = render(view)
@@ -123,7 +123,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("banner.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Submit form
       view
@@ -163,7 +163,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("to_cancel.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show uploaded
       assert render(view) =~ "Image uploaded"
@@ -190,7 +190,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("first.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Capture the first image ID from the database
       first_images =
@@ -212,7 +212,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("second.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Check that the first image is now soft-deleted
       reloaded_first = Ash.get!(GroupImage, first_image.id, authorize?: false)
@@ -236,7 +236,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("preserved.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show uploaded
       assert render(view) =~ "Image uploaded"
@@ -337,7 +337,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("new_banner.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       html = render(view)
       assert html =~ "New image uploaded. Save to apply."
@@ -358,7 +358,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("save_test.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Submit form
       view
@@ -417,7 +417,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("replacement.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show pending preview
       assert render(view) =~ "New image uploaded"
@@ -566,7 +566,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("orphan.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Navigate away (implicit - just don't submit)
       # The pending image should exist with nil group_id

--- a/test/huddlz_web/live/group_live_image_test.exs
+++ b/test/huddlz_web/live/group_live_image_test.exs
@@ -30,7 +30,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
       select_group_location(view)
 
       assert has_element?(view, ".panel-head h2", "Cover image")
-      assert has_element?(view, ".upload-zone")
+      assert has_element?(view, ".cover-upload[data-state=idle]")
       assert has_element?(view, "*", "Drop a 16:9 image")
       assert has_element?(view, "*", "JPG, PNG, WebP · 5 MB max")
     end
@@ -81,6 +81,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("test_banner.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show "Image uploaded" confirmation
       html = render(view)
@@ -122,6 +123,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("banner.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Submit form
       view
@@ -161,6 +163,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("to_cancel.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show uploaded
       assert render(view) =~ "Image uploaded"
@@ -187,6 +190,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("first.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Capture the first image ID from the database
       first_images =
@@ -208,6 +212,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("second.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Check that the first image is now soft-deleted
       reloaded_first = Ash.get!(GroupImage, first_image.id, authorize?: false)
@@ -231,6 +236,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("preserved.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show uploaded
       assert render(view) =~ "Image uploaded"
@@ -290,7 +296,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         |> live(~p"/groups/#{group.slug}/edit")
 
       assert has_element?(view, "h2", "Cover image")
-      assert has_element?(view, ".upload-zone")
+      assert has_element?(view, ".cover-upload[data-state=idle]")
     end
 
     test "shows current image when group has one", %{conn: conn, owner: owner, group: group} do
@@ -331,6 +337,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("new_banner.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       html = render(view)
       assert html =~ "New image uploaded. Save to apply."
@@ -351,6 +358,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("save_test.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Submit form
       view
@@ -409,6 +417,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("replacement.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show pending preview
       assert render(view) =~ "New image uploaded"
@@ -530,8 +539,8 @@ defmodule HuddlzWeb.GroupLiveImageTest do
 
       assert updated_group.current_image_url == nil
       refute has_element?(view, "#remove-group-image-dialog")
-      refute has_element?(view, ".image-preview", "Current image")
-      assert has_element?(view, ".upload-zone", "Drop a 16:9 image")
+      refute has_element?(view, ".cover-upload", "Current image")
+      assert has_element?(view, ".cover-upload[data-state=idle]", "Drop a 16:9 image")
       assert has_element?(view, "*", "Image removed")
     end
   end
@@ -557,6 +566,7 @@ defmodule HuddlzWeb.GroupLiveImageTest do
         }
       ])
       |> render_upload("orphan.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Navigate away (implicit - just don't submit)
       # The pending image should exist with nil group_id

--- a/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
@@ -89,11 +89,12 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         }
       ])
       |> render_upload("test_banner.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show "Image uploaded" confirmation
       html = render(view)
       assert html =~ "Image uploaded"
-      refute has_element?(view, ".upload-zone")
+      refute has_element?(view, ".cover-upload[data-state=idle]")
 
       # Should have created a pending image record
       pending_count =
@@ -125,6 +126,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         }
       ])
       |> render_upload("banner.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show uploaded confirmation
       assert render(view) =~ "Image uploaded"
@@ -174,6 +176,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         }
       ])
       |> render_upload("to_cancel.jpg")
+      |> then(fn _ -> render_async(view) end)
 
       # Should show uploaded
       assert render(view) =~ "Image uploaded"

--- a/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
+++ b/test/huddlz_web/live/huddl_live/new_image_upload_test.exs
@@ -89,7 +89,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         }
       ])
       |> render_upload("test_banner.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show "Image uploaded" confirmation
       html = render(view)
@@ -126,7 +126,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         }
       ])
       |> render_upload("banner.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show uploaded confirmation
       assert render(view) =~ "Image uploaded"
@@ -176,7 +176,7 @@ defmodule HuddlzWeb.HuddlLive.NewImageUploadTest do
         }
       ])
       |> render_upload("to_cancel.jpg")
-      |> then(fn _ -> render_async(view) end)
+      |> then(fn _ -> render_async(view, 5_000) end)
 
       # Should show uploaded
       assert render(view) =~ "Image uploaded"

--- a/test/support/slow_group_images.ex
+++ b/test/support/slow_group_images.ex
@@ -1,0 +1,19 @@
+defmodule Huddlz.Test.SlowGroupImages do
+  @moduledoc """
+  `Huddlz.Storage.GroupImages` with a pause before preparing a pending
+  cover, so a browser scenario can observe the in-progress state of the
+  cover slot. Selected through `:image_storage_overrides`; see
+  `HuddlzWeb.Live.Helpers.ImageUploadPipeline`.
+  """
+
+  alias Huddlz.Storage.GroupImages
+
+  @pause_ms 1_500
+
+  def store_pending(source_path, original_filename, content_type) do
+    Process.sleep(@pause_ms)
+    GroupImages.store_pending(source_path, original_filename, content_type)
+  end
+
+  defdelegate url(path), to: GroupImages
+end


### PR DESCRIPTION
## Summary

Closes #486.

Choosing a cover on the group form broke the page: the browser's preview was an absolutely positioned image dropped under a dropzone that stayed put, the finished cover came back as a 140px strip, and the 16:9 version was made on the LiveView process, so the form froze while it ran. Direction chosen on the design canvas (Create a group · Cover states, plus the phone board): one slot that never changes size, with every state drawn inside it.

- **One cover slot** (`cover_upload/1`) for the group and huddl create and edit forms, at the cover's 16:9 ratio. Idle it is the dashed prompt; a file dragged over it lights it cyan through LiveView's own drop-target class.
- **Uploading.** The browser's preview of the chosen file fills the slot at once, with the file name, size, percentage and a Cancel over the bottom edge. When the bytes are in, the bar reads "Preparing the cover…" while the server makes the 16:9 version. Nothing else on the form moves or disables.
- **Uploaded.** The cover exactly as the card and page will show it, with Replace and the form's own action (Remove, Discard, or Save and Remove on the group edit page) over the corner, and the existing caption under it.
- **Error.** The message lives in the slot, with a way to choose another file, and the form is untouched. A file the image library cannot read now says so instead of leaking the library's own message ("Failed to find load buffer"). A file the browser rules refuse is cleared the next time the form changes, so the slot can take another.
- **Off the LiveView process.** The pipeline copies the finished upload aside, keeps the entry so the preview stays in the slot, and prepares the cover with `start_async`; `handle_async` applies the result and drops the entry. The storage module is resolvable through `:image_storage_overrides`, which only the browser suite sets.

## Verification

- Feature `group_image.feature`: creating a group with a picture now checks the slot shows the stored cover with Replace and Remove and no progress bar left over; a new scenario uploads a file that is not an image, sees the message inside the slot with the browse offer, fills in the rest of the form and creates the group without a cover. The upload step waits for the async preparation.
- Browser scenario `cover_upload_progress.feature`, with preparation held for a moment through the storage override: after choosing a picture the slot holds the browser's own decoded preview with the progress bar inside it, the slot and the name field have not moved, nothing is disabled, typing into the name works, and the slot then settles on the stored cover in the same place with the typed name intact.
- Existing group and huddl image scenarios and LiveView tests pass with the new selectors and an `render_async` after each upload.
- `mix precommit` clean, exit code checked directly.

Screenshots in the comments.
