### PR TITLE
ci: add a CI gate job for branch protection to require

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -251,3 +251,21 @@ jobs:
           _build/browser/traces
         if-no-files-found: ignore
         retention-days: 7
+
+  # One stable check for branch protection to require, whatever the OTP
+  # and Elixir matrix is called this month. Runs even when a job it
+  # depends on fails, and fails with it.
+  ci:
+    name: CI
+    needs: [dependency-audit, test, seeds, browser]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every job to have passed
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "$RESULTS"
+          if echo "$RESULTS" | grep -Eq 'failure|cancelled|skipped'; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

The main ruleset now requires the four CI checks by name. Two of those names carry the OTP and Elixir versions from the workflow matrix, so a version bump would rename them and block every merge until the ruleset was edited to match.

This adds a `CI` job that depends on all four, runs even when one of them fails (`if: always()`), and exits non-zero if any result is not success. Once it has reported on this PR, the ruleset can require `CI` alone.

## Verification

The job's result on this PR: green when the other four are green. Requiring it in the ruleset is a settings change made after this lands.