### PR TITLE
feat(notifications): give every email one layout

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -160,16 +160,14 @@ Unsubscribe links in email footers deep-link to a confirmation page, then a POST
 
 Rules every `Huddlz.Notifications.Senders.*` module follows. New senders should be cargo-cultable from any existing one.
 
-### HTML escaping
+### One layout
 
-Every user-controlled string interpolated into `html_body` MUST go through `Huddlz.Notifications.Senders.HtmlEscape.escape/1`. This includes display names, email addresses, and any value that originated outside the sender module. Plain-text bodies use the raw value.
+Every sender builds its email through `Huddlz.Notifications.Layout.email/1` and describes the message as pieces: a kicker, one title, paragraphs (strings or `{:strong, text}` / `{:link, text, url}` segments), an optional facts block, at most one `{label, url}` action, an optional aside, and a footer. The layout renders the HTML (one 600px table, inline styles, light only) and the plain-text body from the same pieces, so the two cannot drift, and escapes every string itself, so senders pass raw values and never build markup. Huddl emails pass `Layout.huddl_facts/1` (the huddl row or the payload) so they carry what the huddl card carries: when in the huddl's own time zone, where, and the group. The design lives on the canvas as the "Email" sheet.
 
 ### Footer
 
-- **Transactional** senders: no footer. There is no preference toggle, so an unsubscribe link would be misleading.
-- **Activity** senders: include `<hr/>` + a settings link + an unsubscribe link. Generate the unsubscribe token via `Huddlz.Notifications.unsubscribe_token(user, trigger)` so the route flips the right preference key.
-
-(When the second activity sender lands, lift the inline footer HTML into a shared helper — until then, inline keeps the diff small.)
+- **Transactional** senders: `Footer.account/1` with a one-line reason and no links. There is no preference toggle, so an unsubscribe link would be misleading; the word "unsubscribe" must not appear.
+- **Activity** senders: `Footer.activity(user, trigger)`, which adds the settings link and a per-trigger unsubscribe link built from `Huddlz.Notifications.unsubscribe_token(user, trigger)` so the route flips the right preference key.
 
 ### Recovery advice in security notices
 
@@ -194,6 +192,8 @@ Each sender test should at minimum assert:
 - a body keyword that anchors the message
 - `<script>` payload in display name is HTML-escaped
 - `refute email.text_body =~ "<"` — no markup leaks into plain text
+
+`test/huddlz/notifications/senders/layout_coverage_test.exs` walks the trigger registry and the auth and invitation emails and checks each renders through the layout with a footer; a new sender needs a payload there.
 
 ## Testing
 

--- a/lib/huddlz/accounts/user/senders/send_new_user_confirmation_email.ex
+++ b/lib/huddlz/accounts/user/senders/send_new_user_confirmation_email.ex
@@ -6,26 +6,35 @@ defmodule Huddlz.Accounts.User.Senders.SendNewUserConfirmationEmail do
   use AshAuthentication.Sender
   use HuddlzWeb, :verified_routes
 
-  import Swoosh.Email
-
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def send(user, token, _) do
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject("Confirm your email address")
-    |> html_body(body(token: token))
+    user
+    |> build(token)
     |> Mailer.deliver!()
   end
 
-  defp body(params) do
-    url = url(~p"/confirm_new_user/#{params[:token]}")
+  @doc "The email, for tests and samples."
+  def build(user, token) do
+    confirm_url = url(~p"/confirm_new_user/#{token}")
 
-    """
-    <p>Click this link to confirm your email:</p>
-    <p><a href="#{url}">#{url}</a></p>
-    """
+    Layout.email(%{
+      to: user.email,
+      subject: "Confirm your email address",
+      kicker: "Welcome to huddlz",
+      title: "Confirm your email address",
+      paragraphs: [
+        "One quick step and your account is ready: confirm that this address is yours."
+      ],
+      action: {"Confirm my email", confirm_url},
+      aside: "If you didn't create a huddlz account, you can ignore this email.",
+      footer:
+        Footer.account(
+          "You're receiving this email because an account was created with this address."
+        )
+    })
   end
 end

--- a/lib/huddlz/accounts/user/senders/send_password_reset_email.ex
+++ b/lib/huddlz/accounts/user/senders/send_password_reset_email.ex
@@ -1,31 +1,45 @@
 defmodule Huddlz.Accounts.User.Senders.SendPasswordResetEmail do
   @moduledoc """
-  Sends a password reset email
+  Sends a password reset email.
   """
 
   use AshAuthentication.Sender
   use HuddlzWeb, :verified_routes
 
-  import Swoosh.Email
-
   alias Huddlz.Mailer
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def send(user, token, _) do
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject("Reset your password")
-    |> html_body(body(token: token))
+    user
+    |> build(token)
     |> Mailer.deliver!()
   end
 
-  defp body(params) do
-    url = url(~p"/reset/#{params[:token]}")
+  @doc "The email, for tests and samples."
+  def build(user, token) do
+    reset_url = url(~p"/reset/#{token}")
 
-    """
-    <p>Click this link to reset your password:</p>
-    <p><a href="#{url}">#{url}</a></p>
-    """
+    Layout.email(%{
+      to: user.email,
+      subject: "Reset your password",
+      kicker: "Your account",
+      title: "Reset your password",
+      paragraphs: [
+        [
+          "Someone asked to reset the password for the huddlz account at ",
+          {:strong, to_string(user.email)},
+          ". If that was you, choose a new password with the button below."
+        ]
+      ],
+      action: {"Reset password", reset_url},
+      aside:
+        "If you didn't ask for this, you can ignore this email; your password stays as it is.",
+      footer:
+        Footer.account(
+          "You're receiving this email because a password reset was requested for this address."
+        )
+    })
   end
 end

--- a/lib/huddlz/communities/group_invitation/email_worker.ex
+++ b/lib/huddlz/communities/group_invitation/email_worker.ex
@@ -2,14 +2,12 @@ defmodule Huddlz.Communities.GroupInvitation.EmailWorker do
   @moduledoc "Delivers new-recipient invitations with retry, without creating placeholder accounts."
   use Oban.Worker, queue: :notifications, max_attempts: 5, unique: [period: 60]
 
-  import Swoosh.Email
-
   alias Huddlz.Accounts.User
   alias Huddlz.Communities.GroupInvitation
   alias Huddlz.Communities.GroupInvitation.EmailToken
   alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
   alias HuddlzWeb.Endpoint
 
   @impl true
@@ -32,6 +30,31 @@ defmodule Huddlz.Communities.GroupInvitation.EmailWorker do
     end
   end
 
+  @doc "The email for an invitation to an address without an account, for tests and samples."
+  def build(invitation) do
+    url = Endpoint.url() <> "/invitations/email/" <> EmailToken.sign(invitation)
+    name = to_string(invitation.group.name)
+    inviter = invitation.inviter.display_name
+
+    Layout.email(%{
+      to: invitation.email,
+      subject: "Invitation to #{name}",
+      kicker: "Invitation",
+      title: "#{inviter} invited you to #{name}",
+      paragraphs: [
+        [{:strong, inviter}, " invited you to join ", {:strong, name}, " on huddlz."],
+        "Register or sign in with this email address to review the invitation and accept or decline. Joining is always your choice."
+      ],
+      action: {"Review invitation", url},
+      aside:
+        "This invitation expires after 7 days. If you weren't expecting it, you can ignore this email.",
+      footer:
+        Footer.account(
+          "You're receiving this email because someone invited this address to a group on huddlz."
+        )
+    })
+  end
+
   defp deliver_if_allowed(invitation) do
     # Registration may happen while this email waits. Confirmation makes the
     # invitation available in-app and queues the normal registered-user email,
@@ -47,32 +70,7 @@ defmodule Huddlz.Communities.GroupInvitation.EmailWorker do
   end
 
   defp deliver(invitation) do
-    url = Endpoint.url() <> "/invitations/email/" <> EmailToken.sign(invitation)
-    name = to_string(invitation.group.name)
-    inviter = invitation.inviter.display_name
-
-    email =
-      new()
-      |> from(Mailer.from())
-      |> to(to_string(invitation.email))
-      |> subject(HeaderSafe.safe("Invitation to #{name}"))
-      |> text_body("""
-      #{inviter} invited you to join "#{name}" on huddlz.
-      Register or sign in with this email address to review and accept or decline.
-      This invitation expires after 7 days. Joining is always your choice.
-      Review invitation: #{url}
-      If you weren't expecting this invitation, you can ignore this email.
-      """)
-      |> html_body("""
-      <p>#{HtmlEscape.escape(inviter)} invited you to join
-      <strong>#{HtmlEscape.escape(name)}</strong> on huddlz.</p>
-      <p>Register or sign in with this email address to review and accept or decline.</p>
-      <p>This invitation expires after 7 days. Joining is always your choice.</p>
-      <p><a href="#{HtmlEscape.escape(url)}">Review invitation</a></p>
-      <p>If you weren't expecting this invitation, you can ignore this email.</p>
-      """)
-
-    case Mailer.deliver(email) do
+    case invitation |> build() |> Mailer.deliver() do
       {:ok, _result} -> :ok
       {:error, reason} -> {:error, reason}
     end

--- a/lib/huddlz/communities/huddl/changes/notify_cancelled.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_cancelled.ex
@@ -38,7 +38,10 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyCancelled do
       "huddl_id" => huddl.id,
       "huddl_title" => to_string(huddl.title),
       "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
+      "ends_at_iso" => huddl.ends_at && DateTime.to_iso8601(huddl.ends_at),
       "time_zone" => huddl.time_zone,
+      "event_type" => to_string(huddl.event_type),
+      "physical_location" => huddl.physical_location,
       "group_name" => to_string(huddl.group.name),
       "group_slug" => to_string(huddl.group.slug),
       "cancellation_reason" =>

--- a/lib/huddlz/communities/huddl/changes/notify_new_in_group.ex
+++ b/lib/huddlz/communities/huddl/changes/notify_new_in_group.ex
@@ -58,7 +58,10 @@ defmodule Huddlz.Communities.Huddl.Changes.NotifyNewInGroup do
       "huddl_id" => huddl.id,
       "huddl_title" => to_string(huddl.title),
       "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
+      "ends_at_iso" => huddl.ends_at && DateTime.to_iso8601(huddl.ends_at),
       "time_zone" => huddl.time_zone,
+      "event_type" => to_string(huddl.event_type),
+      "physical_location" => huddl.physical_location,
       "group_name" => to_string(huddl.group.name),
       "group_slug" => to_string(huddl.group.slug)
     }

--- a/lib/huddlz/notifications/footer.ex
+++ b/lib/huddlz/notifications/footer.ex
@@ -1,10 +1,13 @@
 defmodule Huddlz.Notifications.Footer do
   @moduledoc """
-  Shared unsubscribe / settings footer markup for Activity emails.
+  The footer every email ends with: why the person is receiving it and,
+  for activity emails, the unsubscribe and settings links. Returns the
+  footer spec `Huddlz.Notifications.Layout` renders in both bodies.
 
-  Builds a per-trigger unsubscribe URL from `Notifications.unsubscribe_token/2`
-  and a link to the notification settings page. Returned as `{html, text}`
-  so senders can splice both bodies.
+  Activity emails get `activity/2`, which builds a per-trigger unsubscribe
+  URL from `Notifications.unsubscribe_token/2`. Transactional emails get
+  `account/1` with a plain reason and no links, since there is no
+  preference to switch off.
   """
 
   use HuddlzWeb, :verified_routes
@@ -12,32 +15,24 @@ defmodule Huddlz.Notifications.Footer do
   alias Huddlz.Accounts.User
   alias Huddlz.Notifications
 
-  @doc """
-  Returns `{html_footer, text_footer}` for the given user + trigger.
-  """
-  @spec build(User.t(), atom()) :: {String.t(), String.t()}
-  def build(%User{} = user, trigger) when is_atom(trigger) do
+  @activity_reason "You're receiving this email because of your huddlz notification settings."
+  @account_reason "You're receiving this email because it concerns your huddlz account."
+
+  @spec activity(User.t(), atom()) :: Notifications.Layout.footer()
+  def activity(%User{} = user, trigger) when is_atom(trigger) do
     token = Notifications.unsubscribe_token(user, trigger)
-    unsub_url = url(~p"/unsubscribe/#{token}")
-    settings_url = url(~p"/profile/notifications")
 
-    html = """
-    <hr/>
-    <p style="font-size: 0.85em; color: #666;">
-      You're receiving this email because of your huddlz notification settings.
-      <a href="#{unsub_url}">Unsubscribe from this kind of email</a>
-      or <a href="#{settings_url}">manage all your preferences</a>.
-    </p>
-    """
+    %{
+      reason: @activity_reason,
+      links: [
+        {"Unsubscribe from this kind of email", url(~p"/unsubscribe/#{token}")},
+        {"Manage all your preferences", url(~p"/profile/notifications")}
+      ]
+    }
+  end
 
-    text = """
-
-    ---
-    You're receiving this email because of your huddlz notification settings.
-    Unsubscribe from this kind of email: #{unsub_url}
-    Manage all your preferences: #{settings_url}
-    """
-
-    {html, text}
+  @spec account(String.t()) :: Notifications.Layout.footer()
+  def account(reason \\ @account_reason) when is_binary(reason) do
+    %{reason: reason, links: []}
   end
 end

--- a/lib/huddlz/notifications/layout.ex
+++ b/lib/huddlz/notifications/layout.ex
@@ -1,0 +1,422 @@
+defmodule Huddlz.Notifications.Layout do
+  @moduledoc """
+  The one layout every outbound email wears, rendered as HTML and plain
+  text from the same pieces so the two can never drift.
+
+  A sender describes the email and gets a `Swoosh.Email` back:
+
+      Layout.email(%{
+        to: user.email,
+        subject: "Tomorrow: \#{huddl.title}",
+        kicker: "Reminder · tomorrow",
+        title: "\#{huddl.title} starts tomorrow",
+        paragraphs: [["Hi \#{name}, you're going to ", {:strong, huddl.title}, "."]],
+        facts: Layout.huddl_facts(huddl),
+        action: {"Open the huddl", url},
+        aside: "The calendar event is attached.",
+        footer: Footer.activity(user, :huddl_reminder_24h)
+      })
+
+  Pieces, in the order they render:
+
+    * `kicker` — one short line above the title, optional.
+    * `title` — the one heading.
+    * `paragraphs` — each a string or a list of segments: a string,
+      `{:strong, text}` or `{:link, text, url}`.
+    * `facts` — `{label, value}` or `{label, value, sub}` rows, optional.
+      Huddl emails use `huddl_facts/1` so they carry what the card carries.
+    * `action` — `{label, url}`, at most one button, optional.
+    * `aside` — a quiet paragraph under the button, optional.
+    * `footer` — `%{reason: text, links: [{label, url}]}`, see
+      `Huddlz.Notifications.Footer`.
+
+  Every string is escaped here, so senders pass raw values. The HTML is
+  one 600px table on the light theme colours with inline styles and a
+  system font stack; there is no dark variant because client support for
+  it is unreliable. The subject goes through `HeaderSafe`.
+  """
+
+  import Swoosh.Email
+
+  alias Huddlz.Communities.Huddl
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.DateTimeFormatter
+  alias Huddlz.Notifications.Senders.HeaderSafe
+
+  @type segment :: String.t() | {:strong, String.t()} | {:link, String.t(), String.t()}
+  @type paragraph :: String.t() | [segment()]
+  @type fact :: {String.t(), String.t()} | {String.t(), String.t(), String.t() | nil}
+  @type footer :: %{reason: String.t(), links: [{String.t(), String.t()}]}
+  @type spec :: %{
+          required(:title) => String.t(),
+          optional(:kicker) => String.t() | nil,
+          optional(:paragraphs) => [paragraph()],
+          optional(:facts) => [fact()],
+          optional(:action) => {String.t(), String.t()} | nil,
+          optional(:aside) => paragraph() | nil,
+          optional(:footer) => footer() | nil,
+          optional(:preheader) => String.t() | nil
+        }
+
+  @font "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+  @bg "#f4f7f7"
+  @panel "#ffffff"
+  @panel2 "#eef3f3"
+  @line "#dde5e6"
+  @text "#0f1a1b"
+  @soft "#3f4f52"
+  @muted "#5c6b6e"
+  @accent "#0b7c83"
+  @ink "#0a6c72"
+  @on_accent "#ffffff"
+
+  @doc """
+  Builds the `Swoosh.Email` for a spec that also carries `:to` and
+  `:subject`. `from` is `Mailer.from/0`.
+  """
+  @spec email(map()) :: Swoosh.Email.t()
+  def email(%{to: to, subject: subject} = spec) do
+    {html, text} = render(spec)
+
+    new()
+    |> from(Mailer.from())
+    |> to(to_string(to))
+    |> subject(HeaderSafe.safe(subject))
+    |> html_body(html)
+    |> text_body(text)
+  end
+
+  @doc "Renders `{html, text}` for a spec."
+  @spec render(spec()) :: {String.t(), String.t()}
+  def render(spec) do
+    {html(spec), text(spec)}
+  end
+
+  @doc """
+  The facts a huddl email carries, the same three as the huddl card:
+  when in the huddl's own time zone, where, and the group. Takes the
+  `Huddl` row (with `group` loaded) or a notification payload.
+  """
+  @spec huddl_facts(Huddl.t() | map()) :: [fact()]
+  def huddl_facts(%Huddl{} = huddl) do
+    when_fact(huddl.starts_at, huddl.ends_at, huddl.time_zone) ++
+      where_fact(huddl.physical_location, huddl.event_type) ++
+      group_fact(huddl.group && huddl.group.name)
+  end
+
+  def huddl_facts(payload) when is_map(payload) do
+    time_zone = DateTimeFormatter.time_zone_from_payload(payload)
+
+    when_fact(parse_iso(payload["starts_at_iso"]), parse_iso(payload["ends_at_iso"]), time_zone) ++
+      where_fact(payload["physical_location"], payload["event_type"]) ++
+      group_fact(payload["group_name"])
+  end
+
+  # ── HTML ─────────────────────────────────────────────────────────
+
+  defp html(spec) do
+    title = esc(spec.title)
+
+    """
+    <!doctype html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
+    <title>#{title}</title>
+    </head>
+    <body style="margin:0;padding:0;background-color:#{@bg};">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">#{esc(preheader(spec))}</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#{@bg};">
+    <tr><td align="center" style="padding:24px 16px;">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px;max-width:100%;">
+    <tr><td style="background-color:#{@panel};border:1px solid #{@line};border-radius:12px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr><td style="padding:20px 32px;border-bottom:1px solid #{@line};">
+    #{brand_html()}
+    </td></tr>
+    <tr><td style="padding:28px 32px 32px;font-family:#{@font};">
+    #{kicker_html(spec[:kicker])}<h1 style="margin:0 0 16px;font-family:#{@font};font-size:22px;font-weight:700;line-height:1.25;letter-spacing:-0.01em;color:#{@text};">#{title}</h1>
+    #{paragraphs_html(spec[:paragraphs] || [])}#{facts_html(spec[:facts] || [])}#{action_html(spec[:action])}#{aside_html(spec[:aside])}
+    </td></tr>
+    </table>
+    </td></tr>
+    <tr><td style="padding:20px 32px 0;font-family:#{@font};font-size:12px;line-height:1.6;color:#{@muted};">
+    #{footer_html(spec[:footer])}
+    </td></tr>
+    </table>
+    </td></tr>
+    </table>
+    </body>
+    </html>
+    """
+  end
+
+  defp brand_html do
+    """
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
+    <td width="32" height="32" align="center" valign="middle" style="width:32px;height:32px;background-color:#{@accent};border-radius:8px;color:#{@on_accent};font-family:#{@font};font-size:17px;font-weight:700;line-height:32px;">h</td>
+    <td style="padding-left:10px;font-family:#{@font};font-size:16px;font-weight:700;letter-spacing:-0.01em;color:#{@text};">huddlz</td>
+    </tr></table>
+    """
+  end
+
+  defp kicker_html(nil), do: ""
+  defp kicker_html(""), do: ""
+
+  defp kicker_html(kicker) do
+    ~s(<p style="margin:0 0 8px;font-size:12px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#{@muted};">#{esc(kicker)}</p>\n)
+  end
+
+  defp paragraphs_html(paragraphs) do
+    Enum.map_join(paragraphs, "", fn paragraph ->
+      ~s(<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#{@soft};">#{segments_html(paragraph)}</p>\n)
+    end)
+  end
+
+  defp segments_html(text) when is_binary(text), do: esc(text)
+
+  defp segments_html(segments) when is_list(segments),
+    do: Enum.map_join(segments, "", &segment_html/1)
+
+  defp segment_html(text) when is_binary(text), do: esc(text)
+
+  defp segment_html({:strong, text}),
+    do: ~s(<strong style="font-weight:600;color:#{@text};">#{esc(text)}</strong>)
+
+  defp segment_html({:link, text, url}),
+    do:
+      ~s(<a href="#{esc(url)}" style="color:#{@ink};text-decoration:underline;">#{esc(text)}</a>)
+
+  defp facts_html([]), do: ""
+
+  defp facts_html(facts) do
+    last = length(facts) - 1
+
+    rows =
+      facts
+      |> Enum.with_index()
+      |> Enum.map_join("", fn {fact, index} ->
+        {label, value, sub} = normalize_fact(fact)
+        border = if index == last, do: "", else: "border-bottom:1px solid #{@line};"
+
+        sub_html =
+          if sub,
+            do:
+              ~s(<br><span style="font-size:13px;font-weight:400;color:#{@muted};">#{esc(sub)}</span>),
+            else: ""
+
+        """
+        <tr>
+        <td valign="top" width="64" style="width:64px;padding:12px 16px 12px 0;#{border}font-family:#{@font};font-size:12px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:#{@muted};">#{esc(label)}</td>
+        <td valign="top" style="padding:12px 0;#{border}font-family:#{@font};font-size:15px;font-weight:600;line-height:1.4;color:#{@text};">#{esc(value)}#{sub_html}</td>
+        </tr>
+        """
+      end)
+
+    """
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px;background-color:#{@panel2};border-radius:10px;">
+    <tr><td style="padding:4px 20px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    #{rows}</table>
+    </td></tr>
+    </table>
+    """
+  end
+
+  defp action_html(nil), do: ""
+
+  defp action_html({label, url}) do
+    """
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:4px 0 16px;">
+    <tr><td style="background-color:#{@accent};border-radius:8px;">
+    <a href="#{esc(url)}" style="display:inline-block;padding:13px 22px;font-family:#{@font};font-size:15px;font-weight:700;color:#{@on_accent};text-decoration:none;">#{esc(label)}</a>
+    </td></tr>
+    </table>
+    """
+  end
+
+  defp aside_html(nil), do: ""
+  defp aside_html(""), do: ""
+
+  defp aside_html(aside) do
+    ~s(<p style="margin:0;font-size:13px;line-height:1.5;color:#{@muted};">#{segments_html(aside)}</p>\n)
+  end
+
+  defp footer_html(nil), do: ~s(<p style="margin:0;">huddlz · #{esc(support_address())}</p>)
+
+  defp footer_html(%{reason: reason} = footer) do
+    links =
+      footer
+      |> Map.get(:links, [])
+      |> Enum.map_join(" · ", fn {label, url} ->
+        ~s(<a href="#{esc(url)}" style="color:#{@ink};text-decoration:underline;">#{esc(label)}</a>)
+      end)
+
+    line = if links == "", do: esc(reason), else: "#{esc(reason)} #{links}."
+
+    """
+    <p style="margin:0 0 6px;">#{line}</p>
+    <p style="margin:0;">huddlz · #{esc(support_address())}</p>
+    """
+  end
+
+  # ── Plain text ───────────────────────────────────────────────────
+
+  defp text(spec) do
+    [
+      "huddlz",
+      "",
+      kicker_text(spec[:kicker]),
+      spec.title,
+      "",
+      paragraphs_text(spec[:paragraphs] || []),
+      facts_text(spec[:facts] || []),
+      action_text(spec[:action]),
+      aside_text(spec[:aside]),
+      "--",
+      footer_text(spec[:footer])
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+    |> Kernel.<>("\n")
+  end
+
+  defp kicker_text(nil), do: nil
+  defp kicker_text(""), do: nil
+  defp kicker_text(kicker), do: String.upcase(kicker)
+
+  defp paragraphs_text(paragraphs) do
+    Enum.map(paragraphs, fn paragraph -> [segments_text(paragraph), ""] end)
+  end
+
+  defp segments_text(text) when is_binary(text), do: text
+
+  defp segments_text(segments) when is_list(segments),
+    do: Enum.map_join(segments, "", &segment_text/1)
+
+  defp segment_text(text) when is_binary(text), do: text
+  defp segment_text({:strong, text}), do: text
+  defp segment_text({:link, text, url}) when text == url, do: url
+  defp segment_text({:link, text, url}), do: "#{text} (#{url})"
+
+  defp facts_text([]), do: nil
+
+  defp facts_text(facts) do
+    facts = Enum.map(facts, &normalize_fact/1)
+    width = facts |> Enum.map(fn {label, _, _} -> String.length(label) end) |> Enum.max()
+
+    lines =
+      Enum.map(facts, fn {label, value, sub} ->
+        String.pad_trailing("#{label}:", width + 2) <> value <> if(sub, do: " (#{sub})", else: "")
+      end)
+
+    lines ++ [""]
+  end
+
+  defp action_text(nil), do: nil
+  defp action_text({label, url}), do: ["#{label}: #{url}", ""]
+
+  defp aside_text(nil), do: nil
+  defp aside_text(""), do: nil
+  defp aside_text(aside), do: [segments_text(aside), ""]
+
+  defp footer_text(nil), do: "huddlz · #{support_address()}"
+
+  defp footer_text(%{reason: reason} = footer) do
+    links = footer |> Map.get(:links, []) |> Enum.map(fn {label, url} -> "#{label}: #{url}" end)
+    [reason | links] ++ ["huddlz · #{support_address()}"]
+  end
+
+  # ── Facts helpers ────────────────────────────────────────────────
+
+  defp when_fact(nil, _ends_at, _time_zone), do: []
+
+  defp when_fact(%DateTime{} = starts_at, ends_at, time_zone) do
+    [
+      {"When", DateTimeFormatter.format_starts_at(starts_at, time_zone),
+       duration(starts_at, ends_at)}
+    ]
+  end
+
+  defp duration(%DateTime{} = starts_at, %DateTime{} = ends_at) do
+    minutes = DateTime.diff(ends_at, starts_at, :minute)
+
+    cond do
+      minutes <= 0 -> nil
+      minutes < 60 -> "#{minutes} minutes"
+      rem(minutes, 60) == 0 -> plural(div(minutes, 60), "hour")
+      true -> "#{plural(div(minutes, 60), "hour")} #{rem(minutes, 60)} minutes"
+    end
+  end
+
+  defp duration(_, _), do: nil
+
+  defp plural(1, word), do: "1 #{word}"
+  defp plural(n, word), do: "#{n} #{word}s"
+
+  defp where_fact(place, event_type) do
+    virtual? = to_string(event_type) in ["virtual", "hybrid"]
+
+    cond do
+      present?(place) and virtual? -> [{"Where", place, "Also online"}]
+      present?(place) -> [{"Where", place}]
+      virtual? -> [{"Where", "Online"}]
+      true -> []
+    end
+  end
+
+  defp group_fact(name) do
+    if present?(name), do: [{"Group", to_string(name)}], else: []
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(value), do: not is_nil(value) and present?(to_string(value))
+
+  defp parse_iso(iso) when is_binary(iso) do
+    case DateTime.from_iso8601(iso) do
+      {:ok, datetime, _} -> datetime
+      _ -> nil
+    end
+  end
+
+  defp parse_iso(_), do: nil
+
+  defp normalize_fact({label, value}), do: {to_string(label), to_string(value), nil}
+
+  defp normalize_fact({label, value, sub}),
+    do: {to_string(label), to_string(value), if(present?(sub), do: to_string(sub), else: nil)}
+
+  defp preheader(spec) do
+    case spec[:preheader] do
+      nil -> spec.title
+      text -> text
+    end
+  end
+
+  defp support_address, do: elem(Mailer.from(), 1)
+
+  # Escapes `& < > "`; apostrophes stay readable because every attribute
+  # in the layout is double-quoted.
+  defp esc(value) do
+    value
+    |> to_string()
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+    |> String.replace("&#39;", "'")
+  end
+
+  defp sentence(text) do
+    case String.split(text, "", parts: 2, trim: true) do
+      [first, rest] -> String.upcase(first) <> rest
+      [first] -> String.upcase(first)
+      [] -> ""
+    end
+  end
+
+  @doc "Upcases the first character, for a title built from a lowercase fallback."
+  def sentence_case(text), do: sentence(to_string(text))
+end

--- a/lib/huddlz/notifications/senders/account_role_changed.ex
+++ b/lib/huddlz/notifications/senders/account_role_changed.ex
@@ -1,81 +1,40 @@
 defmodule Huddlz.Notifications.Senders.AccountRoleChanged do
   @moduledoc """
-  Sender for A5: an admin changed this user's account role.
+  Sender for A3: an administrator changed the recipient's account role.
 
-  Activity-category email — respects the user's notification preferences and
-  includes an unsubscribe link in the footer.
+  Activity category — preferences and the unsubscribe footer apply.
+
+  Payload keys: `"new_role"`, `"previous_role"` (optional).
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, payload) do
     new_role = payload["new_role"] || to_string(user.role)
     previous_role = payload["previous_role"]
 
-    ctx = %{
-      name: user.display_name,
-      new_role: new_role,
-      previous_role: previous_role,
-      settings_url: url(~p"/profile/notifications"),
-      unsubscribe_url:
-        url(~p"/unsubscribe/#{Notifications.unsubscribe_token(user, :account_role_changed)}")
-    }
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject("Your huddlz account role was updated")
-    |> html_body(html_body(ctx))
-    |> text_body(text_body(ctx))
+    Layout.email(%{
+      to: user.email,
+      subject: "Your huddlz account role was updated",
+      kicker: "Your account",
+      title: "Your account role is now #{new_role}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, an administrator just updated your huddlz account role "
+          | change_phrase(previous_role, new_role)
+        ],
+        "If this looks wrong, reply to this email and we'll sort it out."
+      ],
+      footer: Footer.activity(user, :account_role_changed)
+    })
   end
 
-  defp html_body(ctx) do
-    """
-    <p>Hi #{HtmlEscape.escape(ctx.name)},</p>
+  defp change_phrase(nil, new_role), do: ["to ", {:strong, new_role}, "."]
 
-    <p>An administrator just updated your huddlz account role #{html_change_phrase(ctx)}.</p>
-
-    <p>If this looks wrong, reply to this email and we'll sort it out.</p>
-
-    <hr/>
-    <p style="font-size: 0.85em; color: #666;">
-      You're receiving this because role-change notifications are on.
-      <a href="#{ctx.settings_url}">Manage notification settings</a> ·
-      <a href="#{ctx.unsubscribe_url}">Unsubscribe from these</a>
-    </p>
-    """
-  end
-
-  defp text_body(ctx) do
-    """
-    Hi #{ctx.name},
-
-    An administrator just updated your huddlz account role #{text_change_phrase(ctx)}.
-
-    If this looks wrong, reply to this email and we'll sort it out.
-
-    --
-    You're receiving this because role-change notifications are on.
-    Manage notification settings: #{ctx.settings_url}
-    Unsubscribe from these: #{ctx.unsubscribe_url}
-    """
-  end
-
-  defp html_change_phrase(%{previous_role: nil, new_role: new}),
-    do: "to <strong>#{HtmlEscape.escape(new)}</strong>"
-
-  defp html_change_phrase(%{previous_role: prev, new_role: new}),
-    do:
-      "from <strong>#{HtmlEscape.escape(prev)}</strong> to <strong>#{HtmlEscape.escape(new)}</strong>"
-
-  defp text_change_phrase(%{previous_role: nil, new_role: new}), do: "to #{new}"
-  defp text_change_phrase(%{previous_role: prev, new_role: new}), do: "from #{prev} to #{new}"
+  defp change_phrase(previous_role, new_role),
+    do: ["from ", {:strong, previous_role}, " to ", {:strong, new_role}, "."]
 end

--- a/lib/huddlz/notifications/senders/email_changed.ex
+++ b/lib/huddlz/notifications/senders/email_changed.ex
@@ -18,104 +18,58 @@ defmodule Huddlz.Notifications.Senders.EmailChanged do
 
   @behaviour Huddlz.Notifications.Sender
 
-  use HuddlzWeb, :verified_routes
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @subject "Your huddlz email address was changed"
 
   @impl true
   def build(user, %{"audience" => "old"} = payload) do
-    old_email = payload["old_email"]
-    new_email = to_string(user.email)
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_new_email = HtmlEscape.escape(new_email)
-
-    new()
-    |> from(Mailer.from())
     # Recipient header injection is prevented by the `User.email` regex constraint
     # rejecting whitespace (CR/LF). Swoosh does not sanitize recipient strings.
-    |> to(old_email)
-    |> subject(@subject)
-    |> html_body(html_old(safe_name, safe_new_email))
-    |> text_body(text_old(user.display_name, new_email))
+    Layout.email(%{
+      to: payload["old_email"],
+      subject: @subject,
+      kicker: "Security notice",
+      title: "Your email address was changed",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, this is a security notice: the email address on your huddlz account was just changed to ",
+          {:strong, to_string(user.email)},
+          "."
+        ],
+        "If this was you, no action is needed. Future emails from huddlz will go to your new address.",
+        [
+          "If this ",
+          {:strong, "wasn't"},
+          " you, contact support right away so we can restore access. Resetting your password won't help here: the reset email would go to the new address, not this one."
+        ]
+      ],
+      footer: Footer.account()
+    })
   end
 
   def build(user, %{"audience" => "new"} = payload) do
-    old_email = payload["old_email"]
-    new_email = to_string(user.email)
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_old_email = HtmlEscape.escape(old_email)
-
-    new()
-    |> from(Mailer.from())
-    |> to(new_email)
-    |> subject(@subject)
-    |> html_body(html_new(safe_name, safe_old_email))
-    |> text_body(text_new(user.display_name, old_email))
+    Layout.email(%{
+      to: user.email,
+      subject: @subject,
+      kicker: "Your account",
+      title: "This is now your huddlz email address",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, this email address is now associated with your huddlz account. The previous address on file was ",
+          {:strong, payload["old_email"]},
+          "."
+        ],
+        "If you didn't make this change, contact support right away: someone else may have access to your account."
+      ],
+      footer: Footer.account()
+    })
   end
 
   def build(_user, payload) do
     raise ArgumentError,
           "EmailChanged sender received an unknown audience in payload: #{inspect(payload)}. " <>
             "Expected `audience: \"old\"` or `audience: \"new\"`."
-  end
-
-  defp html_old(safe_name, safe_new_email) do
-    """
-    <p>Hi #{safe_name},</p>
-
-    <p>This is a security notice — the email address on your huddlz account was
-    just changed to <strong>#{safe_new_email}</strong>.</p>
-
-    <p>If this was you, no action is needed. Future emails from huddlz will
-    go to your new address.</p>
-
-    <p>If this <strong>wasn't</strong> you, contact support right away so we
-    can restore access. Resetting your password won't help here — the reset
-    email would go to the new address, not this one.</p>
-    """
-  end
-
-  defp text_old(name, new_email) do
-    """
-    Hi #{name},
-
-    This is a security notice — the email address on your huddlz account was
-    just changed to #{new_email}.
-
-    If this was you, no action is needed. Future emails from huddlz will go to
-    your new address.
-
-    If this wasn't you, contact support right away so we can restore access.
-    Resetting your password won't help here — the reset email would go to the
-    new address, not this one.
-    """
-  end
-
-  defp html_new(safe_name, safe_old_email) do
-    """
-    <p>Hi #{safe_name},</p>
-
-    <p>This email address is now associated with your huddlz account.
-    The previous address on file was <strong>#{safe_old_email}</strong>.</p>
-
-    <p>If you didn't make this change, contact support right away — someone
-    else may have access to your account.</p>
-    """
-  end
-
-  defp text_new(name, old_email) do
-    """
-    Hi #{name},
-
-    This email address is now associated with your huddlz account. The
-    previous address on file was #{old_email}.
-
-    If you didn't make this change, contact support right away — someone
-    else may have access to your account.
-    """
   end
 end

--- a/lib/huddlz/notifications/senders/group_archived.ex
+++ b/lib/huddlz/notifications/senders/group_archived.ex
@@ -1,75 +1,57 @@
 defmodule Huddlz.Notifications.Senders.GroupArchived do
   @moduledoc """
-  Sends group archival and permanent deletion notices.
+  Sender for B6: a group the recipient belongs to was archived, or
+  deleted outright. Transactional.
 
-  Sent to every member of the group at the moment of deletion.
-  Transactional — preferences do not apply, no unsubscribe footer.
-
-  Required payload keys:
-
-    * `"group_name"` — display name of the group at the time of removal.
+  An archive carries `"archived_at"` and `"group_slug"`; the group's
+  history stays reachable. A deletion carries neither.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, %{"archived_at" => _, "group_slug" => slug} = payload) do
-    group_url = url(~p"/groups/#{slug}")
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("#{group_name(payload)} has been archived"))
-    |> html_body("""
-    <p>Hi #{HtmlEscape.escape(user.display_name)},</p>
-    <p>The group <strong>#{HtmlEscape.escape(group_name(payload))}</strong> has been archived on huddlz.</p>
-    <p>New activity is closed. Your membership and the group's history are preserved. The owner can restore the group later.</p>
-    <p><a href="#{HtmlEscape.escape(group_url)}">View group history</a></p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    The group "#{group_name(payload)}" has been archived on huddlz.
-    New activity is closed. Your membership and the group's history are preserved.
-    The owner can restore the group later.
-
-    View group history: #{group_url}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "#{group_name(payload)} has been archived",
+      kicker: "Archived",
+      title: Layout.sentence_case("#{group_name(payload)} has been archived"),
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, the group ",
+          {:strong, group_name(payload)},
+          " has been archived on huddlz."
+        ],
+        "New activity is closed. Your membership and the group's history are preserved, and the owner can restore the group later."
+      ],
+      action: {"View group history", url(~p"/groups/#{slug}")},
+      footer:
+        Footer.account("You're receiving this email because you are a member of this group.")
+    })
   end
 
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
-    groups_url = url(~p"/discover?#{[scope: "groups"]}")
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("#{group_name(payload)} has been deleted"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>The group <strong>#{safe_group}</strong> has been deleted on
-    huddlz. You no longer have access to its huddlz or member-only
-    content.</p>
-
-    <p>Browse other groups at <a href="#{groups_url}">#{groups_url}</a>.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    The group "#{group_name(payload)}" has been deleted on huddlz. You no longer
-    have access to its huddlz or member-only content.
-
-    Browse other groups at #{groups_url}.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "#{group_name(payload)} has been deleted",
+      kicker: "Deleted",
+      title: Layout.sentence_case("#{group_name(payload)} has been deleted"),
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, the group ",
+          {:strong, group_name(payload)},
+          " has been deleted on huddlz. You no longer have access to its huddlz or member-only content."
+        ]
+      ],
+      action: {"Browse other groups", url(~p"/discover?#{[scope: "groups"]}")},
+      footer:
+        Footer.account("You're receiving this email because you were a member of this group.")
+    })
   end
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name

--- a/lib/huddlz/notifications/senders/group_invitation.ex
+++ b/lib/huddlz/notifications/senders/group_invitation.ex
@@ -1,16 +1,16 @@
 defmodule Huddlz.Notifications.Senders.GroupInvitation do
   @moduledoc """
-  Email for an actionable private-group invitation.
+  Email for an actionable private-group invitation to a registered user.
+
+  Activity category — preferences and the unsubscribe footer apply.
+
+  Payload keys: `"group_name"`, `"inviter_name"`, `"role"`, `"invitation_id"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias HuddlzWeb.Endpoint
 
   @impl true
@@ -18,32 +18,29 @@ defmodule Huddlz.Notifications.Senders.GroupInvitation do
     group_name = Map.get(payload, "group_name", "a private group")
     inviter_name = Map.get(payload, "inviter_name", "A group organizer")
     role = Map.get(payload, "role", "member")
-    invitation_url = url("/invitations/#{payload["invitation_id"]}")
-    safe_invitation_url = HtmlEscape.escape(invitation_url)
-    {footer_html, footer_text} = Footer.build(user, :group_invitation)
 
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Invitation to #{group_name}"))
-    |> html_body("""
-    <p>Hi #{HtmlEscape.escape(user.display_name)},</p>
-
-    <p>#{HtmlEscape.escape(inviter_name)} invited you to join
-    <strong>#{HtmlEscape.escape(group_name)}</strong> as a
-    #{HtmlEscape.escape(role)}.</p>
-
-    <p><a href="#{safe_invitation_url}">Review invitation</a></p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    #{inviter_name} invited you to join "#{group_name}" as a #{role}.
-    Review the invitation: #{invitation_url}
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Invitation to #{group_name}",
+      kicker: "Invitation",
+      title: "#{inviter_name} invited you to #{group_name}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, inviter_name},
+          " invited you to join ",
+          {:strong, group_name},
+          " as #{article(role)} #{role}. It is a private group on huddlz."
+        ],
+        "Joining is always your choice."
+      ],
+      action: {"Review invitation", Endpoint.url() <> "/invitations/#{payload["invitation_id"]}"},
+      aside: "If you weren't expecting this invitation, you can ignore this email.",
+      footer: Footer.activity(user, :group_invitation)
+    })
   end
 
-  defp url(path), do: Endpoint.url() <> path
+  defp article(word) do
+    if String.starts_with?(to_string(word), ["a", "e", "i", "o", "u"]), do: "an", else: "a"
+  end
 end

--- a/lib/huddlz/notifications/senders/group_member_added.ex
+++ b/lib/huddlz/notifications/senders/group_member_added.ex
@@ -15,42 +15,27 @@ defmodule Huddlz.Notifications.Senders.GroupMemberAdded do
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
-    group_url = Urls.group_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :group_member_added)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("You're now a member of #{group_name(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>You've been added to the group <strong>#{safe_group}</strong> on
-    huddlz. Visit the group page at
-    <a href="#{group_url}">#{group_url}</a> to see upcoming huddlz and
-    say hello.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    You've been added to the group "#{group_name(payload)}" on huddlz.
-    Visit the group page at #{group_url} to see upcoming huddlz and say hello.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "You're now a member of #{group_name(payload)}",
+      kicker: "Welcome",
+      title: "You're now a member of #{group_name(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, you've been added to ",
+          {:strong, group_name(payload)},
+          " on huddlz. Visit the group page to see upcoming huddlz and say hello."
+        ]
+      ],
+      action: {"Open the group", Urls.group_url(payload)},
+      footer: Footer.activity(user, :group_member_added)
+    })
   end
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name

--- a/lib/huddlz/notifications/senders/group_member_joined.ex
+++ b/lib/huddlz/notifications/senders/group_member_joined.ex
@@ -1,57 +1,37 @@
 defmodule Huddlz.Notifications.Senders.GroupMemberJoined do
   @moduledoc """
-  Sender for B1: a user joined a public group.
+  Sender for B1: someone joined a group the recipient organizes.
 
-  Sent to each owner/organizer of the group (deduplicated, actor
-  excluded). Activity category — preferences and the unsubscribe footer
-  apply.
+  Activity category — preferences and the unsubscribe footer apply.
 
-  Required payload keys:
-
-    * `"group_id"` — used to render the group page link.
-    * `"group_name"` — display name of the group.
-    * `"group_slug"` — slug used in the group page URL.
-    * `"joiner_display_name"` — name of the user who joined.
+  Payload keys: `"group_name"`, `"group_slug"`, `"joiner_display_name"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
-    safe_joiner = HtmlEscape.escape(joiner_display_name(payload))
-    group_url = Urls.group_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :group_member_joined)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("#{joiner_display_name(payload)} joined #{group_name(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p><strong>#{safe_joiner}</strong> just joined your group
-    <strong>#{safe_group}</strong>. Say hi or check out the group page
-    at <a href="#{group_url}">#{group_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    #{joiner_display_name(payload)} just joined your group "#{group_name(payload)}".
-    Say hi or check out the group page at #{group_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "#{joiner_display_name(payload)} joined #{group_name(payload)}",
+      kicker: "New member",
+      title: "#{joiner_display_name(payload)} joined #{group_name(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, joiner_display_name(payload)},
+          " just joined your group ",
+          {:strong, group_name(payload)},
+          ". Say hi or check out the group page."
+        ]
+      ],
+      action: {"Open the group", Urls.group_url(payload)},
+      footer: Footer.activity(user, :group_member_joined)
+    })
   end
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name

--- a/lib/huddlz/notifications/senders/group_member_removed.ex
+++ b/lib/huddlz/notifications/senders/group_member_removed.ex
@@ -1,53 +1,36 @@
 defmodule Huddlz.Notifications.Senders.GroupMemberRemoved do
   @moduledoc """
-  Sender for B3: a user has been removed from a group.
+  Sender for B4: the recipient was removed from a group. Transactional.
 
-  Sent to the removed user. Transactional — preferences do not apply,
-  no unsubscribe footer.
-
-  Required payload keys:
-
-    * `"group_name"` — display name of the group at the time of removal.
+  Payload keys: `"group_name"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
-    groups_url = url(~p"/discover?#{[scope: "groups"]}")
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("You were removed from #{group_name(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>You have been removed from the group <strong>#{safe_group}</strong>
-    on huddlz. You no longer have access to its member-only content.</p>
-
-    <p>If you think this was a mistake, reach out to the group's owner
-    directly. You can browse other groups at
-    <a href="#{groups_url}">#{groups_url}</a>.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    You have been removed from the group "#{group_name(payload)}" on huddlz.
-    You no longer have access to its member-only content.
-
-    If you think this was a mistake, reach out to the group's owner directly.
-    Browse other groups at #{groups_url}.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "You were removed from #{group_name(payload)}",
+      kicker: "Membership",
+      title: "You were removed from #{group_name(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, you have been removed from ",
+          {:strong, group_name(payload)},
+          " on huddlz. You no longer have access to its member-only content."
+        ],
+        "If you think this was a mistake, reach out to the group's owner directly."
+      ],
+      action: {"Browse other groups", url(~p"/discover?#{[scope: "groups"]}")},
+      footer:
+        Footer.account("You're receiving this email because you were a member of this group.")
+    })
   end
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name

--- a/lib/huddlz/notifications/senders/group_ownership_transferred.ex
+++ b/lib/huddlz/notifications/senders/group_ownership_transferred.ex
@@ -1,102 +1,70 @@
 defmodule Huddlz.Notifications.Senders.GroupOwnershipTransferred do
   @moduledoc """
-  Sender for B7: ownership of a group was transferred.
+  Sender for B7: ownership of a group moved. Two audiences, both
+  transactional: the previous owner (`role: "previous_owner"`, the
+  default) and the new owner (`role: "new_owner"`).
 
-  Sent to both the previous owner and the new owner. Transactional —
-  preferences do not apply, no unsubscribe footer.
-
-  Required payload keys:
-
-    * `"group_id"` — used for fallback links.
-    * `"group_name"` — display name of the group.
-    * `"group_slug"` — slug for the group page URL.
-    * `"role"` — `"previous_owner"` or `"new_owner"` — used to pick the
-      correct copy for the recipient.
-    * `"new_owner_display_name"` — name of the new owner (used when
-      addressing the previous owner).
-    * `"previous_owner_display_name"` — name of the previous owner
-      (used when addressing the new owner).
+  Payload keys: `"group_name"`, `"group_slug"`, `"role"`,
+  `"new_owner_display_name"`, `"previous_owner_display_name"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    role = payload["role"] || "previous_owner"
-
-    case role do
+    case payload["role"] || "previous_owner" do
       "new_owner" -> build_new_owner(user, payload)
       _ -> build_previous_owner(user, payload)
     end
   end
 
   defp build_previous_owner(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
-    safe_new_owner = HtmlEscape.escape(payload["new_owner_display_name"] || "another member")
-    group_url = Urls.group_url(payload)
+    new_owner = payload["new_owner_display_name"] || "another member"
 
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("You transferred #{group_name(payload)} to a new owner"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>You've transferred ownership of <strong>#{safe_group}</strong> to
-    <strong>#{safe_new_owner}</strong>. You're still part of the group as
-    an organizer and can step away or rejoin anytime.</p>
-
-    <p>The group page is at <a href="#{group_url}">#{group_url}</a>.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    You've transferred ownership of "#{group_name(payload)}" to #{payload["new_owner_display_name"] || "another member"}.
-    You're still part of the group as an organizer and can step away or rejoin anytime.
-
-    The group page is at #{group_url}.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "You transferred #{group_name(payload)} to a new owner",
+      kicker: "Ownership",
+      title: "#{group_name(payload)} has a new owner",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, you've transferred ownership of ",
+          {:strong, group_name(payload)},
+          " to ",
+          {:strong, new_owner},
+          ". You're still part of the group as an organizer and can step away or rejoin anytime."
+        ]
+      ],
+      action: {"Open the group", Urls.group_url(payload)},
+      footer: Footer.account("You're receiving this email because you owned this group.")
+    })
   end
 
   defp build_new_owner(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
+    previous_owner = payload["previous_owner_display_name"] || "The previous owner"
 
-    safe_prev_owner =
-      HtmlEscape.escape(payload["previous_owner_display_name"] || "the previous owner")
-
-    group_url = Urls.group_url(payload)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("You're the new owner of #{group_name(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p><strong>#{safe_prev_owner}</strong> has transferred ownership of
-    <strong>#{safe_group}</strong> to you. The group is now yours to
-    manage.</p>
-
-    <p>Open the group page at <a href="#{group_url}">#{group_url}</a> to
-    review members, organizers, and upcoming huddlz.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    #{payload["previous_owner_display_name"] || "The previous owner"} has transferred ownership of "#{group_name(payload)}" to you.
-    The group is now yours to manage.
-
-    Open the group page at #{group_url} to review members, organizers, and upcoming huddlz.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "You're the new owner of #{group_name(payload)}",
+      kicker: "Ownership",
+      title: "You're the new owner of #{group_name(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, previous_owner},
+          " has transferred ownership of ",
+          {:strong, group_name(payload)},
+          " to you. The group is now yours to manage."
+        ],
+        "Open the group page to review members, organizers, and upcoming huddlz."
+      ],
+      action: {"Open the group", Urls.group_url(payload)},
+      footer: Footer.account("You're receiving this email because you now own this group.")
+    })
   end
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name

--- a/lib/huddlz/notifications/senders/group_role_changed.ex
+++ b/lib/huddlz/notifications/senders/group_role_changed.ex
@@ -1,60 +1,42 @@
 defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
   @moduledoc """
-  Sender for B4: a user's role within a group has changed.
+  Sender for B5: the recipient's role in a group changed.
 
-  Sent to the user whose role changed. Activity category — preferences
-  and the unsubscribe footer apply.
+  Activity category — preferences and the unsubscribe footer apply.
 
-  Required payload keys:
-
-    * `"group_id"` — used for fallback links.
-    * `"group_name"` — display name of the group.
-    * `"group_slug"` — slug for the group page URL.
-    * `"previous_role"` — role string the user used to have.
-    * `"new_role"` — role string the user now has.
+  Payload keys: `"group_name"`, `"group_slug"`, `"previous_role"`, `"new_role"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_group = HtmlEscape.escape(group_name(payload))
-    safe_prev = HtmlEscape.escape(role_label(role_value(payload, "previous_role")))
-    safe_new = HtmlEscape.escape(role_label(role_value(payload, "new_role")))
-    group_url = Urls.group_url(payload)
+    previous = role_label(role_value(payload, "previous_role"))
+    new_role = role_label(role_value(payload, "new_role"))
 
-    {footer_html, footer_text} = Footer.build(user, :group_role_changed)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Your role in #{group_name(payload)} changed"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>Your role in <strong>#{safe_group}</strong> changed from
-    <strong>#{safe_prev}</strong> to <strong>#{safe_new}</strong>.</p>
-
-    <p>Visit the group at <a href="#{group_url}">#{group_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    Your role in "#{group_name(payload)}" changed from #{role_label(role_value(payload, "previous_role"))} to #{role_label(role_value(payload, "new_role"))}.
-
-    Visit the group at #{group_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Your role in #{group_name(payload)} changed",
+      kicker: "Your role",
+      title: "You're now #{article(new_role)} #{new_role} of #{group_name(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, your role in ",
+          {:strong, group_name(payload)},
+          " changed from ",
+          {:strong, previous},
+          " to ",
+          {:strong, new_role},
+          "."
+        ]
+      ],
+      action: {"Open the group", Urls.group_url(payload)},
+      footer: Footer.activity(user, :group_role_changed)
+    })
   end
 
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
@@ -63,11 +45,15 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChanged do
   defp role_value(payload, key) do
     case Map.get(payload, key) do
       value when is_binary(value) -> value
-      value when is_atom(value) -> Atom.to_string(value)
+      value when is_atom(value) and not is_nil(value) -> Atom.to_string(value)
       _ -> ""
     end
   end
 
   defp role_label(""), do: "member"
   defp role_label(role), do: role
+
+  defp article(word) do
+    if String.starts_with?(word, ["a", "e", "i", "o", "u"]), do: "an", else: "a"
+  end
 end

--- a/lib/huddlz/notifications/senders/huddl_cancelled.ex
+++ b/lib/huddlz/notifications/senders/huddl_cancelled.ex
@@ -1,79 +1,47 @@
 defmodule Huddlz.Notifications.Senders.HuddlCancelled do
   @moduledoc """
-  Sender for C3: a huddl has been cancelled.
+  Sender for C3: a huddl the recipient RSVP'd to was cancelled.
 
-  Sent to every user who had RSVP'd at the moment of cancellation.
-  Transactional — preferences do not apply, no unsubscribe footer.
-  People with travel plans need this no matter what their settings say.
+  Sent to every RSVP'd user except the actor. Transactional — a
+  cancellation of plans the person made is not something to switch off,
+  so there is no unsubscribe link.
 
   Required payload keys:
 
-    * `"huddl_title"` — title of the huddl at time of cancellation.
-    * `"starts_at_iso"` — ISO-8601 string of when it was supposed to start.
-    * `"group_name"` — the host group's display name.
-    * `"group_slug"` — the host group's slug, used to link back so the
-      recipient can find replacement huddlz.
+    * `"huddl_title"`, `"starts_at_iso"`, `"group_name"`, `"group_slug"`.
+
+  Optional: `"cancellation_reason"`, `"time_zone"`, `"physical_location"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
-
-    when_text =
-      DateTimeFormatter.format_starts_at_iso(
-        payload["starts_at_iso"],
-        DateTimeFormatter.time_zone_from_payload(payload),
-        payload["starts_at_iso"] || "the scheduled time"
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
-    group_url = Urls.group_url(payload)
-    reason_html = reason_html(payload)
-    reason_text = reason_text(payload)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Cancelled: #{huddl_title(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>The huddl <strong>#{safe_title}</strong> in
-    <strong>#{safe_group}</strong>, scheduled for #{safe_when}, has
-    been cancelled.</p>
-
-    #{reason_html}
-
-    <p>If you'd made plans around this, you'll want to know. Sorry for
-    the disruption.</p>
-
-    <p>You can browse other upcoming huddlz at
-    <a href="#{group_url}">#{group_url}</a>.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    The huddl "#{huddl_title(payload)}" in "#{group_name(payload)}", scheduled for
-    #{when_text}, has been cancelled.
-
-    #{reason_text}
-
-    If you'd made plans around this, you'll want to know. Sorry for the disruption.
-
-    You can browse other upcoming huddlz at #{group_url}.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Cancelled: #{huddl_title(payload)}",
+      kicker: "Cancelled",
+      title: Layout.sentence_case("#{huddl_title(payload)} has been cancelled"),
+      paragraphs:
+        [
+          [
+            "Hi #{user.display_name}, ",
+            {:strong, huddl_title(payload)},
+            " with ",
+            {:strong, group_name(payload)},
+            " has been cancelled. It was scheduled for the time below."
+          ]
+        ] ++
+          reason_paragraphs(payload) ++
+          ["If you'd made plans around this, you'll want to know. Sorry for the disruption."],
+      facts: Layout.huddl_facts(payload),
+      action: {"Browse other huddlz", Urls.group_url(payload)},
+      footer: Footer.account("You're receiving this email because you had RSVP'd to this huddl.")
+    })
   end
 
   defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title
@@ -82,15 +50,10 @@ defmodule Huddlz.Notifications.Senders.HuddlCancelled do
   defp group_name(%{"group_name" => name}) when is_binary(name), do: name
   defp group_name(_), do: "a group"
 
-  defp reason_html(%{"cancellation_reason" => reason}) when is_binary(reason) and reason != "" do
-    "<p>The organizer shared: <strong>#{HtmlEscape.escape(reason)}</strong></p>"
+  defp reason_paragraphs(%{"cancellation_reason" => reason})
+       when is_binary(reason) and reason != "" do
+    [["The organizer shared: ", {:strong, reason}]]
   end
 
-  defp reason_html(_payload), do: ""
-
-  defp reason_text(%{"cancellation_reason" => reason}) when is_binary(reason) and reason != "" do
-    "The organizer shared: #{reason}"
-  end
-
-  defp reason_text(_payload), do: ""
+  defp reason_paragraphs(_payload), do: []
 end

--- a/lib/huddlz/notifications/senders/huddl_new.ex
+++ b/lib/huddlz/notifications/senders/huddl_new.ex
@@ -14,59 +14,37 @@ defmodule Huddlz.Notifications.Senders.HuddlNew do
     * `"starts_at_iso"` — ISO-8601 string of when it starts.
     * `"group_name"` — host group's display name.
     * `"group_slug"` — host group's slug, used to build the huddl URL.
+
+  Optional: `"ends_at_iso"`, `"time_zone"`, `"physical_location"` and
+  `"event_type"` fill in the facts block.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
+    group = group_name(payload)
 
-    when_text =
-      DateTimeFormatter.format_starts_at_iso(
-        payload["starts_at_iso"],
-        DateTimeFormatter.time_zone_from_payload(payload),
-        payload["starts_at_iso"] || "the scheduled time"
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
-    huddl_url = Urls.huddl_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :huddl_new)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("New huddl in #{group_name(payload)}: #{huddl_title(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p><strong>#{safe_group}</strong> just scheduled a new huddl:
-    <strong>#{safe_title}</strong>, on #{safe_when}.</p>
-
-    <p>RSVP if you can make it: <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    "#{group_name(payload)}" just scheduled a new huddl: "#{huddl_title(payload)}",
-    on #{when_text}.
-
-    RSVP if you can make it: #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "New huddl in #{group}: #{huddl_title(payload)}",
+      kicker: "New huddl · #{group}",
+      title: Layout.sentence_case(huddl_title(payload)),
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, group},
+          " just scheduled a new huddl. RSVP if you can make it."
+        ]
+      ],
+      facts: Layout.huddl_facts(payload),
+      action: {"See the huddl and RSVP", Urls.huddl_url(payload)},
+      footer: Footer.activity(user, :huddl_new)
+    })
   end
 
   defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title

--- a/lib/huddlz/notifications/senders/huddl_reminder_1h.ex
+++ b/lib/huddlz/notifications/senders/huddl_reminder_1h.ex
@@ -1,66 +1,54 @@
 defmodule Huddlz.Notifications.Senders.HuddlReminder1h do
   @moduledoc """
-  Sender for D2: 1-hour reminder for an imminent huddl.
+  Sender for D2: 1-hour reminder for an upcoming huddl.
 
   Sent to every user who has RSVP'd at fire time. Activity category —
-  preferences and the unsubscribe footer apply.
-
-  Leads with the virtual link when one is set so the recipient can
-  click straight through to the call rather than hunting for it.
+  preferences and the unsubscribe footer apply. When the recipient may
+  see the virtual link, the button is the call itself.
 
   Required payload keys:
 
-    * `"huddl_id"` — see HuddlReminder24h for the rationale.
+    * `"huddl_id"` — UUID of the huddl. The sender re-reads the row to
+      build the body and attach the live `.ics`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
+  import Swoosh.Email, only: [attachment: 2]
 
   alias Huddlz.Communities.Huddl
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.HuddlAccess
   alias Huddlz.Notifications.ICS
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, payload) do
     huddl = fetch_huddl!(payload, user)
-
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl.title)
-    safe_group = HtmlEscape.escape(huddl.group.name)
     huddl_url = url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}")
-
-    {footer_html, footer_text} = Footer.build(user, :huddl_reminder_1h)
     {ics_filename, ics_content} = ICS.event_for(huddl)
+    {action, aside} = call_to_action(huddl, huddl_url)
 
-    {html_call, text_call} = call_lines(huddl)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Starting soon: #{huddl.title}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p><strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>
-    starts in about an hour.</p>
-    #{html_call}
-    <p>Or open the huddl page at <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    "#{huddl.title}" in "#{huddl.group.name}" starts in about an hour.
-    #{text_call}
-    Or open the huddl page at #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Starting soon: #{huddl.title}",
+      kicker: "Reminder · in about an hour",
+      title: "#{huddl.title} starts soon",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, huddl.title},
+          " with ",
+          {:strong, huddl.group.name},
+          " starts in about an hour."
+        ]
+      ],
+      facts: Layout.huddl_facts(huddl),
+      action: action,
+      aside: aside,
+      footer: Footer.activity(user, :huddl_reminder_1h)
+    })
     |> attachment(
       Swoosh.Attachment.new({:data, ics_content},
         filename: ics_filename,
@@ -73,17 +61,12 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder1h do
     HuddlAccess.for_recipient!(id, user)
   end
 
-  defp call_lines(%Huddl{virtual_link: link}) when is_binary(link) and link != "" do
-    safe_link = HtmlEscape.escape(link)
-
-    html = """
-    <p><strong>Join the call:</strong>
-    <a href="#{safe_link}">#{safe_link}</a></p>
-    """
-
-    text = "Join the call: #{link}\n"
-    {html, text}
+  defp call_to_action(%Huddl{virtual_link: link}, huddl_url)
+       when is_binary(link) and link != "" do
+    {{"Join the call", link}, ["Or open the huddl page: ", {:link, huddl_url, huddl_url}]}
   end
 
-  defp call_lines(_), do: {"", ""}
+  defp call_to_action(_huddl, huddl_url) do
+    {{"Open the huddl", huddl_url}, "The calendar event is attached."}
+  end
 end

--- a/lib/huddlz/notifications/senders/huddl_reminder_24h.ex
+++ b/lib/huddlz/notifications/senders/huddl_reminder_24h.ex
@@ -19,60 +19,38 @@ defmodule Huddlz.Notifications.Senders.HuddlReminder24h do
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
+  import Swoosh.Email, only: [attachment: 2]
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.HuddlAccess
   alias Huddlz.Notifications.ICS
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, payload) do
     huddl = fetch_huddl!(payload, user)
-
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl.title)
-    safe_group = HtmlEscape.escape(huddl.group.name)
-
-    when_text =
-      DateTimeFormatter.format_starts_at(
-        huddl.starts_at,
-        huddl.time_zone
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
     huddl_url = url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}")
-
-    {footer_html, footer_text} = Footer.build(user, :huddl_reminder_24h)
     {ics_filename, ics_content} = ICS.event_for(huddl)
 
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Tomorrow: #{huddl.title}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>This is a reminder that <strong>#{safe_title}</strong> in
-    <strong>#{safe_group}</strong> starts in about 24 hours
-    (#{safe_when}).</p>
-
-    <p>The calendar event is attached. Or open the huddl page at
-    <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    This is a reminder that "#{huddl.title}" in "#{huddl.group.name}" starts in
-    about 24 hours (#{when_text}).
-
-    The calendar event is attached. Or open the huddl page at #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Tomorrow: #{huddl.title}",
+      kicker: "Reminder · tomorrow",
+      title: "#{huddl.title} starts tomorrow",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, you're going to ",
+          {:strong, huddl.title},
+          " with ",
+          {:strong, huddl.group.name},
+          " in about 24 hours. Here is what you need."
+        ]
+      ],
+      facts: Layout.huddl_facts(huddl),
+      action: {"Open the huddl", huddl_url},
+      aside: "The calendar event is attached, in case it is not on your calendar yet.",
+      footer: Footer.activity(user, :huddl_reminder_24h)
+    })
     |> attachment(
       Swoosh.Attachment.new({:data, ics_content},
         filename: ics_filename,

--- a/lib/huddlz/notifications/senders/huddl_series_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_series_updated.ex
@@ -1,98 +1,65 @@
 defmodule Huddlz.Notifications.Senders.HuddlSeriesUpdated do
   @moduledoc """
-  Sender for C4: a recurring huddl series was modified (the editor
-  chose `edit_type: "all"`).
+  Sender for C4: a recurring series the recipient attends was updated.
 
-  Sent once to each person with an RSVP on a retained occurrence. The
-  payload points to that person's next upcoming RSVP, so the target remains
-  useful and authorized without sending one message per occurrence. Activity
-  category — preferences and the unsubscribe footer apply.
+  Activity category — preferences and the unsubscribe footer apply.
+  Updated `.ics` files for the recipient's upcoming RSVPs are attached
+  when the payload lists them.
 
-  Required payload keys are the same as C2 (`huddl_id`,
-  `huddl_title`, `starts_at_iso`, `group_name`, `group_slug`,
-  `changed_fields`), but the values describe the next-instance row
-  rather than the row that triggered the edit. `calendar_huddlz` contains
-  schedule payloads for that recipient's active, future RSVPs. Each gets its
-  own attachment with the same UID as its confirmation; waitlisted and cancelled
-  huddlz are excluded. Older queued payloads without this key remain valid.
+  Required payload keys:
+
+    * `"huddl_id"`, `"huddl_title"`, `"starts_at_iso"`, `"group_name"`,
+      `"group_slug"`, `"changed_fields"`.
+
+  Optional: `"calendar_huddlz"` — the instances to attach.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
+  import Swoosh.Email, only: [attachment: 2]
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.ICS
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.ChangedFields
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
-
-    when_text =
-      DateTimeFormatter.format_starts_at_iso(
-        payload["starts_at_iso"],
-        DateTimeFormatter.time_zone_from_payload(payload),
-        payload["starts_at_iso"] || "the scheduled time"
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
-    safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
-
-    calendar_note =
-      if Map.get(payload, "calendar_huddlz", []) == [],
-        do: "",
-        else:
-          "Updated calendar entries for your upcoming RSVPs are attached. Open each attachment to update that date in your calendar."
-
-    huddl_url = Urls.huddl_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :huddl_series_updated)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Recurring series updated: #{huddl_title(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>The recurring huddl series in <strong>#{safe_group}</strong>
-    has been updated.</p>
-
-    <p><strong>What changed:</strong> #{safe_changed}.</p>
-
-    <p>Your next upcoming instance, <strong>#{safe_title}</strong>,
-    is now scheduled for #{safe_when}. See it at
-    <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-
-    <p>#{calendar_note}</p>
-
-    <p>You will still receive the usual reminders for each huddl you are attending.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    The recurring huddl series in "#{group_name(payload)}" has been updated.
-
-    What changed: #{ChangedFields.summary(payload)}.
-
-    Your next upcoming instance, "#{huddl_title(payload)}", is now scheduled for
-    #{when_text}. See it at #{huddl_url}.
-
-    #{calendar_note}
-
-    You will still receive the usual reminders for each huddl you are attending.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Recurring series updated: #{huddl_title(payload)}",
+      kicker: "Series updated · #{group_name(payload)}",
+      title: "The #{huddl_title(payload)} series has been updated",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, the recurring huddl series in ",
+          {:strong, group_name(payload)},
+          " has been updated."
+        ],
+        ["What changed: ", {:strong, ChangedFields.summary(payload)}, "."],
+        [
+          "Your next upcoming instance, ",
+          {:strong, huddl_title(payload)},
+          ", is now scheduled as below."
+        ]
+      ],
+      facts: Layout.huddl_facts(payload),
+      action: {"See the next huddl", Urls.huddl_url(payload)},
+      aside: calendar_aside(payload),
+      footer: Footer.activity(user, :huddl_series_updated)
+    })
     |> attach_calendars(payload)
+  end
+
+  defp calendar_aside(payload) do
+    base = "You will still receive the usual reminders for each huddl you are attending."
+
+    if Map.get(payload, "calendar_huddlz", []) == [],
+      do: base,
+      else:
+        "Updated calendar entries for your upcoming RSVPs are attached; open each one to update that date in your calendar. " <>
+          base
   end
 
   defp attach_calendars(email, payload) do

--- a/lib/huddlz/notifications/senders/huddl_updated.ex
+++ b/lib/huddlz/notifications/senders/huddl_updated.ex
@@ -1,32 +1,27 @@
 defmodule Huddlz.Notifications.Senders.HuddlUpdated do
   @moduledoc """
-  Sender for C2: a meaningful field on a huddl was changed (`title`,
-  `starts_at`, `ends_at`, `time_zone`, `physical_location`, `virtual_link`,
-  `max_attendees`, or `is_private`).
+  Sender for C2: a huddl the recipient RSVP'd to was meaningfully
+  updated.
 
-  Sent to every user who has currently RSVP'd, excluding the actor.
-  Activity category — preferences and the unsubscribe footer apply.
+  Sent to every RSVP'd user except the actor. Activity category —
+  preferences and the unsubscribe footer apply. When the payload
+  carries the full schedule an updated `.ics` is attached.
 
   Required payload keys:
 
-    * `"huddl_id"`, `"huddl_title"`, `"starts_at_iso"`, `"ends_at_iso"`,
-      `"time_zone"`, `"group_name"`, `"group_slug"` — schedule and routing data.
-    * `"changed_fields"` — list of attribute strings that were
-      modified, used to render a "what changed" line in the body.
+    * `"huddl_id"`, `"huddl_title"`, `"starts_at_iso"`, `"group_name"`,
+      `"group_slug"`, `"changed_fields"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
+  import Swoosh.Email, only: [attachment: 2]
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.HuddlAccess
   alias Huddlz.Notifications.ICS
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.ChangedFields
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
@@ -38,52 +33,33 @@ defmodule Huddlz.Notifications.Senders.HuddlUpdated do
         HuddlAccess.virtual_link(payload["huddl_id"], user)
       )
 
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
-
-    when_text =
-      DateTimeFormatter.format_starts_at_iso(
-        payload["starts_at_iso"],
-        DateTimeFormatter.time_zone_from_payload(payload),
-        payload["starts_at_iso"] || "the scheduled time"
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
-    safe_changed = HtmlEscape.escape(ChangedFields.summary(payload))
-    huddl_url = Urls.huddl_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :huddl_updated)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Updated: #{huddl_title(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>The huddl <strong>#{safe_title}</strong> in
-    <strong>#{safe_group}</strong> has been updated.</p>
-
-    <p><strong>What changed:</strong> #{safe_changed}.</p>
-
-    <p>It is currently scheduled for #{safe_when}. See the latest
-    details at <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    The huddl "#{huddl_title(payload)}" in "#{group_name(payload)}" has been updated.
-
-    What changed: #{ChangedFields.summary(payload)}.
-
-    It is currently scheduled for #{when_text}. See the latest details at
-    #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Updated: #{huddl_title(payload)}",
+      kicker: "Updated · #{group_name(payload)}",
+      title: Layout.sentence_case(huddl_title(payload)),
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, huddl_title(payload)},
+          " with ",
+          {:strong, group_name(payload)},
+          " has been updated."
+        ],
+        ["What changed: ", {:strong, ChangedFields.summary(payload)}, "."]
+      ],
+      facts: Layout.huddl_facts(payload),
+      action: {"See the latest details", Urls.huddl_url(payload)},
+      aside: calendar_aside(payload),
+      footer: Footer.activity(user, :huddl_updated)
+    })
     |> maybe_attach_calendar(payload)
   end
+
+  defp calendar_aside(%{"ends_at_iso" => ends_at}) when is_binary(ends_at),
+    do: "An updated calendar event is attached."
+
+  defp calendar_aside(_), do: nil
 
   defp maybe_attach_calendar(
          email,

--- a/lib/huddlz/notifications/senders/password_changed.ex
+++ b/lib/huddlz/notifications/senders/password_changed.ex
@@ -1,48 +1,41 @@
 defmodule Huddlz.Notifications.Senders.PasswordChanged do
   @moduledoc """
-  Sender for A3: password successfully changed.
+  Sender for A1: the recipient's password was changed. Transactional
+  security notice.
 
-  Sent to a user immediately after their password changes, as a security
-  notice. Always sends (transactional) — preference toggles do not apply.
+  The recipient's address is the current account email, so the
+  password-reset channel is intact and the notice may point at `/reset`.
+  See `docs/notifications.md` § Recovery advice in security notices.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, _payload) do
     reset_url = url(~p"/reset")
-    safe_name = HtmlEscape.escape(user.display_name)
 
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject("Your huddlz password was changed")
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>This is a security notice — your huddlz password was just changed.</p>
-
-    <p>If this was you, no action is needed.</p>
-
-    <p>If this <strong>wasn't</strong> you, reset your password immediately at
-    <a href="#{reset_url}">#{reset_url}</a>
-    and consider reviewing your account for any other unexpected changes.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    This is a security notice — your huddlz password was just changed.
-
-    If this was you, no action is needed.
-
-    If this wasn't you, reset your password immediately at #{reset_url}
-    and consider reviewing your account for any other unexpected changes.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Your huddlz password was changed",
+      kicker: "Security notice",
+      title: "Your password was changed",
+      paragraphs: [
+        "Hi #{user.display_name}, this is a security notice: your huddlz password was just changed.",
+        "If this was you, no action is needed.",
+        [
+          "If this ",
+          {:strong, "wasn't"},
+          " you, reset your password immediately at ",
+          {:link, reset_url, reset_url},
+          " and consider reviewing your account for any other unexpected changes."
+        ]
+      ],
+      footer: Footer.account()
+    })
   end
 end

--- a/lib/huddlz/notifications/senders/recurring_huddl_generation_failed.ex
+++ b/lib/huddlz/notifications/senders/recurring_huddl_generation_failed.ex
@@ -1,49 +1,37 @@
 defmodule Huddlz.Notifications.Senders.RecurringHuddlGenerationFailed do
   @moduledoc """
-  Tells an organizer when all attempts to generate a recurring huddl series fail.
+  Sender for C5: the recurring dates for a series could not all be
+  generated. Sent to the organizer who saved it. Transactional.
 
-  This notification is transactional because the organizer must know that the
-  future dates they requested were not created.
+  Payload keys: `"huddl_id"`, `"huddl_title"`, `"group_name"`, `"group_slug"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
-    huddl_url = Urls.huddl_url(payload)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("Recurring dates need attention: #{huddl_title(payload)}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>We couldn't generate all recurring dates for
-    <strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>.</p>
-
-    <p>The original huddl is still available. Review it at
-    <a href="#{huddl_url}">#{huddl_url}</a>, then save the series again to retry.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    We couldn't generate all recurring dates for "#{huddl_title(payload)}" in
-    "#{group_name(payload)}".
-
-    The original huddl is still available. Review it at #{huddl_url}, then save
-    the series again to retry.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "Recurring dates need attention: #{huddl_title(payload)}",
+      kicker: "Needs attention",
+      title: "Some recurring dates could not be created",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, we couldn't generate all recurring dates for ",
+          {:strong, huddl_title(payload)},
+          " in ",
+          {:strong, group_name(payload)},
+          "."
+        ],
+        "The original huddl is still available. Review it, then save the series again to retry."
+      ],
+      action: {"Review the huddl", Urls.huddl_url(payload)},
+      footer: Footer.account("You're receiving this email because you organize this huddl.")
+    })
   end
 
   defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title

--- a/lib/huddlz/notifications/senders/rsvp_cancelled.ex
+++ b/lib/huddlz/notifications/senders/rsvp_cancelled.ex
@@ -1,64 +1,41 @@
 defmodule Huddlz.Notifications.Senders.RsvpCancelled do
   @moduledoc """
-  Sender for E2: someone cancelled their RSVP to a huddl in a group I
-  organize.
+  Sender for E2: someone cancelled their RSVP to a huddl the recipient
+  organizes.
 
-  Sent to each owner/organizer of the group (deduplicated, actor
-  excluded). Activity category — preferences and the unsubscribe footer
-  apply.
+  Activity category — preferences and the unsubscribe footer apply.
 
-  Required payload keys:
-
-    * `"huddl_id"` — used to render the huddl page link.
-    * `"huddl_title"` — display name of the huddl.
-    * `"group_name"` — display name of the group.
-    * `"group_slug"` — slug used in the huddl page URL.
-    * `"rsvper_display_name"` — name of the user who cancelled.
+  Payload keys: `"huddl_id"`, `"huddl_title"`, `"group_name"`,
+  `"group_slug"`, `"rsvper_display_name"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
-    safe_rsvper = HtmlEscape.escape(rsvper_display_name(payload))
-    huddl_url = Urls.huddl_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :rsvp_cancelled)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(
-      HeaderSafe.safe(
-        "#{rsvper_display_name(payload)} cancelled their RSVP to #{huddl_title(payload)}"
-      )
-    )
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p><strong>#{safe_rsvper}</strong> cancelled their RSVP to
-    <strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>.
-    See the current attendee list at <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    #{rsvper_display_name(payload)} cancelled their RSVP to "#{huddl_title(payload)}" in "#{group_name(payload)}".
-    See the current attendee list at #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "#{rsvper_display_name(payload)} cancelled their RSVP to #{huddl_title(payload)}",
+      kicker: "RSVP cancelled · #{group_name(payload)}",
+      title: "#{rsvper_display_name(payload)} can't make #{huddl_title(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, rsvper_display_name(payload)},
+          " cancelled their RSVP to ",
+          {:strong, huddl_title(payload)},
+          " with ",
+          {:strong, group_name(payload)},
+          "."
+        ]
+      ],
+      action: {"See who's coming", Urls.huddl_url(payload)},
+      footer: Footer.activity(user, :rsvp_cancelled)
+    })
   end
 
   defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title

--- a/lib/huddlz/notifications/senders/rsvp_confirmation.ex
+++ b/lib/huddlz/notifications/senders/rsvp_confirmation.ex
@@ -17,58 +17,38 @@ defmodule Huddlz.Notifications.Senders.RsvpConfirmation do
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
+  import Swoosh.Email, only: [attachment: 2]
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
   alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.HuddlAccess
   alias Huddlz.Notifications.ICS
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, payload) do
     huddl = fetch_huddl!(payload, user)
-
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl.title)
-    safe_group = HtmlEscape.escape(huddl.group.name)
-
-    when_text =
-      DateTimeFormatter.format_starts_at(
-        huddl.starts_at,
-        huddl.time_zone
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
     huddl_url = url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}")
-
-    {footer_html, footer_text} = Footer.build(user, :rsvp_confirmation)
     {ics_filename, ics_content} = ICS.event_for(huddl)
 
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("You're going to #{huddl.title}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>You're confirmed for <strong>#{safe_title}</strong> in
-    <strong>#{safe_group}</strong> on #{safe_when}.</p>
-
-    <p>The calendar event is attached. Or open the huddl page at
-    <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    You're confirmed for "#{huddl.title}" in "#{huddl.group.name}" on #{when_text}.
-
-    The calendar event is attached. Or open the huddl page at #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "You're going to #{huddl.title}",
+      kicker: "You're going",
+      title: huddl.title,
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, you're confirmed for ",
+          {:strong, huddl.title},
+          " with ",
+          {:strong, huddl.group.name},
+          "."
+        ]
+      ],
+      facts: Layout.huddl_facts(huddl),
+      action: {"Open the huddl", huddl_url},
+      aside: "The calendar event is attached so you can save it to your calendar.",
+      footer: Footer.activity(user, :rsvp_confirmation)
+    })
     |> attachment(
       Swoosh.Attachment.new({:data, ics_content},
         filename: ics_filename,

--- a/lib/huddlz/notifications/senders/rsvp_received.ex
+++ b/lib/huddlz/notifications/senders/rsvp_received.ex
@@ -1,61 +1,40 @@
 defmodule Huddlz.Notifications.Senders.RsvpReceived do
   @moduledoc """
-  Sender for E1: someone RSVPd to a huddl in a group I organize.
+  Sender for E1: someone RSVP'd to a huddl the recipient organizes.
 
-  Sent to each owner/organizer of the group (deduplicated, actor
-  excluded). Activity category — preferences and the unsubscribe footer
-  apply.
+  Activity category — preferences and the unsubscribe footer apply.
 
-  Required payload keys:
-
-    * `"huddl_id"` — used to render the huddl page link.
-    * `"huddl_title"` — display name of the huddl.
-    * `"group_name"` — display name of the group.
-    * `"group_slug"` — slug used in the huddl page URL.
-    * `"rsvper_display_name"` — name of the user who RSVPd.
+  Payload keys: `"huddl_id"`, `"huddl_title"`, `"group_name"`,
+  `"group_slug"`, `"rsvper_display_name"`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
-  import Swoosh.Email
-
-  alias Huddlz.Mailer
   alias Huddlz.Notifications.Footer
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
   alias Huddlz.Notifications.Senders.Urls
 
   @impl true
   def build(user, payload) do
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl_title(payload))
-    safe_group = HtmlEscape.escape(group_name(payload))
-    safe_rsvper = HtmlEscape.escape(rsvper_display_name(payload))
-    huddl_url = Urls.huddl_url(payload)
-
-    {footer_html, footer_text} = Footer.build(user, :rsvp_received)
-
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(
-      HeaderSafe.safe("#{rsvper_display_name(payload)} RSVPd to #{huddl_title(payload)}")
-    )
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p><strong>#{safe_rsvper}</strong> just RSVPd to
-    <strong>#{safe_title}</strong> in <strong>#{safe_group}</strong>.
-    See the full attendee list at <a href="#{huddl_url}">#{huddl_url}</a>.</p>
-    #{footer_html}
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    #{rsvper_display_name(payload)} just RSVPd to "#{huddl_title(payload)}" in "#{group_name(payload)}".
-    See the full attendee list at #{huddl_url}.
-    #{footer_text}
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "#{rsvper_display_name(payload)} RSVPd to #{huddl_title(payload)}",
+      kicker: "New RSVP · #{group_name(payload)}",
+      title: "#{rsvper_display_name(payload)} is going to #{huddl_title(payload)}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, ",
+          {:strong, rsvper_display_name(payload)},
+          " just RSVPd to ",
+          {:strong, huddl_title(payload)},
+          " with ",
+          {:strong, group_name(payload)},
+          "."
+        ]
+      ],
+      action: {"See who's coming", Urls.huddl_url(payload)},
+      footer: Footer.activity(user, :rsvp_received)
+    })
   end
 
   defp huddl_title(%{"huddl_title" => title}) when is_binary(title), do: title

--- a/lib/huddlz/notifications/senders/waitlist_promoted.ex
+++ b/lib/huddlz/notifications/senders/waitlist_promoted.ex
@@ -1,73 +1,56 @@
 defmodule Huddlz.Notifications.Senders.WaitlistPromoted do
   @moduledoc """
-  Sender for the waitlist promotion email: a user was moved off the
-  waitlist into an active RSVP, either because someone cancelled or
-  because the organizer raised the capacity.
+  Sender for E4: a waitlisted user was promoted to attendee.
 
-  Transactional — the recipient may have shelved their plans assuming
-  they wouldn't get in. Includes an `.ics` calendar attachment so they
-  can save the huddl to their calendar.
+  Transactional — the person asked to attend and now can, so no
+  preference applies and there is no unsubscribe link. Includes the
+  `.ics` calendar attachment.
 
   Required payload keys:
 
     * `"huddl_id"` — UUID of the huddl. The sender re-reads the row to
-      construct the email body and attach the live `.ics`.
+      build the body and attach the live `.ics`.
   """
 
   @behaviour Huddlz.Notifications.Sender
 
   use HuddlzWeb, :verified_routes
-  import Swoosh.Email
+  import Swoosh.Email, only: [attachment: 2]
 
-  alias Huddlz.Mailer
-  alias Huddlz.Notifications.DateTimeFormatter
+  alias Huddlz.Notifications.Footer
   alias Huddlz.Notifications.HuddlAccess
   alias Huddlz.Notifications.ICS
-  alias Huddlz.Notifications.Senders.HeaderSafe
-  alias Huddlz.Notifications.Senders.HtmlEscape
+  alias Huddlz.Notifications.Layout
 
   @impl true
   def build(user, payload) do
     huddl = fetch_huddl!(payload, user)
-
-    safe_name = HtmlEscape.escape(user.display_name)
-    safe_title = HtmlEscape.escape(huddl.title)
-    safe_group = HtmlEscape.escape(huddl.group.name)
-
-    when_text =
-      DateTimeFormatter.format_starts_at(
-        huddl.starts_at,
-        huddl.time_zone
-      )
-
-    safe_when = HtmlEscape.escape(when_text)
     huddl_url = url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}")
-
     {ics_filename, ics_content} = ICS.event_for(huddl)
 
-    new()
-    |> from(Mailer.from())
-    |> to(to_string(user.email))
-    |> subject(HeaderSafe.safe("You're in: #{huddl.title}"))
-    |> html_body("""
-    <p>Hi #{safe_name},</p>
-
-    <p>A spot opened up in <strong>#{safe_title}</strong>
-    (#{safe_group}) on #{safe_when}, and you've been promoted from the
-    waitlist. You're now confirmed as an attendee.</p>
-
-    <p>The calendar event is attached. Open the huddl page at
-    <a href="#{huddl_url}">#{huddl_url}</a> if you need to back out.</p>
-    """)
-    |> text_body("""
-    Hi #{user.display_name},
-
-    A spot opened up in "#{huddl.title}" (#{huddl.group.name}) on #{when_text},
-    and you've been promoted from the waitlist. You're now confirmed as an attendee.
-
-    The calendar event is attached. Open the huddl page at #{huddl_url} if you need
-    to back out.
-    """)
+    Layout.email(%{
+      to: user.email,
+      subject: "You're in: #{huddl.title}",
+      kicker: "Off the waitlist",
+      title: "You're in: #{huddl.title}",
+      paragraphs: [
+        [
+          "Hi #{user.display_name}, a spot opened up in ",
+          {:strong, huddl.title},
+          " with ",
+          {:strong, huddl.group.name},
+          " and you've been promoted from the waitlist. You're now confirmed as an attendee."
+        ]
+      ],
+      facts: Layout.huddl_facts(huddl),
+      action: {"Open the huddl", huddl_url},
+      aside:
+        "The calendar event is attached. Open the huddl page if you need to back out so the spot can go to someone else.",
+      footer:
+        Footer.account(
+          "You're receiving this email because you joined the waitlist for this huddl."
+        )
+    })
     |> attachment(
       Swoosh.Attachment.new({:data, ics_content},
         filename: ics_filename,

--- a/test/features/step_definitions/private_group_invitation_steps.exs
+++ b/test/features/step_definitions/private_group_invitation_steps.exs
@@ -46,11 +46,14 @@ defmodule PrivateGroupInvitationSteps do
   end
 
   step "I follow that invitation email while signed out", context do
-    [{_, [{_, url}], _}] =
+    [url] =
       context.invitation_email_body
-      |> Floki.parse_fragment!()
+      |> Floki.parse_document!()
       |> Floki.find("a")
-      |> Enum.filter(fn {_, _, content} -> Floki.text(content) == "Review invitation" end)
+      |> Enum.filter(fn {_, _, content} ->
+        String.trim(Floki.text(content)) == "Review invitation"
+      end)
+      |> Floki.attribute("href")
 
     uri = URI.parse(url)
     path = uri.path <> if(uri.query, do: "?" <> uri.query, else: "")

--- a/test/huddlz/notifications/group_membership_notifications_test.exs
+++ b/test/huddlz/notifications/group_membership_notifications_test.exs
@@ -195,8 +195,8 @@ defmodule Huddlz.Notifications.GroupMembershipNotificationsTest do
       assert_email_sent(fn email ->
         email.subject == "Your role in Promo Group changed" and
           email.to == [{"", to_string(member.email)}] and
-          email.html_body =~ "<strong>member</strong>" and
-          email.html_body =~ "<strong>organizer</strong>" and
+          email.html_body =~ "member</strong>" and
+          email.html_body =~ "organizer</strong>" and
           email.html_body =~ "/unsubscribe/"
       end)
     end

--- a/test/huddlz/notifications/layout_test.exs
+++ b/test/huddlz/notifications/layout_test.exs
@@ -1,0 +1,222 @@
+defmodule Huddlz.Notifications.LayoutTest do
+  use Huddlz.DataCase, async: true
+
+  alias Huddlz.Mailer
+  alias Huddlz.Notifications.DateTimeFormatter
+  alias Huddlz.Notifications.Footer
+  alias Huddlz.Notifications.Layout
+
+  @spec_base %{
+    to: "sam@example.com",
+    subject: "Tomorrow: Saturday Soccer",
+    kicker: "Reminder · tomorrow",
+    title: "Saturday Soccer starts tomorrow",
+    paragraphs: [
+      ["Hi Sam, you're going to ", {:strong, "Saturday Soccer"}, " with Pickup Sports."],
+      "Here is what you need."
+    ],
+    facts: [
+      {"When", "Sat Sep 12, 2026 at 10:00 AM EDT", "2 hours"},
+      {"Where", "Laurelhurst Park"},
+      {"Group", "Pickup Sports"}
+    ],
+    action: {"Open the huddl", "https://huddlz.test/groups/pickup-sports/huddlz/1"},
+    aside: ["The calendar event is attached. ", {:link, "Open it", "https://huddlz.test/ics"}],
+    footer: %{
+      reason: "You're receiving this email because of your huddlz notification settings.",
+      links: [{"Unsubscribe from this kind of email", "https://huddlz.test/unsubscribe/t"}]
+    }
+  }
+
+  describe "email/1" do
+    test "builds a Swoosh email with both bodies, the sender and a header-safe subject" do
+      email = Layout.email(%{@spec_base | subject: "Tomorrow:\r\nBcc: x"})
+
+      assert email.to == [{"", "sam@example.com"}]
+      assert email.from == Mailer.from()
+      assert email.subject == "Tomorrow: Bcc: x"
+      assert email.html_body =~ "<!doctype html>"
+      assert email.text_body =~ "Saturday Soccer starts tomorrow"
+    end
+  end
+
+  describe "render/1 HTML" do
+    setup do
+      {html, text} = Layout.render(@spec_base)
+      %{html: html, text: text}
+    end
+
+    test "wears the chrome: mark, kicker, title, facts, one button and the footer", %{html: html} do
+      assert html =~ ~s(>huddlz</td>)
+      assert html =~ "REMINDER · TOMORROW" or html =~ "Reminder · tomorrow"
+      assert html =~ "<h1"
+      assert html =~ "Saturday Soccer starts tomorrow</h1>"
+      assert html =~ ">When</td>"
+      assert html =~ "2 hours"
+      assert html =~ ~s(href="https://huddlz.test/groups/pickup-sports/huddlz/1")
+      assert html =~ "Open the huddl</a>"
+      assert html =~ "Unsubscribe from this kind of email</a>"
+      assert html =~ "huddlz notification settings"
+    end
+
+    test "uses inline styles on a table layout with no dark scheme", %{html: html} do
+      assert html =~ ~s(<table role="presentation")
+      assert html =~ ~s(<meta name="color-scheme" content="light">)
+      refute html =~ "<style"
+      refute html =~ "prefers-color-scheme"
+    end
+
+    test "renders strong and link segments", %{html: html} do
+      assert html =~ "<strong style=\"font-weight:600;color:#0f1a1b;\">Saturday Soccer</strong>"
+
+      assert html =~
+               ~s(<a href="https://huddlz.test/ics" style="color:#0a6c72;text-decoration:underline;">Open it</a>)
+    end
+
+    test "escapes every string it is given" do
+      {html, _text} =
+        Layout.render(%{
+          title: "<script>alert(1)</script>",
+          kicker: "<b>k</b>",
+          paragraphs: [
+            ["Hi ", {:strong, "<i>Sam</i>"}, " ", {:link, "<x>", "https://a.test/?a=1&b=2"}]
+          ],
+          facts: [{"<When>", "<v>", "<s>"}],
+          action: {"<Go>", "https://a.test/?q=<1>"},
+          aside: "<aside>",
+          footer: %{reason: "<why>", links: [{"<l>", "https://a.test/<u>"}]}
+        })
+
+      refute html =~ "<script>"
+      refute html =~ "<b>k</b>"
+      refute html =~ "<i>Sam</i>"
+      refute html =~ "<aside>"
+      assert html =~ "&lt;script&gt;alert(1)&lt;/script&gt;"
+      assert html =~ "https://a.test/?a=1&amp;b=2"
+      assert html =~ "https://a.test/?q=&lt;1&gt;"
+      assert html =~ "&lt;When&gt;"
+      assert html =~ "&lt;why&gt;"
+    end
+
+    test "leaves out the pieces that are not given" do
+      {html, text} = Layout.render(%{title: "Just a title", footer: Footer.account()})
+
+      refute html =~ "<h1" == false
+      refute html =~ "text-transform:uppercase"
+      refute html =~ "border-radius:10px"
+      refute html =~ "display:inline-block"
+      assert html =~ "concerns your huddlz account"
+      refute text =~ "unsubscribe"
+    end
+  end
+
+  describe "render/1 plain text" do
+    test "is the twin of the HTML: same pieces, no markup" do
+      {_html, text} = Layout.render(@spec_base)
+
+      assert text ==
+               """
+               huddlz
+
+               REMINDER · TOMORROW
+               Saturday Soccer starts tomorrow
+
+               Hi Sam, you're going to Saturday Soccer with Pickup Sports.
+
+               Here is what you need.
+
+               When:  Sat Sep 12, 2026 at 10:00 AM EDT (2 hours)
+               Where: Laurelhurst Park
+               Group: Pickup Sports
+
+               Open the huddl: https://huddlz.test/groups/pickup-sports/huddlz/1
+
+               The calendar event is attached. Open it (https://huddlz.test/ics)
+
+               --
+               You're receiving this email because of your huddlz notification settings.
+               Unsubscribe from this kind of email: https://huddlz.test/unsubscribe/t
+               huddlz · #{elem(Mailer.from(), 1)}
+               """
+
+      refute text =~ "<"
+    end
+
+    test "writes a bare URL once when a link's text is its URL" do
+      {_html, text} =
+        Layout.render(%{
+          title: "T",
+          paragraphs: [
+            ["Reset at ", {:link, "https://h.test/reset", "https://h.test/reset"}, "."]
+          ]
+        })
+
+      assert text =~ "Reset at https://h.test/reset."
+      refute text =~ "(https://h.test/reset)"
+    end
+  end
+
+  describe "huddl_facts/1" do
+    test "from a huddl row: when in the huddl's zone with the duration, where, and the group" do
+      owner = generate(user(role: :user))
+
+      group =
+        generate(group(name: "Pickup Sports", is_public: true, owner_id: owner.id, actor: owner))
+
+      huddl =
+        generate(
+          huddl(
+            title: "Saturday Soccer",
+            group_id: group.id,
+            creator_id: owner.id,
+            actor: owner,
+            date: ~D[2026-09-12],
+            start_time: ~T[10:00:00],
+            duration_minutes: 120
+          )
+        )
+
+      huddl = Ash.load!(huddl, :group, authorize?: false)
+
+      assert Layout.huddl_facts(huddl) == [
+               {"When", DateTimeFormatter.format_starts_at(huddl.starts_at, huddl.time_zone),
+                "2 hours"},
+               {"Where", huddl.physical_location},
+               {"Group", "Pickup Sports"}
+             ]
+
+      assert huddl.physical_location =~ "Main St"
+    end
+
+    test "from a payload, marking virtual and hybrid huddlz" do
+      base = %{
+        "starts_at_iso" => "2026-09-12T14:00:00Z",
+        "ends_at_iso" => "2026-09-12T15:30:00Z",
+        "time_zone" => "America/New_York",
+        "group_name" => "Pickup Sports"
+      }
+
+      assert Layout.huddl_facts(Map.put(base, "event_type", "virtual")) == [
+               {"When", "Sat Sep 12, 2026 at 10:00 AM EDT", "1 hour 30 minutes"},
+               {"Where", "Online"},
+               {"Group", "Pickup Sports"}
+             ]
+
+      assert Layout.huddl_facts(
+               Map.merge(base, %{"event_type" => "hybrid", "physical_location" => "The Loft"})
+             ) == [
+               {"When", "Sat Sep 12, 2026 at 10:00 AM EDT", "1 hour 30 minutes"},
+               {"Where", "The Loft", "Also online"},
+               {"Group", "Pickup Sports"}
+             ]
+    end
+
+    test "skips what the payload does not have" do
+      assert Layout.huddl_facts(%{"group_name" => "Pickup Sports"}) == [
+               {"Group", "Pickup Sports"}
+             ]
+
+      assert Layout.huddl_facts(%{}) == []
+    end
+  end
+end

--- a/test/huddlz/notifications/senders/account_role_changed_test.exs
+++ b/test/huddlz/notifications/senders/account_role_changed_test.exs
@@ -37,15 +37,15 @@ defmodule Huddlz.Notifications.Senders.AccountRoleChangedTest do
 
       assert email.subject == "Your huddlz account role was updated"
       assert email.html_body =~ "admin"
-      assert email.html_body =~ "from <strong>user</strong> to <strong>admin</strong>"
+      assert email.html_body =~ ~r{from <strong[^>]*>user</strong> to <strong[^>]*>admin</strong>}
     end
 
     test "omits the 'from X' phrasing when previous_role is missing" do
       user = generate(user(role: :admin))
       email = AccountRoleChanged.build(user, %{"new_role" => "admin"})
 
-      refute email.html_body =~ ~r{from <strong>}
-      assert email.html_body =~ "to <strong>admin</strong>"
+      refute email.html_body =~ ~r{from <strong}
+      assert email.html_body =~ ~r{to <strong[^>]*>admin</strong>}
     end
 
     test "includes a working unsubscribe link in both bodies" do

--- a/test/huddlz/notifications/senders/group_role_changed_test.exs
+++ b/test/huddlz/notifications/senders/group_role_changed_test.exs
@@ -29,8 +29,8 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChangedTest do
       email = GroupRoleChanged.build(user, payload())
 
       assert email.subject == "Your role in Inner Circle changed"
-      assert email.html_body =~ "<strong>member</strong>"
-      assert email.html_body =~ "<strong>organizer</strong>"
+      assert email.html_body =~ "member</strong>"
+      assert email.html_body =~ "organizer</strong>"
       assert email.text_body =~ "from member to organizer"
     end
 
@@ -75,8 +75,8 @@ defmodule Huddlz.Notifications.Senders.GroupRoleChangedTest do
           payload(%{"previous_role" => :member, "new_role" => :organizer})
         )
 
-      assert email.html_body =~ "<strong>member</strong>"
-      assert email.html_body =~ "<strong>organizer</strong>"
+      assert email.html_body =~ "member</strong>"
+      assert email.html_body =~ "organizer</strong>"
     end
   end
 end

--- a/test/huddlz/notifications/senders/layout_coverage_test.exs
+++ b/test/huddlz/notifications/senders/layout_coverage_test.exs
@@ -1,0 +1,228 @@
+defmodule Huddlz.Notifications.Senders.LayoutCoverageTest do
+  @moduledoc """
+  Every email the app sends renders through `Huddlz.Notifications.Layout`
+  with a footer: the trigger registry's senders, the two authentication
+  emails and the email-address invitation.
+
+  Set `EMAIL_SAMPLES_DIR` to also write each rendered email to disk, for
+  screenshots: `EMAIL_SAMPLES_DIR=/tmp/emails mix test <this file>`.
+  """
+
+  use Huddlz.DataCase, async: false
+
+  alias Huddlz.Accounts.User.Senders.SendNewUserConfirmationEmail
+  alias Huddlz.Accounts.User.Senders.SendPasswordResetEmail
+  alias Huddlz.Communities
+  alias Huddlz.Communities.GroupInvitation.EmailWorker
+  alias Huddlz.Notifications.Triggers
+
+  @chrome ~s(>huddlz</td>)
+  @button "display:inline-block;padding:13px 22px"
+
+  setup do
+    owner = generate(user(role: :user, display_name: "Alex Rivera"))
+    recipient = generate(user(role: :user, display_name: "Sam Okafor"))
+
+    group =
+      generate(
+        group(
+          name: "Pickup Sports",
+          slug: "pickup-sports",
+          is_public: true,
+          owner_id: owner.id,
+          actor: owner
+        )
+      )
+
+    huddl =
+      generate(
+        huddl(
+          title: "Saturday Soccer",
+          group_id: group.id,
+          creator_id: owner.id,
+          actor: owner,
+          date: Date.add(Huddlz.Generator.eastern_today(), 3),
+          start_time: ~T[10:00:00],
+          duration_minutes: 120
+        )
+      )
+
+    huddl = Ash.load!(huddl, :group, authorize?: false)
+
+    huddl_payload = %{
+      "huddl_id" => huddl.id,
+      "huddl_title" => to_string(huddl.title),
+      "starts_at_iso" => DateTime.to_iso8601(huddl.starts_at),
+      "ends_at_iso" => DateTime.to_iso8601(huddl.ends_at),
+      "time_zone" => huddl.time_zone,
+      "event_type" => "in_person",
+      "physical_location" => huddl.physical_location,
+      "group_name" => to_string(group.name),
+      "group_slug" => to_string(group.slug)
+    }
+
+    group_payload = %{
+      "group_id" => group.id,
+      "group_name" => to_string(group.name),
+      "group_slug" => to_string(group.slug)
+    }
+
+    payloads = %{
+      password_changed: %{},
+      email_changed: %{"audience" => "old", "old_email" => "sam.old@example.com"},
+      account_role_changed: %{"previous_role" => "user", "new_role" => "admin"},
+      group_member_joined: Map.put(group_payload, "joiner_display_name", "Jordan Lee"),
+      group_member_added: group_payload,
+      group_invitation:
+        Map.merge(group_payload, %{
+          "invitation_id" => Ecto.UUID.generate(),
+          "inviter_name" => owner.display_name,
+          "role" => "member"
+        }),
+      group_member_removed: group_payload,
+      group_role_changed:
+        Map.merge(group_payload, %{"previous_role" => "member", "new_role" => "organizer"}),
+      group_archived:
+        Map.put(group_payload, "archived_at", DateTime.to_iso8601(DateTime.utc_now())),
+      group_ownership_transferred:
+        Map.merge(group_payload, %{"role" => "new_owner", "previous_owner_display_name" => "Alex"}),
+      huddl_new: huddl_payload,
+      huddl_updated: Map.put(huddl_payload, "changed_fields", ["starts_at", "physical_location"]),
+      huddl_cancelled: Map.put(huddl_payload, "cancellation_reason", "Rain all weekend"),
+      huddl_series_updated: Map.put(huddl_payload, "changed_fields", ["schedule"]),
+      recurring_huddl_generation_failed: huddl_payload,
+      huddl_reminder_24h: %{"huddl_id" => huddl.id},
+      huddl_reminder_1h: %{"huddl_id" => huddl.id},
+      rsvp_received: Map.put(huddl_payload, "rsvper_display_name", "Jordan Lee"),
+      rsvp_cancelled: Map.put(huddl_payload, "rsvper_display_name", "Jordan Lee"),
+      rsvp_confirmation: %{"huddl_id" => huddl.id},
+      waitlist_promoted: %{"huddl_id" => huddl.id}
+    }
+
+    %{owner: owner, recipient: recipient, group: group, payloads: payloads}
+  end
+
+  test "every registered sender renders through the layout with a footer that fits its category",
+       %{recipient: recipient, payloads: payloads} do
+    # The digest senders are registered but deferred; they have no module yet.
+    triggers =
+      Triggers.all()
+      |> Enum.filter(fn {_trigger, %{sender: sender}} -> Code.ensure_loaded?(sender) end)
+      |> Map.new()
+
+    missing = Map.keys(triggers) -- Map.keys(payloads)
+    assert missing == [], "add a sample payload for: #{inspect(missing)}"
+
+    for {trigger, %{sender: sender, category: category}} <- triggers do
+      email = build(sender, recipient, payloads[trigger])
+      save_sample(trigger, email)
+
+      assert_layout(email, trigger)
+
+      case category do
+        :activity ->
+          assert email.html_body =~ "/unsubscribe/", "#{trigger} lacks the unsubscribe link"
+          assert email.text_body =~ "/unsubscribe/", "#{trigger} text lacks the unsubscribe link"
+          assert email.html_body =~ "/profile/notifications"
+
+        _transactional ->
+          refute email.html_body =~ "unsubscribe", "#{trigger} is transactional"
+          refute email.text_body =~ "unsubscribe", "#{trigger} is transactional"
+          assert email.text_body =~ "You're receiving this email because"
+      end
+    end
+  end
+
+  test "huddl emails carry the huddl's facts: when, where and group", %{
+    recipient: recipient,
+    payloads: payloads
+  } do
+    for trigger <- [
+          :huddl_new,
+          :huddl_updated,
+          :huddl_cancelled,
+          :huddl_series_updated,
+          :huddl_reminder_24h,
+          :huddl_reminder_1h,
+          :rsvp_confirmation,
+          :waitlist_promoted
+        ] do
+      %{sender: sender} = Triggers.fetch!(trigger)
+      email = build(sender, recipient, payloads[trigger])
+
+      for label <- ["When", "Where", "Group"] do
+        assert email.html_body =~ ">#{label}</td>", "#{trigger} lacks the #{label} fact"
+        assert email.text_body =~ "#{label}:", "#{trigger} text lacks the #{label} fact"
+      end
+
+      assert email.html_body =~ "Pickup Sports"
+      assert email.html_body =~ "Main St"
+      assert email.html_body =~ "EDT" or email.html_body =~ "EST"
+    end
+  end
+
+  test "the authentication emails render through the layout", %{recipient: recipient} do
+    reset = SendPasswordResetEmail.build(recipient, "reset-token")
+    save_sample(:password_reset, reset)
+    assert_layout(reset, :password_reset)
+    assert reset.html_body =~ @button
+    assert reset.html_body =~ "/reset/reset-token"
+    assert reset.text_body =~ "Reset password: "
+    refute reset.html_body =~ "unsubscribe"
+
+    confirm = SendNewUserConfirmationEmail.build(recipient, "confirm-token")
+    save_sample(:new_user_confirmation, confirm)
+    assert_layout(confirm, :new_user_confirmation)
+    assert confirm.html_body =~ "/confirm_new_user/confirm-token"
+    refute confirm.html_body =~ "unsubscribe"
+  end
+
+  test "the invitation to an address without an account renders through the layout", %{
+    owner: owner
+  } do
+    private_group = generate(group(name: "Founder Coffee", is_public: false, actor: owner))
+
+    invitation =
+      Communities.invite_to_group_by_email!(private_group.id, "new.person@example.com", :member,
+        actor: owner
+      )
+
+    invitation = Ash.load!(invitation, [:group, :inviter], authorize?: false)
+    email = EmailWorker.build(invitation)
+    save_sample(:email_invitation, email)
+
+    assert_layout(email, :email_invitation)
+    assert email.to == [{"", "new.person@example.com"}]
+    assert email.html_body =~ "/invitations/email/"
+    assert email.html_body =~ "Review invitation</a>"
+    refute email.html_body =~ "unsubscribe"
+  end
+
+  # Keeps the compiler from tracing the registry's not-yet-written digest senders.
+  defp build(sender, user, payload), do: sender.build(user, payload)
+
+  defp assert_layout(email, name) do
+    assert email.html_body =~ @chrome, "#{name} does not wear the layout"
+    assert email.html_body =~ "<h1", "#{name} has no title"
+    assert email.html_body =~ "huddlz · ", "#{name} has no footer"
+    assert email.text_body =~ "\n--\n", "#{name} text has no footer"
+    assert String.starts_with?(email.text_body, "huddlz\n"), "#{name} text has no header"
+    refute email.text_body =~ "<", "#{name} leaks markup into plain text"
+  end
+
+  defp save_sample(name, email) do
+    case System.get_env("EMAIL_SAMPLES_DIR") do
+      nil ->
+        :ok
+
+      dir ->
+        File.mkdir_p!(dir)
+        File.write!(Path.join(dir, "#{name}.html"), email.html_body)
+
+        File.write!(
+          Path.join(dir, "#{name}.txt"),
+          "Subject: #{email.subject}\n\n" <> email.text_body
+        )
+    end
+  end
+end

--- a/test/huddlz_web/live/basic_password_reset_test.exs
+++ b/test/huddlz_web/live/basic_password_reset_test.exs
@@ -74,7 +74,7 @@ defmodule HuddlzWeb.BasicPasswordResetTest do
       reset_link =
         assert_email_sent(fn email ->
           if email.subject == "Reset your password" do
-            case Regex.run(~r{<a href="([^"]+)">}, email.html_body) do
+            case Regex.run(~r{<a href="([^"]+)"}, email.html_body) do
               [_, url] -> url
               _ -> false
             end

--- a/test/huddlz_web/live/password_reset_full_flow_test.exs
+++ b/test/huddlz_web/live/password_reset_full_flow_test.exs
@@ -45,7 +45,7 @@ defmodule HuddlzWeb.PasswordResetFullFlowTest do
         assert_email_sent(fn email ->
           if email.subject == "Reset your password" do
             # Extract the full URL from the email
-            case Regex.run(~r{<a href="([^"]+)">}, email.html_body) do
+            case Regex.run(~r{<a href="([^"]+)"}, email.html_body) do
               [_, url] -> url
               _ -> false
             end
@@ -105,7 +105,7 @@ defmodule HuddlzWeb.PasswordResetFullFlowTest do
       reset_link =
         assert_email_sent(fn email ->
           if email.subject == "Reset your password" do
-            case Regex.run(~r{<a href="([^"]+)">}, email.html_body) do
+            case Regex.run(~r{<a href="([^"]+)"}, email.html_body) do
               [_, url] -> url
               _ -> false
             end
@@ -163,7 +163,7 @@ defmodule HuddlzWeb.PasswordResetFullFlowTest do
       reset_link =
         assert_email_sent(fn email ->
           if email.subject == "Reset your password" do
-            case Regex.run(~r{<a href="([^"]+)">}, email.html_body) do
+            case Regex.run(~r{<a href="([^"]+)"}, email.html_body) do
               [_, url] -> url
               _ -> false
             end

--- a/test/huddlz_web/live/password_validation_test.exs
+++ b/test/huddlz_web/live/password_validation_test.exs
@@ -301,7 +301,7 @@ defmodule HuddlzWeb.PasswordValidationTest do
   end
 
   defp reset_link_from_email(%{subject: "Reset your password", html_body: body}) do
-    case Regex.run(~r{<a href="([^"]+)">}, body) do
+    case Regex.run(~r{<a href="([^"]+)"}, body) do
       [_, url] -> url
       _ -> false
     end


### PR DESCRIPTION
Closes #489.

Every email huddlz sends now wears the same chrome: the mark and wordmark in a header, one card with a kicker, a title, short paragraphs, at most one button and a quiet aside, and a footer that says why the person got it. Activity emails keep the unsubscribe and preferences links; account emails carry a plain reason and no unsubscribe. Huddl emails carry the same facts as the huddl card: when in the huddl's own time zone with the duration, where, and the group.

Design: the canvas "Email" sheet on the Components page.

## How it works

- `Huddlz.Notifications.Layout` renders a spec (kicker, title, paragraphs as strings or `{:strong, _}` / `{:link, _, _}` segments, facts, action, aside, footer) to both bodies. The HTML is one 600px table with inline styles on the light theme colours and a system font stack; the plain text is built from the same pieces, so it cannot drift. The layout escapes every string, so senders pass raw values and never build markup.
- `Huddlz.Notifications.Footer` returns the footer spec: `activity/2` with the per-trigger unsubscribe and settings links, `account/1` with a reason.
- `Layout.huddl_facts/1` takes the huddl row or a payload. The new-huddl and cancelled payloads now carry the end time, event type and place so the facts block is complete.
- All 21 registry senders, the password reset and confirmation emails, and the invitation to an address without an account build through `Layout.email/1`. The 1-hour reminder's button is the call link when the recipient may see it.
- Light only, by design. There is no dark variant because client support for it is unreliable; the light background is explicit so clients keep it.

## Tests

- `layout_test.exs`: chrome, escaping, optional pieces, the exact plain-text twin, and the facts from a row and from a payload.
- `layout_coverage_test.exs` walks the trigger registry plus the auth and invitation emails and checks each renders through the layout with the footer its category calls for and, for huddl emails, the three facts. With `EMAIL_SAMPLES_DIR` set it writes every rendered email to disk, which is where the screenshots below come from.
- Existing sender tests updated where they pinned bare `<strong>` tags or the old anchor shape.

## Verified

- Rendered samples of all 24 emails in Chromium at 700px, light scheme; two also captured with the OS in dark scheme, where the explicit light background holds. Real mail clients were not checked from here.
