### PR TITLE
feat(organize): show turnout on past rows and nudge the overview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2745,6 +2745,29 @@ body .org-huddl-meta .dot { width: 3px; height: 3px; border-radius: 50%; backgro
 
 body .org-huddl-rsvps { display: flex; flex-direction: column; gap: 6px; }
 body .org-huddl-rsvps .n { color: var(--soft); font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
+body .org-huddl-turnout { color: var(--text); font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; }
+body .org-huddl-turnout.missing { color: var(--muted); font-weight: 500; }
+body .org-huddl-show-rate { white-space: nowrap; }
+
+/* One-line reminder on the overview while a recent huddl is uncounted. */
+body .nudge {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  color: var(--soft);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+body .nudge-icon { flex: 0 0 auto; color: var(--accent-ink); }
+body .nudge strong { color: var(--text); font-weight: 600; }
+body .nudge a { margin-left: auto; color: var(--accent-ink); font-weight: 600; white-space: nowrap; text-decoration: none; }
+body .nudge a:hover { text-decoration: underline; }
 
 body .org-huddl-series {
   display: inline-flex;

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -24,7 +24,18 @@ defmodule HuddlzWeb.OrganizeLive do
   require Ash.Query
 
   @group_loads [:current_image_url, :member_count]
-  @huddl_loads [:rsvp_count, :status, :group, :display_image_url, :huddl_template]
+  @huddl_loads [
+    :rsvp_count,
+    :status,
+    :group,
+    :display_image_url,
+    :huddl_template,
+    :turnout_total,
+    :show_rate
+  ]
+  # A recently ended huddl with no turnout is worth one reminder on the
+  # overview; after this many days the moment has passed.
+  @turnout_nudge_days 14
   @huddlz_filters [:published, :draft, :past, :cancelled]
   # Rows shown before "Show more". A weekly series alone can run to a
   # hundred dates, so the list pages rather than folding anything.
@@ -49,6 +60,7 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_filter, :published)
      |> assign(:upcoming_huddlz, [])
      |> assign(:open_rsvps, 0)
+     |> assign(:turnout_nudge, nil)
      |> assign(:invitation_count, 0)
      |> assign(:invitation_form, invitation_form())
      |> assign(:member_lookup, %{})
@@ -113,6 +125,7 @@ defmodule HuddlzWeb.OrganizeLive do
     socket
     |> assign(:upcoming_huddlz, upcoming)
     |> assign(:open_rsvps, open_rsvps)
+    |> assign(:turnout_nudge, latest_uncounted_huddl(group, user))
   end
 
   defp load_section(socket, :huddlz, group, user) do
@@ -144,6 +157,22 @@ defmodule HuddlzWeb.OrganizeLive do
     socket
     |> assign(:pending_member_action, nil)
     |> push_navigate(to: ~p"/organize/#{group.slug}")
+  end
+
+  # The most recent huddl that ended within the nudge window and has been
+  # neither counted nor dismissed. One at a time: the freshest memory first.
+  defp latest_uncounted_huddl(group, user) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@turnout_nudge_days, :day)
+
+    Huddlz.Communities.Huddl
+    |> Ash.Query.for_read(:huddlz_for_organizer, %{state: :past}, actor: user)
+    |> Ash.Query.filter(
+      group_id == ^group.id and ends_at > ^cutoff and
+        is_nil(turnout_recorded_at) and is_nil(turnout_skipped_at)
+    )
+    |> Ash.Query.sort(ends_at: :desc)
+    |> Ash.Query.limit(1)
+    |> Ash.read_one!(actor: user)
   end
 
   defp load_group(slug, user) do
@@ -297,6 +326,7 @@ defmodule HuddlzWeb.OrganizeLive do
             can_edit_group={@can_edit_group}
             upcoming_huddlz={@upcoming_huddlz}
             open_rsvps={@open_rsvps}
+            turnout_nudge={@turnout_nudge}
           />
         <% :huddlz -> %>
           <.huddlz_view
@@ -413,6 +443,7 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :group, :map, required: true
   attr :upcoming_huddlz, :list, required: true
   attr :open_rsvps, :integer, required: true
+  attr :turnout_nudge, :map, default: nil
 
   attr :can_edit_group, :boolean, required: true
 
@@ -438,6 +469,15 @@ defmodule HuddlzWeb.OrganizeLive do
           + Create huddl
         </a>
       </div>
+    </div>
+
+    <div :if={@turnout_nudge} id="turnout-nudge" class="nudge" role="status">
+      <.icon name="hero-users" class="size-5 nudge-icon" />
+      <span>
+        <strong>{@turnout_nudge.title}</strong>
+        ended {nudge_ended(@turnout_nudge)} and has no turnout yet.
+      </span>
+      <.link navigate={huddl_show_path(@group, @turnout_nudge)}>Add turnout</.link>
     </div>
 
     <div class="kpis">
@@ -642,6 +682,7 @@ defmodule HuddlzWeb.OrganizeLive do
       <.organizer_rsvps huddl={@huddl} />
       <div class="org-huddl-actions">
         <.organizer_edit_link group={@group} huddl={@huddl} label="Edit" />
+        <.organizer_turnout_action group={@group} huddl={@huddl} />
         <.link
           :if={@huddl.huddl_template && @huddl.status not in [:cancelled, :completed]}
           navigate={huddl_edit_path(@group, @huddl, "all")}
@@ -700,8 +741,60 @@ defmodule HuddlzWeb.OrganizeLive do
       >
         <span style={"width: #{capacity_percent(@huddl)}%"}></span>
       </div>
+      <span
+        :if={@huddl.status == :completed}
+        class={["org-huddl-turnout", turnout_missing_class(@huddl)]}
+      >
+        {turnout_label(@huddl)}
+      </span>
     </div>
     """
+  end
+
+  attr :group, :map, required: true
+  attr :huddl, :map, required: true
+
+  # A past row either wears its show rate or offers to record one.
+  defp organizer_turnout_action(assigns) do
+    ~H"""
+    <%= if @huddl.status == :completed do %>
+      <.pill :if={@huddl.show_rate} variant={:cyan} class="org-huddl-show-rate">
+        {@huddl.show_rate}% showed
+      </.pill>
+      <.link
+        :if={is_nil(@huddl.turnout_recorded_at)}
+        navigate={huddl_show_path(@group, @huddl)}
+        class="btn-secondary btn-sm org-huddl-add-turnout"
+      >
+        Add turnout
+      </.link>
+    <% end %>
+    """
+  end
+
+  defp turnout_label(%{turnout_recorded_at: nil}), do: "No turnout yet"
+
+  defp turnout_label(huddl) do
+    [
+      huddl.turnout_in_room && "#{huddl.turnout_in_room} in the room",
+      huddl.turnout_on_call && "#{huddl.turnout_on_call} on the call"
+    ]
+    |> Enum.reject(&(!&1))
+    |> Enum.join(" · ")
+  end
+
+  defp turnout_missing_class(%{turnout_recorded_at: nil}), do: "missing"
+  defp turnout_missing_class(_huddl), do: nil
+
+  defp nudge_ended(huddl) do
+    local = DateTime.shift_zone!(huddl.ends_at, huddl.time_zone)
+    today = DateTime.now!(huddl.time_zone) |> DateTime.to_date()
+
+    case Date.diff(today, DateTime.to_date(local)) do
+      0 -> "today"
+      1 -> "yesterday"
+      _ -> "on " <> Calendar.strftime(local, "%a, %b %-d")
+    end
   end
 
   attr :group, :map, required: true

--- a/test/features/organize_turnout.feature
+++ b/test/features/organize_turnout.feature
@@ -1,0 +1,57 @@
+@database @conn @organize_turnout
+Feature: Turnout across Organize
+  As an organizer
+  I want past huddlz to show how many came, and a reminder when a recent one is uncounted
+  So that the numbers I plan with are turnout, not RSVPs
+
+  Background:
+    Given the following users exist:
+      | email            | display_name | role    |
+      | host@example.com | Host User    | regular |
+    And a public group "Portland Elixir" exists with owner "host@example.com"
+    And I am signed in as "host@example.com"
+
+  Scenario: A counted past row shows turnout and show rate
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    And the turnout for "Elixir hack night" was recorded as 2 in the room
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    Then the past row for "Elixir hack night" shows "4 RSVPs", "2 in the room" and "50% showed"
+
+  Scenario: A hybrid past row shows both counts
+    Given the hybrid huddl "Lightning talks" in "Portland Elixir" ended yesterday with 4 RSVPs
+    And the turnout for "Lightning talks" was recorded as 3 in the room and 2 on the call
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    Then the past row for "Lightning talks" shows "3 in the room", "2 on the call" and "125% showed"
+
+  Scenario: An uncounted past row offers Add turnout
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    Then the past row for "Elixir hack night" shows "4 RSVPs" and "No turnout yet"
+    When I click "Add turnout"
+    Then I should see "How many came?"
+
+  Scenario: The overview nudges about the latest uncounted huddl
+    Given the in-person huddl "Elixir office hours" in "Portland Elixir" ended 3 days ago with 4 RSVPs
+    And the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then the overview nudge names "Elixir hack night"
+    And the overview nudge does not name "Elixir office hours"
+    When I click "Add turnout"
+    Then I should see "How many came?"
+
+  Scenario: A dismissed huddl is not nudged
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    And the turnout prompt for "Elixir hack night" was skipped
+    When I visit "/organize/portland-elixir"
+    Then there is no overview nudge
+
+  Scenario: A counted huddl is not nudged
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    And the turnout for "Elixir hack night" was recorded as 2 in the room
+    When I visit "/organize/portland-elixir"
+    Then there is no overview nudge
+
+  Scenario: An old huddl is not nudged
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended 15 days ago with 4 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then there is no overview nudge

--- a/test/features/step_definitions/organize_turnout_steps.exs
+++ b/test/features/step_definitions/organize_turnout_steps.exs
@@ -1,0 +1,109 @@
+defmodule OrganizeTurnoutSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import PhoenixTest
+
+  require Ash.Query
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities
+  alias Huddlz.Communities.{Group, Huddl, HuddlAttendee}
+
+  step "the {word} huddl {string} in {string} ended {int} days ago with {int} RSVPs",
+       %{args: [kind, title, group_name, days, rsvps]} = context do
+    group = Group |> Ash.Query.filter(name == ^group_name) |> Ash.read_one!(authorize?: false)
+    starts_at = DateTime.add(DateTime.utc_now(), -days, :day)
+
+    attrs = [
+      title: title,
+      group_id: group.id,
+      creator_id: group.owner_id,
+      is_private: false,
+      starts_at: starts_at,
+      ends_at: DateTime.add(starts_at, 2, :hour)
+    ]
+
+    huddl = generate(past_huddl(attrs ++ kind_attrs(kind)))
+
+    for _ <- 1..rsvps//1 do
+      attendee = generate(user(role: :user))
+
+      HuddlAttendee
+      |> Ash.Changeset.for_create(:rsvp, %{huddl_id: huddl.id, user_id: attendee.id})
+      |> Ash.create!(authorize?: false)
+    end
+
+    Map.update(context, :huddlz, [huddl], &[huddl | &1])
+  end
+
+  step "the turnout for {string} was recorded as {int} in the room and {int} on the call",
+       %{args: [title, in_room, on_call]} = context do
+    huddl = find_huddl(title)
+    owner = Ash.get!(User, huddl.group.owner_id, authorize?: false)
+    Communities.record_turnout!(huddl, %{in_room: in_room, on_call: on_call}, actor: owner)
+    context
+  end
+
+  step "the turnout prompt for {string} was skipped", %{args: [title]} = context do
+    huddl = find_huddl(title)
+    owner = Ash.get!(User, huddl.group.owner_id, authorize?: false)
+    Communities.skip_turnout!(huddl, actor: owner)
+    context
+  end
+
+  step "the past row for {string} shows {string}, {string} and {string}",
+       %{args: [title | texts], session: session} = context do
+    assert_row_texts(session, find_huddl(title), texts)
+    context
+  end
+
+  step "the past row for {string} shows {string} and {string}",
+       %{args: [title | texts], session: session} = context do
+    assert_row_texts(session, find_huddl(title), texts)
+    context
+  end
+
+  step "the overview nudge names {string}", %{args: [title], session: session} = context do
+    huddl = find_huddl(title)
+
+    session
+    |> assert_has("#turnout-nudge", text: title)
+    |> assert_has("#turnout-nudge a[href='/groups/#{huddl.group.slug}/huddlz/#{huddl.id}']",
+      text: "Add turnout"
+    )
+
+    context
+  end
+
+  step "the overview nudge does not name {string}",
+       %{args: [title], session: session} = context do
+    refute_has(session, "#turnout-nudge", text: title)
+    context
+  end
+
+  step "there is no overview nudge", %{session: session} = context do
+    refute_has(session, "#turnout-nudge")
+    context
+  end
+
+  defp assert_row_texts(session, huddl, texts) do
+    Enum.reduce(texts, session, fn text, session ->
+      assert_has(session, "#organize-huddl-#{huddl.id}", text: text)
+    end)
+  end
+
+  defp kind_attrs("in-person"), do: [event_type: :in_person, virtual_link: nil]
+
+  defp kind_attrs("virtual"),
+    do: [event_type: :virtual, physical_location: nil, virtual_link: "https://meet.example.com/x"]
+
+  defp kind_attrs("hybrid"), do: [event_type: :hybrid, virtual_link: "https://meet.example.com/x"]
+
+  defp find_huddl(title) do
+    Huddl
+    |> Ash.Query.filter(title == ^title)
+    |> Ash.Query.load(:group)
+    |> Ash.read_one!(authorize?: false)
+  end
+end


### PR DESCRIPTION
Closes #508

Turnout now shows up wherever an organizer manages past huddlz.

- Past rows on the Organize Huddlz tab show the recorded count under the RSVPs ("3 in the room", "19 in the room · 8 on the call") with a show-rate pill, or "No turnout yet" with an Add turnout button that leads to the huddl's prompt.
- The group overview carries a one-line nudge naming the most recent huddl that ended within the last 14 days and has been neither counted nor dismissed, linking to record it. One nudge at a time; dismissed, counted and older huddlz are never nudged.

`test/features/organize_turnout.feature` covers the counted row (in-person and hybrid), the uncounted row, and the four nudge cases. Member access to Organize is already covered by the workspace feature.

Screenshots in the first comment.
