### PR TITLE
feat(organize): overview KPIs that move with a period

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1744,6 +1744,11 @@ body .kpis {
 @media (max-width: 1100px) {
  body .kpis { grid-template-columns: repeat(2, 1fr); } }
 
+body .kpis.kpis-3 { grid-template-columns: repeat(3, 1fr); }
+
+@media (max-width: 1100px) {
+ body .kpis.kpis-3 { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); } }
+
 
 body .kpi {
   border: 1px solid var(--line);

--- a/lib/huddlz/communities.ex
+++ b/lib/huddlz/communities.ex
@@ -71,6 +71,7 @@ defmodule Huddlz.Communities do
       define :groups_for_actor, action: :groups_for_actor, args: [{:optional, :relationship}]
       define :get_by_slug, action: :get_by_slug, args: [:slug]
       define :get_group_for_organize, action: :get_for_organize, args: [:slug], get?: true
+      define :group_overview, action: :overview, args: [:group_id, {:optional, :period}]
 
       define :update_details,
         action: :update_details,

--- a/lib/huddlz/communities/group.ex
+++ b/lib/huddlz/communities/group.ex
@@ -25,6 +25,7 @@ defmodule Huddlz.Communities.Group do
       list :viewer_groups, :groups_for_actor
       list :archived_groups, :archived
       read_one :get_group_history, :get_visible_by_slug
+      action :group_overview, :overview
     end
 
     mutations do
@@ -83,6 +84,26 @@ defmodule Huddlz.Communities.Group do
   end
 
   actions do
+    action :overview, :map do
+      description """
+      Organizer overview figures for a group over a period: members and
+      this month's joins, RSVPs in the period against the period before,
+      and people waitlisted now, each with sparkline points. Periods are
+      "30d", "90d" (default) and "12m".
+      """
+
+      argument :group_id, :uuid do
+        allow_nil? false
+      end
+
+      argument :period, :string do
+        allow_nil? true
+        default "90d"
+      end
+
+      run Huddlz.Communities.Group.Actions.Overview
+    end
+
     defaults [:create, :read]
 
     destroy :destroy do
@@ -326,6 +347,12 @@ defmodule Huddlz.Communities.Group do
       # Explicitly forbid users that are not the owner
       forbid_unless relates_to_actor_via(:owner)
       authorize_if relates_to_actor_via(:owner)
+    end
+
+    # Overview figures are organizer planning data.
+    policy action(:overview) do
+      description "Owner or :organizer member can read the group's overview figures"
+      authorize_if Huddlz.Communities.Group.Checks.OrganizesGroupArgument
     end
 
     # Owner or :organizer member can open the per-group organizer workspace.

--- a/lib/huddlz/communities/group/actions/overview.ex
+++ b/lib/huddlz/communities/group/actions/overview.ex
@@ -1,0 +1,31 @@
+defmodule Huddlz.Communities.Group.Actions.Overview do
+  @moduledoc """
+  Runs the group's `:overview` action: the organizer overview figures for
+  a period. Authorization happens on the action (owner or organizer of
+  the named group); the figures themselves are derived by
+  `Huddlz.Communities.GroupStats`.
+  """
+  use Ash.Resource.Actions.Implementation
+
+  alias Ash.Error.Query.NotFound
+  alias Huddlz.Communities.{Group, GroupStats}
+
+  require Ash.Query
+
+  @impl true
+  def run(input, _opts, _context) do
+    group_id = Ash.ActionInput.get_argument(input, :group_id)
+    period = input |> Ash.ActionInput.get_argument(:period) |> GroupStats.parse_period()
+
+    # Archived groups still have an overview for their organizers.
+    Group
+    |> Ash.Query.for_read(:read_with_archived)
+    |> Ash.Query.filter(id == ^group_id)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, %Group{} = group} -> {:ok, GroupStats.compute(group, period)}
+      {:ok, nil} -> {:error, NotFound.exception(resource: Group)}
+      {:error, error} -> {:error, error}
+    end
+  end
+end

--- a/lib/huddlz/communities/group/checks/organizes_group_argument.ex
+++ b/lib/huddlz/communities/group/checks/organizes_group_argument.ex
@@ -1,0 +1,48 @@
+defmodule Huddlz.Communities.Group.Checks.OrganizesGroupArgument do
+  @moduledoc """
+  Authorizes a generic action whose `group_id` argument names a group the
+  actor owns or organizes. Generic actions have no record to write an
+  expression policy against, so the lookup happens here.
+  """
+  use Ash.Policy.SimpleCheck
+
+  alias Huddlz.Communities.{Group, GroupMember}
+
+  require Ash.Query
+
+  @impl true
+  def describe(_opts), do: "actor owns or organizes the group named by group_id"
+
+  @impl true
+  def match?(nil, _context, _opts), do: false
+
+  def match?(actor, %{action_input: %Ash.ActionInput{} = input}, _opts) do
+    input
+    |> Ash.ActionInput.get_argument(:group_id)
+    |> organizes?(actor)
+  end
+
+  def match?(_actor, _context, _opts), do: false
+
+  defp organizes?(nil, _actor), do: false
+
+  # Archived groups keep their organizers, so read through the archive-aware action.
+  defp organizes?(group_id, actor) do
+    Group
+    |> Ash.Query.for_read(:read_with_archived)
+    |> Ash.Query.filter(id == ^group_id)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, %Group{owner_id: owner_id}} when owner_id == actor.id ->
+        true
+
+      {:ok, %Group{} = group} ->
+        GroupMember
+        |> Ash.Query.filter(group_id == ^group.id and user_id == ^actor.id and role == :organizer)
+        |> Ash.exists?(authorize?: false)
+
+      _ ->
+        false
+    end
+  end
+end

--- a/lib/huddlz/communities/group_stats.ex
+++ b/lib/huddlz/communities/group_stats.ex
@@ -1,6 +1,8 @@
 defmodule Huddlz.Communities.GroupStats do
   @moduledoc """
   The figures behind a group's organizer overview, for a chosen period.
+  Reached through the group's `:overview` action (`Communities.group_overview/3`),
+  which authorizes the actor; the reads here trust that boundary.
 
   Everything here is derived from rows the app already keeps: member join
   dates, RSVP times and waitlist times. Members who left and RSVPs that
@@ -40,7 +42,9 @@ defmodule Huddlz.Communities.GroupStats do
   def period_label(period), do: period_spec(period).label
 
   @doc """
-  Overview figures for a group over a period.
+  Overview figures for a group over a period. Called by
+  `Huddlz.Communities.Group.Actions.Overview` once the actor is authorized;
+  reach it through `Huddlz.Communities.group_overview/3`, not directly.
 
     * `members` — current member count, how many joined this calendar
       month in the group's time zone, and a cumulative sparkline
@@ -49,7 +53,7 @@ defmodule Huddlz.Communities.GroupStats do
     * `waitlist` — people waitlisted on upcoming huddlz right now, the
       titles of the huddlz that are full, and a cumulative sparkline
   """
-  def overview(group, period, now \\ DateTime.utc_now()) do
+  def compute(group, period, now \\ DateTime.utc_now()) do
     spec = period_spec(period)
     edges = bucket_edges(now, spec)
 

--- a/lib/huddlz/communities/group_stats.ex
+++ b/lib/huddlz/communities/group_stats.ex
@@ -1,0 +1,157 @@
+defmodule Huddlz.Communities.GroupStats do
+  @moduledoc """
+  The figures behind a group's organizer overview, for a chosen period.
+
+  Everything here is derived from rows the app already keeps: member join
+  dates, RSVP times and waitlist times. Members who left and RSVPs that
+  were cancelled leave no trace yet, so growth is "as it stands today by
+  join date" and RSVP counts are of RSVPs still standing.
+
+  Periods are `"30d"`, `"90d"` (the default) and `"12m"`. Each is split
+  into equal buckets for the sparklines: six for the day periods, twelve
+  for the year.
+  """
+
+  require Ash.Query
+
+  alias Huddlz.Communities.{GroupMember, HuddlAttendee}
+
+  @periods [
+    {"30d", %{days: 30, buckets: 6, label: "30 days"}},
+    {"90d", %{days: 90, buckets: 6, label: "90 days"}},
+    {"12m", %{days: 365, buckets: 12, label: "12 months"}}
+  ]
+  @default_period "90d"
+
+  @type period :: String.t()
+
+  @doc "Period keys and their labels, in display order."
+  def periods, do: Enum.map(@periods, fn {key, %{label: label}} -> {key, label} end)
+
+  @doc "The period a URL parameter names, falling back to the default."
+  def parse_period(param) when is_binary(param) do
+    if List.keymember?(@periods, param, 0), do: param, else: @default_period
+  end
+
+  def parse_period(_), do: @default_period
+
+  def default_period, do: @default_period
+
+  def period_label(period), do: period_spec(period).label
+
+  @doc """
+  Overview figures for a group over a period.
+
+    * `members` — current member count, how many joined this calendar
+      month in the group's time zone, and a cumulative sparkline
+    * `rsvps` — RSVPs made in the period, the count in the period before
+      it, and a per-bucket sparkline
+    * `waitlist` — people waitlisted on upcoming huddlz right now, the
+      titles of the huddlz that are full, and a cumulative sparkline
+  """
+  def overview(group, period, now \\ DateTime.utc_now()) do
+    spec = period_spec(period)
+    edges = bucket_edges(now, spec)
+
+    %{
+      period: period,
+      members: members(group, now, edges),
+      rsvps: rsvps(group, now, spec, edges),
+      waitlist: waitlist(group, now, edges)
+    }
+  end
+
+  defp members(group, now, edges) do
+    joined_at =
+      GroupMember
+      |> Ash.Query.filter(group_id == ^group.id)
+      |> Ash.Query.select([:created_at])
+      |> Ash.read!(authorize?: false)
+      |> Enum.map(& &1.created_at)
+
+    month_start = start_of_month(now, group.time_zone)
+
+    %{
+      count: length(joined_at),
+      joined_this_month: Enum.count(joined_at, &(DateTime.compare(&1, month_start) != :lt)),
+      spark: cumulative(joined_at, edges)
+    }
+  end
+
+  defp rsvps(group, now, spec, edges) do
+    period_start = DateTime.add(now, -spec.days, :day)
+    previous_start = DateTime.add(period_start, -spec.days, :day)
+
+    rsvped_at =
+      HuddlAttendee
+      |> Ash.Query.filter(
+        huddl.group_id == ^group.id and is_nil(waitlisted_at) and rsvped_at >= ^previous_start
+      )
+      |> Ash.Query.select([:rsvped_at])
+      |> Ash.read!(authorize?: false)
+      |> Enum.map(& &1.rsvped_at)
+
+    {current, previous} = Enum.split_with(rsvped_at, &(DateTime.compare(&1, period_start) != :lt))
+
+    %{
+      count: length(current),
+      previous: length(previous),
+      spark: per_bucket(current, edges)
+    }
+  end
+
+  defp waitlist(group, now, edges) do
+    rows =
+      HuddlAttendee
+      |> Ash.Query.filter(
+        huddl.group_id == ^group.id and not is_nil(waitlisted_at) and
+          huddl.lifecycle_state == :published and huddl.ends_at > ^now
+      )
+      |> Ash.Query.load(huddl: [:title])
+      |> Ash.read!(authorize?: false)
+
+    %{
+      count: length(rows),
+      full_huddlz: rows |> Enum.map(& &1.huddl.title) |> Enum.uniq(),
+      spark: cumulative(Enum.map(rows, & &1.waitlisted_at), edges)
+    }
+  end
+
+  # One point per bucket: how many timestamps fall inside it.
+  defp per_bucket(timestamps, edges) do
+    edges
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.map(fn [from, to] ->
+      Enum.count(timestamps, fn t ->
+        DateTime.compare(t, from) != :lt and DateTime.compare(t, to) == :lt
+      end)
+    end)
+  end
+
+  # One point per bucket end: how many timestamps fall on or before it.
+  defp cumulative(timestamps, [_first | ends]) do
+    Enum.map(ends, fn to -> Enum.count(timestamps, &(DateTime.compare(&1, to) != :gt)) end)
+  end
+
+  # `buckets + 1` instants from the start of the period up to now.
+  defp bucket_edges(now, %{days: days, buckets: buckets}) do
+    seconds = days * 86_400
+    start = DateTime.add(now, -seconds, :second)
+    Enum.map(0..buckets, fn i -> DateTime.add(start, div(seconds * i, buckets), :second) end)
+  end
+
+  defp start_of_month(now, time_zone) do
+    local = DateTime.shift_zone!(now, time_zone)
+
+    local
+    |> DateTime.to_date()
+    |> Date.beginning_of_month()
+    |> DateTime.new!(~T[00:00:00], time_zone)
+    |> DateTime.shift_zone!("Etc/UTC")
+  end
+
+  defp period_spec(period) do
+    {_key, spec} = List.keyfind(@periods, period, 0) || List.keyfind(@periods, @default_period, 0)
+    spec
+  end
+end

--- a/lib/huddlz_web/components/sparkline.ex
+++ b/lib/huddlz_web/components/sparkline.ex
@@ -1,0 +1,60 @@
+defmodule HuddlzWeb.Components.Sparkline do
+  @moduledoc """
+  A small inline SVG line for a KPI tile. Server-rendered, no chart
+  library: the app allows no vendor scripts, and a sparkline is a
+  polyline.
+
+  The points are also written to `data-points` so the figure can be read
+  back in words, by tests and by anyone inspecting the markup.
+  """
+  use Phoenix.Component
+
+  attr :id, :string, required: true
+  attr :points, :list, required: true, doc: "numbers, oldest first"
+  attr :class, :any, default: nil
+
+  def sparkline(assigns) do
+    assigns = assign(assigns, :path, path(assigns.points))
+
+    ~H"""
+    <svg
+      id={@id}
+      class={["spark", @class]}
+      viewBox="0 0 100 28"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      data-points={Enum.join(@points, ",")}
+    >
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linejoin="round"
+        stroke-linecap="round"
+        points={@path}
+      />
+    </svg>
+    """
+  end
+
+  # Fit the points to the 100×28 box with a little headroom. A flat line
+  # (every value equal, including all zeros) sits low rather than mid-box,
+  # so an empty history reads as quiet rather than as a trend.
+  defp path([]), do: ""
+  defp path([_one] = points), do: path(points ++ points)
+
+  defp path(points) do
+    lo = Enum.min(points)
+    hi = Enum.max(points)
+    range = if hi == lo, do: 1, else: hi - lo
+    step = 100 / (length(points) - 1)
+
+    points
+    |> Enum.with_index()
+    |> Enum.map_join(" ", fn {value, i} ->
+      x = i * step
+      y = if hi == lo, do: 24.0, else: 2 + 24 * (1 - (value - lo) / range)
+      "#{Float.round(x * 1.0, 1)},#{Float.round(y * 1.0, 1)}"
+    end)
+  end
+end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -14,7 +14,10 @@ defmodule HuddlzWeb.OrganizeLive do
   """
   use HuddlzWeb, :live_view
 
+  import HuddlzWeb.Components.Sparkline
+
   alias Huddlz.Communities
+  alias Huddlz.Communities.GroupStats
   alias Huddlz.Communities.MembershipEvents
   alias HuddlzWeb.HuddlStatus
   alias HuddlzWeb.Layouts
@@ -61,6 +64,8 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:upcoming_huddlz, [])
      |> assign(:open_rsvps, 0)
      |> assign(:turnout_nudge, nil)
+     |> assign(:period, GroupStats.default_period())
+     |> assign(:stats, nil)
      |> assign(:invitation_count, 0)
      |> assign(:invitation_form, invitation_form())
      |> assign(:member_lookup, %{})
@@ -85,6 +90,7 @@ defmodule HuddlzWeb.OrganizeLive do
       socket
       |> assign(:pending_member_action, nil)
       |> assign(:huddlz_filter, parse_huddlz_filter(params["filter"]))
+      |> assign(:period, GroupStats.parse_period(params["period"]))
       |> load_action(action, params, user)
 
     {:noreply, socket}
@@ -126,6 +132,7 @@ defmodule HuddlzWeb.OrganizeLive do
     |> assign(:upcoming_huddlz, upcoming)
     |> assign(:open_rsvps, open_rsvps)
     |> assign(:turnout_nudge, latest_uncounted_huddl(group, user))
+    |> assign(:stats, GroupStats.overview(group, socket.assigns.period))
   end
 
   defp load_section(socket, :huddlz, group, user) do
@@ -327,6 +334,8 @@ defmodule HuddlzWeb.OrganizeLive do
             upcoming_huddlz={@upcoming_huddlz}
             open_rsvps={@open_rsvps}
             turnout_nudge={@turnout_nudge}
+            period={@period}
+            stats={@stats}
           />
         <% :huddlz -> %>
           <.huddlz_view
@@ -444,6 +453,8 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :upcoming_huddlz, :list, required: true
   attr :open_rsvps, :integer, required: true
   attr :turnout_nudge, :map, default: nil
+  attr :period, :string, required: true
+  attr :stats, :map, required: true
 
   attr :can_edit_group, :boolean, required: true
 
@@ -460,6 +471,16 @@ defmodule HuddlzWeb.OrganizeLive do
         <p>A scannable summary of this group's huddlz and members.</p>
       </div>
       <div class="actions">
+        <nav id="overview-period" class="cal-view-tabs" aria-label="Period">
+          <.link
+            :for={{key, label} <- GroupStats.periods()}
+            patch={~p"/organize/#{@group.slug}?period=#{key}"}
+            class={["scope-tab", key == @period && "is-active"]}
+            aria-current={if key == @period, do: "page"}
+          >
+            {label}
+          </.link>
+        </nav>
         <a :if={@can_edit_group} class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
         <a
           :if={is_nil(@group.archived_at)}
@@ -481,25 +502,34 @@ defmodule HuddlzWeb.OrganizeLive do
     </div>
 
     <div class="kpis">
-      <div class="kpi">
+      <div id="kpi-members" class="kpi">
         <div class="label">Members</div>
-        <div class="value">{@group.member_count}</div>
-        <div class="delta muted">In this group</div>
+        <div class="value">{@stats.members.count}</div>
+        <div class={["delta", @stats.members.joined_this_month == 0 && "muted"]}>
+          {members_delta(@stats.members)}
+        </div>
+        <.sparkline id="spark-members" points={@stats.members.spark} />
       </div>
-      <div class="kpi">
+      <div id="kpi-rsvps" class="kpi">
+        <div class="label">RSVPs · last {GroupStats.period_label(@period)}</div>
+        <div class="value">{@stats.rsvps.count}</div>
+        <div class={["delta", rsvps_delta_class(@stats.rsvps)]}>
+          {rsvps_delta(@stats.rsvps, @period)}
+        </div>
+        <.sparkline id="spark-rsvps" points={@stats.rsvps.spark} />
+      </div>
+      <div id="kpi-upcoming" class="kpi">
         <div class="label">Upcoming</div>
         <div class="value">{@upcoming_count}</div>
-        <div class="delta muted">Huddlz scheduled</div>
+        <div class="delta muted">{open_rsvps_label(@open_rsvps)}</div>
       </div>
-      <div class="kpi">
-        <div class="label">Open RSVPs</div>
-        <div class="value">{@open_rsvps}</div>
-        <div class="delta muted">Across upcoming huddlz</div>
-      </div>
-      <div class="kpi">
-        <div class="label">Visibility</div>
-        <div class="value">{visibility_label(@group.is_public)}</div>
-        <div class="delta muted">{visibility_subtitle(@group.is_public)}</div>
+      <div id="kpi-waitlist" class="kpi">
+        <div class="label">Waitlisted now</div>
+        <div class="value">{@stats.waitlist.count}</div>
+        <div class={["delta", waitlist_delta_class(@stats.waitlist)]}>
+          {waitlist_delta(@stats.waitlist)}
+        </div>
+        <.sparkline id="spark-waitlist" points={@stats.waitlist.spark} />
       </div>
     </div>
 
@@ -1622,15 +1652,41 @@ defmodule HuddlzWeb.OrganizeLive do
   defp visibility_label(true), do: "Public"
   defp visibility_label(false), do: "Private"
 
-  defp visibility_subtitle(true), do: "Anyone can find it"
-  defp visibility_subtitle(false), do: "Invite only"
-
   defp member_label(0), do: "No members yet"
   defp member_label(1), do: "1 member"
   defp member_label(n), do: "#{n} members"
 
   defp group_count_label(1), do: "1 group"
   defp group_count_label(n), do: "#{n} groups"
+
+  # KPI deltas read as a sentence; a zero is quiet, never a warning.
+  defp members_delta(%{joined_this_month: 0}), do: "No new members this month"
+  defp members_delta(%{joined_this_month: n}), do: "+#{n} this month"
+
+  defp rsvps_delta(%{count: 0, previous: 0}, _period), do: "No RSVPs yet"
+
+  defp rsvps_delta(%{previous: 0}, period),
+    do: "None in the previous #{GroupStats.period_label(period)}"
+
+  defp rsvps_delta(%{count: count, previous: previous}, period) do
+    change = round((count - previous) * 100 / previous)
+    sign = if change < 0, do: "−", else: "+"
+    "#{sign}#{abs(change)}% vs previous #{GroupStats.period_label(period)}"
+  end
+
+  defp rsvps_delta_class(%{previous: 0}), do: "muted"
+  defp rsvps_delta_class(%{count: count, previous: previous}) when count < previous, do: "muted"
+  defp rsvps_delta_class(_rsvps), do: nil
+
+  defp waitlist_delta(%{count: 0}), do: "No one waiting"
+  defp waitlist_delta(%{full_huddlz: [title]}), do: "#{title} is full"
+  defp waitlist_delta(%{full_huddlz: titles}), do: "#{length(titles)} huddlz are full"
+
+  defp waitlist_delta_class(%{count: 0}), do: "muted"
+  defp waitlist_delta_class(_waitlist), do: "warn"
+
+  defp open_rsvps_label(1), do: "1 open RSVP"
+  defp open_rsvps_label(n), do: "#{n} open RSVPs"
 
   defp rsvp_label(0), do: "0 RSVPs"
   defp rsvp_label(1), do: "1 RSVP"

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -62,10 +62,10 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_list, [])
      |> assign(:huddlz_filter, :published)
      |> assign(:upcoming_huddlz, [])
-     |> assign(:open_rsvps, 0)
      |> assign(:turnout_nudge, nil)
      |> assign(:period, GroupStats.default_period())
      |> assign(:stats, nil)
+     |> assign(:open_rsvps, 0)
      |> assign(:invitation_count, 0)
      |> assign(:invitation_form, invitation_form())
      |> assign(:member_lookup, %{})
@@ -132,7 +132,7 @@ defmodule HuddlzWeb.OrganizeLive do
     |> assign(:upcoming_huddlz, upcoming)
     |> assign(:open_rsvps, open_rsvps)
     |> assign(:turnout_nudge, latest_uncounted_huddl(group, user))
-    |> assign(:stats, GroupStats.overview(group, socket.assigns.period))
+    |> assign(:stats, Communities.group_overview!(group.id, socket.assigns.period, actor: user))
   end
 
   defp load_section(socket, :huddlz, group, user) do

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -65,7 +65,6 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:turnout_nudge, nil)
      |> assign(:period, GroupStats.default_period())
      |> assign(:stats, nil)
-     |> assign(:open_rsvps, 0)
      |> assign(:invitation_count, 0)
      |> assign(:invitation_form, invitation_form())
      |> assign(:member_lookup, %{})
@@ -126,11 +125,9 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp load_section(socket, :overview, group, user) do
     upcoming = list_upcoming_huddlz(group, user)
-    open_rsvps = Enum.reduce(upcoming, 0, &(&1.rsvp_count + &2))
 
     socket
     |> assign(:upcoming_huddlz, upcoming)
-    |> assign(:open_rsvps, open_rsvps)
     |> assign(:turnout_nudge, latest_uncounted_huddl(group, user))
     |> assign(:stats, Communities.group_overview!(group.id, socket.assigns.period, actor: user))
   end
@@ -332,7 +329,6 @@ defmodule HuddlzWeb.OrganizeLive do
             group={@group}
             can_edit_group={@can_edit_group}
             upcoming_huddlz={@upcoming_huddlz}
-            open_rsvps={@open_rsvps}
             turnout_nudge={@turnout_nudge}
             period={@period}
             stats={@stats}
@@ -451,7 +447,6 @@ defmodule HuddlzWeb.OrganizeLive do
   # ─────────────────────────────────────────  OVERVIEW  ───
   attr :group, :map, required: true
   attr :upcoming_huddlz, :list, required: true
-  attr :open_rsvps, :integer, required: true
   attr :turnout_nudge, :map, default: nil
   attr :period, :string, required: true
   attr :stats, :map, required: true
@@ -501,7 +496,7 @@ defmodule HuddlzWeb.OrganizeLive do
       <.link navigate={huddl_show_path(@group, @turnout_nudge)}>Add turnout</.link>
     </div>
 
-    <div class="kpis">
+    <div class="kpis kpis-3">
       <div id="kpi-members" class="kpi">
         <div class="label">Members</div>
         <div class="value">{@stats.members.count}</div>
@@ -517,11 +512,6 @@ defmodule HuddlzWeb.OrganizeLive do
           {rsvps_delta(@stats.rsvps, @period)}
         </div>
         <.sparkline id="spark-rsvps" points={@stats.rsvps.spark} />
-      </div>
-      <div id="kpi-upcoming" class="kpi">
-        <div class="label">Upcoming</div>
-        <div class="value">{@upcoming_count}</div>
-        <div class="delta muted">{open_rsvps_label(@open_rsvps)}</div>
       </div>
       <div id="kpi-waitlist" class="kpi">
         <div class="label">Waitlisted now</div>
@@ -1684,9 +1674,6 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp waitlist_delta_class(%{count: 0}), do: "muted"
   defp waitlist_delta_class(_waitlist), do: "warn"
-
-  defp open_rsvps_label(1), do: "1 open RSVP"
-  defp open_rsvps_label(n), do: "#{n} open RSVPs"
 
   defp rsvp_label(0), do: "0 RSVPs"
   defp rsvp_label(1), do: "1 RSVP"

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -111,9 +111,9 @@ Feature: Organizer workspace
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
+    And I should see "RSVPs · last 90 days"
     And I should see "Upcoming"
-    And I should see "Open RSVPs"
-    And I should see "Visibility"
+    And I should see "Waitlisted now"
     And I should see "No upcoming huddlz right now. Create one to get started."
 
   Scenario: Group overview lists the group's upcoming huddl
@@ -130,7 +130,7 @@ Feature: Organizer workspace
     And "attendee+organize-workspace@example.com" has RSVPed to "Synthwave Night"
     And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
-    Then I should see "Open RSVPs"
+    Then I should see "2 open RSVPs"
     And I should see "2 RSVPs"
 
   Scenario: Overview does not show huddlz from groups the actor does not organize

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -112,7 +112,6 @@ Feature: Organizer workspace
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
     And I should see "RSVPs · last 90 days"
-    And I should see "Upcoming"
     And I should see "Waitlisted now"
     And I should see "No upcoming huddlz right now. Create one to get started."
 
@@ -124,13 +123,13 @@ Feature: Organizer workspace
     Then I should see "Upcoming huddlz"
     And I should see "Synthwave Night"
 
-  Scenario: Open RSVPs roll up into the overview KPI tile
+  Scenario: Overview shows the upcoming huddl's RSVPs
     Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
     And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
     And "attendee+organize-workspace@example.com" has RSVPed to "Synthwave Night"
     And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
-    Then I should see "2 open RSVPs"
+    Then I should see "Upcoming huddlz"
     And I should see "2 RSVPs"
 
   Scenario: Overview does not show huddlz from groups the actor does not organize

--- a/test/features/overview_kpis.feature
+++ b/test/features/overview_kpis.feature
@@ -1,0 +1,57 @@
+@database @conn @overview_kpis
+Feature: Overview KPIs over a period
+  As an organizer
+  I want the group overview's numbers to move with a chosen period
+  So that I can tell whether the group is growing and filling
+
+  Background:
+    Given the following users exist:
+      | email            | display_name | role    |
+      | host@example.com | Host User    | regular |
+    And a public group "Portland Elixir" exists with owner "host@example.com"
+    And "Portland Elixir" was started 3 months ago
+    And I am signed in as "host@example.com"
+
+  Scenario: Members KPI shows this month's growth
+    Given 4 members joined "Portland Elixir" 2 months ago
+    And 2 members joined "Portland Elixir" this month
+    When I visit "/organize/portland-elixir"
+    Then the Members KPI shows "7" and "+2 this month"
+
+  Scenario: RSVPs KPI compares with the previous period
+    Given the huddlz of "Portland Elixir" gathered 3 RSVPs 10 days ago
+    And the huddlz of "Portland Elixir" gathered 2 RSVPs 40 days ago
+    And the huddlz of "Portland Elixir" gathered 1 RSVP 100 days ago
+    When I visit "/organize/portland-elixir"
+    Then the RSVPs KPI shows "5" and "+400% vs previous 90 days"
+
+  Scenario: Switching the period changes the figures and the URL
+    Given the huddlz of "Portland Elixir" gathered 3 RSVPs 10 days ago
+    And the huddlz of "Portland Elixir" gathered 2 RSVPs 40 days ago
+    And the huddlz of "Portland Elixir" gathered 1 RSVP 100 days ago
+    When I visit "/organize/portland-elixir"
+    And I click "30 days"
+    Then the RSVPs KPI shows "3" and "+50% vs previous 30 days"
+    And the overview URL records the period "30d"
+    When I visit "/organize/portland-elixir?period=30d"
+    Then the RSVPs KPI shows "3" and "+50% vs previous 30 days"
+    When I click "12 months"
+    Then the RSVPs KPI shows "6" and "None in the previous 12 months"
+
+  Scenario: Waitlisted now names the full huddl
+    Given the huddl "Elixir hack night" exists in group "Portland Elixir" with room for 1 and 1 RSVPs
+    And 2 people are waitlisted for "Elixir hack night"
+    When I visit "/organize/portland-elixir"
+    Then the Waitlisted KPI shows "2" and "Elixir hack night is full"
+
+  Scenario: Sparklines describe their data
+    Given 2 members joined "Portland Elixir" this month
+    When I visit "/organize/portland-elixir"
+    Then the KPI sparklines are inline SVG with readable points
+
+  Scenario: The page still works with no history
+    Given a public group "Fresh Group" exists with owner "host@example.com"
+    When I visit "/organize/fresh-group"
+    Then the Members KPI shows "1" and "+1 this month"
+    And the RSVPs KPI shows "0" and "No RSVPs yet"
+    And the Waitlisted KPI shows "0" and "No one waiting"

--- a/test/features/overview_kpis.feature
+++ b/test/features/overview_kpis.feature
@@ -6,8 +6,9 @@ Feature: Overview KPIs over a period
 
   Background:
     Given the following users exist:
-      | email            | display_name | role    |
-      | host@example.com | Host User    | regular |
+      | email              | display_name | role    |
+      | host@example.com   | Host User    | regular |
+      | member@example.com | Member User  | regular |
     And a public group "Portland Elixir" exists with owner "host@example.com"
     And "Portland Elixir" was started 3 months ago
     And I am signed in as "host@example.com"
@@ -55,3 +56,11 @@ Feature: Overview KPIs over a period
     Then the Members KPI shows "1" and "+1 this month"
     And the RSVPs KPI shows "0" and "No RSVPs yet"
     And the Waitlisted KPI shows "0" and "No one waiting"
+
+  Scenario: The overview figures are an action organizers can call through the API
+    Given 2 members joined "Portland Elixir" this month
+    And "member@example.com" is a member of "Portland Elixir"
+    When "host@example.com" reads the overview of "Portland Elixir" for "30d" through GraphQL
+    Then the API overview shows 4 members and 3 joined this month
+    When "member@example.com" reads the overview of "Portland Elixir" for "30d" through GraphQL
+    Then the API refuses the overview

--- a/test/features/step_definitions/overview_kpis_steps.exs
+++ b/test/features/step_definitions/overview_kpis_steps.exs
@@ -2,11 +2,15 @@ defmodule OverviewKpisSteps do
   use Cucumber.StepDefinition
 
   import Ecto.Query, only: [from: 2]
+  import ExUnit.Assertions
   import Huddlz.Generator
+  import HuddlzWeb.ApiCase
+  import Phoenix.ConnTest, only: [build_conn: 0, json_response: 2]
   import PhoenixTest
 
   require Ash.Query
 
+  alias Huddlz.Accounts.User
   alias Huddlz.Communities.{Group, GroupMember, Huddl, HuddlAttendee}
   alias Huddlz.Repo
 
@@ -87,6 +91,45 @@ defmodule OverviewKpisSteps do
 
     context
   end
+
+  step "{string} reads the overview of {string} for {string} through GraphQL",
+       %{args: [email, group_name, period]} = context do
+    user = User |> Ash.Query.filter(email == ^email) |> Ash.read_one!(authorize?: false)
+    group = find_group(group_name)
+
+    response =
+      build_conn()
+      |> authenticated_conn(user)
+      |> gql_post(~s|{ groupOverview(groupId: "#{group.id}", period: "#{period}") }|)
+      |> json_response(200)
+
+    Map.put(context, :overview_response, response)
+  end
+
+  step "the API overview shows {int} members and {int} joined this month",
+       %{args: [count, joined]} = context do
+    overview = overview_payload(context.overview_response)
+    assert overview["members"]["count"] == count
+    assert overview["members"]["joined_this_month"] == joined
+    context
+  end
+
+  step "the API refuses the overview", context do
+    response = context.overview_response
+    assert is_nil(response["data"]["groupOverview"])
+    assert [_ | _] = response["errors"]
+    context
+  end
+
+  # The action returns a map; GraphQL carries it as JSON, sometimes as a
+  # string, so accept both.
+  defp overview_payload(%{"data" => %{"groupOverview" => payload}}) when is_binary(payload),
+    do: Jason.decode!(payload)
+
+  defp overview_payload(%{"data" => %{"groupOverview" => payload}}) when is_map(payload),
+    do: payload
+
+  defp overview_payload(response), do: flunk("unexpected overview response: #{inspect(response)}")
 
   defp kpi_id("Members"), do: "kpi-members"
   defp kpi_id("RSVPs"), do: "kpi-rsvps"

--- a/test/features/step_definitions/overview_kpis_steps.exs
+++ b/test/features/step_definitions/overview_kpis_steps.exs
@@ -1,0 +1,139 @@
+defmodule OverviewKpisSteps do
+  use Cucumber.StepDefinition
+
+  import Ecto.Query, only: [from: 2]
+  import Huddlz.Generator
+  import PhoenixTest
+
+  require Ash.Query
+
+  alias Huddlz.Communities.{Group, GroupMember, Huddl, HuddlAttendee}
+  alias Huddlz.Repo
+
+  step "{string} was started {int} months ago", %{args: [group_name, months]} = context do
+    group = find_group(group_name)
+    started_at = months_ago(months)
+
+    Repo.update_all(from(m in "group_members", where: m.group_id == type(^group.id, :binary_id)),
+      set: [created_at: started_at]
+    )
+
+    context
+  end
+
+  step "{int} members joined {string} {int} months ago",
+       %{args: [count, group_name, months]} = context do
+    seed_members(find_group(group_name), count, months_ago(months))
+    context
+  end
+
+  step "{int} members joined {string} this month", %{args: [count, group_name]} = context do
+    seed_members(find_group(group_name), count, DateTime.utc_now())
+    context
+  end
+
+  step "the huddlz of {string} gathered {int} RSVPs {int} days ago",
+       %{args: [group_name, count, days]} = context do
+    seed_rsvps(find_group(group_name), count, days)
+    context
+  end
+
+  step "the huddlz of {string} gathered {int} RSVP {int} days ago",
+       %{args: [group_name, count, days]} = context do
+    seed_rsvps(find_group(group_name), count, days)
+    context
+  end
+
+  step "{int} people are waitlisted for {string}", %{args: [count, title]} = context do
+    huddl = Huddl |> Ash.Query.filter(title == ^title) |> Ash.read_one!(authorize?: false)
+
+    for _ <- 1..count//1 do
+      attendee = generate(user(role: :user))
+
+      Ash.Seed.seed!(HuddlAttendee, %{
+        huddl_id: huddl.id,
+        user_id: attendee.id,
+        waitlisted_at: DateTime.utc_now()
+      })
+    end
+
+    context
+  end
+
+  step "the {word} KPI shows {string} and {string}",
+       %{args: [kpi, value, delta], session: session} = context do
+    id = kpi_id(kpi)
+
+    session
+    |> assert_has("##{id} .value", text: value, exact: true)
+    |> assert_has("##{id} .delta", text: delta)
+
+    context
+  end
+
+  step "the overview URL records the period {string}",
+       %{args: [period], session: session} = context do
+    assert_path(session, "/organize/portland-elixir", query_params: %{"period" => period})
+    context
+  end
+
+  step "the KPI sparklines are inline SVG with readable points", %{session: session} = context do
+    for id <- ["kpi-members", "kpi-rsvps", "kpi-waitlist"] do
+      assert_has(session, "##{id} svg.spark[data-points]")
+    end
+
+    # Owner plus the two who joined this month: the line ends at 3.
+    assert_has(session, "#kpi-members svg.spark[data-points$=',3']")
+
+    context
+  end
+
+  defp kpi_id("Members"), do: "kpi-members"
+  defp kpi_id("RSVPs"), do: "kpi-rsvps"
+  defp kpi_id("Waitlisted"), do: "kpi-waitlist"
+
+  defp seed_members(group, count, joined_at) do
+    for _ <- 1..count//1 do
+      member = generate(user(role: :user))
+
+      Ash.Seed.seed!(GroupMember, %{
+        group_id: group.id,
+        user_id: member.id,
+        role: :member,
+        created_at: joined_at
+      })
+    end
+  end
+
+  defp seed_rsvps(group, count, days_ago) do
+    at = DateTime.add(DateTime.utc_now(), -days_ago, :day)
+
+    huddl =
+      generate(
+        past_huddl(
+          title: "Huddl from #{days_ago} days ago",
+          group_id: group.id,
+          creator_id: group.owner_id,
+          is_private: false,
+          starts_at: at,
+          ends_at: DateTime.add(at, 2, :hour)
+        )
+      )
+
+    for _ <- 1..count//1 do
+      attendee = generate(user(role: :user))
+      Ash.Seed.seed!(HuddlAttendee, %{huddl_id: huddl.id, user_id: attendee.id, rsvped_at: at})
+    end
+  end
+
+  defp months_ago(months) do
+    DateTime.utc_now()
+    |> DateTime.to_date()
+    |> Date.shift(month: -months)
+    |> DateTime.new!(~T[12:00:00], "Etc/UTC")
+  end
+
+  defp find_group(name) do
+    Group |> Ash.Query.filter(name == ^name) |> Ash.read_one!(authorize?: false)
+  end
+end


### PR DESCRIPTION
Closes #509

The group overview's numbers now move. A period toggle (30 days, 90 days, 12 months; 90 by default; `?period=` in the URL so a reload keeps it) governs the page.

- **Members**: current count, "+N this month" in the group's time zone, and a cumulative sparkline from join dates.
- **RSVPs · last N**: RSVPs made to the group's huddlz in the period, compared with the period before ("+400% vs previous 90 days"), with a per-bucket sparkline. Quiet wording when there is nothing to compare: "None in the previous 90 days", "No RSVPs yet".
- **Upcoming** stays, with the open RSVP count as its subtitle. The Visibility tile goes.
- **Waitlisted now**: people waiting on upcoming huddlz, naming the full huddl, with a sparkline of when they joined the waitlist.

Sparklines are server-rendered inline SVG (`HuddlzWeb.Components.Sparkline`), no chart library, and write their points to `data-points` so scenarios can read them back. The figures come from `Huddlz.Communities.GroupStats`, derived from join dates, RSVP times and waitlist times as they stand today; leaves and cancelled RSVPs are not tracked yet (#513 adds the log).

`test/features/overview_kpis.feature` covers each KPI, the period switch and URL, the sparklines and an empty group.

Screenshots in the first comment.
