### PR TITLE
feat(organize): next huddl panel with its signup curve

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1795,6 +1795,128 @@ body .kpi .spark {
   opacity: 0.9;
 }
 
+/* ─────────────────────────────────────────  CHARTS  ──── */
+body .chart {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+body .chart text {
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  fill: var(--muted);
+}
+
+body .chart .axis { stroke: var(--line); stroke-width: 1; }
+body .chart .grid { stroke: var(--line); stroke-width: 1; stroke-dasharray: 2 4; }
+
+body .chart .line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+body .chart .area { fill: var(--accent); opacity: 0.1; }
+body .chart .dot { fill: var(--panel); stroke: var(--accent); stroke-width: 2; }
+
+body .chart .typical {
+  fill: none;
+  stroke: var(--line-strong);
+  stroke-width: 2;
+  stroke-dasharray: 4 4;
+}
+
+body .chart .cap { stroke: var(--soft); stroke-width: 1.5; }
+
+body .legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+body .legend span { display: inline-flex; align-items: center; gap: 6px; }
+
+body .legend i {
+  display: inline-block;
+  width: 12px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+}
+
+body .legend i.typ {
+  background: repeating-linear-gradient(90deg, var(--line-strong) 0 3px, transparent 3px 6px);
+}
+
+body .legend i.cap { height: 2px; background: var(--soft); }
+
+body .stat { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+
+body .stat .big {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+body .stat .cmp { font-size: 12px; font-weight: 600; color: var(--muted); }
+
+body .next-huddl-body { display: grid; grid-template-columns: minmax(0, 1fr); gap: 20px; }
+body .next-huddl-chart { max-width: 720px; }
+
+body .next-huddl-others {
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+
+body .next-huddl-others .count { white-space: nowrap; }
+
+@media (min-width: 900px) {
+  body .next-huddl-body.has-others {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 28px;
+  }
+
+  body .next-huddl-body.has-others .next-huddl-others {
+    padding: 0 0 0 28px;
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+}
+
+body .next-huddl-others .label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+body .next-huddl-others ul {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+body .next-huddl-others a { color: var(--text); font-weight: 500; }
+body .next-huddl-others a:hover { color: var(--accent-ink); }
+
 /* ─────────────────────────────────────────  TABLES / LISTS  ──── */
 body .panel {
   border: 1px solid var(--line);

--- a/lib/huddlz/communities/group/actions/overview.ex
+++ b/lib/huddlz/communities/group/actions/overview.ex
@@ -13,7 +13,7 @@ defmodule Huddlz.Communities.Group.Actions.Overview do
   require Ash.Query
 
   @impl true
-  def run(input, _opts, _context) do
+  def run(input, _opts, context) do
     group_id = Ash.ActionInput.get_argument(input, :group_id)
     period = input |> Ash.ActionInput.get_argument(:period) |> GroupStats.parse_period()
 
@@ -23,7 +23,7 @@ defmodule Huddlz.Communities.Group.Actions.Overview do
     |> Ash.Query.filter(id == ^group_id)
     |> Ash.read_one(authorize?: false)
     |> case do
-      {:ok, %Group{} = group} -> {:ok, GroupStats.compute(group, period)}
+      {:ok, %Group{} = group} -> {:ok, GroupStats.compute(group, period, context.actor)}
       {:ok, nil} -> {:error, NotFound.exception(resource: Group)}
       {:error, error} -> {:error, error}
     end

--- a/lib/huddlz/communities/group_stats.ex
+++ b/lib/huddlz/communities/group_stats.ex
@@ -12,11 +12,19 @@ defmodule Huddlz.Communities.GroupStats do
   Periods are `"30d"`, `"90d"` (the default) and `"12m"`. Each is split
   into equal buckets for the sparklines: six for the day periods, twelve
   for the year.
+
+  The next huddl's signup curve is one point per day since it was
+  published: how many RSVPs stood by the end of that day. The group's
+  typical curve is the same measure averaged over its past huddlz, drawn
+  only once there are three of them to average.
   """
 
   require Ash.Query
 
-  alias Huddlz.Communities.{GroupMember, HuddlAttendee}
+  alias Huddlz.Communities.{GroupMember, Huddl, HuddlAttendee}
+
+  @day 86_400
+  @typical_min_history 3
 
   @periods [
     {"30d", %{days: 30, buckets: 6, label: "30 days"}},
@@ -45,6 +53,8 @@ defmodule Huddlz.Communities.GroupStats do
   Overview figures for a group over a period. Called by
   `Huddlz.Communities.Group.Actions.Overview` once the actor is authorized;
   reach it through `Huddlz.Communities.group_overview/3`, not directly.
+  The actor is the organizer asking, used to read the group's huddlz
+  through the organizer read.
 
     * `members` — current member count, how many joined this calendar
       month in the group's time zone, and a cumulative sparkline
@@ -52,8 +62,11 @@ defmodule Huddlz.Communities.GroupStats do
       it, and a per-bucket sparkline
     * `waitlist` — people waitlisted on upcoming huddlz right now, the
       titles of the huddlz that are full, and a cumulative sparkline
+    * `next_huddl` — the next upcoming huddl with its RSVPs, capacity,
+      signup curve since publish, the group's typical curve (or nil) and
+      the other upcoming huddlz; nil when nothing is upcoming
   """
-  def compute(group, period, now \\ DateTime.utc_now()) do
+  def compute(group, period, actor, now \\ DateTime.utc_now()) do
     spec = period_spec(period)
     edges = bucket_edges(now, spec)
 
@@ -61,7 +74,8 @@ defmodule Huddlz.Communities.GroupStats do
       period: period,
       members: members(group, now, edges),
       rsvps: rsvps(group, now, spec, edges),
-      waitlist: waitlist(group, now, edges)
+      waitlist: waitlist(group, now, edges),
+      next_huddl: next_huddl(group, actor, now)
     }
   end
 
@@ -120,6 +134,87 @@ defmodule Huddlz.Communities.GroupStats do
       spark: cumulative(Enum.map(rows, & &1.waitlisted_at), edges)
     }
   end
+
+  defp next_huddl(group, actor, now) do
+    case organizer_huddlz(group, actor, :published, starts_at: :asc) do
+      [] ->
+        nil
+
+      [next | others] ->
+        published_at = next.published_at || next.inserted_at
+        days = days_between(published_at, now)
+
+        next
+        |> huddl_summary()
+        |> Map.merge(%{
+          published_at: published_at,
+          days: days,
+          curve:
+            cumulative_by_day(standing_rsvp_times([next.id])[next.id] || [], published_at, days),
+          typical: typical_curve(group, actor, days),
+          others: Enum.map(others, &huddl_summary/1)
+        })
+    end
+  end
+
+  # The group's past huddlz averaged day by day since each was published.
+  # Nil until there are enough of them for an average to mean anything.
+  defp typical_curve(group, actor, days) do
+    past =
+      group
+      |> organizer_huddlz(actor, :past, starts_at: :desc)
+      |> Enum.reject(&is_nil(&1.published_at))
+
+    if length(past) < @typical_min_history do
+      nil
+    else
+      times = standing_rsvp_times(Enum.map(past, & &1.id))
+
+      past
+      |> Enum.map(&cumulative_by_day(times[&1.id] || [], &1.published_at, days))
+      |> Enum.zip_with(fn counts -> Float.round(Enum.sum(counts) / length(counts), 1) end)
+    end
+  end
+
+  defp organizer_huddlz(group, actor, state, sort) do
+    Huddl
+    |> Ash.Query.for_read(:huddlz_for_organizer, %{state: state}, actor: actor)
+    |> Ash.Query.filter(group_id == ^group.id)
+    |> Ash.Query.sort(sort)
+    |> Ash.Query.load([:rsvp_count, :waitlist_count])
+    |> Ash.read!(actor: actor)
+  end
+
+  defp huddl_summary(huddl) do
+    %{
+      id: huddl.id,
+      title: huddl.title,
+      starts_at: huddl.starts_at,
+      time_zone: huddl.time_zone,
+      rsvp_count: huddl.rsvp_count,
+      capacity: huddl.max_attendees,
+      waitlist_count: huddl.waitlist_count
+    }
+  end
+
+  # Standing (non-waitlisted) RSVP times, grouped by huddl.
+  defp standing_rsvp_times(huddl_ids) do
+    HuddlAttendee
+    |> Ash.Query.filter(huddl_id in ^huddl_ids and is_nil(waitlisted_at))
+    |> Ash.Query.select([:huddl_id, :rsvped_at])
+    |> Ash.read!(authorize?: false)
+    |> Enum.group_by(& &1.huddl_id, & &1.rsvped_at)
+  end
+
+  # One point per day from publish: RSVPs standing by the end of that day.
+  defp cumulative_by_day(timestamps, published_at, days) do
+    Enum.map(0..days, fn d ->
+      day_end = DateTime.add(published_at, (d + 1) * @day, :second)
+      Enum.count(timestamps, &(DateTime.compare(&1, day_end) == :lt))
+    end)
+  end
+
+  defp days_between(from, to), do: max(div(DateTime.diff(to, from, :second), @day), 0)
 
   # One point per bucket: how many timestamps fall inside it.
   defp per_bucket(timestamps, edges) do

--- a/lib/huddlz_web/components/signup_chart.ex
+++ b/lib/huddlz_web/components/signup_chart.ex
@@ -1,0 +1,144 @@
+defmodule HuddlzWeb.Components.SignupChart do
+  @moduledoc """
+  The next huddl's signup curve: RSVPs by day since it was published,
+  drawn as inline SVG on the design tokens. Behind it, optionally, the
+  group's typical curve (dashed) and the capacity (dotted).
+
+  Server-rendered like the sparkline, and readable back the same way:
+  each line carries its points in `data-points`.
+  """
+  use Phoenix.Component
+
+  @width 600
+  @height 200
+  @left 32
+  @right 16
+  @top 14
+  @bottom 28
+
+  attr :id, :string, required: true
+  attr :curve, :list, required: true, doc: "RSVPs standing at the end of each day since publish"
+  attr :typical, :list, default: nil, doc: "the group's typical curve over the same days, or nil"
+  attr :capacity, :integer, default: nil
+
+  def signup_chart(assigns) do
+    assigns = assign(assigns, :chart, layout(assigns))
+
+    ~H"""
+    <svg
+      class="chart signup-chart"
+      viewBox={"0 0 #{@chart.width} #{@chart.height}"}
+      role="img"
+      aria-label={description(@curve, @capacity)}
+    >
+      <%= for {value, y, kind} <- @chart.gridlines do %>
+        <line class={kind} x1={@chart.left} x2={@chart.right} y1={y} y2={y} />
+        <text x={@chart.left - 8} y={y} text-anchor="end" dominant-baseline="middle">{value}</text>
+      <% end %>
+
+      <%= if @capacity do %>
+        <line
+          id={"#{@id}-capacity"}
+          class="cap"
+          stroke-dasharray="2 3"
+          data-capacity={@capacity}
+          x1={@chart.left}
+          x2={@chart.right}
+          y1={@chart.capacity_y}
+          y2={@chart.capacity_y}
+        />
+        <text x={@chart.right} y={@chart.capacity_y - 7} text-anchor="end">cap {@capacity}</text>
+      <% end %>
+
+      <polyline
+        :if={@typical}
+        id={"#{@id}-typical"}
+        class="typical"
+        data-points={Enum.join(@typical, ",")}
+        points={@chart.typical_path}
+      />
+
+      <path class="area" d={@chart.area_path} />
+      <polyline
+        id={"#{@id}-curve"}
+        class="line"
+        data-points={Enum.join(@curve, ",")}
+        data-days={length(@curve) - 1}
+        points={@chart.curve_path}
+      />
+      <circle class="dot" cx={@chart.last_x} cy={@chart.last_y} r="3.5" />
+
+      <text
+        :for={{label, x, anchor} <- @chart.day_labels}
+        x={x}
+        y={@chart.height - 8}
+        text-anchor={anchor}
+      >
+        {label}
+      </text>
+    </svg>
+    """
+  end
+
+  defp layout(%{curve: curve, typical: typical, capacity: capacity}) do
+    n = length(curve)
+    hi = ceiling([capacity | curve ++ (typical || [])])
+    plot_width = @width - @left - @right
+    plot_height = @height - @top - @bottom
+    x = fn i -> Float.round(@left + i * plot_width / max(n - 1, 1), 1) end
+    y = fn v -> Float.round(@top + plot_height * (1 - v / hi), 1) end
+
+    points = fn values ->
+      values |> Enum.with_index() |> Enum.map_join(" ", fn {v, i} -> "#{x.(i)},#{y.(v)}" end)
+    end
+
+    %{
+      width: @width,
+      height: @height,
+      left: @left,
+      right: @width - @right,
+      gridlines: gridlines(hi, y),
+      capacity_y: capacity && y.(capacity),
+      typical_path: typical && points.(typical),
+      curve_path: points.(curve),
+      area_path:
+        "M#{x.(0)},#{y.(0)} L#{String.replace(points.(curve), " ", " L")} L#{x.(n - 1)},#{y.(0)} Z",
+      last_x: x.(n - 1),
+      last_y: y.(List.last(curve)),
+      day_labels: day_labels(n - 1, x)
+    }
+  end
+
+  # The top gridline: the largest value rounded up to something round.
+  defp ceiling(values) do
+    max = values |> Enum.reject(&is_nil/1) |> Enum.max(fn -> 0 end) |> ceil()
+
+    cond do
+      max <= 5 -> 5
+      max <= 10 -> 10
+      max <= 50 -> div(max + 4, 5) * 5
+      true -> div(max + 9, 10) * 10
+    end
+  end
+
+  defp gridlines(hi, y) do
+    [{0, :axis}, {div(hi, 2), :grid}, {hi, :grid}]
+    |> Enum.map(fn {value, kind} -> {value, y.(value), kind} end)
+  end
+
+  defp day_labels(0, x), do: [{"published today", x.(0), "start"}]
+
+  defp day_labels(days, x) when days < 4,
+    do: [{"published", x.(0), "start"}, {"today", x.(days), "end"}]
+
+  defp day_labels(days, x) do
+    mid = div(days, 2)
+    [{"published", x.(0), "start"}, {"day #{mid}", x.(mid), "middle"}, {"today", x.(days), "end"}]
+  end
+
+  defp description(curve, nil),
+    do: "#{List.last(curve)} RSVPs over #{length(curve)} days since publish"
+
+  defp description(curve, capacity),
+    do: "#{List.last(curve)} of #{capacity} RSVPs over #{length(curve)} days since publish"
+end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -7,7 +7,7 @@ defmodule HuddlzWeb.OrganizeLive do
   Routes:
 
     * `/organize` — landing picker (owned groups + create CTA, or empty state)
-    * `/organize/:group_slug` — overview (KPIs + upcoming huddlz)
+    * `/organize/:group_slug` — overview (KPIs + next huddl)
     * `/organize/:group_slug/huddlz` — huddlz list, lifecycle filters
     * `/organize/:group_slug/members` — roster grouped by role
     * `/organize/:group_slug/settings` — owner-only group administration
@@ -15,6 +15,7 @@ defmodule HuddlzWeb.OrganizeLive do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Components.Sparkline
+  import HuddlzWeb.Components.SignupChart
 
   alias Huddlz.Communities
   alias Huddlz.Communities.GroupStats
@@ -43,8 +44,6 @@ defmodule HuddlzWeb.OrganizeLive do
   # Rows shown before "Show more". A weekly series alone can run to a
   # hundred dates, so the list pages rather than folding anything.
   @huddlz_page 20
-  @upcoming_loads [:rsvp_count, :group]
-  @upcoming_preview_limit 5
 
   on_mount {HuddlzWeb.LiveUserAuth, :live_user_required}
   on_mount {HuddlzWeb.LiveUserAuth, :app}
@@ -61,7 +60,6 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:owned_groups, [])
      |> assign(:huddlz_list, [])
      |> assign(:huddlz_filter, :published)
-     |> assign(:upcoming_huddlz, [])
      |> assign(:turnout_nudge, nil)
      |> assign(:period, GroupStats.default_period())
      |> assign(:stats, nil)
@@ -124,10 +122,7 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp load_section(socket, :overview, group, user) do
-    upcoming = list_upcoming_huddlz(group, user)
-
     socket
-    |> assign(:upcoming_huddlz, upcoming)
     |> assign(:turnout_nudge, latest_uncounted_huddl(group, user))
     |> assign(:stats, Communities.group_overview!(group.id, socket.assigns.period, actor: user))
   end
@@ -184,14 +179,6 @@ defmodule HuddlzWeb.OrganizeLive do
       {:ok, %Huddlz.Communities.Group{} = group} -> {:ok, group}
       _ -> :error
     end
-  end
-
-  defp list_upcoming_huddlz(group, user) do
-    Communities.list_upcoming_huddlz!(
-      actor: user,
-      load: @upcoming_loads,
-      query: [filter: [group_id: group.id]]
-    )
   end
 
   defp list_group_huddlz(group, state, user) do
@@ -328,7 +315,6 @@ defmodule HuddlzWeb.OrganizeLive do
           <.overview_view
             group={@group}
             can_edit_group={@can_edit_group}
-            upcoming_huddlz={@upcoming_huddlz}
             turnout_nudge={@turnout_nudge}
             period={@period}
             stats={@stats}
@@ -446,7 +432,6 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # ─────────────────────────────────────────  OVERVIEW  ───
   attr :group, :map, required: true
-  attr :upcoming_huddlz, :list, required: true
   attr :turnout_nudge, :map, default: nil
   attr :period, :string, required: true
   attr :stats, :map, required: true
@@ -454,10 +439,7 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :can_edit_group, :boolean, required: true
 
   defp overview_view(assigns) do
-    assigns =
-      assigns
-      |> assign(:preview_limit, @upcoming_preview_limit)
-      |> assign(:upcoming_count, length(assigns.upcoming_huddlz))
+    assigns = assign(assigns, :next, assigns.stats.next_huddl)
 
     ~H"""
     <div class="page-head">
@@ -523,39 +505,54 @@ defmodule HuddlzWeb.OrganizeLive do
       </div>
     </div>
 
-    <div class="panel">
+    <div id="next-huddl" class="panel">
       <div class="panel-head">
         <div>
-          <h2>Upcoming huddlz</h2>
-          <div class="panel-sub">Next on the calendar</div>
+          <h2>Next huddl</h2>
+          <div :if={@next} class="panel-sub">
+            <.link navigate={huddl_show_path(@group, @next)}>{@next.title}</.link>
+            · {short_date(@next)}
+          </div>
+          <div :if={is_nil(@next)} class="panel-sub">Next on the calendar</div>
         </div>
-        <.link
-          :if={@upcoming_count > @preview_limit}
-          navigate={~p"/organize/#{@group.slug}/huddlz"}
-          class="pill"
-        >
-          View all
-        </.link>
+        <.link :if={@next} navigate={huddl_show_path(@group, @next)} class="pill">Open</.link>
       </div>
 
-      <%= if @upcoming_huddlz == [] do %>
-        <p class="muted">No upcoming huddlz right now. Create one to get started.</p>
-      <% else %>
-        <div class="row-list">
-          <div
-            :for={huddl <- Enum.take(@upcoming_huddlz, @preview_limit)}
-            class="row row-split"
-          >
-            <div>
-              <div class="row-title">
-                <.link navigate={~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"}>
-                  {huddl.title}
-                </.link>
-              </div>
-              <div class="meta">{format_starts_at(huddl)}</div>
+      <%= if @next do %>
+        <div class={["next-huddl-body", @next.others != [] && "has-others"]}>
+          <div class="next-huddl-chart">
+            <div class="stat">
+              <span class="big">{signups_figure(@next)}</span>
+              <span class="cmp">{published_ago(@next.days)}</span>
             </div>
-            <span class="pill">{rsvp_label(huddl.rsvp_count)}</span>
+            <.signup_chart
+              id="next-huddl"
+              curve={@next.curve}
+              typical={@next.typical}
+              capacity={@next.capacity}
+            />
+            <div class="legend">
+              <span><i></i>RSVPs since publish</span>
+              <span :if={@next.typical}><i class="typ"></i>Typical for this group</span>
+              <span :if={@next.capacity}><i class="cap"></i>Capacity</span>
+            </div>
           </div>
+          <div :if={@next.others != []} class="next-huddl-others">
+            <div class="label">Also upcoming</div>
+            <ul id="next-huddl-others">
+              <li :for={huddl <- @next.others}>
+                <.link navigate={huddl_show_path(@group, huddl)}>{huddl.title}</.link>
+                <span class="count">· {signups_figure(huddl)}{waitlisted_suffix(huddl)}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      <% else %>
+        <p class="muted">
+          Nothing on the calendar yet. Create a huddl and its signups will show here.
+        </p>
+        <div :if={is_nil(@group.archived_at)} class="panel-cta">
+          <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>Create a huddl</a>
         </div>
       <% end %>
     </div>
@@ -862,6 +859,20 @@ defmodule HuddlzWeb.OrganizeLive do
   defp huddlz_filter_label(:cancelled), do: "Cancelled"
 
   defp huddl_show_path(group, huddl), do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}"
+
+  defp short_date(%{starts_at: starts_at, time_zone: time_zone}) do
+    starts_at |> DateTime.shift_zone!(time_zone) |> Calendar.strftime("%b %-d")
+  end
+
+  defp signups_figure(%{capacity: nil, rsvp_count: count}), do: rsvp_label(count)
+  defp signups_figure(%{capacity: capacity, rsvp_count: count}), do: "#{count} / #{capacity}"
+
+  defp waitlisted_suffix(%{waitlist_count: 0}), do: ""
+  defp waitlisted_suffix(%{waitlist_count: count}), do: " · #{count} waitlisted"
+
+  defp published_ago(0), do: "published today"
+  defp published_ago(1), do: "published yesterday"
+  defp published_ago(days), do: "published #{days} days ago"
 
   defp huddl_edit_path(group, huddl, "all"),
     do: ~p"/groups/#{group.slug}/huddlz/#{huddl.id}/edit?edit_type=all"
@@ -1630,14 +1641,6 @@ defmodule HuddlzWeb.OrganizeLive do
   defp format_member_meta(_), do: ""
 
   defp format_date_short(%DateTime{} = at), do: Calendar.strftime(at, "%b %d, %Y")
-
-  defp format_starts_at(%{starts_at: %DateTime{} = starts_at, time_zone: time_zone}) do
-    starts_at
-    |> DateTime.shift_zone!(time_zone)
-    |> Calendar.strftime("%b %d, %Y · %I:%M %p %Z")
-  end
-
-  defp format_starts_at(_), do: ""
 
   defp visibility_label(true), do: "Public"
   defp visibility_label(false), do: "Private"

--- a/test/features/next_huddl_panel.feature
+++ b/test/features/next_huddl_panel.feature
@@ -1,0 +1,50 @@
+@database @conn @next_huddl_panel
+Feature: Next huddl panel on the overview
+  As an organizer
+  I want the overview to show how my next huddl is filling
+  So that I can tell at a glance whether to push it or leave it
+
+  Background:
+    Given the following users exist:
+      | email            | display_name | role    |
+      | host@example.com | Host User    | regular |
+    And a public group "Portland Elixir" exists with owner "host@example.com"
+    And I am signed in as "host@example.com"
+
+  Scenario: The next huddl's signup curve
+    Given the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 20 and 18 RSVPs
+    And "Elixir hack night" was published 14 days ago and its RSVPs came in evenly since
+    When I visit "/organize/portland-elixir"
+    Then the next huddl panel names "Elixir hack night"
+    And the next huddl panel shows "18 / 20"
+    And the signup curve has one point per day for 14 days and ends at 18
+    And the signup chart marks the capacity of 20
+    And I should not see "Upcoming huddlz"
+
+  Scenario: The typical curve appears with enough history
+    Given "Portland Elixir" has 3 past huddlz
+    And the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 20 and 18 RSVPs
+    And "Elixir hack night" was published 14 days ago and its RSVPs came in evenly since
+    When I visit "/organize/portland-elixir"
+    Then the panel also draws the group's typical curve
+
+  Scenario: No typical curve without history
+    Given "Portland Elixir" has 2 past huddlz
+    And the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 20 and 18 RSVPs
+    And "Elixir hack night" was published 14 days ago and its RSVPs came in evenly since
+    When I visit "/organize/portland-elixir"
+    Then only the huddl's own curve is drawn
+
+  Scenario: Other upcoming huddlz are listed
+    Given the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 20 and 18 RSVPs
+    And the huddl "Elixir office hours" in "Portland Elixir" starts in 10 days with room for 20 and 8 RSVPs
+    And the huddl "Phoenix workshop" in "Portland Elixir" starts in 17 days with room for 1 and 1 RSVPs
+    And 6 people are waitlisted for "Phoenix workshop"
+    When I visit "/organize/portland-elixir"
+    Then the next huddl panel names "Elixir hack night"
+    And the panel lists the other upcoming huddl "Elixir office hours · 8 / 20"
+    And the panel lists the other upcoming huddl "Phoenix workshop · 1 / 1 · 6 waitlisted"
+
+  Scenario: Nothing upcoming
+    When I visit "/organize/portland-elixir"
+    Then the panel invites me to create a huddl

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -105,7 +105,7 @@ Feature: Organizer workspace
     Then I should see "Phoenix Devs"
     And I should not see "That group doesn't exist, or you don't organize it."
 
-  Scenario: Group overview shows zeroed KPIs and empty upcoming list
+  Scenario: Group overview shows zeroed KPIs and an empty next huddl panel
     Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
     And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
@@ -113,14 +113,14 @@ Feature: Organizer workspace
     And I should see "Members"
     And I should see "RSVPs · last 90 days"
     And I should see "Waitlisted now"
-    And I should see "No upcoming huddlz right now. Create one to get started."
+    And I should see "Nothing on the calendar yet. Create a huddl and its signups will show here."
 
-  Scenario: Group overview lists the group's upcoming huddl
+  Scenario: Group overview names the group's next huddl
     Given a public group "Cyberpunk Builders" exists with owner "host+organize-workspace@example.com"
     And the huddl "Synthwave Night" exists in group "Cyberpunk Builders" hosted by "host+organize-workspace@example.com"
     And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
-    Then I should see "Upcoming huddlz"
+    Then I should see "Next huddl"
     And I should see "Synthwave Night"
 
   Scenario: Overview shows the upcoming huddl's RSVPs
@@ -129,7 +129,7 @@ Feature: Organizer workspace
     And "attendee+organize-workspace@example.com" has RSVPed to "Synthwave Night"
     And I am signed in as "host+organize-workspace@example.com"
     When I visit "/organize/cyberpunk-builders"
-    Then I should see "Upcoming huddlz"
+    Then I should see "Next huddl"
     And I should see "2 RSVPs"
 
   Scenario: Overview does not show huddlz from groups the actor does not organize

--- a/test/features/step_definitions/next_huddl_panel_steps.exs
+++ b/test/features/step_definitions/next_huddl_panel_steps.exs
@@ -1,0 +1,175 @@
+defmodule NextHuddlPanelSteps do
+  use Cucumber.StepDefinition
+
+  import Ecto.Query, only: [from: 2]
+  import Huddlz.Generator
+  import PhoenixTest
+
+  require Ash.Query
+
+  alias Huddlz.Communities.{Group, Huddl, HuddlAttendee}
+  alias Huddlz.Repo
+
+  @day 86_400
+
+  step "the huddl {string} in {string} starts in {int} days with room for {int} and {int} RSVPs",
+       %{args: [title, group_name, days, capacity, rsvps]} = context do
+    group = find_group(group_name)
+    host = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
+
+    huddl =
+      generate(
+        huddl(
+          title: title,
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          max_attendees: capacity,
+          date: Date.add(eastern_today(), days),
+          actor: host
+        )
+      )
+
+    # The host is RSVPed on creation; top up to the asked-for count.
+    standing = huddl |> Ash.load!(:rsvp_count, authorize?: false) |> Map.fetch!(:rsvp_count)
+
+    for _ <- 1..(rsvps - standing)//1 do
+      attendee = generate(user(role: :user))
+
+      Ash.Seed.seed!(HuddlAttendee, %{
+        huddl_id: huddl.id,
+        user_id: attendee.id,
+        rsvped_at: DateTime.utc_now()
+      })
+    end
+
+    context
+  end
+
+  step "{string} was published {int} days ago and its RSVPs came in evenly since",
+       %{args: [title, days]} = context do
+    huddl = find_huddl(title)
+    now = DateTime.utc_now()
+    published_at = DateTime.add(now, -days * @day, :second)
+
+    Repo.update_all(from(h in "huddlz", where: h.id == type(^huddl.id, :binary_id)),
+      set: [published_at: published_at]
+    )
+
+    rows =
+      HuddlAttendee
+      |> Ash.Query.filter(huddl_id == ^huddl.id and is_nil(waitlisted_at))
+      |> Ash.Query.sort(rsvped_at: :asc)
+      |> Ash.read!(authorize?: false)
+
+    # First RSVP at publish, the last one an hour ago, the rest spread between.
+    span = DateTime.diff(now, published_at, :second) - 3600
+    last = max(length(rows) - 1, 1)
+
+    rows
+    |> Enum.with_index()
+    |> Enum.each(fn {row, i} ->
+      at = DateTime.add(published_at, div(span * i, last), :second)
+
+      Repo.update_all(from(a in "huddl_attendees", where: a.id == type(^row.id, :binary_id)),
+        set: [rsvped_at: at]
+      )
+    end)
+
+    context
+  end
+
+  step "{string} has {int} past huddlz", %{args: [group_name, count]} = context do
+    group = find_group(group_name)
+    now = DateTime.utc_now()
+
+    for n <- 1..count//1 do
+      starts_at = DateTime.add(now, -(n * 7) * @day, :second)
+      published_at = DateTime.add(starts_at, -14 * @day, :second)
+
+      huddl =
+        generate(
+          past_huddl(
+            title: "Past huddl #{n}",
+            group_id: group.id,
+            creator_id: group.owner_id,
+            is_private: false,
+            starts_at: starts_at,
+            ends_at: DateTime.add(starts_at, 2 * 3600, :second),
+            published_at: published_at
+          )
+        )
+
+      # Three RSVPs, one a day, starting the day after publish.
+      for d <- 1..3 do
+        attendee = generate(user(role: :user))
+
+        Ash.Seed.seed!(HuddlAttendee, %{
+          huddl_id: huddl.id,
+          user_id: attendee.id,
+          rsvped_at: DateTime.add(published_at, d * @day, :second)
+        })
+      end
+    end
+
+    context
+  end
+
+  step "the next huddl panel names {string}", %{args: [title], session: session} = context do
+    assert_has(session, "#next-huddl .panel-head", text: title)
+    context
+  end
+
+  step "the next huddl panel shows {string}", %{args: [figure], session: session} = context do
+    assert_has(session, "#next-huddl .stat .big", text: figure, exact: true)
+    context
+  end
+
+  step "the signup curve has one point per day for {int} days and ends at {int}",
+       %{args: [days, last], session: session} = context do
+    assert_has(session, "#next-huddl-curve[data-days='#{days}'][data-points$=',#{last}']")
+    context
+  end
+
+  step "the signup chart marks the capacity of {int}",
+       %{args: [capacity], session: session} = context do
+    assert_has(session, "#next-huddl-capacity[data-capacity='#{capacity}']")
+    context
+  end
+
+  step "the panel also draws the group's typical curve", %{session: session} = context do
+    assert_has(session, "#next-huddl-curve[data-points]")
+    assert_has(session, "#next-huddl-typical[data-points]")
+    context
+  end
+
+  step "only the huddl's own curve is drawn", %{session: session} = context do
+    session
+    |> assert_has("#next-huddl-curve[data-points]")
+    |> refute_has("#next-huddl-typical")
+
+    context
+  end
+
+  step "the panel lists the other upcoming huddl {string}",
+       %{args: [line], session: session} = context do
+    assert_has(session, "#next-huddl-others li", text: line, exact: true)
+    context
+  end
+
+  step "the panel invites me to create a huddl", %{session: session} = context do
+    session
+    |> assert_has("#next-huddl", text: "Nothing on the calendar yet")
+    |> assert_has("#next-huddl a", text: "Create a huddl")
+
+    context
+  end
+
+  defp find_group(name) do
+    Group |> Ash.Query.filter(name == ^name) |> Ash.read_one!(authorize?: false)
+  end
+
+  defp find_huddl(title) do
+    Huddl |> Ash.Query.filter(title == ^title) |> Ash.read_one!(authorize?: false)
+  end
+end


### PR DESCRIPTION
Closes #511.

The organizer overview's upcoming list becomes a Next huddl panel: the next huddl's RSVPs against its capacity, its signup curve by day since publish, the group's typical curve behind it once there are three past huddlz to average, the capacity as a dotted line, and the other upcoming huddlz listed with their counts and waitlist size. With nothing upcoming the panel invites the organizer to create a huddl.

## How it works

- The figures come through the existing Group `:overview` action as a `next_huddl` entry, so the GraphQL `groupOverview` query carries them too. Upcoming and past huddlz are read through the organizer read with the actor; RSVP times are read behind the action boundary.
- The signup curve is one point per day since publish: RSVPs standing by the end of that day. The typical curve is the same measure averaged over the group's past huddlz that carry a publish date; it is nil below three.
- `<.signup_chart>` is a server-rendered inline SVG on the tokens, like the sparkline. Each line carries its points in `data-points`, the curve its day count in `data-days`, the capacity line its value in `data-capacity`.
- On wide screens the chart sits beside the "Also upcoming" list; on phones they stack.

## Scenarios

`test/features/next_huddl_panel.feature` covers the five acceptance criteria: the curve and capacity for a huddl published 14 days ago with 18 of 20 RSVPs, the typical curve with three past huddlz, its absence with two, the other upcoming huddlz including a full one with a waitlist, and the empty state. The workspace scenarios that asserted the old list now assert the panel.

## Notes

- Cancelled RSVPs leave no trace yet, so the curves count RSVPs still standing by their RSVP time (#513 adds the log).
- The chart's viewBox is sized for a wide panel; when #510 puts member growth beside it, the chart width comes down with it.
