### PR TITLE
feat(organize): member growth chart on the overview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1832,6 +1832,17 @@ body .chart .typical {
 }
 
 body .chart .cap { stroke: var(--soft); stroke-width: 1.5; }
+body .chart .col { fill: var(--line-strong); }
+body .chart .val { fill: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
+body .chart .callout {
+  fill: var(--text);
+  font-weight: 700;
+  font-size: 12px;
+  paint-order: stroke;
+  stroke: var(--panel);
+  stroke-width: 4px;
+  stroke-linejoin: round;
+}
 
 body .legend {
   display: flex;
@@ -1858,6 +1869,7 @@ body .legend i.typ {
 }
 
 body .legend i.cap { height: 2px; background: var(--soft); }
+body .legend i.sq { width: 10px; height: 10px; background: var(--line-strong); }
 
 body .stat { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
 
@@ -1871,8 +1883,23 @@ body .stat .big {
 
 body .stat .cmp { font-size: 12px; font-weight: 600; color: var(--muted); }
 
+body .overview-row { display: grid; grid-template-columns: minmax(0, 1fr); gap: 24px; }
+
+@media (min-width: 1100px) {
+  body .overview-row { grid-template-columns: minmax(0, 5fr) minmax(0, 3fr); align-items: stretch; }
+}
+
+body .growth-chart-wrap { max-width: 800px; }
+body .growth-chart-wrap .compact-only { display: none; }
+
+@media (max-width: 640px) {
+  body .growth-chart-wrap .wide-only { display: none; }
+  body .growth-chart-wrap .compact-only { display: block; }
+}
+body #member-growth-panel .panel-head .stat { margin: 0; flex: 0 0 auto; }
+body #next-huddl { container-type: inline-size; }
 body .next-huddl-body { display: grid; grid-template-columns: minmax(0, 1fr); gap: 20px; }
-body .next-huddl-chart { max-width: 720px; }
+body .next-huddl-chart { max-width: 560px; }
 
 body .next-huddl-others {
   padding-top: 16px;
@@ -1881,7 +1908,7 @@ body .next-huddl-others {
 
 body .next-huddl-others .count { white-space: nowrap; }
 
-@media (min-width: 900px) {
+@container (min-width: 560px) {
   body .next-huddl-body.has-others {
     grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     gap: 28px;

--- a/lib/huddlz/communities/group_stats.ex
+++ b/lib/huddlz/communities/group_stats.ex
@@ -11,7 +11,9 @@ defmodule Huddlz.Communities.GroupStats do
 
   Periods are `"30d"`, `"90d"` (the default) and `"12m"`. Each is split
   into equal buckets for the sparklines: six for the day periods, twelve
-  for the year.
+  for the year. Member growth buckets by calendar month for the year, by
+  fortnight for 90 days and by week for 30 days, the last bucket running
+  up to now.
 
   The next huddl's signup curve is one point per day since it was
   published: how many RSVPs stood by the end of that day. The group's
@@ -27,10 +29,11 @@ defmodule Huddlz.Communities.GroupStats do
   @typical_min_history 3
 
   @periods [
-    {"30d", %{days: 30, buckets: 6, label: "30 days"}},
-    {"90d", %{days: 90, buckets: 6, label: "90 days"}},
-    {"12m", %{days: 365, buckets: 12, label: "12 months"}}
+    {"30d", %{days: 30, buckets: 6, label: "30 days", growth: :week}},
+    {"90d", %{days: 90, buckets: 6, label: "90 days", growth: :fortnight}},
+    {"12m", %{days: 365, buckets: 12, label: "12 months", growth: :month}}
   ]
+  @growth_bucket_days %{week: 7, fortnight: 14}
   @default_period "90d"
 
   @type period :: String.t()
@@ -58,6 +61,8 @@ defmodule Huddlz.Communities.GroupStats do
 
     * `members` — current member count, how many joined this calendar
       month in the group's time zone, and a cumulative sparkline
+    * `growth` — the period bucketed by month, fortnight or week: members
+      at each bucket's end, how many joined in it, and the total gained
     * `rsvps` — RSVPs made in the period, the count in the period before
       it, and a per-bucket sparkline
     * `waitlist` — people waitlisted on upcoming huddlz right now, the
@@ -69,24 +74,27 @@ defmodule Huddlz.Communities.GroupStats do
   def compute(group, period, actor, now \\ DateTime.utc_now()) do
     spec = period_spec(period)
     edges = bucket_edges(now, spec)
+    joined_at = member_join_times(group)
 
     %{
       period: period,
-      members: members(group, now, edges),
+      members: members(joined_at, group, now, edges),
+      growth: growth(joined_at, group, now, spec),
       rsvps: rsvps(group, now, spec, edges),
       waitlist: waitlist(group, now, edges),
       next_huddl: next_huddl(group, actor, now)
     }
   end
 
-  defp members(group, now, edges) do
-    joined_at =
-      GroupMember
-      |> Ash.Query.filter(group_id == ^group.id)
-      |> Ash.Query.select([:created_at])
-      |> Ash.read!(authorize?: false)
-      |> Enum.map(& &1.created_at)
+  defp member_join_times(group) do
+    GroupMember
+    |> Ash.Query.filter(group_id == ^group.id)
+    |> Ash.Query.select([:created_at])
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.created_at)
+  end
 
+  defp members(joined_at, group, now, edges) do
     month_start = start_of_month(now, group.time_zone)
 
     %{
@@ -94,6 +102,76 @@ defmodule Huddlz.Communities.GroupStats do
       joined_this_month: Enum.count(joined_at, &(DateTime.compare(&1, month_start) != :lt)),
       spark: cumulative(joined_at, edges)
     }
+  end
+
+  # Members at the end of each bucket, reconstructed from the join dates of
+  # today's members, with the joins inside each bucket.
+  defp growth(joined_at, group, now, spec) do
+    buckets =
+      group
+      |> growth_buckets(now, spec)
+      |> Enum.map(fn {label, from, to} ->
+        %{
+          label: label,
+          starts_at: from,
+          ends_at: to,
+          joined: Enum.count(joined_at, &within?(&1, from, to)),
+          members: Enum.count(joined_at, &(DateTime.compare(&1, to) == :lt))
+        }
+      end)
+
+    %{
+      unit: spec.growth,
+      gained: buckets |> Enum.map(& &1.joined) |> Enum.sum(),
+      buckets: buckets
+    }
+  end
+
+  # Twelve calendar months in the group's time zone, this month last.
+  defp growth_buckets(group, now, %{growth: :month, buckets: count}) do
+    this_month = start_of_month(now, group.time_zone)
+
+    starts =
+      Enum.map((count - 1)..0//-1, fn back ->
+        shift_months(this_month, -back, group.time_zone)
+      end)
+
+    starts
+    |> Enum.zip(tl(starts) ++ [now])
+    |> Enum.map(fn {from, to} ->
+      {from |> DateTime.shift_zone!(group.time_zone) |> Calendar.strftime("%b"), from, to}
+    end)
+  end
+
+  # Whole weeks or fortnights from the start of the period, the last one
+  # running up to now.
+  defp growth_buckets(group, now, %{growth: unit, days: days}) do
+    bucket_days = @growth_bucket_days[unit]
+    start = DateTime.add(now, -days, :day)
+
+    0..(days - 1)//bucket_days
+    |> Enum.map(fn offset ->
+      from = DateTime.add(start, offset, :day)
+      to = DateTime.add(from, bucket_days, :day)
+      {label_date(from, group.time_zone), from, min_datetime(to, now)}
+    end)
+  end
+
+  defp within?(t, from, to),
+    do: DateTime.compare(t, from) != :lt and DateTime.compare(t, to) == :lt
+
+  defp min_datetime(a, b), do: if(DateTime.compare(a, b) == :gt, do: b, else: a)
+
+  defp label_date(at, time_zone),
+    do: at |> DateTime.shift_zone!(time_zone) |> Calendar.strftime("%b %-d")
+
+  defp shift_months(month_start, months, time_zone) do
+    month_start
+    |> DateTime.shift_zone!(time_zone)
+    |> DateTime.to_date()
+    |> Date.shift(month: months)
+    |> DateTime.new!(~T[00:00:00], time_zone)
+    |> DateTime.shift_zone!("Etc/UTC")
   end
 
   defp rsvps(group, now, spec, edges) do

--- a/lib/huddlz_web/components/growth_chart.ex
+++ b/lib/huddlz_web/components/growth_chart.ex
@@ -1,0 +1,195 @@
+defmodule HuddlzWeb.Components.GrowthChart do
+  @moduledoc """
+  Member growth over a period: a line of members at each bucket's end
+  above a strip of bars for how many joined in each bucket. Inline SVG
+  on the design tokens, server-rendered like the sparkline.
+
+  Readable back from the markup: the line and the bar strip carry their
+  values in `data-points`, each dot and bar its bucket label and value,
+  and the root the bucket unit and count.
+  """
+  use Phoenix.Component
+
+  @left 36
+  @right 20
+  @top 26
+  @bar_width 26
+  @wide %{line_height: 140, bar_gap: 26, bar_height: 44, bottom: 30}
+  @compact %{line_height: 110, bar_gap: 22, bar_height: 32, bottom: 26}
+  @compact_label_limit 8
+
+  attr :id, :string, required: true
+  attr :unit, :atom, required: true, values: [:month, :fortnight, :week]
+
+  attr :buckets, :list,
+    required: true,
+    doc: "maps with :label, :members (at the bucket's end) and :joined (inside it)"
+
+  attr :width, :integer, default: 720, doc: "viewBox width"
+
+  attr :compact, :boolean,
+    default: false,
+    doc: "a shorter chart that labels every other bucket when there are many"
+
+  attr :class, :any, default: nil
+
+  def growth_chart(assigns) do
+    assigns = assign(assigns, :chart, layout(assigns))
+
+    ~H"""
+    <svg
+      id={@id}
+      class={["chart growth-chart", @class]}
+      viewBox={"0 0 #{@chart.width} #{@chart.height}"}
+      role="img"
+      aria-label={description(@buckets, @unit)}
+      data-unit={@unit}
+      data-buckets={length(@buckets)}
+    >
+      <%= for {value, y} <- @chart.gridlines do %>
+        <line class="grid" x1={@chart.left} x2={@chart.right} y1={y} y2={y} />
+        <text x={@chart.left - 8} y={y} text-anchor="end" dominant-baseline="middle">{value}</text>
+      <% end %>
+
+      <path class="area" d={@chart.area_path} />
+      <polyline
+        id={"#{@id}-line"}
+        class="line"
+        data-points={Enum.map_join(@buckets, ",", & &1.members)}
+        points={@chart.line_path}
+      />
+      <circle
+        :for={{bucket, {x, y}} <- Enum.zip(@buckets, @chart.line_points)}
+        class="dot"
+        data-label={bucket.label}
+        data-members={bucket.members}
+        cx={x}
+        cy={y}
+        r="3.5"
+      />
+      <text
+        class="callout"
+        x={@chart.callout_x}
+        y={@chart.callout_y}
+        text-anchor={@chart.callout_anchor}
+      >
+        {List.last(@buckets).members} members
+      </text>
+
+      <line class="axis" x1={@chart.left} x2={@chart.right} y1={@chart.bar_base} y2={@chart.bar_base} />
+      <g id={"#{@id}-bars"} data-points={Enum.map_join(@buckets, ",", & &1.joined)}>
+        <%= for {bucket, {x, height}} <- Enum.zip(@buckets, @chart.bars) do %>
+          <rect
+            class="col"
+            data-label={bucket.label}
+            data-joined={bucket.joined}
+            x={x - @chart.bar_width / 2}
+            y={@chart.bar_base - height}
+            width={@chart.bar_width}
+            height={height}
+            rx="3"
+          />
+          <text
+            :if={@chart.bar_values?}
+            class="val"
+            x={x}
+            y={@chart.bar_base - height - 5}
+            text-anchor="middle"
+          >
+            {joined_label(bucket.joined)}
+          </text>
+        <% end %>
+      </g>
+
+      <text
+        :for={{label, x} <- @chart.labels}
+        x={x}
+        y={@chart.height - 6}
+        text-anchor="middle"
+      >
+        {label}
+      </text>
+    </svg>
+    """
+  end
+
+  defp layout(%{buckets: buckets, width: width, compact: compact}) do
+    dims = if compact, do: @compact, else: @wide
+    n = length(buckets)
+    members = Enum.map(buckets, & &1.members)
+    joined = Enum.map(buckets, & &1.joined)
+    {lo, hi, step} = scale(members)
+    plot_width = width - @left - @right
+    bar_base = @top + dims.line_height + dims.bar_gap + dims.bar_height
+    x = fn i -> Float.round(@left + i * plot_width / max(n - 1, 1), 1) end
+    y = fn v -> Float.round(@top + dims.line_height * (1 - (v - lo) / (hi - lo)), 1) end
+    line_points = members |> Enum.with_index() |> Enum.map(fn {v, i} -> {x.(i), y.(v)} end)
+    line_path = Enum.map_join(line_points, " ", fn {px, py} -> "#{px},#{py}" end)
+    {last_x, last_y} = List.last(line_points)
+    most_joined = max(Enum.max(joined), 1)
+
+    crowded? = compact and n > @compact_label_limit
+
+    %{
+      width: width,
+      height: bar_base + dims.bottom,
+      left: @left,
+      right: width - @right,
+      gridlines: Enum.map(lo..hi//step, fn v -> {v, y.(v)} end),
+      line_path: line_path,
+      line_points: line_points,
+      area_path:
+        "M#{x.(0)},#{y.(lo)} L#{String.replace(line_path, " ", " L")} L#{x.(n - 1)},#{y.(lo)} Z",
+      callout_x: last_x - 10,
+      callout_y: last_y - 12,
+      callout_anchor: "end",
+      bar_base: bar_base,
+      bar_width: min(@bar_width, Float.round(plot_width / n * 0.6, 1)),
+      bar_values?: not crowded?,
+      bars:
+        joined
+        |> Enum.with_index()
+        |> Enum.map(fn {v, i} -> {x.(i), Float.round(dims.bar_height * v / most_joined, 1)} end),
+      labels: labels(buckets, x, crowded?)
+    }
+  end
+
+  # Every bucket's label, or every other one from the newest back when
+  # the chart is too narrow for them all.
+  defp labels(buckets, x, crowded?) do
+    n = length(buckets)
+
+    buckets
+    |> Enum.with_index()
+    |> Enum.filter(fn {_bucket, i} -> not crowded? or rem(n - 1 - i, 2) == 0 end)
+    |> Enum.map(fn {bucket, i} -> {bucket.label, x.(i)} end)
+  end
+
+  # A scale for the line: a round step so that the members fit within
+  # a few gridlines, from a round floor to a round ceiling.
+  defp scale(members) do
+    lo = Enum.min(members)
+    hi = Enum.max(members)
+    step = nice_step(max(hi - lo, 1) / 2)
+    floor = max(div(lo, step) * step, 0)
+    ceiling = max(div(hi + step - 1, step) * step, floor + step)
+    {floor, ceiling, step}
+  end
+
+  defp nice_step(raw) do
+    magnitude = :math.pow(10, floor(:math.log10(max(raw, 1))))
+
+    Enum.find_value([1, 2, 5, 10], fn m ->
+      step = round(m * magnitude)
+      if step >= raw, do: step
+    end)
+  end
+
+  defp joined_label(0), do: "0"
+  defp joined_label(n), do: "+#{n}"
+
+  defp description(buckets, unit) do
+    gained = buckets |> Enum.map(& &1.joined) |> Enum.sum()
+    "#{List.last(buckets).members} members, #{gained} joined over #{length(buckets)} #{unit}s"
+  end
+end

--- a/lib/huddlz_web/components/signup_chart.ex
+++ b/lib/huddlz_web/components/signup_chart.ex
@@ -9,7 +9,6 @@ defmodule HuddlzWeb.Components.SignupChart do
   """
   use Phoenix.Component
 
-  @width 600
   @height 200
   @left 32
   @right 16
@@ -20,6 +19,7 @@ defmodule HuddlzWeb.Components.SignupChart do
   attr :curve, :list, required: true, doc: "RSVPs standing at the end of each day since publish"
   attr :typical, :list, default: nil, doc: "the group's typical curve over the same days, or nil"
   attr :capacity, :integer, default: nil
+  attr :width, :integer, default: 400, doc: "viewBox width; the height is fixed"
 
   def signup_chart(assigns) do
     assigns = assign(assigns, :chart, layout(assigns))
@@ -80,10 +80,10 @@ defmodule HuddlzWeb.Components.SignupChart do
     """
   end
 
-  defp layout(%{curve: curve, typical: typical, capacity: capacity}) do
+  defp layout(%{curve: curve, typical: typical, capacity: capacity, width: width}) do
     n = length(curve)
     hi = ceiling([capacity | curve ++ (typical || [])])
-    plot_width = @width - @left - @right
+    plot_width = width - @left - @right
     plot_height = @height - @top - @bottom
     x = fn i -> Float.round(@left + i * plot_width / max(n - 1, 1), 1) end
     y = fn v -> Float.round(@top + plot_height * (1 - v / hi), 1) end
@@ -93,10 +93,10 @@ defmodule HuddlzWeb.Components.SignupChart do
     end
 
     %{
-      width: @width,
+      width: width,
       height: @height,
       left: @left,
-      right: @width - @right,
+      right: width - @right,
       gridlines: gridlines(hi, y),
       capacity_y: capacity && y.(capacity),
       typical_path: typical && points.(typical),

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -15,6 +15,7 @@ defmodule HuddlzWeb.OrganizeLive do
   use HuddlzWeb, :live_view
 
   import HuddlzWeb.Components.Sparkline
+  import HuddlzWeb.Components.GrowthChart
   import HuddlzWeb.Components.SignupChart
 
   alias Huddlz.Communities
@@ -505,59 +506,98 @@ defmodule HuddlzWeb.OrganizeLive do
       </div>
     </div>
 
-    <div id="next-huddl" class="panel">
-      <div class="panel-head">
-        <div>
-          <h2>Next huddl</h2>
-          <div :if={@next} class="panel-sub">
-            <.link navigate={huddl_show_path(@group, @next)}>{@next.title}</.link>
-            · {short_date(@next)}
+    <div class="overview-row">
+      <div id="member-growth-panel" class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Member growth</h2>
+            <div class="panel-sub">{growth_sub(@stats.growth.unit)}</div>
           </div>
-          <div :if={is_nil(@next)} class="panel-sub">Next on the calendar</div>
+          <div class="stat">
+            <span class="big">+{@stats.growth.gained}</span>
+            <span class="cmp">in {GroupStats.period_label(@period)}</span>
+          </div>
         </div>
-        <.link :if={@next} navigate={huddl_show_path(@group, @next)} class="pill">Open</.link>
+        <div class="growth-chart-wrap">
+          <.growth_chart
+            id="member-growth"
+            class="wide-only"
+            unit={@stats.growth.unit}
+            buckets={@stats.growth.buckets}
+          />
+          <.growth_chart
+            id="member-growth-compact"
+            class="compact-only"
+            width={360}
+            compact
+            unit={@stats.growth.unit}
+            buckets={@stats.growth.buckets}
+          />
+        </div>
+        <div class="legend">
+          <span><i></i>Members</span>
+          <span><i class="sq"></i>Joined that {@stats.growth.unit}</span>
+        </div>
       </div>
 
-      <%= if @next do %>
-        <div class={["next-huddl-body", @next.others != [] && "has-others"]}>
-          <div class="next-huddl-chart">
-            <div class="stat">
-              <span class="big">{signups_figure(@next)}</span>
-              <span class="cmp">{published_ago(@next.days)}</span>
+      <div id="next-huddl" class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Next huddl</h2>
+            <div :if={@next} class="panel-sub">
+              <.link navigate={huddl_show_path(@group, @next)}>{@next.title}</.link>
+              · {short_date(@next)}
             </div>
-            <.signup_chart
-              id="next-huddl"
-              curve={@next.curve}
-              typical={@next.typical}
-              capacity={@next.capacity}
-            />
-            <div class="legend">
-              <span><i></i>RSVPs since publish</span>
-              <span :if={@next.typical}><i class="typ"></i>Typical for this group</span>
-              <span :if={@next.capacity}><i class="cap"></i>Capacity</span>
+            <div :if={is_nil(@next)} class="panel-sub">Next on the calendar</div>
+          </div>
+          <.link :if={@next} navigate={huddl_show_path(@group, @next)} class="pill">Open</.link>
+        </div>
+
+        <%= if @next do %>
+          <div class={["next-huddl-body", @next.others != [] && "has-others"]}>
+            <div class="next-huddl-chart">
+              <div class="stat">
+                <span class="big">{signups_figure(@next)}</span>
+                <span class="cmp">{published_ago(@next.days)}</span>
+              </div>
+              <.signup_chart
+                id="next-huddl"
+                curve={@next.curve}
+                typical={@next.typical}
+                capacity={@next.capacity}
+              />
+              <div class="legend">
+                <span><i></i>RSVPs since publish</span>
+                <span :if={@next.typical}><i class="typ"></i>Typical for this group</span>
+                <span :if={@next.capacity}><i class="cap"></i>Capacity</span>
+              </div>
+            </div>
+            <div :if={@next.others != []} class="next-huddl-others">
+              <div class="label">Also upcoming</div>
+              <ul id="next-huddl-others">
+                <li :for={huddl <- @next.others}>
+                  <.link navigate={huddl_show_path(@group, huddl)}>{huddl.title}</.link>
+                  <span class="count">· {signups_figure(huddl)}{waitlisted_suffix(huddl)}</span>
+                </li>
+              </ul>
             </div>
           </div>
-          <div :if={@next.others != []} class="next-huddl-others">
-            <div class="label">Also upcoming</div>
-            <ul id="next-huddl-others">
-              <li :for={huddl <- @next.others}>
-                <.link navigate={huddl_show_path(@group, huddl)}>{huddl.title}</.link>
-                <span class="count">· {signups_figure(huddl)}{waitlisted_suffix(huddl)}</span>
-              </li>
-            </ul>
+        <% else %>
+          <p class="muted">
+            Nothing on the calendar yet. Create a huddl and its signups will show here.
+          </p>
+          <div :if={is_nil(@group.archived_at)} class="panel-cta">
+            <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>Create a huddl</a>
           </div>
-        </div>
-      <% else %>
-        <p class="muted">
-          Nothing on the calendar yet. Create a huddl and its signups will show here.
-        </p>
-        <div :if={is_nil(@group.archived_at)} class="panel-cta">
-          <a class="btn-primary" href={~p"/groups/#{@group.slug}/huddlz/new"}>Create a huddl</a>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
     """
   end
+
+  defp growth_sub(:month), do: "Members at month end, with how many joined each month"
+  defp growth_sub(:fortnight), do: "Members at each fortnight's end, with how many joined in it"
+  defp growth_sub(:week), do: "Members at each week's end, with how many joined that week"
 
   # ─────────────────────────────────────────  HUDDLZ  ───
   attr :group, :map, required: true

--- a/test/features/member_growth.feature
+++ b/test/features/member_growth.feature
@@ -1,0 +1,33 @@
+@database @conn @member_growth
+Feature: Member growth on the overview
+  As an organizer
+  I want to see how the group has grown over the period
+  So that I can tell whether it is gaining members steadily
+
+  Background:
+    Given the following users exist:
+      | email            | display_name | role    |
+      | host@example.com | Host User    | regular |
+    And a public group "Portland Elixir" exists with owner "host@example.com"
+    And I am signed in as "host@example.com"
+
+  Scenario: Growth over twelve months
+    Given 5 members joined "Portland Elixir" 20 months ago
+    And 2 members joined "Portland Elixir" in each of the last 6 months
+    When I visit "/organize/portland-elixir?period=12m"
+    Then the growth chart shows a point per month ending this month at 18 members with 3 joined
+    And the growth panel head shows "+13" gained in "12 months"
+
+  Scenario: A short period buckets by week
+    Given 2 members joined "Portland Elixir" in each of the last 6 months
+    When I visit "/organize/portland-elixir"
+    And I click "30 days"
+    Then the growth chart shows one bucket per week
+    When I click "90 days"
+    Then the growth chart shows one bucket per fortnight
+
+  Scenario: Months with no joins still appear
+    Given 2 members joined "Portland Elixir" in each of the last 6 months
+    But nobody joined "Portland Elixir" 3 months ago
+    When I visit "/organize/portland-elixir?period=12m"
+    Then the month 3 months ago shows a zero bar and the line stays flat at 4 through it

--- a/test/features/step_definitions/member_growth_steps.exs
+++ b/test/features/step_definitions/member_growth_steps.exs
@@ -1,0 +1,118 @@
+defmodule MemberGrowthSteps do
+  use Cucumber.StepDefinition
+
+  import Ecto.Query, only: [from: 2]
+  import Huddlz.Generator
+  import PhoenixTest
+
+  require Ash.Query
+
+  alias Huddlz.Communities.{Group, GroupMember}
+  alias Huddlz.Repo
+
+  step "{int} members joined {string} in each of the last {int} months",
+       %{args: [count, group_name, months]} = context do
+    group = find_group(group_name)
+
+    # This month counts as one of them; each batch joins as its month opens.
+    for n <- (months - 1)..0//-1 do
+      joined_at = month_start(group, n)
+
+      for _ <- 1..count//1 do
+        member = generate(user(role: :user))
+
+        Ash.Seed.seed!(GroupMember, %{
+          group_id: group.id,
+          user_id: member.id,
+          role: :member,
+          created_at: joined_at
+        })
+      end
+    end
+
+    context
+  end
+
+  step "nobody joined {string} {int} months ago", %{args: [group_name, months]} = context do
+    group = find_group(group_name)
+    from = month_start(group, months)
+    to = month_start(group, months - 1)
+
+    Repo.delete_all(
+      from(m in "group_members",
+        where:
+          m.group_id == type(^group.id, :binary_id) and m.created_at >= ^from and
+            m.created_at < ^to
+      )
+    )
+
+    context
+  end
+
+  step "the growth chart shows a point per month ending this month at {int} members with {int} joined",
+       %{args: [members, joined], session: session} = context do
+    this_month = month_label(0)
+
+    session
+    |> assert_has("#member-growth[data-unit='month'][data-buckets='12']")
+    |> assert_has("#member-growth-line[data-points$=',#{members}']")
+    |> assert_has("#member-growth-bars[data-points$=',#{joined}']")
+    |> assert_has("#member-growth .dot[data-label='#{this_month}'][data-members='#{members}']")
+    |> assert_has("#member-growth .col[data-label='#{this_month}'][data-joined='#{joined}']")
+
+    context
+  end
+
+  step "the growth panel head shows {string} gained in {string}",
+       %{args: [gained, period], session: session} = context do
+    session
+    |> assert_has("#member-growth-panel .stat .big", text: gained, exact: true)
+    |> assert_has("#member-growth-panel .stat .cmp", text: "in #{period}", exact: true)
+
+    context
+  end
+
+  step "the growth chart shows one bucket per week", %{session: session} = context do
+    assert_has(session, "#member-growth[data-unit='week'][data-buckets='5']")
+    context
+  end
+
+  step "the growth chart shows one bucket per fortnight", %{session: session} = context do
+    assert_has(session, "#member-growth[data-unit='fortnight'][data-buckets='7']")
+    context
+  end
+
+  step "the month {int} months ago shows a zero bar and the line stays flat at {int} through it",
+       %{args: [months, members], session: session} = context do
+    session
+    |> assert_has("#member-growth .col[data-label='#{month_label(months)}'][data-joined='0']")
+    |> assert_has(
+      "#member-growth .dot[data-label='#{month_label(months + 1)}'][data-members='#{members}']"
+    )
+    |> assert_has(
+      "#member-growth .dot[data-label='#{month_label(months)}'][data-members='#{members}']"
+    )
+
+    context
+  end
+
+  defp month_start(group, months_ago) do
+    group.time_zone
+    |> DateTime.now!()
+    |> DateTime.to_date()
+    |> Date.beginning_of_month()
+    |> Date.shift(month: -months_ago)
+    |> DateTime.new!(~T[00:00:00], group.time_zone)
+  end
+
+  defp month_label(months_ago) do
+    eastern_today()
+    |> Date.beginning_of_month()
+    |> Date.shift(month: -months_ago)
+    |> Calendar.strftime("%b")
+  end
+
+  defp find_group(name) do
+    Group |> Ash.Query.filter(name == ^name) |> Ash.read_one!(authorize?: false)
+  end
+end


### PR DESCRIPTION
Closes #510.

A Member growth panel below the KPIs, beside the next huddl: members at each bucket's end as a line over a strip of bars for how many joined in it, with the total gained in the period in the panel head. Twelve months bucket by calendar month, 90 days by fortnight, 30 days by week; the last bucket runs up to now, so this month (or this week) is partial like the KPIs.

## How it works

- The figures join the Group `:overview` action as a `growth` entry (unit, gained, and per bucket the label, edges, joins and members at the end), so the GraphQL `groupOverview` query carries them too. Month-end totals are reconstructed from the join dates of current members, as the ticket notes; leaves come later with the activity log.
- `<.growth_chart>` is inline SVG on the tokens like the signup chart. The root carries `data-unit` and `data-buckets`, the line and the bar strip their values in `data-points`, and each dot and bar its bucket label and value.
- Phones get a compact render of the same data (every other label, no per-bar figures) swapped in by CSS, so the text stays legible instead of scaling down with the wide chart.
- The next huddl panel moves into the right column; its chart now takes a width and its two-column body responds to the panel's own width with a container query rather than the viewport.

## Scenarios

`test/features/member_growth.feature` covers the three acceptance criteria: a point per month ending this month with the current count and the month's joins plus the gained figure in the head, weekly and fortnightly bucketing for the short periods, and a month with no joins showing a zero bar under a flat line. The months are relative to today rather than named, so the scenarios keep passing as the calendar moves.

## Notes

- The bars had been invisible at first: the capacity progress bar's `.bar` rule sets a height, and CSS height applies to SVG rects too. The chart's bars use their own class.
