### PR TITLE
fix(ui): add skip navigation and consistent keyboard focus

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6054,32 +6054,39 @@ body .photo-delete-preview figcaption { overflow-wrap: anywhere; }
   body .photo-open:hover img { transform: none; }
 }
 
-/* Keyboard shortcuts and programmatically focused page context. */
+/* Skip link and programmatically focused page context. Interactive controls
+   keep their own focus rings; these rules cover the targets that had none. */
 .skip-link {
   position: fixed;
   top: 12px;
   left: 12px;
   z-index: 1000;
   padding: 12px 18px;
-  background: var(--bg, #fff);
-  color: var(--text, #111);
+  background: var(--panel);
+  color: var(--text);
   border: 2px solid var(--accent);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   transform: translateY(-200%);
 }
-.skip-link:focus { transform: translateY(0); }
-body :is(a, button, input, select, textarea, [tabindex]):focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 4px;
-}
+.skip-link:focus { transform: translateY(0); outline: none; }
+
+/* When focus lands on page context the move itself is the signal. */
+#main-content:focus,
+main :is(h1, h2)[tabindex="-1"]:focus,
+#flash-error:focus { outline: none; }
+
 .error-summary {
   grid-column: 1 / -1;
   margin-bottom: 24px;
-  padding: 20px;
-  border: 2px solid var(--danger, #b42318);
-  border-radius: 10px;
+  padding: 16px 20px;
+  background: var(--panel);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius);
 }
-.error-summary h2 { margin: 0 0 12px; font-size: 1rem; font-weight: 600; }
+.error-summary:focus { outline: none; box-shadow: 0 0 0 3px var(--danger-soft); }
+.error-summary h2 { margin: 0 0 8px; font-size: 1rem; font-weight: 600; }
 .error-summary ul { margin: 0; padding-left: 20px; list-style: disc; }
-.error-summary a { text-decoration: underline; text-underline-offset: 3px; }
-.error-summary li + li { margin-top: 8px; }
+.error-summary li + li { margin-top: 4px; }
+.error-summary a { color: var(--text); text-decoration: underline; text-underline-offset: 3px; }
+.error-summary a:hover { color: var(--accent-ink); }
+.error-summary a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6053,3 +6053,33 @@ body .photo-delete-preview figcaption { overflow-wrap: anywhere; }
   body .photo-tile img { transition: none; }
   body .photo-open:hover img { transform: none; }
 }
+
+/* Keyboard shortcuts and programmatically focused page context. */
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 1000;
+  padding: 12px 18px;
+  background: var(--bg, #fff);
+  color: var(--text, #111);
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  transform: translateY(-200%);
+}
+.skip-link:focus { transform: translateY(0); }
+body :is(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+.error-summary {
+  grid-column: 1 / -1;
+  margin-bottom: 24px;
+  padding: 20px;
+  border: 2px solid var(--danger, #b42318);
+  border-radius: 10px;
+}
+.error-summary h2 { margin: 0 0 12px; font-size: 1rem; font-weight: 600; }
+.error-summary ul { margin: 0; padding-left: 20px; list-style: disc; }
+.error-summary a { text-decoration: underline; text-underline-offset: 3px; }
+.error-summary li + li { margin-top: 8px; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,6 +27,7 @@ import {mountMobileNavigation} from "./mobile_navigation.mjs"
 import {createCoverImageHook} from "./cover_image.mjs"
 import {createCoverCropHook} from "./cover_crop.mjs"
 import {mountPageLoading} from "./page_loading.mjs"
+import {mountFocusNavigation} from "./focus_navigation.mjs"
 
 // The appearance setting lives on <html data-theme>, outside any LiveView.
 // Settings pushes a "theme" event after saving; "system" drops the attribute
@@ -38,8 +39,6 @@ window.addEventListener("phx:theme", ({detail}) => {
     document.documentElement.dataset.theme = detail.theme
   }
 })
-
-import {mountFocusNavigation} from "./focus_navigation.mjs"
 
 const Hooks = {}
 
@@ -159,7 +158,7 @@ mountPageLoading({topbar})
 liveSocket.connect()
 
 mountMobileNavigation()
-mountFocusNavigation()
+mountFocusNavigation({liveSocket})
 
 // "/" focuses the chrome search box, GitHub-style. Skipped while the user
 // is already typing in an editable field, or when modifier keys are held.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -39,6 +39,8 @@ window.addEventListener("phx:theme", ({detail}) => {
   }
 })
 
+import {mountFocusNavigation} from "./focus_navigation.mjs"
+
 const Hooks = {}
 
 Hooks.CoverImage = createCoverImageHook()
@@ -157,6 +159,7 @@ mountPageLoading({topbar})
 liveSocket.connect()
 
 mountMobileNavigation()
+mountFocusNavigation()
 
 // "/" focuses the chrome search box, GitHub-style. Skipped while the user
 // is already typing in an editable field, or when modifier keys are held.

--- a/assets/js/focus_navigation.mjs
+++ b/assets/js/focus_navigation.mjs
@@ -1,11 +1,11 @@
 // Focus page context only after navigation, never while someone is typing or
 // filtering the current page. Live redirects can finish before the new join.
-export function mountFocusNavigation() {
+export function mountFocusNavigation({liveSocket}) {
   let previousMain = document.querySelector("#main-content")
   let previousPath = location.pathname
   let navigation = false
   let leavingDialog = false
-  watchSubmissions()
+  watchSubmissions(liveSocket)
   watchModalRemoval()
 
   document.addEventListener("input", () => { navigation = false })
@@ -50,12 +50,12 @@ function focusPage(main) {
 
 // LiveView locks submitted forms until their reply has patched the DOM. Watch
 // that public loading class rather than guessing a timeout or reacting to validation.
-function watchSubmissions() {
+function watchSubmissions(liveSocket) {
   document.addEventListener("submit", event => {
     const form = event.target
     if (!form.matches("form[phx-submit]")) return
     form.querySelector(".error-summary")?.remove()
-    const previousInfo = document.querySelector("#flash-info")?.textContent
+    dismissStaleError(liveSocket)
     const observer = new MutationObserver(records => {
       const completed = records.some(record =>
         record.target === form && record.attributeName === "class" &&
@@ -65,7 +65,7 @@ function watchSubmissions() {
         restoreLostFocus()
       } else if (completed && !form.classList.contains("phx-submit-loading")) {
         observer.disconnect()
-        requestAnimationFrame(() => submissionFinished(form, previousInfo))
+        requestAnimationFrame(() => submissionFinished(form))
       }
     })
     observer.observe(document.body, {subtree: true, childList: true, attributes: true, attributeFilter: ["class"], attributeOldValue: true})
@@ -84,7 +84,15 @@ function watchSubmissions() {
   })
 }
 
-function submissionFinished(form, previousInfo) {
+// A flash stands until something clears it. Run the error flash's own dismiss
+// commands before the submission, so whatever stands once the reply lands
+// belongs to it. Not a DOM click: that would trip a dialog's click-away.
+function dismissStaleError(liveSocket) {
+  const flash = document.querySelector("#flash-error")
+  if (flash) liveSocket.execJS(flash, flash.getAttribute("phx-click"))
+}
+
+function submissionFinished(form) {
   if (!form.isConnected || form.hasAttribute("phx-trigger-action")) return
   const dialog = visibleDialog()
   if (dialog && !dialog.contains(form)) return
@@ -117,9 +125,7 @@ function submissionFinished(form, previousInfo) {
     return
   }
   const error = document.querySelector("#flash-error")
-  const info = document.querySelector("#flash-info")?.textContent
-  const newSuccess = info && info !== previousInfo
-  if (error && !newSuccess) {
+  if (error) {
     error.tabIndex = -1
     error.focus({preventScroll: true})
     return

--- a/assets/js/focus_navigation.mjs
+++ b/assets/js/focus_navigation.mjs
@@ -20,7 +20,9 @@ export function mountFocusNavigation() {
   window.addEventListener("phx:page-loading-start", ({detail}) => {
     if (detail.kind === "redirect" ||
         (detail.kind === "patch" && new URL(detail.to, location.href).pathname !== previousPath)) {
-      leavingDialog = !!visibleDialog()
+      // Closing a patched dialog restores its trigger; a redirect still needs
+      // to focus and announce the destination page.
+      leavingDialog = detail.kind === "patch" && !!visibleDialog()
       navigation = true
     }
   })

--- a/assets/js/focus_navigation.mjs
+++ b/assets/js/focus_navigation.mjs
@@ -1,0 +1,155 @@
+// Focus page context only after navigation, never while someone is typing or
+// filtering the current page. Live redirects can finish before the new join.
+export function mountFocusNavigation() {
+  let previousMain = document.querySelector("#main-content")
+  let previousPath = location.pathname
+  let navigation = false
+  let leavingDialog = false
+  watchSubmissions()
+  watchModalRemoval()
+
+  document.addEventListener("input", () => { navigation = false })
+  document.addEventListener("submit", () => { navigation = false }, true)
+
+  document.addEventListener("click", event => {
+    if (!event.target.closest(".skip-link")) return
+    event.preventDefault()
+    document.querySelector("#main-content")?.focus()
+  })
+
+  window.addEventListener("phx:page-loading-start", ({detail}) => {
+    if (detail.kind === "redirect" ||
+        (detail.kind === "patch" && new URL(detail.to, location.href).pathname !== previousPath)) {
+      leavingDialog = !!visibleDialog()
+      navigation = true
+    }
+  })
+  window.addEventListener("phx:page-loading-stop", () => {
+    requestAnimationFrame(() => {
+      const main = document.querySelector("#main-content")
+      if (!main || (main === previousMain && location.pathname === previousPath)) return
+      previousPath = location.pathname
+      previousMain = main
+      if (!navigation) return
+      navigation = false
+      if (!leavingDialog && !visibleDialog()) focusPage(main)
+    })
+  })
+}
+
+function focusPage(main) {
+  const heading = main.querySelector("h1")
+  const target = heading || main
+  target.setAttribute("tabindex", "-1")
+  target.focus({preventScroll: true})
+  const status = document.querySelector("#page-context")
+  if (status) status.textContent = heading?.textContent.trim() || document.title
+}
+
+// LiveView locks submitted forms until their reply has patched the DOM. Watch
+// that public loading class rather than guessing a timeout or reacting to validation.
+function watchSubmissions() {
+  document.addEventListener("submit", event => {
+    const form = event.target
+    if (!form.matches("form[phx-submit]")) return
+    form.querySelector(".error-summary")?.remove()
+    const previousInfo = document.querySelector("#flash-info")?.textContent
+    const observer = new MutationObserver(records => {
+      const completed = records.some(record =>
+        record.target === form && record.attributeName === "class" &&
+        record.oldValue?.includes("phx-submit-loading"))
+      if (!form.isConnected) {
+        observer.disconnect()
+        restoreLostFocus()
+      } else if (completed && !form.classList.contains("phx-submit-loading")) {
+        observer.disconnect()
+        requestAnimationFrame(() => submissionFinished(form, previousInfo))
+      }
+    })
+    observer.observe(document.body, {subtree: true, childList: true, attributes: true, attributeFilter: ["class"], attributeOldValue: true})
+  }, true)
+
+  document.addEventListener("input", event => {
+    event.target.closest("form")?.querySelector(".error-summary")?.remove()
+  })
+  document.addEventListener("click", event => {
+    const link = event.target.closest(".error-summary a")
+    if (!link) return
+    const field = document.getElementById(link.hash.slice(1))
+    if (!field) return
+    event.preventDefault()
+    field.focus()
+  })
+}
+
+function submissionFinished(form, previousInfo) {
+  if (!form.isConnected || form.hasAttribute("phx-trigger-action")) return
+  const dialog = visibleDialog()
+  if (dialog && !dialog.contains(form)) return
+  const fields = [...form.querySelectorAll('[aria-invalid="true"]')]
+    .filter(field => field.id && !field.disabled && field.getClientRects().length)
+  if (fields.length) {
+    const summary = document.createElement("section")
+    summary.className = "error-summary"
+    summary.tabIndex = -1
+    summary.setAttribute("aria-label", "Please correct the following errors")
+    const title = document.createElement("h2")
+    title.textContent = "Please correct the following errors"
+    const list = document.createElement("ul")
+    for (const field of fields) {
+      const label = field.labels?.[0]?.textContent.trim() || field.getAttribute("aria-label") || "Field"
+      const errors = (field.getAttribute("aria-describedby") || "").split(/\s+/)
+        .map(id => document.getElementById(id))
+        .filter(element => element?.classList.contains("form-error"))
+        .map(element => element.textContent.trim())
+      const item = document.createElement("li")
+      const link = document.createElement("a")
+      link.href = `#${field.id}`
+      link.textContent = `${label}: ${errors.join("; ") || "Check this field"}`
+      item.append(link)
+      list.append(item)
+    }
+    summary.append(title, list)
+    form.prepend(summary)
+    summary.focus()
+    return
+  }
+  const error = document.querySelector("#flash-error")
+  const info = document.querySelector("#flash-info")?.textContent
+  const newSuccess = info && info !== previousInfo
+  if (error && !newSuccess) {
+    error.tabIndex = -1
+    error.focus({preventScroll: true})
+    return
+  }
+  const heading = form.querySelector("h2")
+  if (heading) {
+    heading.tabIndex = -1
+    heading.focus({preventScroll: true})
+  }
+}
+
+function visibleDialog() {
+  return [...document.querySelectorAll('[role="dialog"]')]
+    .find(dialog => dialog.getClientRects().length && getComputedStyle(dialog).visibility !== "hidden")
+}
+
+// A successful destructive action may remove the button that opened a dialog.
+// Let its normal restoration finish first; only recover focus left on the body.
+function watchModalRemoval() {
+  new MutationObserver(records => {
+    const removedDialog = records.some(record => [...record.removedNodes].some(node =>
+      node.nodeType === Node.ELEMENT_NODE &&
+      (node.matches("[data-cc-modal]") || node.querySelector("[data-cc-modal]"))))
+    if (!removedDialog) return
+    restoreLostFocus()
+  }).observe(document.body, {childList: true, subtree: true})
+}
+
+function restoreLostFocus() {
+  requestAnimationFrame(() => {
+    if (document.activeElement === document.body && !visibleDialog()) {
+      document.querySelector("#main-content")?.focus({preventScroll: true})
+    }
+  })
+}

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -333,6 +333,7 @@ defmodule HuddlzWeb.Components.HuddlForm do
     <.modal
       :if={@live_action == :new_location}
       id="new-location-modal"
+      return_focus="#saved-location-picker-input"
       show
       on_cancel={JS.patch(@cancel_path)}
     >

--- a/lib/huddlz_web/components/huddl_form.ex
+++ b/lib/huddlz_web/components/huddl_form.ex
@@ -326,6 +326,7 @@ defmodule HuddlzWeb.Components.HuddlForm do
   attr :live_action, :atom, required: true
   attr :modal_location_address, :string, default: nil
   attr :modal_location_name, :string, default: nil
+  attr :modal_location_form, :any, required: true
   attr :cancel_path, :string, required: true
 
   def location_modal(assigns) do
@@ -362,20 +363,15 @@ defmodule HuddlzWeb.Components.HuddlForm do
           />
         </div>
 
-        <div class="form-row">
-          <label class="form-label" for="location-name-input">
-            Location name (optional)
-          </label>
-          <input
-            type="text"
-            id="location-name-input"
-            name="location_name"
-            value={@modal_location_name}
-            phx-debounce="100"
-            placeholder="e.g., Community Center"
-            class="form-input"
-          />
-        </div>
+        <.input
+          field={@modal_location_form[:name]}
+          id="location-name-input"
+          name="location_name"
+          label="Location name (optional)"
+          value={@modal_location_name}
+          phx-debounce="100"
+          placeholder="e.g., Community Center"
+        />
 
         <div class="form-foot is-flush">
           <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -47,6 +47,7 @@ defmodule HuddlzWeb.Layouts do
     assigns = assign_new(assigns, :signed_in, fn -> assigns.current_user != nil end)
 
     ~H"""
+    <a :if={@signed_in} href="#main-content" class="skip-link">Skip to main content</a>
     <%= if @signed_in do %>
       <button
         type="button"
@@ -232,7 +233,13 @@ defmodule HuddlzWeb.Layouts do
       </aside>
     <% end %>
 
-    <main class="main" data-mobile-nav-background>
+    <main
+      id="main-content"
+      tabindex="-1"
+      aria-label="Main content"
+      class="main"
+      data-mobile-nav-background
+    >
       <header class="content-topbar">
         <%= if @signed_in do %>
           <button
@@ -327,9 +334,9 @@ defmodule HuddlzWeb.Layouts do
         </a>
       </header>
 
-      <div class="auth-frame">
+      <main id="main-content" tabindex="-1" aria-label="Main content" class="auth-frame">
         {render_slot(@inner_block)}
-      </div>
+      </main>
     </div>
     """
   end

--- a/lib/huddlz_web/components/layouts/root.html.heex
+++ b/lib/huddlz_web/components/layouts/root.html.heex
@@ -45,5 +45,7 @@
   </head>
   <body class={Map.get(assigns, :body_class, "")}>
     {@inner_content}
+    <div id="page-context" class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+    </div>
   </body>
 </html>

--- a/lib/huddlz_web/live/group_live/edit.ex
+++ b/lib/huddlz_web/live/group_live/edit.ex
@@ -362,7 +362,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
           :if={is_nil(@group.archived_at)}
           id="archive-group"
           variant={:secondary}
-          phx-click="open_archive_dialog"
+          phx-click={JS.push_focus() |> JS.push("open_archive_dialog")}
         >Archive group</.button>
         <.button
           :if={@group.archived_at}
@@ -384,7 +384,7 @@ defmodule HuddlzWeb.GroupLive.Edit do
         show
         on_cancel={JS.push("close_archive_dialog")}
       >
-        <h2>Archive {@group.name}?</h2>
+        <h2 id="archive-group-dialog-title">Archive {@group.name}?</h2>
         <p>
           Members keep access to the group's history and will be notified that it is archived. New activity is closed until you restore it.
         </p>

--- a/lib/huddlz_web/live/group_live/locations.ex
+++ b/lib/huddlz_web/live/group_live/locations.ex
@@ -90,7 +90,11 @@ defmodule HuddlzWeb.GroupLive.Locations do
           </p>
         </div>
         <div class="actions">
-          <.button variant={:primary} patch={~p"/groups/#{@group.slug}/locations/new"}>
+          <.button
+            id="add-address"
+            variant={:primary}
+            patch={~p"/groups/#{@group.slug}/locations/new"}
+          >
             Add Address
           </.button>
         </div>
@@ -218,10 +222,11 @@ defmodule HuddlzWeb.GroupLive.Locations do
       <.modal
         :if={@live_action == :new_location}
         id="new-location-modal"
+        return_focus="#add-address"
         show
         on_cancel={JS.patch(~p"/groups/#{@group.slug}/locations")}
       >
-        <h2 class="modal-title">Add New Address</h2>
+        <h2 id="new-location-modal-title" class="modal-title">Add New Address</h2>
         <p class="modal-sub">
           Saved venues show up in the venue picker for everyone in your group.
         </p>

--- a/lib/huddlz_web/live/group_live/locations.ex
+++ b/lib/huddlz_web/live/group_live/locations.ex
@@ -252,18 +252,15 @@ defmodule HuddlzWeb.GroupLive.Locations do
             />
           </div>
 
-          <div class="form-row">
-            <label class="form-label" for="location-name-input">Location name (optional)</label>
-            <input
-              type="text"
-              id="location-name-input"
-              name="location_name"
-              value={@modal_location_name}
-              phx-debounce="100"
-              placeholder="e.g., Community Center"
-              class="form-input"
-            />
-          </div>
+          <.input
+            field={@modal_location_form[:name]}
+            id="location-name-input"
+            name="location_name"
+            label="Location name (optional)"
+            value={@modal_location_name}
+            phx-debounce="100"
+            placeholder="e.g., Community Center"
+          />
 
           <div class="form-foot is-flush">
             <.button variant={:primary} type="submit" disabled={is_nil(@modal_location_address)}>
@@ -280,32 +277,25 @@ defmodule HuddlzWeb.GroupLive.Locations do
   end
 
   @impl true
-  def handle_event("save_new_location", _params, socket) do
+  def handle_event("save_new_location", params, socket) do
     user = socket.assigns.current_user
-    address = socket.assigns.modal_location_address
-    name = socket.assigns.modal_location_name
-    name = if name == "", do: nil, else: name
 
-    case Communities.create_group_location(
-           name,
-           address,
-           socket.assigns.modal_location_lat,
-           socket.assigns.modal_location_lng,
-           socket.assigns.modal_location_time_zone,
-           socket.assigns.group.id,
-           actor: user
-         ) do
+    case ModalLocationHelpers.submit(socket, socket.assigns.group.id, params) do
       {:ok, _location} ->
         locations = load_group_locations(socket.assigns.group.id, user)
 
         {:noreply,
          socket
          |> assign(:locations, locations)
+         |> clear_flash(:error)
          |> put_flash(:info, "Location saved")
          |> push_patch(to: ~p"/groups/#{socket.assigns.group.slug}/locations")}
 
-      {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "Failed to save location")}
+      {:error, form} ->
+        {:noreply,
+         socket
+         |> assign(:modal_location_form, to_form(form))
+         |> put_flash(:error, "Failed to save location")}
     end
   end
 

--- a/lib/huddlz_web/live/helpers/modal_location_helpers.ex
+++ b/lib/huddlz_web/live/helpers/modal_location_helpers.ex
@@ -3,15 +3,20 @@ defmodule HuddlzWeb.Live.Helpers.ModalLocationHelpers do
   Shared state handling for the "Select a location" modal used in the
   huddl and group new/edit/locations LiveViews.
 
-  The modal owns five socket assigns:
+  The modal owns the following socket assigns:
 
     * `:modal_location_address` — full display text (nil when empty)
     * `:modal_location_lat` / `:modal_location_lng` — geocoded coordinates
     * `:modal_location_time_zone` — canonical IANA time zone
     * `:modal_location_name` — short name (bound to the name input)
+    * `:modal_location_form` — Ash form carrying saved-location validation errors
   """
 
-  import Phoenix.Component, only: [assign: 2]
+  import Phoenix.Component, only: [assign: 2, to_form: 1]
+
+  alias AshPhoenix.Form
+  alias Huddlz.Communities
+  alias Huddlz.Communities.GroupLocation
 
   @doc "Initialize all modal location assigns to their empty values."
   def init(socket) do
@@ -20,12 +25,29 @@ defmodule HuddlzWeb.Live.Helpers.ModalLocationHelpers do
       modal_location_lat: nil,
       modal_location_lng: nil,
       modal_location_time_zone: nil,
-      modal_location_name: ""
+      modal_location_name: "",
+      modal_location_form: to_form(Form.for_create(GroupLocation, :create, domain: Communities))
     )
   end
 
   @doc "Reset the modal location assigns to their empty values."
   def clear(socket), do: init(socket)
+
+  @doc "Submit the saved location with trusted address data and the entered name."
+  def submit(socket, group_id, params) do
+    params = %{
+      "name" => Map.get(params, "location_name", socket.assigns.modal_location_name),
+      "address" => socket.assigns.modal_location_address,
+      "latitude" => socket.assigns.modal_location_lat,
+      "longitude" => socket.assigns.modal_location_lng,
+      "time_zone" => socket.assigns.modal_location_time_zone,
+      "group_id" => group_id
+    }
+
+    GroupLocation
+    |> Form.for_create(:create, domain: Communities, actor: socket.assigns.current_user)
+    |> Form.submit(params: params)
+  end
 
   @doc """
   Apply a location-selected payload from the LocationAutocomplete component.

--- a/lib/huddlz_web/live/huddl_live/edit.ex
+++ b/lib/huddlz_web/live/huddl_live/edit.ex
@@ -359,6 +359,7 @@ defmodule HuddlzWeb.HuddlLive.Edit do
         cancel_path={~p"/groups/#{@group_slug}/huddlz/#{@huddl.id}/edit"}
         modal_location_address={@modal_location_address}
         modal_location_name={@modal_location_name}
+        modal_location_form={@modal_location_form}
       />
     </Layouts.app>
     """
@@ -485,34 +486,27 @@ defmodule HuddlzWeb.HuddlLive.Edit do
   end
 
   @impl true
-  def handle_event("save_location", _params, socket) do
+  def handle_event("save_location", params, socket) do
     user = socket.assigns.current_user
-    address = socket.assigns.modal_location_address
-    name = socket.assigns.modal_location_name
-    name = if name == "", do: nil, else: name
 
-    case Communities.create_group_location(
-           name,
-           address,
-           socket.assigns.modal_location_lat,
-           socket.assigns.modal_location_lng,
-           socket.assigns.modal_location_time_zone,
-           socket.assigns.huddl.group.id,
-           actor: user
-         ) do
+    case ModalLocationHelpers.submit(socket, socket.assigns.huddl.group.id, params) do
       {:ok, location} ->
         group_locations = load_group_locations(socket.assigns.huddl.group.id, user)
 
         {:noreply,
          socket
          |> assign(:group_locations, group_locations)
+         |> clear_flash(:error)
          |> apply_saved_location_to_form(location)
          |> push_patch(
            to: ~p"/groups/#{socket.assigns.group_slug}/huddlz/#{socket.assigns.huddl.id}/edit"
          )}
 
-      {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "Failed to save location")}
+      {:error, form} ->
+        {:noreply,
+         socket
+         |> assign(:modal_location_form, to_form(form))
+         |> put_flash(:error, "Failed to save location")}
     end
   end
 

--- a/lib/huddlz_web/live/huddl_live/new.ex
+++ b/lib/huddlz_web/live/huddl_live/new.ex
@@ -275,6 +275,7 @@ defmodule HuddlzWeb.HuddlLive.New do
         cancel_path={~p"/groups/#{@group.slug}/huddlz/new"}
         modal_location_address={@modal_location_address}
         modal_location_name={@modal_location_name}
+        modal_location_form={@modal_location_form}
       />
     </Layouts.app>
     """
@@ -354,32 +355,25 @@ defmodule HuddlzWeb.HuddlLive.New do
   end
 
   @impl true
-  def handle_event("save_location", _params, socket) do
+  def handle_event("save_location", params, socket) do
     user = socket.assigns.current_user
-    address = socket.assigns.modal_location_address
-    name = socket.assigns.modal_location_name
-    name = if name == "", do: nil, else: name
 
-    case Communities.create_group_location(
-           name,
-           address,
-           socket.assigns.modal_location_lat,
-           socket.assigns.modal_location_lng,
-           socket.assigns.modal_location_time_zone,
-           socket.assigns.group.id,
-           actor: user
-         ) do
+    case ModalLocationHelpers.submit(socket, socket.assigns.group.id, params) do
       {:ok, location} ->
         group_locations = load_group_locations(socket.assigns.group.id, user)
 
         {:noreply,
          socket
          |> assign(:group_locations, group_locations)
+         |> clear_flash(:error)
          |> apply_saved_location_to_form(location)
          |> push_patch(to: new_huddl_path(socket))}
 
-      {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "Failed to save location")}
+      {:error, form} ->
+        {:noreply,
+         socket
+         |> assign(:modal_location_form, to_form(form))
+         |> put_flash(:error, "Failed to save location")}
     end
   end
 

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -218,22 +218,33 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   defp create_invitation(socket, group, user, role, email, params) do
-    case Communities.invite_to_group_by_email(group.id, email, role, actor: user) do
+    params = Map.merge(params, %{"group_id" => group.id, "email" => email, "role" => role})
+
+    form =
+      AshPhoenix.Form.for_create(Huddlz.Communities.GroupInvitation, :invite,
+        domain: Communities,
+        actor: user,
+        as: "invitation",
+        params: params
+      )
+
+    case AshPhoenix.Form.submit(form, params: params) do
       {:ok, _invitation} ->
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Invitation sent to #{email}.")
          |> assign(:invitation_form, invitation_form())
          |> refresh_invitations(group, user)}
 
-      {:error, _reason} ->
+      {:error, form} ->
         {:noreply,
          socket
          |> put_flash(
            :error,
            "Could not send that invitation. They may already be a member or have a pending invitation."
          )
-         |> assign(:invitation_form, invitation_form(params))}
+         |> assign(:invitation_form, to_form(form))}
     end
   end
 
@@ -1102,7 +1113,7 @@ defmodule HuddlzWeb.OrganizeLive do
         :if={@transfer_candidates != []}
         for={@transfer_target_form}
         id="transfer-ownership-target-form"
-        phx-submit="open_transfer_action"
+        phx-submit={JS.push_focus(to: "#open-transfer-ownership") |> JS.push("open_transfer_action")}
         class="mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end"
       >
         <.select
@@ -1240,7 +1251,7 @@ defmodule HuddlzWeb.OrganizeLive do
       <.button
         :if={@can_promote}
         id={"promote-member-#{@entry.id}"}
-        phx-click="open_member_action"
+        phx-click={JS.push_focus() |> JS.push("open_member_action")}
         phx-value-id={@entry.id}
         phx-value-action="promote"
         class="text-sm"
@@ -1250,7 +1261,7 @@ defmodule HuddlzWeb.OrganizeLive do
       <.button
         :if={@can_demote}
         id={"demote-member-#{@entry.id}"}
-        phx-click="open_member_action"
+        phx-click={JS.push_focus() |> JS.push("open_member_action")}
         phx-value-id={@entry.id}
         phx-value-action="demote"
         class="text-sm"
@@ -1261,7 +1272,7 @@ defmodule HuddlzWeb.OrganizeLive do
         :if={@can_remove}
         id={"remove-member-#{@entry.id}"}
         variant={:destructive}
-        phx-click="open_member_action"
+        phx-click={JS.push_focus() |> JS.push("open_member_action")}
         phx-value-id={@entry.id}
         phx-value-action="remove"
         class="text-sm"

--- a/lib/huddlz_web/live/profile_live.ex
+++ b/lib/huddlz_web/live/profile_live.ex
@@ -421,6 +421,7 @@ defmodule HuddlzWeb.ProfileLive do
 
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Display name updated successfully")
          |> assign(:current_user, updated_user)
          |> assign(:form, form)}
@@ -495,6 +496,7 @@ defmodule HuddlzWeb.ProfileLive do
       {:ok, updated_user} ->
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Password updated successfully")
          |> assign(:current_user, updated_user)
          |> assign(:password_form, password_form(updated_user))
@@ -546,6 +548,7 @@ defmodule HuddlzWeb.ProfileLive do
 
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Profile picture removed")
          |> assign(:remove_avatar_dialog_open, false)
          |> assign(:current_user, updated_user)}
@@ -579,6 +582,7 @@ defmodule HuddlzWeb.ProfileLive do
 
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Home location updated")
          |> assign(:current_user, updated_user)
          |> assign(:location_error, nil)}
@@ -597,6 +601,7 @@ defmodule HuddlzWeb.ProfileLive do
       {:ok, updated_user} ->
         {:noreply,
          socket
+         |> clear_flash(:error)
          |> put_flash(:info, "Home location cleared")
          |> assign(:current_user, updated_user)}
 
@@ -731,6 +736,7 @@ defmodule HuddlzWeb.ProfileLive do
     {:ok, updated_user} = Ash.load(user, [:current_profile_picture_url], actor: user)
 
     socket
+    |> clear_flash(:error)
     |> put_flash(:info, flash_message)
     |> assign(:current_user, updated_user)
     |> assign(:avatar_error, nil)

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -28,6 +28,7 @@ The command builds the actual app assets, starts the test endpoint and Chromium,
 
 | Feature | Browser-specific acceptance check |
 | --- | --- |
+| Keyboard focus | Skip navigation, page context, linked submission errors across forms, correction and repeated saves, and dialog focus restoration |
 | Home location | ArrowDown/Enter select a suggestion without a native form submission |
 | Calendar | Actual `Intl` time-zone detection moves a late Denver huddl to the next New York calendar day |
 | Organizer | Native Tab, arrow keys, Space, visible focus, and switch state survive LiveView patches |

--- a/test/browser/features/focus_navigation.feature
+++ b/test/browser/features/focus_navigation.feature
@@ -1,0 +1,64 @@
+@focus_browser
+Feature: Keyboard access to page content
+  Scenario: Skip persistent navigation and follow a page change
+    Given I am signed in on the groups page for keyboard navigation
+    When I use the skip link
+    Then keyboard focus is in the main content
+    When I follow the profile link
+    Then the new page context receives keyboard focus
+
+  Scenario: A failed sign in offers keyboard links to invalid fields
+    Given I open sign in for keyboard navigation
+    When I submit the empty sign in form
+    Then the error summary receives focus and links to the invalid email
+    When I follow the email error link
+    Then the email field receives focus and describes its error
+
+  Scenario: Correcting profile errors preserves typing focus and saving focuses the section
+    Given I am signed in on the groups page for keyboard navigation
+    When I follow the profile link
+    And I submit an empty display name
+    Then the profile error summary receives focus
+    When I correct my display name
+    Then typing focus stays in the display name field
+    When I save my corrected profile
+    Then the account information heading receives focus
+    When I save my corrected profile
+    Then the account information heading receives focus
+
+  Scenario Outline: Organizer forms focus their invalid fields consistently
+    Given I open the "<surface>" form as a group owner
+    When I submit that form with an empty "<field>"
+    Then that form shows a focused error summary with an invalid field link
+
+    Examples:
+      | surface       | field         |
+      | group         | Group Name    |
+      | huddl         | Title         |
+      | address book  | Location name |
+      | invitation    | Email         |
+
+  Scenario: Dismissing the address dialog returns to its trigger
+    Given I open the "address book" form as a group owner
+    When I open the address dialog and dismiss it with Escape
+    Then focus returns to Add Address
+
+  Scenario: Dismissing group archival returns to Archive group
+    Given I open the "group" form as a group owner
+    When I open group archival and dismiss it with Escape
+    Then focus returns to Archive group
+
+  Scenario: Dismissing a member action returns to the member
+    Given I open member management with a member to promote
+    When I open promotion and dismiss it with Escape
+    Then focus returns to Promote
+
+  Scenario: A completed member action returns focus when its trigger disappears
+    Given I open member management with a member to promote
+    When I confirm the member promotion
+    Then focus returns to the member page content
+
+  Scenario: Saving an address-book name returns to page content
+    Given I open the "address book" form as a group owner
+    When I save a new address-book name
+    Then keyboard focus is in the main content

--- a/test/browser/features/focus_navigation.feature
+++ b/test/browser/features/focus_navigation.feature
@@ -48,6 +48,12 @@ Feature: Keyboard access to page content
     When I open group archival and dismiss it with Escape
     Then focus returns to Archive group
 
+  @archive_focus
+  Scenario: Archiving a group announces the resulting page
+    Given I open the "group" form as a group owner
+    When I confirm group archival
+    Then the archived group's page receives focus and is announced
+
   Scenario: Dismissing a member action returns to the member
     Given I open member management with a member to promote
     When I open promotion and dismiss it with Escape
@@ -62,3 +68,17 @@ Feature: Keyboard access to page content
     Given I open the "address book" form as a group owner
     When I save a new address-book name
     Then keyboard focus is in the main content
+
+  @location_creation_focus
+  Scenario Outline: Correcting a new saved location from <surface> keeps keyboard focus in the dialog
+    Given I open a new address dialog from "<surface>"
+    When I try to save a new address with a name longer than 200 characters
+    Then the address dialog focuses a summary linking to the invalid name
+    When I follow the location name error and correct it
+    Then I can save the address and return to the page
+
+    Examples:
+      | surface        |
+      | address book   |
+      | huddl creation |
+      | huddl editing  |

--- a/test/browser/steps/focus_navigation_steps.exs
+++ b/test/browser/steps/focus_navigation_steps.exs
@@ -64,7 +64,12 @@ defmodule BrowserFocusSteps do
   step "the email field receives focus and describes its error", context do
     context.conn
     |> assert_has("#user_email:focus[aria-invalid=true][aria-describedby]")
-    |> assert_browser("getComputedStyle(document.activeElement).outlineStyle !== 'none'")
+    |> assert_browser("""
+    (() => {
+      const style = getComputedStyle(document.activeElement);
+      return style.outlineStyle !== 'none' || style.boxShadow !== 'none';
+    })()
+    """)
 
     context
   end

--- a/test/browser/steps/focus_navigation_steps.exs
+++ b/test/browser/steps/focus_navigation_steps.exs
@@ -3,6 +3,7 @@ defmodule BrowserFocusSteps do
 
   import Huddlz.Generator
   import Huddlz.Test.BrowserHelpers
+  import Huddlz.Test.MoxHelpers
   import PhoenixTest
   import PhoenixTest.Playwright, only: [press: 3]
 
@@ -194,6 +195,27 @@ defmodule BrowserFocusSteps do
     context
   end
 
+  step "I confirm group archival", context do
+    conn =
+      context.conn
+      |> press("#archive-group", "Enter")
+      |> assert_has("#archive-group-dialog button:focus")
+      |> click_button("Yes, archive group")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the archived group's page receives focus and is announced", context do
+    context.conn
+    |> assert_has("main h1:focus")
+    |> assert_browser("""
+    document.querySelector('#page-context').textContent.trim() ===
+      document.querySelector('main h1').textContent.trim()
+    """)
+
+    context
+  end
+
   step "I open member management with a member to promote", context do
     owner = generate(user(role: :user))
     member = generate(user(role: :user))
@@ -247,5 +269,93 @@ defmodule BrowserFocusSteps do
       |> assert_has(".row-title", text: "Community room")
 
     Map.put(context, :conn, conn)
+  end
+
+  step "I open a new address dialog from {string}", %{args: [surface]} = context do
+    owner = generate(user(role: :user))
+    group = generate(group(owner_id: owner.id, actor: owner))
+
+    {path, link} =
+      case surface do
+        "address book" ->
+          {"/groups/#{group.slug}/locations", "Add Address"}
+
+        "huddl creation" ->
+          {"/groups/#{group.slug}/huddlz/new", "Add new address"}
+
+        "huddl editing" ->
+          huddl = generate(huddl(group_id: group.id, creator_id: owner.id, actor: owner))
+          {"/groups/#{group.slug}/huddlz/#{huddl.id}/edit", "Add new address"}
+      end
+
+    conn =
+      context.conn
+      |> sign_in(owner)
+      |> visit(path)
+      |> assert_has(".phx-connected")
+      |> click_link(link)
+      |> assert_has("#new-location-modal input:focus")
+
+    Map.merge(context, %{conn: conn, location_surface: surface})
+  end
+
+  step "I try to save a new address with a name longer than 200 characters", context do
+    stub_places_autocomplete(%{"saint" => [:saint_augustine]})
+    stub_place_details(:defaults)
+
+    conn =
+      context.conn
+      |> fill_in("Search for an address", with: "saint")
+      |> assert_has("#modal-address-autocomplete [role=option]")
+      |> press("#modal-address-autocomplete-input", "ArrowDown")
+      |> assert_has("#modal-address-autocomplete[data-has-highlight=true]")
+      |> press("#modal-address-autocomplete-input", "Enter")
+      |> assert_has("#new-location-form button[type=submit]:not([disabled])")
+      |> fill_in("Location name (optional)", with: String.duplicate("a", 201))
+      |> press("#new-location-form button[type=submit]", "Enter")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the address dialog focuses a summary linking to the invalid name", context do
+    context.conn
+    |> assert_has("#new-location-modal .error-summary:focus")
+    |> assert_has("#new-location-modal .error-summary a[href='#location-name-input']")
+    |> assert_has("#location-name-input[aria-invalid=true][aria-describedby]")
+
+    context
+  end
+
+  step "I follow the location name error and correct it", context do
+    conn =
+      context.conn
+      |> press(".error-summary a[href='#location-name-input']", "Enter")
+      |> assert_has("#location-name-input:focus")
+      |> assert_browser("""
+      document.getElementById(document.activeElement.getAttribute('aria-describedby'))
+        .textContent.includes('200')
+      """)
+      |> fill_in("Location name (optional)", with: "Community room")
+      |> press("#new-location-form button[type=submit]", "Enter")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I can save the address and return to the page", context do
+    conn = refute_has(context.conn, "#new-location-modal")
+
+    case context.location_surface do
+      "address book" ->
+        conn
+        |> assert_has(".row-title", text: "Community room")
+        |> assert_has("#add-address:focus")
+
+      _huddl ->
+        conn
+        |> assert_has("[data-testid=saved-location-display]", text: "Community room")
+        |> assert_has("#main-content:focus")
+    end
+
+    context
   end
 end

--- a/test/browser/steps/focus_navigation_steps.exs
+++ b/test/browser/steps/focus_navigation_steps.exs
@@ -1,0 +1,251 @@
+defmodule BrowserFocusSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+  import PhoenixTest.Playwright, only: [press: 3]
+
+  step "I am signed in on the groups page for keyboard navigation", context do
+    member = generate(user(role: :user))
+    conn = context.conn |> sign_in(member) |> visit("/groups") |> assert_has(".phx-connected")
+    Map.put(context, :conn, conn)
+  end
+
+  step "I use the skip link", context do
+    conn =
+      context.conn
+      |> press("body", "Tab")
+      |> assert_has("a.skip-link:focus-visible")
+      |> press(":focus", "Enter")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "keyboard focus is in the main content", context do
+    context.conn |> assert_has("main#main-content:focus")
+    context
+  end
+
+  step "I follow the profile link", context do
+    Map.put(context, :conn, press(context.conn, "#sidebar-user", "Enter"))
+  end
+
+  step "the new page context receives keyboard focus", context do
+    context.conn |> assert_has("main h1:focus") |> assert_has("#page-context", text: "Profile")
+    context
+  end
+
+  step "I open sign in for keyboard navigation", context do
+    Map.put(context, :conn, context.conn |> visit("/sign-in") |> assert_has(".phx-connected"))
+  end
+
+  step "I submit the empty sign in form", context do
+    Map.put(
+      context,
+      :conn,
+      press(context.conn, "#password-sign-in-form button[type=submit]", "Enter")
+    )
+  end
+
+  step "the error summary receives focus and links to the invalid email", context do
+    context.conn
+    |> assert_has(".error-summary:focus")
+    |> assert_has(".error-summary a[href='#user_email']")
+
+    context
+  end
+
+  step "I follow the email error link", context do
+    Map.put(context, :conn, press(context.conn, ".error-summary a[href='#user_email']", "Enter"))
+  end
+
+  step "the email field receives focus and describes its error", context do
+    context.conn
+    |> assert_has("#user_email:focus[aria-invalid=true][aria-describedby]")
+    |> assert_browser("getComputedStyle(document.activeElement).outlineStyle !== 'none'")
+
+    context
+  end
+
+  step "I submit an empty display name", context do
+    conn =
+      context.conn
+      |> fill_in("Display name", with: "")
+      |> press("#profile-form button[type=submit]", "Enter")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the profile error summary receives focus", context do
+    context.conn |> assert_has("#profile-form .error-summary:focus")
+    context
+  end
+
+  step "I correct my display name", context do
+    {:ok, _} =
+      PlaywrightEx.Frame.fill(context.conn.frame_id,
+        selector: "#profile-form input[name=\"form[display_name]\"]",
+        value: "Keyboard member",
+        timeout: 5000
+      )
+
+    context
+  end
+
+  step "typing focus stays in the display name field", context do
+    context.conn
+    |> assert_has("#profile-form input:focus")
+    |> assert_browser("document.activeElement.value === 'Keyboard member'")
+    |> refute_has("#profile-form .error-summary")
+
+    context
+  end
+
+  step "I save my corrected profile", context do
+    Map.put(context, :conn, press(context.conn, "#profile-form button[type=submit]", "Enter"))
+  end
+
+  step "the account information heading receives focus", context do
+    context.conn |> assert_has("#profile-form h2:focus", text: "Account information")
+    context
+  end
+
+  step "I open the {string} form as a group owner", %{args: [surface]} = context do
+    owner = generate(user(role: :user))
+    group = generate(group(owner_id: owner.id, is_public: surface != "invitation", actor: owner))
+
+    {path, selector} =
+      case surface do
+        "group" ->
+          {"/groups/#{group.slug}/edit", "#edit-group-form"}
+
+        "huddl" ->
+          {"/groups/#{group.slug}/huddlz/new", "#huddl-form"}
+
+        "invitation" ->
+          {"/organize/#{group.slug}/members", "#group-invitation-form"}
+
+        "address book" ->
+          generate(group_location(group_id: group.id, actor: owner))
+          {"/groups/#{group.slug}/locations", "#location-rename-form"}
+      end
+
+    conn = context.conn |> sign_in(owner) |> visit(path) |> assert_has(".phx-connected")
+    conn = if surface == "address book", do: click_button(conn, "Rename"), else: conn
+    Map.merge(context, %{conn: conn, focus_form: selector})
+  end
+
+  step "I submit that form with an empty {string}", %{args: [label]} = context do
+    conn =
+      context.conn
+      |> fill_in(label, with: "")
+      |> press(context.focus_form <> " button[type=submit]", "Enter")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "that form shows a focused error summary with an invalid field link", context do
+    context.conn
+    |> assert_has(context.focus_form <> " .error-summary:focus")
+    |> assert_browser("""
+    (() => {
+      const summary = document.activeElement;
+      return [...summary.querySelectorAll('a')].every(link => {
+        const field = document.getElementById(link.hash.slice(1));
+        return field?.getAttribute('aria-invalid') === 'true' && field.getAttribute('aria-describedby');
+      });
+    })()
+    """)
+
+    context
+  end
+
+  step "I open the address dialog and dismiss it with Escape", context do
+    conn =
+      context.conn
+      |> click_button("Cancel")
+      |> click_link("Add Address")
+      |> assert_has("#new-location-modal input:focus")
+      |> press(":focus", "Tab")
+      |> press(":focus", "Escape")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "focus returns to Add Address", context do
+    context.conn |> assert_browser("!document.querySelector('#new-location-modal')")
+    context.conn |> assert_has("a:focus", text: "Add Address")
+    context
+  end
+
+  step "I open group archival and dismiss it with Escape", context do
+    conn =
+      context.conn
+      |> press("#archive-group", "Enter")
+      |> assert_has("#archive-group-dialog button:focus")
+      |> press(":focus", "Escape")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "focus returns to Archive group", context do
+    context.conn |> assert_has("#archive-group:focus")
+    context
+  end
+
+  step "I open member management with a member to promote", context do
+    owner = generate(user(role: :user))
+    member = generate(user(role: :user))
+    group = generate(group(owner_id: owner.id, actor: owner))
+    generate(group_member(group_id: group.id, user_id: member.id, role: :member, actor: owner))
+
+    conn =
+      context.conn
+      |> sign_in(owner)
+      |> visit("/organize/#{group.slug}/members")
+      |> assert_has(".phx-connected")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I open promotion and dismiss it with Escape", context do
+    conn =
+      context.conn
+      |> press("button[id^=promote-member-]", "Enter")
+      |> assert_has("#member-action-dialog button:focus")
+      |> press(":focus", "Escape")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "focus returns to Promote", context do
+    context.conn |> assert_has("button[id^=promote-member-]:focus")
+    context
+  end
+
+  step "I confirm the member promotion", context do
+    conn =
+      context.conn
+      |> press("button[id^=promote-member-]", "Enter")
+      |> assert_has("#member-action-dialog button:focus")
+      |> press("#member-action-confirm", "Enter")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "focus returns to the member page content", context do
+    context.conn |> assert_has("#main-content:focus") |> assert_has("button[id^=demote-member-]")
+    context
+  end
+
+  step "I save a new address-book name", context do
+    conn =
+      context.conn
+      |> fill_in("Location name", with: "Community room")
+      |> press("#location-rename-form button[type=submit]", "Enter")
+      |> assert_has(".row-title", text: "Community room")
+
+    Map.put(context, :conn, conn)
+  end
+end

--- a/test/huddlz_web/live/profile_live_test.exs
+++ b/test/huddlz_web/live/profile_live_test.exs
@@ -184,8 +184,8 @@ defmodule HuddlzWeb.ProfileLiveTest do
       |> click_button("Save changes")
       |> assert_has("*", text: "Failed to update display name")
 
-      # Test too long (> 30 chars)
-      long_name = String.duplicate("a", 31)
+      # Test too long (> 70 chars)
+      long_name = String.duplicate("a", 71)
 
       session
       |> fill_in("Display name", with: long_name)


### PR DESCRIPTION
Add a visible-on-focus skip link before the sidebar and move focus to the new page context after navigation. Failed submissions focus a summary with links to invalid fields; successful saves and dialog dismissal return focus to a useful heading or trigger.

Organizer invitations now expose field-level validation errors, and successful profile updates clear stale errors. Browser scenarios cover the affected form areas, repeated saves, and modal restoration when a trigger disappears.

Closes #304.
