### PR TITLE
feat(organize): turnout on the overview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1744,11 +1744,6 @@ body .kpis {
 @media (max-width: 1100px) {
  body .kpis { grid-template-columns: repeat(2, 1fr); } }
 
-body .kpis.kpis-3 { grid-template-columns: repeat(3, 1fr); }
-
-@media (max-width: 1100px) {
- body .kpis.kpis-3 { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); } }
-
 
 body .kpi {
   border: 1px solid var(--line);
@@ -1833,6 +1828,22 @@ body .chart .typical {
 
 body .chart .cap { stroke: var(--soft); stroke-width: 1.5; }
 body .chart .col { fill: var(--line-strong); }
+body .chart .col.room { fill: var(--accent); opacity: 0.85; }
+body .chart .col.call { fill: var(--accent-deep); }
+
+body .chart .col.none {
+  fill: none;
+  stroke: var(--line-strong);
+  stroke-width: 1.5;
+  stroke-dasharray: 3 3;
+}
+
+body .turnout-chart .pair text {
+  paint-order: stroke;
+  stroke: var(--panel);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+}
 body .chart .val { fill: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
 body .chart .callout {
   fill: var(--text);
@@ -1870,8 +1881,12 @@ body .legend i.typ {
 
 body .legend i.cap { height: 2px; background: var(--soft); }
 body .legend i.sq { width: 10px; height: 10px; background: var(--line-strong); }
+body .legend i.sq.room { background: var(--accent); }
+body .legend i.sq.call { background: var(--accent-deep); }
+body .legend i.sq.none { background: none; border: 1.5px dashed var(--line-strong); }
 
-body .stat { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+body .stat { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 8px; margin-bottom: 8px; }
+body .stat .big { white-space: nowrap; }
 
 body .stat .big {
   font-size: 26px;
@@ -1889,12 +1904,18 @@ body .overview-row { display: grid; grid-template-columns: minmax(0, 1fr); gap: 
   body .overview-row { grid-template-columns: minmax(0, 5fr) minmax(0, 3fr); align-items: stretch; }
 }
 
-body .growth-chart-wrap { max-width: 800px; }
-body .growth-chart-wrap .compact-only { display: none; }
+body .growth-chart-wrap,
+body .turnout-chart-wrap { max-width: 800px; }
+
+body .growth-chart-wrap .compact-only,
+body .turnout-chart-wrap .compact-only { display: none; }
 
 @media (max-width: 640px) {
-  body .growth-chart-wrap .wide-only { display: none; }
-  body .growth-chart-wrap .compact-only { display: block; }
+  body .growth-chart-wrap .wide-only,
+  body .turnout-chart-wrap .wide-only { display: none; }
+
+  body .growth-chart-wrap .compact-only,
+  body .turnout-chart-wrap .compact-only { display: block; }
 }
 body #member-growth-panel .panel-head .stat { margin: 0; flex: 0 0 auto; }
 body #next-huddl { container-type: inline-size; }

--- a/lib/huddlz/communities/group_stats.ex
+++ b/lib/huddlz/communities/group_stats.ex
@@ -19,6 +19,12 @@ defmodule Huddlz.Communities.GroupStats do
   published: how many RSVPs stood by the end of that day. The group's
   typical curve is the same measure averaged over its past huddlz, drawn
   only once there are three of them to average.
+
+  Turnout comes from the counts organizers record after a huddl ends. The
+  show rate over a period is turnout divided by RSVPs across the counted
+  huddlz that ended in it. The next huddl's expected turnout applies the
+  show rate of counted huddlz of its own type from the last year, once
+  there are three of them.
   """
 
   require Ash.Query
@@ -27,6 +33,9 @@ defmodule Huddlz.Communities.GroupStats do
 
   @day 86_400
   @typical_min_history 3
+  @expected_min_history 3
+  @expected_history_days 365
+  @turnout_chart_limit 8
 
   @periods [
     {"30d", %{days: 30, buckets: 6, label: "30 days", growth: :week}},
@@ -67,14 +76,21 @@ defmodule Huddlz.Communities.GroupStats do
       it, and a per-bucket sparkline
     * `waitlist` — people waitlisted on upcoming huddlz right now, the
       titles of the huddlz that are full, and a cumulative sparkline
+    * `turnout` — counted huddlz that ended in the period: how many, their
+      RSVPs and turnout, the show rate (nil without counts) and a
+      sparkline of per-huddl show rates
+    * `turnout_chart` — the last few past huddlz, oldest first, each with
+      RSVPs, capacity and turnout (room and call) or marked uncounted
     * `next_huddl` — the next upcoming huddl with its RSVPs, capacity,
-      signup curve since publish, the group's typical curve (or nil) and
-      the other upcoming huddlz; nil when nothing is upcoming
+      signup curve since publish, the group's typical curve (or nil), the
+      expected turnout (or nil) and the other upcoming huddlz; nil when
+      nothing is upcoming
   """
   def compute(group, period, actor, now \\ DateTime.utc_now()) do
     spec = period_spec(period)
     edges = bucket_edges(now, spec)
     joined_at = member_join_times(group)
+    past = organizer_huddlz(group, actor, :past, starts_at: :desc)
 
     %{
       period: period,
@@ -82,9 +98,79 @@ defmodule Huddlz.Communities.GroupStats do
       growth: growth(joined_at, group, now, spec),
       rsvps: rsvps(group, now, spec, edges),
       waitlist: waitlist(group, now, edges),
-      next_huddl: next_huddl(group, actor, now)
+      turnout: turnout(past, now, spec),
+      turnout_chart: turnout_chart(past),
+      next_huddl: next_huddl(group, actor, past, now)
     }
   end
+
+  defp turnout(past, now, spec) do
+    period_start = DateTime.add(now, -spec.days, :day)
+
+    counted =
+      Enum.filter(past, &(counted?(&1) and DateTime.compare(&1.ends_at, period_start) != :lt))
+
+    rsvps = counted |> Enum.map(& &1.rsvp_count) |> Enum.sum()
+    came = counted |> Enum.map(&turnout_total/1) |> Enum.sum()
+
+    %{
+      counted: length(counted),
+      rsvps: rsvps,
+      turnout: came,
+      show_rate: show_rate(came, rsvps),
+      spark:
+        counted
+        |> Enum.reverse()
+        |> Enum.map(&show_rate(turnout_total(&1), &1.rsvp_count))
+        |> Enum.reject(&is_nil/1)
+    }
+  end
+
+  defp turnout_chart(past) do
+    past
+    |> Enum.take(@turnout_chart_limit)
+    |> Enum.reverse()
+    |> Enum.map(fn huddl ->
+      %{
+        id: huddl.id,
+        title: huddl.title,
+        starts_at: huddl.starts_at,
+        time_zone: huddl.time_zone,
+        rsvp_count: huddl.rsvp_count,
+        capacity: huddl.max_attendees,
+        counted?: counted?(huddl),
+        in_room: huddl.turnout_in_room,
+        on_call: huddl.turnout_on_call,
+        turnout: if(counted?(huddl), do: turnout_total(huddl))
+      }
+    end)
+  end
+
+  # About how many to expect at the next huddl: the show rate of counted
+  # huddlz of the same type in the last year, applied to its RSVPs.
+  defp expected_turnout(next, past, now) do
+    since = DateTime.add(now, -@expected_history_days, :day)
+
+    alike =
+      Enum.filter(past, fn huddl ->
+        counted?(huddl) and huddl.event_type == next.event_type and
+          DateTime.compare(huddl.ends_at, since) != :lt
+      end)
+
+    rsvps = alike |> Enum.map(& &1.rsvp_count) |> Enum.sum()
+
+    if length(alike) >= @expected_min_history and rsvps > 0 do
+      came = alike |> Enum.map(&turnout_total/1) |> Enum.sum()
+      %{count: round(came * next.rsvp_count / rsvps), from: length(alike)}
+    end
+  end
+
+  defp counted?(huddl), do: not is_nil(huddl.turnout_recorded_at)
+
+  defp turnout_total(huddl), do: (huddl.turnout_in_room || 0) + (huddl.turnout_on_call || 0)
+
+  defp show_rate(_came, 0), do: nil
+  defp show_rate(came, rsvps), do: round(came * 100 / rsvps)
 
   defp member_join_times(group) do
     GroupMember
@@ -213,7 +299,7 @@ defmodule Huddlz.Communities.GroupStats do
     }
   end
 
-  defp next_huddl(group, actor, now) do
+  defp next_huddl(group, actor, past, now) do
     case organizer_huddlz(group, actor, :published, starts_at: :asc) do
       [] ->
         nil
@@ -229,7 +315,8 @@ defmodule Huddlz.Communities.GroupStats do
           days: days,
           curve:
             cumulative_by_day(standing_rsvp_times([next.id])[next.id] || [], published_at, days),
-          typical: typical_curve(group, actor, days),
+          typical: typical_curve(past, days),
+          expected: expected_turnout(next, past, now),
           others: Enum.map(others, &huddl_summary/1)
         })
     end
@@ -237,11 +324,8 @@ defmodule Huddlz.Communities.GroupStats do
 
   # The group's past huddlz averaged day by day since each was published.
   # Nil until there are enough of them for an average to mean anything.
-  defp typical_curve(group, actor, days) do
-    past =
-      group
-      |> organizer_huddlz(actor, :past, starts_at: :desc)
-      |> Enum.reject(&is_nil(&1.published_at))
+  defp typical_curve(past, days) do
+    past = Enum.reject(past, &is_nil(&1.published_at))
 
     if length(past) < @typical_min_history do
       nil
@@ -269,6 +353,7 @@ defmodule Huddlz.Communities.GroupStats do
       title: huddl.title,
       starts_at: huddl.starts_at,
       time_zone: huddl.time_zone,
+      event_type: huddl.event_type,
       rsvp_count: huddl.rsvp_count,
       capacity: huddl.max_attendees,
       waitlist_count: huddl.waitlist_count

--- a/lib/huddlz_web/components/sparkline.ex
+++ b/lib/huddlz_web/components/sparkline.ex
@@ -24,6 +24,7 @@ defmodule HuddlzWeb.Components.Sparkline do
       preserveAspectRatio="none"
       aria-hidden="true"
       data-points={Enum.join(@points, ",")}
+      data-count={length(@points)}
     >
       <polyline
         fill="none"

--- a/lib/huddlz_web/components/turnout_chart.ex
+++ b/lib/huddlz_web/components/turnout_chart.ex
@@ -1,0 +1,205 @@
+defmodule HuddlzWeb.Components.TurnoutChart do
+  @moduledoc """
+  Turnout per huddl: for each past huddl, its RSVPs beside how many came,
+  the room and the call stacked, with a capacity tick over the pair and a
+  dashed outline reading "?" where no turnout was recorded. Inline SVG on
+  the design tokens, server-rendered like the other charts.
+
+  Readable back from the markup: each pair carries the huddl, its RSVPs,
+  turnout and capacity as data attributes, and each bar its count.
+  """
+  use Phoenix.Component
+
+  @height 300
+  @left 36
+  @right 20
+  @top 20
+  @bottom 34
+  @bar_width 18
+  @gap 4
+
+  attr :id, :string, required: true
+
+  attr :huddlz, :list,
+    required: true,
+    doc:
+      "oldest first: maps with :id, :starts_at, :time_zone, :rsvp_count, :capacity, :counted?, :in_room, :on_call, :turnout"
+
+  attr :width, :integer, default: 660, doc: "viewBox width"
+  attr :class, :any, default: nil
+
+  def turnout_chart(assigns) do
+    assigns = assign(assigns, :chart, layout(assigns))
+
+    ~H"""
+    <svg
+      id={@id}
+      class={["chart turnout-chart", @class]}
+      viewBox={"0 0 #{@chart.width} #{@chart.height}"}
+      role="img"
+      aria-label={description(@huddlz)}
+      data-huddlz={length(@huddlz)}
+    >
+      <%= for {value, y, kind} <- @chart.gridlines do %>
+        <line class={kind} x1={@chart.left} x2={@chart.right} y1={y} y2={y} />
+        <text x={@chart.left - 8} y={y} text-anchor="end" dominant-baseline="middle">{value}</text>
+      <% end %>
+
+      <g
+        :for={{huddl, slot} <- Enum.zip(@huddlz, @chart.slots)}
+        class="pair"
+        data-huddl={huddl.id}
+        data-rsvps={huddl.rsvp_count}
+        data-turnout={huddl.turnout}
+        data-counted={to_string(huddl.counted?)}
+        data-capacity={huddl.capacity}
+      >
+        <rect
+          class="col rsvps"
+          data-count={huddl.rsvp_count}
+          x={slot.rsvps_x}
+          y={slot.rsvps_y}
+          width={@chart.bar_width}
+          height={@chart.base - slot.rsvps_y}
+          rx="3"
+        />
+        <text x={slot.rsvps_x + @chart.bar_width / 2} y={slot.rsvps_label_y} text-anchor="middle">
+          {huddl.rsvp_count}
+        </text>
+
+        <line
+          :if={huddl.capacity}
+          class="cap"
+          data-capacity={huddl.capacity}
+          x1={slot.rsvps_x - 3}
+          x2={slot.came_x + @chart.bar_width + 3}
+          y1={slot.capacity_y}
+          y2={slot.capacity_y}
+        />
+
+        <%= if huddl.counted? do %>
+          <rect
+            class="col room"
+            data-count={huddl.in_room || 0}
+            x={slot.came_x}
+            y={slot.room_y}
+            width={@chart.bar_width}
+            height={@chart.base - slot.room_y}
+            rx="3"
+          />
+          <rect
+            :if={(huddl.on_call || 0) > 0}
+            class="col call"
+            data-count={huddl.on_call}
+            x={slot.came_x}
+            y={slot.came_y}
+            width={@chart.bar_width}
+            height={slot.room_y - slot.came_y}
+            rx="3"
+          />
+          <text
+            class="val"
+            x={slot.came_x + @chart.bar_width / 2}
+            y={slot.came_label_y}
+            text-anchor="middle"
+          >
+            {huddl.turnout}
+          </text>
+        <% else %>
+          <rect
+            class="col none"
+            x={slot.came_x}
+            y={slot.rsvps_y}
+            width={@chart.bar_width}
+            height={@chart.base - slot.rsvps_y}
+            rx="3"
+          />
+          <text
+            class="val"
+            x={slot.came_x + @chart.bar_width / 2}
+            y={slot.rsvps_label_y}
+            text-anchor="middle"
+          >
+            ?
+          </text>
+        <% end %>
+
+        <text x={slot.x} y={@chart.height - 10} text-anchor="middle">{label(huddl)}</text>
+      </g>
+    </svg>
+    """
+  end
+
+  defp layout(%{huddlz: huddlz, width: width}) do
+    n = max(length(huddlz), 1)
+    hi = ceiling(Enum.flat_map(huddlz, &[&1.rsvp_count, &1.turnout, &1.capacity]))
+    plot_width = width - @left - @right
+    plot_height = @height - @top - @bottom
+    base = @top + plot_height
+    slot_width = plot_width / n
+    bar_width = min(@bar_width, Float.round(slot_width * 0.3, 1))
+    y = fn v -> Float.round(@top + plot_height * (1 - (v || 0) / hi), 1) end
+
+    slots =
+      Enum.map(0..(n - 1), fn i ->
+        x = Float.round(@left + slot_width * i + slot_width / 2, 1)
+        huddl = Enum.at(huddlz, i)
+        room = (huddl && huddl.in_room) || 0
+        came = (huddl && huddl.turnout) || 0
+
+        capacity_y = huddl && huddl.capacity && y.(huddl.capacity)
+        rsvps_y = y.(huddl && huddl.rsvp_count)
+        came_y = y.(came)
+
+        %{
+          x: x,
+          rsvps_x: Float.round(x - bar_width - @gap / 2, 1),
+          came_x: Float.round(x + @gap / 2, 1),
+          rsvps_y: rsvps_y,
+          rsvps_label_y: label_y(rsvps_y, capacity_y),
+          capacity_y: capacity_y,
+          room_y: y.(room),
+          came_y: came_y,
+          came_label_y: label_y(came_y, capacity_y)
+        }
+      end)
+
+    %{
+      width: width,
+      height: @height,
+      left: @left,
+      right: width - @right,
+      base: base,
+      bar_width: bar_width,
+      gridlines: [{0, y.(0), "axis"}, {div(hi, 2), y.(div(hi, 2)), "grid"}, {hi, y.(hi), "grid"}],
+      slots: slots
+    }
+  end
+
+  # A value sits just above its bar, or above the capacity tick when the
+  # bar top is close enough that the two would collide.
+  defp label_y(bar_y, nil), do: bar_y - 5
+  defp label_y(bar_y, cap_y) when abs(bar_y - cap_y) < 12, do: min(bar_y, cap_y) - 5
+  defp label_y(bar_y, _cap_y), do: bar_y - 5
+
+  # The top gridline: the largest value rounded up to something round.
+  defp ceiling(values) do
+    max = values |> Enum.reject(&is_nil/1) |> Enum.max(fn -> 0 end)
+
+    cond do
+      max <= 5 -> 5
+      max <= 10 -> 10
+      max <= 50 -> div(max + 4, 5) * 5
+      true -> div(max + 9, 10) * 10
+    end
+  end
+
+  defp label(%{starts_at: starts_at, time_zone: time_zone}) do
+    starts_at |> DateTime.shift_zone!(time_zone) |> Calendar.strftime("%b %-d")
+  end
+
+  defp description(huddlz) do
+    counted = Enum.count(huddlz, & &1.counted?)
+    "RSVPs and turnout for the last #{length(huddlz)} huddlz, #{counted} counted"
+  end
+end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -17,6 +17,7 @@ defmodule HuddlzWeb.OrganizeLive do
   import HuddlzWeb.Components.Sparkline
   import HuddlzWeb.Components.GrowthChart
   import HuddlzWeb.Components.SignupChart
+  import HuddlzWeb.Components.TurnoutChart
 
   alias Huddlz.Communities
   alias Huddlz.Communities.GroupStats
@@ -483,7 +484,7 @@ defmodule HuddlzWeb.OrganizeLive do
       <.link navigate={huddl_show_path(@group, @turnout_nudge)}>Add turnout</.link>
     </div>
 
-    <div class="kpis kpis-3">
+    <div class="kpis">
       <div id="kpi-members" class="kpi">
         <div class="label">Members</div>
         <div class="value">{@stats.members.count}</div>
@@ -499,6 +500,19 @@ defmodule HuddlzWeb.OrganizeLive do
           {rsvps_delta(@stats.rsvps, @period)}
         </div>
         <.sparkline id="spark-rsvps" points={@stats.rsvps.spark} />
+      </div>
+      <div id="kpi-showrate" class="kpi">
+        <div class="label">Show rate · last {GroupStats.period_label(@period)}</div>
+        <div class="value">{show_rate_value(@stats.turnout)}</div>
+        <div class={["delta", @stats.turnout.counted == 0 && "muted"]}>
+          <%= if @stats.turnout.counted == 0 do %>
+            <.link navigate={~p"/organize/#{@group.slug}/huddlz?filter=past"}>Record turnout</.link>
+            after a huddl
+          <% else %>
+            {show_rate_delta(@stats.turnout)}
+          <% end %>
+        </div>
+        <.sparkline id="spark-showrate" points={@stats.turnout.spark} />
       </div>
       <div id="kpi-waitlist" class="kpi">
         <div class="label">Waitlisted now</div>
@@ -562,7 +576,7 @@ defmodule HuddlzWeb.OrganizeLive do
             <div class="next-huddl-chart">
               <div class="stat">
                 <span class="big">{signups_figure(@next)}</span>
-                <span class="cmp">{published_ago(@next.days)}</span>
+                <span class="cmp">{published_ago(@next.days)}{expectation(@next)}</span>
               </div>
               <.signup_chart
                 id="next-huddl"
@@ -597,30 +611,84 @@ defmodule HuddlzWeb.OrganizeLive do
       </div>
     </div>
 
-    <div id="recent-activity" class="panel">
-      <div class="panel-head">
-        <div>
-          <h2>Recent activity</h2>
-          <div class="panel-sub">Joins, RSVPs and cancellations</div>
+    <div class="overview-row">
+      <div id="turnout-panel" class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Turnout per huddl</h2>
+            <div class="panel-sub">{turnout_sub(@stats.turnout_chart)}</div>
+          </div>
+          <.link navigate={~p"/organize/#{@group.slug}/huddlz?filter=past"} class="pill">
+            All past huddlz
+          </.link>
         </div>
-        <.link navigate={~p"/organize/#{@group.slug}/members"} class="pill">All members</.link>
+        <p :if={@stats.turnout_chart == []} class="muted">
+          No past huddlz yet. Once one ends, its RSVPs and turnout will show here.
+        </p>
+        <div :if={@stats.turnout_chart != []} class="turnout-chart-wrap">
+          <.turnout_chart id="turnout-chart" class="wide-only" huddlz={@stats.turnout_chart} />
+          <.turnout_chart
+            id="turnout-chart-compact"
+            class="compact-only"
+            width={360}
+            huddlz={Enum.take(@stats.turnout_chart, -5)}
+          />
+          <div class="legend">
+            <span><i class="sq"></i>RSVPs</span>
+            <span><i class="sq room"></i>In the room</span>
+            <span><i class="sq call"></i>On the call</span>
+            <span><i class="cap"></i>Capacity</span>
+            <span><i class="sq none"></i>No turnout</span>
+          </div>
+        </div>
       </div>
-      <p :if={@activity == []} class="muted">
-        Nothing yet. Joins, RSVPs and cancellations will show here as they happen.
-      </p>
-      <ol :if={@activity != []} class="feed">
-        <li :for={entry <- @activity} class="item" data-kind={entry.kind}>
-          <.person_mark user={entry.user} />
-          <span class="what">
-            <i class={["kind", activity_tone(entry.kind)]}></i>
-            <.activity_line entry={entry} />
-          </span>
-          <span class="when">{feed_time(entry.occurred_at, @group.time_zone)}</span>
-        </li>
-      </ol>
+
+      <div id="recent-activity" class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Recent activity</h2>
+            <div class="panel-sub">Joins, RSVPs and cancellations</div>
+          </div>
+          <.link navigate={~p"/organize/#{@group.slug}/members"} class="pill">All members</.link>
+        </div>
+        <p :if={@activity == []} class="muted">
+          Nothing yet. Joins, RSVPs and cancellations will show here as they happen.
+        </p>
+        <ol :if={@activity != []} class="feed">
+          <li :for={entry <- @activity} class="item" data-kind={entry.kind}>
+            <.person_mark user={entry.user} />
+            <span class="what">
+              <i class={["kind", activity_tone(entry.kind)]}></i>
+              <.activity_line entry={entry} />
+            </span>
+            <span class="when">{feed_time(entry.occurred_at, @group.time_zone)}</span>
+          </li>
+        </ol>
+      </div>
     </div>
     """
   end
+
+  defp show_rate_value(%{show_rate: nil}), do: "—"
+  defp show_rate_value(%{show_rate: rate}), do: "#{rate}%"
+
+  defp show_rate_delta(%{counted: 1}), do: "Over 1 counted huddl"
+  defp show_rate_delta(%{counted: n}), do: "Over #{n} counted huddlz"
+
+  defp turnout_sub([]), do: "RSVPs next to how many actually came"
+
+  defp turnout_sub(huddlz) do
+    "RSVPs next to how many actually came, last #{length(huddlz)} huddlz. Dashed means no turnout was recorded."
+  end
+
+  defp expectation(%{expected: nil}), do: ""
+
+  defp expectation(%{expected: %{count: count}, event_type: type}),
+    do: " · expect about #{count} #{expected_where(type)}"
+
+  defp expected_where(:virtual), do: "on the call"
+  defp expected_where(:hybrid), do: "in the room or on the call"
+  defp expected_where(_in_person), do: "in the room"
 
   # The app's mark for a person: their picture, or initials on a gradient
   # that stays the same for them wherever they appear.

--- a/test/features/overview_turnout.feature
+++ b/test/features/overview_turnout.feature
@@ -1,0 +1,53 @@
+@database @conn @overview_turnout
+Feature: Turnout on the overview
+  As an organizer
+  I want the overview to show how many people actually come
+  So that I plan with turnout, not RSVPs
+
+  Background:
+    Given the following users exist:
+      | email            | display_name | role    |
+      | host@example.com | Host User    | regular |
+    And a public group "Portland Elixir" exists with owner "host@example.com"
+    And I am signed in as "host@example.com"
+
+  Scenario: Show rate across counted huddlz
+    Given 7 counted in-person huddlz in "Portland Elixir" each with 25 RSVPs and 16 in the room
+    When I visit "/organize/portland-elixir"
+    Then the Show rate KPI shows "64%" and "Over 7 counted huddlz"
+    And the show rate sparkline has 7 points
+
+  Scenario: Turnout chart pairs RSVPs with counts
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended 3 days ago with 20 RSVPs
+    And "Elixir hack night" had room for 20
+    And the turnout for "Elixir hack night" was recorded as 11 in the room
+    When I visit "/organize/portland-elixir"
+    Then the turnout chart pairs "Elixir hack night" as 20 RSVPs and 11 came, with a capacity tick at 20
+
+  Scenario: Hybrid turnout stacks room and call
+    Given the hybrid huddl "Lightning talks" in "Portland Elixir" ended 5 days ago with 30 RSVPs
+    And the turnout for "Lightning talks" was recorded as 19 in the room and 8 on the call
+    When I visit "/organize/portland-elixir"
+    Then the turnout bar for "Lightning talks" reads 27 with 19 in the room and 8 on the call
+
+  Scenario: Uncounted huddlz are marked, not hidden
+    Given the in-person huddl "Elixir office hours" in "Portland Elixir" ended 2 days ago with 12 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then the turnout chart shows "Elixir office hours" with 12 RSVPs and an uncounted outline reading "?"
+
+  Scenario: Expected turnout appears with enough history
+    Given 3 counted in-person huddlz in "Portland Elixir" each with 20 RSVPs and 12 in the room
+    And the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 30 and 18 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then the Next huddl panel says "expect about 11 in the room"
+
+  Scenario: Expected turnout is hidden without history
+    Given 2 counted in-person huddlz in "Portland Elixir" each with 20 RSVPs and 12 in the room
+    And the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 30 and 18 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then the Next huddl panel shows no expectation
+
+  Scenario: No show rate without counts
+    Given the in-person huddl "Elixir office hours" in "Portland Elixir" ended 2 days ago with 12 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then the Show rate KPI reads as not yet available and points at recording turnout

--- a/test/features/step_definitions/overview_turnout_steps.exs
+++ b/test/features/step_definitions/overview_turnout_steps.exs
@@ -1,0 +1,155 @@
+defmodule OverviewTurnoutSteps do
+  use Cucumber.StepDefinition
+
+  import Ecto.Query, only: [from: 2]
+  import Huddlz.Generator
+  import PhoenixTest
+
+  require Ash.Query
+
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities
+  alias Huddlz.Communities.{Group, Huddl, HuddlAttendee}
+  alias Huddlz.Repo
+
+  step "{int} counted in-person huddlz in {string} each with {int} RSVPs and {int} in the room",
+       %{args: [count, group_name, rsvps, in_room]} = context do
+    group = find_group(group_name)
+    owner = Ash.get!(User, group.owner_id, authorize?: false)
+
+    # One a week, the most recent a week ago.
+    for n <- 1..count//1 do
+      starts_at = DateTime.add(DateTime.utc_now(), -(n * 7), :day)
+
+      huddl =
+        generate(
+          past_huddl(
+            title: "Counted huddl #{n}",
+            group_id: group.id,
+            creator_id: owner.id,
+            is_private: false,
+            event_type: :in_person,
+            starts_at: starts_at,
+            ends_at: DateTime.add(starts_at, 2, :hour)
+          )
+        )
+
+      for _ <- 1..rsvps//1 do
+        attendee = generate(user(role: :user))
+
+        Ash.Seed.seed!(HuddlAttendee, %{
+          huddl_id: huddl.id,
+          user_id: attendee.id,
+          rsvped_at: starts_at
+        })
+      end
+
+      Communities.record_turnout!(huddl, %{in_room: in_room}, actor: owner)
+    end
+
+    context
+  end
+
+  step "{string} had room for {int}", %{args: [title, capacity]} = context do
+    huddl = find_huddl(title)
+
+    Repo.update_all(from(h in "huddlz", where: h.id == type(^huddl.id, :binary_id)),
+      set: [max_attendees: capacity]
+    )
+
+    context
+  end
+
+  step "the Show rate KPI shows {string} and {string}",
+       %{args: [value, delta], session: session} = context do
+    session
+    |> assert_has("#kpi-showrate .value", text: value, exact: true)
+    |> assert_has("#kpi-showrate .delta", text: delta)
+
+    context
+  end
+
+  step "the show rate sparkline has {int} points", %{args: [count], session: session} = context do
+    assert_has(session, "#kpi-showrate svg.spark[data-count='#{count}']")
+    context
+  end
+
+  step "the Show rate KPI reads as not yet available and points at recording turnout",
+       %{session: session} = context do
+    session
+    |> assert_has("#kpi-showrate .value", text: "—", exact: true)
+    |> assert_has("#kpi-showrate .delta a[href='/organize/portland-elixir/huddlz?filter=past']",
+      text: "Record turnout"
+    )
+
+    context
+  end
+
+  step "the turnout chart pairs {string} as {int} RSVPs and {int} came, with a capacity tick at {int}",
+       %{args: [title, rsvps, came, capacity], session: session} = context do
+    pair = pair(title)
+
+    session
+    |> assert_has(
+      "#{pair}[data-rsvps='#{rsvps}'][data-turnout='#{came}'][data-capacity='#{capacity}']"
+    )
+    |> assert_has("#{pair} .col.rsvps")
+    |> assert_has("#{pair} .col.room")
+    |> assert_has("#{pair} .cap[data-capacity='#{capacity}']")
+    |> assert_has("#{pair} text", text: "#{rsvps}", exact: true)
+    |> assert_has("#{pair} text.val", text: "#{came}", exact: true)
+
+    context
+  end
+
+  step "the turnout bar for {string} reads {int} with {int} in the room and {int} on the call",
+       %{args: [title, total, in_room, on_call], session: session} = context do
+    pair = pair(title)
+
+    session
+    |> assert_has("#{pair}[data-turnout='#{total}']")
+    |> assert_has("#{pair} .col.room[data-count='#{in_room}']")
+    |> assert_has("#{pair} .col.call[data-count='#{on_call}']")
+    |> assert_has("#{pair} text.val", text: "#{total}", exact: true)
+
+    context
+  end
+
+  step "the turnout chart shows {string} with {int} RSVPs and an uncounted outline reading {string}",
+       %{args: [title, rsvps, mark], session: session} = context do
+    pair = pair(title)
+
+    session
+    |> assert_has("#{pair}[data-rsvps='#{rsvps}'][data-counted='false']")
+    |> assert_has("#{pair} .col.none")
+    |> assert_has("#{pair} text.val", text: mark, exact: true)
+
+    context
+  end
+
+  step "the Next huddl panel says {string}", %{args: [line], session: session} = context do
+    assert_has(session, "#next-huddl .stat .cmp", text: line)
+    context
+  end
+
+  step "the Next huddl panel shows no expectation", %{session: session} = context do
+    session
+    |> assert_has("#next-huddl .stat .cmp", text: "published today", exact: true)
+    |> refute_has("#next-huddl .stat", text: "expect about")
+
+    context
+  end
+
+  defp pair(title) do
+    huddl = find_huddl(title)
+    "#turnout-chart .pair[data-huddl='#{huddl.id}']"
+  end
+
+  defp find_group(name) do
+    Group |> Ash.Query.filter(name == ^name) |> Ash.read_one!(authorize?: false)
+  end
+
+  defp find_huddl(title) do
+    Huddl |> Ash.Query.filter(title == ^title) |> Ash.read_one!(authorize?: false)
+  end
+end


### PR DESCRIPTION
Closes #512.

Turnout reaches the overview. A Show rate KPI joins the row: turnout divided by RSVPs across the huddlz counted in the period, with a sparkline of per-huddl show rates. A Turnout per huddl panel pairs each of the last eight past huddlz' RSVP bar with its turnout bar, room and call stacked, a capacity tick over the pair, and a dashed outline reading "?" where nothing was recorded. The Next huddl panel says "expect about N in the room" (or on the call) once the group has three counted huddlz of that type in the last year.

## How it works

- The figures join the Group `:overview` action: `turnout` (counted, RSVPs, turnout, show rate or nil, sparkline), `turnout_chart` (the last eight past huddlz oldest first, each with RSVPs, capacity, room and call, or marked uncounted) and `next_huddl.expected` (count and how many huddlz it rests on, or nil). GraphQL `groupOverview` carries them too. Past huddlz are read once through the organizer read and shared with the typical curve.
- Show rate over a period counts huddlz that ended in it; the expectation uses counted huddlz of the next huddl's own type from the last 365 days, and it can exceed 100% like the per-huddl figure.
- `<.turnout_chart>` is inline SVG on the tokens like the other charts. Each pair carries the huddl, its RSVPs, turnout, counted flag and capacity as data attributes, and each bar its count. Value labels move above the capacity tick when the bar top would collide with it. Phones get a compact render of the last five.
- The KPI row is four tiles again. The turnout panel sits beside recent activity in a second row.
- Without any counted huddl in the period the KPI reads "—" and links to the past huddlz to record turnout.

## Scenarios

`test/features/overview_turnout.feature` covers the seven acceptance criteria: the show rate across seven counted huddlz with the count named, a pair of bars with a capacity tick, a hybrid huddl's stacked bar, an uncounted huddl's dashed outline, the expectation with three counted in-person huddlz, its absence with two, and the KPI without counts.

## Notes

- Show rate uses the sums across huddlz rather than an average of per-huddl rates, so a big huddl weighs more than a small one; the sparkline shows the per-huddl rates.
- Dev group seeded with eight "(turnout overview demo)" past huddlz from the design.
