### PR TITLE
feat(seo): site card as the default link preview picture

### DIFF
--- a/lib/huddlz_web/components/layouts/root.html.heex
+++ b/lib/huddlz_web/components/layouts/root.html.heex
@@ -8,6 +8,7 @@
     <% meta_title = meta[:title] || assigns[:page_title] || "huddlz" %>
     <% meta_description =
       meta[:description] || "Find and join local community gatherings on huddlz." %>
+    <% meta_image = meta[:image] || url(~p"/og/card.png") %>
     <meta name="description" content={meta_description} />
     <meta property="og:site_name" content="huddlz" />
     <meta property="og:type" content={meta[:type] || "website"} />
@@ -17,17 +18,11 @@
     <%= if meta[:url] do %>
       <meta property="og:url" content={meta[:url]} />
     <% end %>
-    <%= if meta[:image] do %>
-      <meta property="og:image" content={meta[:image]} />
-      <meta name="twitter:card" content="summary_large_image" />
-    <% else %>
-      <meta name="twitter:card" content="summary" />
-    <% end %>
+    <meta property="og:image" content={meta_image} />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={meta_title} />
     <meta name="twitter:description" content={meta_description} />
-    <%= if meta[:image] do %>
-      <meta name="twitter:image" content={meta[:image]} />
-    <% end %>
+    <meta name="twitter:image" content={meta_image} />
     <.live_title default="huddlz" suffix=" · huddlz">
       {assigns[:page_title]}
     </.live_title>

--- a/lib/huddlz_web/controllers/og_image_controller.ex
+++ b/lib/huddlz_web/controllers/og_image_controller.ex
@@ -1,7 +1,8 @@
 defmodule HuddlzWeb.OgImageController do
   @moduledoc """
-  Serves the generated link-preview card for a public huddl or group. Private
-  or unpublished ones are as invisible here as they are on their page.
+  Serves the generated link-preview card for a public huddl or group, and the
+  site card every other page shares. Private or unpublished huddlz and groups
+  are as invisible here as they are on their page.
   """
   use HuddlzWeb, :controller
 
@@ -9,6 +10,10 @@ defmodule HuddlzWeb.OgImageController do
   alias HuddlzWeb.OgImage
 
   require Logger
+
+  def site(conn, _params) do
+    send_card(conn, OgImage.site_etag(), &OgImage.site_card/0, "the site")
+  end
 
   def huddl(conn, %{"id" => id}) do
     with {:ok, huddl} <- Communities.get_huddl(id, load: [:status, :group], actor: nil),

--- a/lib/huddlz_web/og_image.ex
+++ b/lib/huddlz_web/og_image.ex
@@ -1,7 +1,7 @@
 defmodule HuddlzWeb.OgImage do
   @moduledoc """
   Draws the link-preview card advertised as `og:image` for a huddl or group
-  that has no cover picture.
+  that has no cover picture, and the site card every other page shares.
 
   Chat apps and social sites fetch that picture when someone pastes a link,
   so this is the first thing many people see of a huddl or group. The card
@@ -24,6 +24,9 @@ defmodule HuddlzWeb.OgImage do
 
   @doc "Renders a group's card as a PNG binary."
   def group_card(group), do: group |> group_svg() |> render_png()
+
+  @doc "Renders the site card, shared by pages with no picture of their own, as a PNG binary."
+  def site_card, do: site_svg() |> render_png()
 
   defp render_png(svg) do
     with {:ok, image} <- Image.from_binary(svg) do
@@ -52,6 +55,27 @@ defmodule HuddlzWeb.OgImage do
        group.description && to_string(group.description)}
 
     ~s("og-#{:erlang.phash2(fingerprint)}")
+  end
+
+  @doc "A strong ETag for the site card; it only changes with this module."
+  def site_etag, do: ~s("og-site-#{@version}")
+
+  @doc """
+  The site card as SVG markup: the mark, the wordmark and the tagline, on
+  the same ground as the other cards.
+  """
+  def site_svg do
+    """
+    <svg xmlns="http://www.w3.org/2000/svg" width="#{@width}" height="#{@height}" viewBox="0 0 #{@width} #{@height}">
+      <rect width="#{@width}" height="#{@height}" fill="#0b1112"/>
+      <rect x="0" y="#{@height - 6}" width="#{@width}" height="6" fill="#18cbd4"/>
+      <rect x="72" y="182" width="168" height="168" rx="40" fill="#18cbd4"/>
+      <text x="156" y="303" text-anchor="middle" font-family="#{font()}" font-size="112" font-weight="700" fill="#05191b">h</text>
+      <text x="288" y="306" font-family="#{font()}" font-size="112" font-weight="700" letter-spacing="-3" fill="#eef5f5">huddlz</text>
+      <text x="72" y="428" font-family="#{font()}" font-size="36" font-weight="500" fill="#b3bfc1">Find and join local community gatherings.</text>
+      <text x="72" y="486" font-family="#{font()}" font-size="28" fill="#7f8c8f">huddlz.com</text>
+    </svg>
+    """
   end
 
   @doc "A huddl's card as SVG markup."

--- a/lib/huddlz_web/router.ex
+++ b/lib/huddlz_web/router.ex
@@ -40,6 +40,7 @@ defmodule HuddlzWeb.Router do
     get "/robots.txt", SitemapController, :robots
     get "/sitemap.xml", SitemapController, :index
     get "/sitemap-:file", SitemapController, :child
+    get "/og/card.png", OgImageController, :site
     get "/og/huddlz/:id/card.png", OgImageController, :huddl
     get "/og/groups/:slug/card.png", OgImageController, :group
   end

--- a/test/features/link_preview_image.feature
+++ b/test/features/link_preview_image.feature
@@ -1,9 +1,10 @@
-@database @conn
+@database @conn @link_preview_image
 Feature: Link previews without a cover picture
   When someone pastes a huddl or group link into a chat, the preview should
   carry a picture even if the organizer never uploaded a cover. For a huddl the
   picture cascades: its own cover, then its group's cover, then a card drawn on
-  the fly. For a group: its cover, then a card.
+  the fly. For a group: its cover, then a card. Every other page shares the
+  huddlz site card, so a pasted huddlz.com link never unfurls without a picture.
 
   Scenario: A public huddl without a cover advertises a generated preview picture
     Given a public group "Phoenix Elixir Meetup" hosting an upcoming huddl "Hands-on with Ash Framework" with no cover picture
@@ -32,3 +33,18 @@ Feature: Link previews without a cover picture
     Given a private group "Board of directors"
     When a link preview fetches that group's preview picture
     Then there is nothing to fetch
+
+  Scenario: The home page advertises the site card
+    When a link preview fetches the home page
+    Then the page advertises the huddlz site card as its preview picture
+    And that picture is a 1200 by 630 PNG
+
+  Scenario: Pages without their own picture share the site card
+    When a link preview fetches the discover page
+    Then the page advertises the huddlz site card as its preview picture
+
+  Scenario: Pages with their own picture keep it
+    Given a public group "Phoenix Elixir Meetup" with no cover picture
+    When a link preview fetches the group page
+    Then the page advertises a generated group preview picture
+    And the page does not advertise the site card

--- a/test/features/step_definitions/link_preview_image_steps.exs
+++ b/test/features/step_definitions/link_preview_image_steps.exs
@@ -157,6 +157,25 @@ defmodule LinkPreviewImageSteps do
     Map.put(context, :group, group)
   end
 
+  step "a link preview fetches the home page", context do
+    Map.put(context, :page_html, context.conn |> get("/") |> html_response(200))
+  end
+
+  step "a link preview fetches the discover page", context do
+    Map.put(context, :page_html, context.conn |> get("/discover") |> html_response(200))
+  end
+
+  step "the page advertises the huddlz site card as its preview picture", context do
+    [image_url] = preview_images(context.page_html)
+    assert image_url == HuddlzWeb.Endpoint.url() <> "/og/card.png"
+    Map.put(context, :image_url, image_url)
+  end
+
+  step "the page does not advertise the site card", context do
+    refute (HuddlzWeb.Endpoint.url() <> "/og/card.png") in preview_images(context.page_html)
+    context
+  end
+
   step "a link preview fetches the group page", context do
     html =
       context.conn
@@ -179,5 +198,9 @@ defmodule LinkPreviewImageSteps do
 
   step "a link preview fetches that group's preview picture", context do
     Map.put(context, :response, get(build_conn(), "/og/groups/#{context.group.slug}/card.png"))
+  end
+
+  defp preview_images(html) do
+    html |> Floki.parse_document!() |> Floki.attribute(~s(meta[property="og:image"]), "content")
   end
 end


### PR DESCRIPTION
Closes #525.

Sharing `huddlz.com` unfurled with a blank image. Every page now advertises a picture: a generated huddlz site card at `/og/card.png` is the root layout's fallback `og:image`, so the home page, discover, groups, calendar and the rest get a large-image card. Huddl and group pages keep their own cover or generated card.

## How it works

- `HuddlzWeb.OgImage.site_svg/0` draws the card on the same ground and palette as the huddl and group cards: the mark, the wordmark, the tagline and `huddlz.com`, 1200×630. `OgImageController.site/2` serves it with the same cache headers and a version-keyed etag.
- The root layout resolves `meta_image` as the page's own image or the site card, and always writes `og:image`, `twitter:image` and `summary_large_image`. The old branch that fell back to a `summary` card is gone.

## Scenarios

`test/features/link_preview_image.feature` (now tagged `@link_preview_image`) gains three: the home page advertises the site card and it is a 1200 by 630 PNG, the discover page shares it, and a group page keeps its own card rather than the site card.
