### PR TITLE
feat(organize): show leaves and net growth

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1829,6 +1829,7 @@ body .chart .typical {
 body .chart .cap { stroke: var(--soft); stroke-width: 1.5; }
 body .chart .col { fill: var(--line-strong); }
 body .chart .col.room { fill: var(--accent); opacity: 0.85; }
+body .chart .col.left { fill: var(--warn); opacity: 0.85; }
 body .chart .col.call { fill: var(--accent-deep); }
 
 body .chart .col.none {
@@ -1882,6 +1883,7 @@ body .legend i.typ {
 body .legend i.cap { height: 2px; background: var(--soft); }
 body .legend i.sq { width: 10px; height: 10px; background: var(--line-strong); }
 body .legend i.sq.room { background: var(--accent); }
+body .legend i.sq.left { background: var(--warn); }
 body .legend i.sq.call { background: var(--accent-deep); }
 body .legend i.sq.none { background: none; border: 1.5px dashed var(--line-strong); }
 
@@ -1918,6 +1920,11 @@ body .turnout-chart-wrap .compact-only { display: none; }
   body .turnout-chart-wrap .compact-only { display: block; }
 }
 body #member-growth-panel .panel-head .stat { margin: 0; flex: 0 0 auto; }
+
+@media (max-width: 640px) {
+  body #member-growth-panel .panel-head { flex-wrap: wrap; }
+  body #member-growth-panel .panel-head .stat { flex-basis: 100%; }
+}
 body #next-huddl { container-type: inline-size; }
 body .next-huddl-body { display: grid; grid-template-columns: minmax(0, 1fr); gap: 20px; }
 body .next-huddl-chart { max-width: 560px; }

--- a/lib/huddlz/communities/group_stats.ex
+++ b/lib/huddlz/communities/group_stats.ex
@@ -5,9 +5,11 @@ defmodule Huddlz.Communities.GroupStats do
   which authorizes the actor; the reads here trust that boundary.
 
   Everything here is derived from rows the app already keeps: member join
-  dates, RSVP times and waitlist times. Members who left and RSVPs that
-  were cancelled leave no trace yet, so growth is "as it stands today by
-  join date" and RSVP counts are of RSVPs still standing.
+  dates, RSVP times and waitlist times, plus the group activity log for
+  what those rows forget. Leaves come from the log, and so do the joins of
+  people who have since left; members at any past moment are counted back
+  from today's members through those joins and leaves. RSVPs that were
+  cancelled leave no trace yet, so RSVP counts are of RSVPs still standing.
 
   Periods are `"30d"`, `"90d"` (the default) and `"12m"`. Each is split
   into equal buckets for the sparklines: six for the day periods, twelve
@@ -29,7 +31,7 @@ defmodule Huddlz.Communities.GroupStats do
 
   require Ash.Query
 
-  alias Huddlz.Communities.{GroupMember, Huddl, HuddlAttendee}
+  alias Huddlz.Communities.{GroupActivity, GroupMember, Huddl, HuddlAttendee}
 
   @day 86_400
   @typical_min_history 3
@@ -69,9 +71,10 @@ defmodule Huddlz.Communities.GroupStats do
   through the organizer read.
 
     * `members` — current member count, how many joined this calendar
-      month in the group's time zone, and a cumulative sparkline
+      month in the group's time zone, and a sparkline of members over time
     * `growth` — the period bucketed by month, fortnight or week: members
-      at each bucket's end, how many joined in it, and the total gained
+      at each bucket's end, how many joined and left in it, and the totals
+      joined, left and gained (net)
     * `rsvps` — RSVPs made in the period, the count in the period before
       it, and a per-bucket sparkline
     * `waitlist` — people waitlisted on upcoming huddlz right now, the
@@ -89,13 +92,13 @@ defmodule Huddlz.Communities.GroupStats do
   def compute(group, period, actor, now \\ DateTime.utc_now()) do
     spec = period_spec(period)
     edges = bucket_edges(now, spec)
-    joined_at = member_join_times(group)
+    membership = membership_history(group)
     past = organizer_huddlz(group, actor, :past, starts_at: :desc)
 
     %{
       period: period,
-      members: members(joined_at, group, now, edges),
-      growth: growth(joined_at, group, now, spec),
+      members: members(membership, group, now, edges),
+      growth: growth(membership, group, now, spec),
       rsvps: rsvps(group, now, spec, edges),
       waitlist: waitlist(group, now, edges),
       turnout: turnout(past, now, spec),
@@ -172,27 +175,66 @@ defmodule Huddlz.Communities.GroupStats do
   defp show_rate(_came, 0), do: nil
   defp show_rate(came, rsvps), do: round(came * 100 / rsvps)
 
-  defp member_join_times(group) do
-    GroupMember
-    |> Ash.Query.filter(group_id == ^group.id)
-    |> Ash.Query.select([:created_at])
-    |> Ash.read!(authorize?: false)
-    |> Enum.map(& &1.created_at)
-  end
+  # Combine current join dates with the log, keeping each membership's first
+  # join. Accepting an invitation while already a member is not another join.
+  defp membership_history(group) do
+    rows =
+      GroupMember
+      |> Ash.Query.filter(group_id == ^group.id)
+      |> Ash.Query.select([:user_id, :created_at])
+      |> Ash.read!(authorize?: false)
 
-  defp members(joined_at, group, now, edges) do
-    month_start = start_of_month(now, group.time_zone)
+    activity =
+      GroupActivity
+      |> Ash.Query.filter(
+        group_id == ^group.id and kind in [:joined, :accepted_invitation, :left]
+      )
+      |> Ash.Query.select([:user_id, :kind, :occurred_at])
+      |> Ash.read!(authorize?: false)
+
+    current_joins =
+      Enum.map(rows, &%{kind: :joined, user_id: &1.user_id, occurred_at: &1.created_at})
+
+    {_members, joined_at} =
+      (current_joins ++ activity)
+      |> Enum.sort_by(& &1.occurred_at, DateTime)
+      |> Enum.reduce({MapSet.new(), []}, &membership_join/2)
 
     %{
-      count: length(joined_at),
-      joined_this_month: Enum.count(joined_at, &(DateTime.compare(&1, month_start) != :lt)),
-      spark: cumulative(joined_at, edges)
+      count: length(rows),
+      joined_at: joined_at,
+      left_at: for(%{kind: :left, occurred_at: at} <- activity, do: at)
     }
   end
 
-  # Members at the end of each bucket, reconstructed from the join dates of
-  # today's members, with the joins inside each bucket.
-  defp growth(joined_at, group, now, spec) do
+  defp membership_join(%{kind: :left, user_id: user_id}, {members, joined_at}) do
+    {MapSet.delete(members, user_id), joined_at}
+  end
+
+  defp membership_join(%{user_id: user_id, occurred_at: at}, {members, joined_at}) do
+    if MapSet.member?(members, user_id) do
+      {members, joined_at}
+    else
+      {MapSet.put(members, user_id), [at | joined_at]}
+    end
+  end
+
+  defp members(membership, group, now, edges) do
+    month_start = start_of_month(now, group.time_zone)
+    [_first | ends] = edges
+
+    %{
+      count: membership.count,
+      joined_this_month:
+        Enum.count(membership.joined_at, &(DateTime.compare(&1, month_start) != :lt)),
+      spark: Enum.map(ends, &members_at(membership, &1))
+    }
+  end
+
+  # Members at the end of each bucket, counted back from today's members
+  # through the joins and leaves since, with the joins and leaves inside
+  # each bucket.
+  defp growth(membership, group, now, spec) do
     buckets =
       group
       |> growth_buckets(now, spec)
@@ -201,16 +243,30 @@ defmodule Huddlz.Communities.GroupStats do
           label: label,
           starts_at: from,
           ends_at: to,
-          joined: Enum.count(joined_at, &within?(&1, from, to)),
-          members: Enum.count(joined_at, &(DateTime.compare(&1, to) == :lt))
+          joined: Enum.count(membership.joined_at, &within?(&1, from, to)),
+          left: Enum.count(membership.left_at, &within?(&1, from, to)),
+          members: members_at(membership, to)
         }
       end)
 
+    joined = buckets |> Enum.map(& &1.joined) |> Enum.sum()
+    left = buckets |> Enum.map(& &1.left) |> Enum.sum()
+
     %{
       unit: spec.growth,
-      gained: buckets |> Enum.map(& &1.joined) |> Enum.sum(),
+      joined: joined,
+      left: left,
+      gained: joined - left,
       buckets: buckets
     }
+  end
+
+  # Today's count, minus everyone who joined after the moment, plus
+  # everyone who left after it. The last point is always today's count.
+  defp members_at(membership, at) do
+    joined_since = Enum.count(membership.joined_at, &(DateTime.compare(&1, at) != :lt))
+    left_since = Enum.count(membership.left_at, &(DateTime.compare(&1, at) != :lt))
+    membership.count - joined_since + left_since
   end
 
   # Twelve calendar months in the group's time zone, this month last.

--- a/lib/huddlz_web/components/growth_chart.ex
+++ b/lib/huddlz_web/components/growth_chart.ex
@@ -1,12 +1,13 @@
 defmodule HuddlzWeb.Components.GrowthChart do
   @moduledoc """
   Member growth over a period: a line of members at each bucket's end
-  above a strip of bars for how many joined in each bucket. Inline SVG
-  on the design tokens, server-rendered like the sparkline.
+  above a strip of bars for how many joined in each bucket, with a smaller
+  bar below the axis for how many left. Inline SVG on the design tokens,
+  server-rendered like the sparkline.
 
   Readable back from the markup: the line and the bar strip carry their
-  values in `data-points`, each dot and bar its bucket label and value,
-  and the root the bucket unit and count.
+  values in `data-points` (leaves in `data-left`), each dot and bar its
+  bucket label and value, and the root the bucket unit and count.
   """
   use Phoenix.Component
 
@@ -14,8 +15,8 @@ defmodule HuddlzWeb.Components.GrowthChart do
   @right 20
   @top 26
   @bar_width 26
-  @wide %{line_height: 140, bar_gap: 26, bar_height: 44, bottom: 30}
-  @compact %{line_height: 110, bar_gap: 22, bar_height: 32, bottom: 26}
+  @wide %{line_height: 140, bar_gap: 26, bar_height: 44, leave_height: 22, bottom: 30}
+  @compact %{line_height: 110, bar_gap: 22, bar_height: 32, leave_height: 16, bottom: 26}
   @compact_label_limit 8
 
   attr :id, :string, required: true
@@ -23,7 +24,7 @@ defmodule HuddlzWeb.Components.GrowthChart do
 
   attr :buckets, :list,
     required: true,
-    doc: "maps with :label, :members (at the bucket's end) and :joined (inside it)"
+    doc: "maps with :label, :members (at the bucket's end), :joined and :left (inside it)"
 
   attr :width, :integer, default: 720, doc: "viewBox width"
 
@@ -77,7 +78,11 @@ defmodule HuddlzWeb.Components.GrowthChart do
       </text>
 
       <line class="axis" x1={@chart.left} x2={@chart.right} y1={@chart.bar_base} y2={@chart.bar_base} />
-      <g id={"#{@id}-bars"} data-points={Enum.map_join(@buckets, ",", & &1.joined)}>
+      <g
+        id={"#{@id}-bars"}
+        data-points={Enum.map_join(@buckets, ",", & &1.joined)}
+        data-left={Enum.map_join(@buckets, ",", & &1.left)}
+      >
         <%= for {bucket, {x, height}} <- Enum.zip(@buckets, @chart.bars) do %>
           <rect
             class="col"
@@ -99,6 +104,27 @@ defmodule HuddlzWeb.Components.GrowthChart do
             {joined_label(bucket.joined)}
           </text>
         <% end %>
+        <%= for {bucket, {x, height}} <- Enum.zip(@buckets, @chart.leave_bars), bucket.left > 0 do %>
+          <rect
+            class="col left"
+            data-label={bucket.label}
+            data-left={bucket.left}
+            x={x - @chart.bar_width / 2}
+            y={@chart.bar_base}
+            width={@chart.bar_width}
+            height={height}
+            rx="3"
+          />
+          <text
+            :if={@chart.bar_values?}
+            class="val"
+            x={x}
+            y={@chart.bar_base + height + 13}
+            text-anchor="middle"
+          >
+            −{bucket.left}
+          </text>
+        <% end %>
       </g>
 
       <text
@@ -118,6 +144,7 @@ defmodule HuddlzWeb.Components.GrowthChart do
     n = length(buckets)
     members = Enum.map(buckets, & &1.members)
     joined = Enum.map(buckets, & &1.joined)
+    left = Enum.map(buckets, & &1.left)
     {lo, hi, step} = scale(members)
     plot_width = width - @left - @right
     bar_base = @top + dims.line_height + dims.bar_gap + dims.bar_height
@@ -127,12 +154,14 @@ defmodule HuddlzWeb.Components.GrowthChart do
     line_path = Enum.map_join(line_points, " ", fn {px, py} -> "#{px},#{py}" end)
     {last_x, last_y} = List.last(line_points)
     most_joined = max(Enum.max(joined), 1)
+    most_left = max(Enum.max(left), 1)
+    leave_track = if Enum.any?(left, &(&1 > 0)), do: dims.leave_height + 14, else: 0
 
     crowded? = compact and n > @compact_label_limit
 
     %{
       width: width,
-      height: bar_base + dims.bottom,
+      height: bar_base + leave_track + dims.bottom,
       left: @left,
       right: width - @right,
       gridlines: Enum.map(lo..hi//step, fn v -> {v, y.(v)} end),
@@ -150,6 +179,10 @@ defmodule HuddlzWeb.Components.GrowthChart do
         joined
         |> Enum.with_index()
         |> Enum.map(fn {v, i} -> {x.(i), Float.round(dims.bar_height * v / most_joined, 1)} end),
+      leave_bars:
+        left
+        |> Enum.with_index()
+        |> Enum.map(fn {v, i} -> {x.(i), Float.round(dims.leave_height * v / most_left, 1)} end),
       labels: labels(buckets, x, crowded?)
     }
   end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -532,8 +532,8 @@ defmodule HuddlzWeb.OrganizeLive do
             <div class="panel-sub">{growth_sub(@stats.growth.unit)}</div>
           </div>
           <div class="stat">
-            <span class="big">+{@stats.growth.gained}</span>
-            <span class="cmp">in {GroupStats.period_label(@period)}</span>
+            <span class="big">{signed(@stats.growth.gained)}</span>
+            <span class="cmp">{growth_cmp(@stats.growth, @period)}</span>
           </div>
         </div>
         <div class="growth-chart-wrap">
@@ -555,6 +555,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <div class="legend">
           <span><i></i>Members</span>
           <span><i class="sq"></i>Joined that {@stats.growth.unit}</span>
+          <span :if={@stats.growth.left > 0}><i class="sq left"></i>Left that {@stats.growth.unit}</span>
         </div>
       </div>
 
@@ -759,6 +760,14 @@ defmodule HuddlzWeb.OrganizeLive do
       true -> Calendar.strftime(day, "%b %-d")
     end
   end
+
+  defp signed(n) when n < 0, do: "−#{abs(n)}"
+  defp signed(n), do: "+#{n}"
+
+  defp growth_cmp(%{left: 0}, period), do: "in #{GroupStats.period_label(period)}"
+
+  defp growth_cmp(%{joined: joined, left: left}, period),
+    do: "in #{GroupStats.period_label(period)} · #{joined} joined, #{left} left"
 
   defp growth_sub(:month), do: "Members at month end, with how many joined each month"
   defp growth_sub(:fortnight), do: "Members at each fortnight's end, with how many joined in it"

--- a/test/features/member_growth.feature
+++ b/test/features/member_growth.feature
@@ -8,6 +8,7 @@ Feature: Member growth on the overview
     Given the following users exist:
       | email            | display_name | role    |
       | host@example.com | Host User    | regular |
+      | sam@example.com  | Sam Nguyen   | regular |
     And a public group "Portland Elixir" exists with owner "host@example.com"
     And I am signed in as "host@example.com"
 
@@ -31,3 +32,34 @@ Feature: Member growth on the overview
     But nobody joined "Portland Elixir" 3 months ago
     When I visit "/organize/portland-elixir?period=12m"
     Then the month 3 months ago shows a zero bar and the line stays flat at 4 through it
+
+  Scenario: A leave shows as a dip
+    Given 2 members joined "Portland Elixir" in each of the last 6 months
+    And "Sam Nguyen" joined "Portland Elixir" 4 months ago and left 2 months ago
+    When I visit "/organize/portland-elixir?period=12m"
+    Then the month 2 months ago shows 2 joined and 1 left, and the line stands at 8 after it
+    And the growth panel head shows "+13" net in "12 months" from "14 joined" and "1 left"
+
+  Scenario: Without leaves nothing changes
+    Given 2 members joined "Portland Elixir" in each of the last 6 months
+    When I visit "/organize/portland-elixir?period=12m"
+    Then the growth panel head shows "+13" gained in "12 months"
+    And no month shows anyone leaving
+
+  Scenario: Rejoining preserves the earlier membership
+    Given "Sam Nguyen" joined "Portland Elixir" 4 months ago and left 2 months ago
+    And "Sam Nguyen" rejoined "Portland Elixir" 1 month ago
+    When I visit "/organize/portland-elixir?period=12m"
+    Then the growth panel head shows "+2" net in "12 months" from "3 joined" and "1 left"
+    And the month 2 months ago shows 0 joined and 1 left, and the line stands at 0 after it
+    And the month 6 months ago shows a zero bar and the line stays flat at 0 through it
+    And the Members sparkline starts at 0, dips from 1 to 0, and ends at 2
+
+  Scenario: Accepting an invitation while already a member does not add another join
+    Given a private group "Portland Friends" exists with owner "host@example.com"
+    And "Sam Nguyen" was added to "Portland Friends" 4 months ago, accepted an invitation 3 months ago and left 2 months ago
+    When I visit "/organize/portland-friends?period=12m"
+    Then the growth panel head shows "+1" net in "12 months" from "2 joined" and "1 left"
+    And the month 3 months ago shows a zero bar and the line stays flat at 1 through it
+    And the month 2 months ago shows 0 joined and 1 left, and the line stands at 0 after it
+    And the Members sparkline starts at 0, dips from 1 to 0, and ends at 1

--- a/test/features/step_definitions/member_growth_steps.exs
+++ b/test/features/step_definitions/member_growth_steps.exs
@@ -7,7 +7,9 @@ defmodule MemberGrowthSteps do
 
   require Ash.Query
 
-  alias Huddlz.Communities.{Group, GroupMember}
+  alias Huddlz.Accounts.User
+  alias Huddlz.Communities
+  alias Huddlz.Communities.{Group, GroupActivity, GroupMember}
   alias Huddlz.Repo
 
   step "{int} members joined {string} in each of the last {int} months",
@@ -46,6 +48,95 @@ defmodule MemberGrowthSteps do
       )
     )
 
+    context
+  end
+
+  step "{string} joined {string} {int} months ago and left {int} months ago",
+       %{args: [name, group_name, joined_ago, left_ago]} = context do
+    person = User |> Ash.Query.filter(display_name == ^name) |> Ash.read_one!(authorize?: false)
+    group = find_group(group_name)
+
+    Communities.join_group!(group.id, actor: person)
+    backdate_activity(group, person, :joined, month_start(group, joined_ago))
+
+    membership =
+      GroupMember
+      |> Ash.Query.filter(group_id == ^group.id and user_id == ^person.id)
+      |> Ash.read_one!(authorize?: false)
+
+    Communities.leave_group!(membership, actor: person)
+    backdate_activity(group, person, :left, month_start(group, left_ago))
+    context
+  end
+
+  step "{string} rejoined {string} {int} month ago",
+       %{args: [name, group_name, months]} = context do
+    person = User |> Ash.Query.filter(display_name == ^name) |> Ash.read_one!(authorize?: false)
+    group = find_group(group_name)
+    membership = Communities.join_group!(group.id, actor: person)
+    at = month_start(group, months)
+
+    Repo.update_all(from(m in "group_members", where: m.id == type(^membership.id, :binary_id)),
+      set: [created_at: DateTime.shift_zone!(at, "Etc/UTC")]
+    )
+
+    backdate_activity(group, person, :joined, at)
+    context
+  end
+
+  step "the month {int} months ago shows {int} joined and {int} left, and the line stands at {int} after it",
+       %{args: [months, joined, left, members], session: session} = context do
+    label = month_label(months)
+
+    session
+    |> assert_has("#member-growth .col[data-label='#{label}'][data-joined='#{joined}']")
+    |> assert_has("#member-growth .col.left[data-label='#{label}'][data-left='#{left}']")
+    |> assert_has("#member-growth .dot[data-label='#{label}'][data-members='#{members}']")
+
+    context
+  end
+
+  step "{string} was added to {string} {int} months ago, accepted an invitation {int} months ago and left {int} months ago",
+       %{args: [name, group_name, joined_ago, accepted_ago, left_ago]} = context do
+    person = User |> Ash.Query.filter(display_name == ^name) |> Ash.read_one!(authorize?: false)
+    group = find_group(group_name)
+    owner = Ash.get!(User, group.owner_id, authorize?: false)
+    invitation = Communities.invite_to_group!(group.id, person.id, :member, actor: owner)
+    membership = Communities.add_member!(group.id, person.id, :member, actor: owner)
+    backdate_activity(group, person, :joined, month_start(group, joined_ago))
+
+    Communities.accept_group_invitation!(invitation, actor: person)
+    backdate_activity(group, person, :accepted_invitation, month_start(group, accepted_ago))
+
+    Communities.leave_group!(membership, actor: person)
+    backdate_activity(group, person, :left, month_start(group, left_ago))
+    context
+  end
+
+  step "the growth panel head shows {string} net in {string} from {string} and {string}",
+       %{args: [net, period, joined, left], session: session} = context do
+    session
+    |> assert_has("#member-growth-panel .stat .big", text: net, exact: true)
+    |> assert_has("#member-growth-panel .stat .cmp", text: "in #{period}")
+    |> assert_has("#member-growth-panel .stat .cmp", text: joined)
+    |> assert_has("#member-growth-panel .stat .cmp", text: left)
+
+    context
+  end
+
+  step "the Members sparkline starts at {int}, dips from {int} to {int}, and ends at {int}",
+       %{args: [first, before_leave, after_leave, last], session: session} = context do
+    assert_has(
+      session,
+      "#spark-members[data-points^='#{first},'][data-points*=',#{before_leave},#{after_leave},'][data-points$=',#{last}']"
+    )
+
+    context
+  end
+
+  step "no month shows anyone leaving", %{session: session} = context do
+    none = List.duplicate("0", 12) |> Enum.join(",")
+    assert_has(session, "#member-growth-bars[data-left='#{none}']")
     context
   end
 
@@ -94,6 +185,20 @@ defmodule MemberGrowthSteps do
     )
 
     context
+  end
+
+  # The log is written as the action runs; the scenario then says when.
+  defp backdate_activity(group, person, kind, at) do
+    row =
+      GroupActivity
+      |> Ash.Query.filter(group_id == ^group.id and user_id == ^person.id and kind == ^kind)
+      |> Ash.Query.sort(occurred_at: :desc)
+      |> Ash.Query.limit(1)
+      |> Ash.read_one!(authorize?: false)
+
+    Repo.update_all(from(a in "group_activities", where: a.id == type(^row.id, :binary_id)),
+      set: [occurred_at: DateTime.shift_zone!(at, "Etc/UTC")]
+    )
   end
 
   defp month_start(group, months_ago) do


### PR DESCRIPTION
Closes #531.

Member growth shows leaves below the axis, reflects them in the line and Members sparkline, and reports net growth with joins and leaves spelled out. Periods without leaves keep their existing presentation.

History preserves earlier memberships when someone rejoins and counts an invitation acceptance as a join only when the person is not already a member.

Joins that predate the activity log remain unavailable for people who have since left.
