### PR TITLE
feat(huddl): say when a huddl is in its shared-link preview

### DIFF
--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -1410,7 +1410,7 @@ defmodule HuddlzWeb.HuddlLive.Show do
 
   defp huddl_meta(huddl) do
     %{
-      title: "#{huddl.title} · huddlz",
+      title: "#{huddl.title} · #{preview_when(huddl)}",
       description: MetaHelpers.description(huddl, "Find and join this huddl on huddlz."),
       type: "event",
       url: url(~p"/groups/#{huddl.group.slug}/huddlz/#{huddl.id}"),
@@ -1418,6 +1418,14 @@ defmodule HuddlzWeb.HuddlLive.Show do
         MetaHelpers.image_url(huddl.display_image_url, HuddlCoverImages) ||
           url(~p"/og/huddlz/#{huddl.id}/card.png")
     }
+  end
+
+  # "Sat, Jul 20, 2030 · 12:00 PM EDT": a pasted link is read later and
+  # elsewhere, so the year and zone stay in, unlike the page's own hero line.
+  defp preview_when(huddl) do
+    starts_at = DateTime.shift_zone!(huddl.starts_at, huddl.time_zone)
+
+    "#{Calendar.strftime(starts_at, "%a, %b %-d, %Y")} · #{format_time_only(starts_at)} #{starts_at.zone_abbr}"
   end
 
   defp previous_start(huddl),

--- a/test/features/huddl_link_preview.feature
+++ b/test/features/huddl_link_preview.feature
@@ -1,0 +1,19 @@
+@database @conn @huddl_link_preview
+Feature: Shared huddl links say when the huddl is
+  Pasting a huddl link into a chat should tell readers when it takes place
+  without opening it. The preview's title carries the date and start time in
+  the huddl's own zone, next to its name; the description and picture stay
+  as they were.
+
+  Scenario: A shared huddl link says when it takes place
+    Given a public huddl "Community lunch" in "America/New_York" on 2030-07-20 at 12:00
+    When a link preview fetches the huddl page
+    Then the preview title reads "Community lunch · Sat, Jul 20, 2030 · 12:00 PM EDT"
+    And the huddl page shows "Sat, Jul 20"
+    And the huddl page shows "12:00 PM"
+    And the preview still carries the huddl's description and picture
+
+  Scenario: The time is the huddl's own, not the reader's
+    Given a public huddl "Community lunch" in "America/Chicago" on 2030-07-20 at 12:00
+    When a link preview fetches the huddl page
+    Then the preview title reads "Community lunch · Sat, Jul 20, 2030 · 12:00 PM CDT"

--- a/test/features/step_definitions/huddl_link_preview_steps.exs
+++ b/test/features/step_definitions/huddl_link_preview_steps.exs
@@ -1,0 +1,66 @@
+defmodule HuddlLinkPreviewSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+
+  @description "Bring your lunch and meet the community."
+
+  step "a public huddl {string} in {string} on {word} at {word}",
+       %{args: [title, time_zone, date, time]} = context do
+    owner = generate(user(role: :user))
+
+    group =
+      generate(group(is_public: true, time_zone: time_zone, owner_id: owner.id, actor: owner))
+
+    huddl =
+      generate(
+        huddl(
+          group_id: group.id,
+          creator_id: owner.id,
+          is_private: false,
+          title: title,
+          description: @description,
+          date: Date.from_iso8601!(date),
+          start_time: Time.from_iso8601!(time <> ":00"),
+          duration_minutes: 60,
+          actor: owner
+        )
+      )
+
+    Map.merge(context, %{group: group, huddl: huddl})
+  end
+
+  step "the preview title reads {string}", %{args: [title]} = context do
+    document = Floki.parse_document!(context.page_html)
+
+    assert meta(document, ~s(meta[property="og:title"])) == [title]
+    assert meta(document, ~s(meta[name="twitter:title"])) == [title]
+
+    context
+  end
+
+  step "the huddl page shows {string}", %{args: [text]} = context do
+    body =
+      context.page_html
+      |> Floki.parse_document!()
+      |> Floki.find("body")
+      |> Floki.text()
+
+    assert body =~ text, "expected the page body to show #{inspect(text)}"
+    context
+  end
+
+  step "the preview still carries the huddl's description and picture", context do
+    document = Floki.parse_document!(context.page_html)
+
+    assert meta(document, ~s(meta[property="og:description"])) == [@description]
+
+    assert meta(document, ~s(meta[property="og:image"])) ==
+             [HuddlzWeb.Endpoint.url() <> "/og/huddlz/#{context.huddl.id}/card.png"]
+
+    context
+  end
+
+  defp meta(document, selector), do: Floki.attribute(document, selector, "content")
+end

--- a/test/huddlz_web/live/huddl_live/show_test.exs
+++ b/test/huddlz_web/live/huddl_live/show_test.exs
@@ -187,7 +187,10 @@ defmodule HuddlzWeb.HuddlLive.ShowTest do
         |> html_response(200)
 
       assert meta_content(html, ~s(meta[property="og:type"])) == "event"
-      assert meta_content(html, ~s(meta[property="og:title"])) == "#{huddl.title} · huddlz"
+
+      assert meta_content(html, ~s(meta[property="og:title"])) =~
+               ~r/^#{Regex.escape(huddl.title)} · \w{3}, \w{3} \d{1,2}, \d{4} · \d{1,2}:\d{2} [AP]M E[DS]T$/
+
       assert meta_content(html, ~s(meta[name="description"])) == huddl.description
       assert meta_content(html, ~s(meta[property="og:description"])) == huddl.description
       assert meta_content(html, ~s(meta[name="twitter:description"])) == huddl.description


### PR DESCRIPTION
Closes #534.

A shared huddl link's preview now says when the huddl takes place. The Open Graph and Twitter title read `Community lunch · Sat, Jul 20, 2030 · 12:00 PM EDT`, formatted in the huddl's own zone. The year and zone stay in because a pasted link is read later and elsewhere.

The `· huddlz` suffix leaves the preview title: previews already show the site name on their own row, and the suffix crowded a title that now carries a date. The browser tab title, description and picture are unchanged. The group page's preview title keeps its suffix; this PR only touches huddlz.

## Tests

`test/features/huddl_link_preview.feature` (`--only huddl_link_preview`) fetches the page with a plain conn GET, the same response link-preview crawlers read, and checks the title, that the page body shows the same date and time, and that the description and picture tags still stand. A second scenario uses a Chicago group to show the time is the huddl's own. The existing unit test that pinned the old title now matches the new shape.

`mix precommit` is clean.
