### PR TITLE
fix(ui): center organizer toolbar actions

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1119,7 +1119,7 @@ body .page-head p {
   line-height: 1.5;
 }
 
-body .page-head .actions { display: flex; gap: 8px; flex: 0 0 auto; }
+body .page-head .actions { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
 
 body .eyebrow {
   color: var(--accent-ink);


### PR DESCRIPTION
Vertically center the organizer overview’s Edit group and Create huddl actions beside the date-range selector. Existing spacing and mobile wrapping are preserved.

Visually verified at 1280px desktop and 320px mobile widths.

Closes #535

![Desktop overview with vertically centered toolbar actions at 1280px](https://github.com/user-attachments/assets/5dad5341-02f8-4888-8135-44ba302a987e)

![Mobile overview with wrapped toolbar controls at 320px](https://github.com/user-attachments/assets/ceddbbcb-0188-4c14-ba3d-1751529b5942)