### PR TITLE
fix(ui): clarify organizer summary time ranges

### DIFF
--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -484,7 +484,10 @@ defmodule HuddlzWeb.OrganizeLive do
       <.link navigate={huddl_show_path(@group, @turnout_nudge)}>Add turnout</.link>
     </div>
 
-    <div class="kpis">
+    <p id="overview-summary-scope" class="mb-3 text-sm text-[var(--muted)]">
+      RSVPs and show rate cover the selected period. Members and waitlisted counts are current totals.
+    </p>
+    <div class="kpis" aria-describedby="overview-summary-scope">
       <div id="kpi-members" class="kpi">
         <div class="label">Members</div>
         <div class="value">{@stats.members.count}</div>
@@ -494,7 +497,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <.sparkline id="spark-members" points={@stats.members.spark} />
       </div>
       <div id="kpi-rsvps" class="kpi">
-        <div class="label">RSVPs · last {GroupStats.period_label(@period)}</div>
+        <div class="label">RSVPs</div>
         <div class="value">{@stats.rsvps.count}</div>
         <div class={["delta", rsvps_delta_class(@stats.rsvps)]}>
           {rsvps_delta(@stats.rsvps, @period)}
@@ -502,7 +505,7 @@ defmodule HuddlzWeb.OrganizeLive do
         <.sparkline id="spark-rsvps" points={@stats.rsvps.spark} />
       </div>
       <div id="kpi-showrate" class="kpi">
-        <div class="label">Show rate · last {GroupStats.period_label(@period)}</div>
+        <div class="label">Show rate</div>
         <div class="value">{show_rate_value(@stats.turnout)}</div>
         <div class={["delta", @stats.turnout.counted == 0 && "muted"]}>
           <%= if @stats.turnout.counted == 0 do %>

--- a/test/features/organize_workspace.feature
+++ b/test/features/organize_workspace.feature
@@ -111,7 +111,7 @@ Feature: Organizer workspace
     When I visit "/organize/cyberpunk-builders"
     Then I should see "Cyberpunk Builders"
     And I should see "Members"
-    And I should see "RSVPs · last 90 days"
+    And I should see "RSVPs"
     And I should see "Waitlisted now"
     And I should see "Nothing on the calendar yet. Create a huddl and its signups will show here."
 

--- a/test/features/overview_kpis.feature
+++ b/test/features/overview_kpis.feature
@@ -13,6 +13,20 @@ Feature: Overview KPIs over a period
     And "Portland Elixir" was started 3 months ago
     And I am signed in as "host@example.com"
 
+  Scenario: Summary headings stay consistent when switching the period
+    When I visit "/organize/portland-elixir"
+    Then the summary headings omit the selected range
+    And I should see "RSVPs and show rate cover the selected period. Members and waitlisted counts are current totals."
+    When I click "30 days"
+    Then the summary headings omit the selected range
+    And the overview URL records the period "30d"
+    When I click "12 months"
+    Then the summary headings omit the selected range
+    And the overview URL records the period "12m"
+    When I click "90 days"
+    Then the summary headings omit the selected range
+    And the overview URL records the period "90d"
+
   Scenario: Members KPI shows this month's growth
     Given 4 members joined "Portland Elixir" 2 months ago
     And 2 members joined "Portland Elixir" this month

--- a/test/features/step_definitions/overview_kpis_steps.exs
+++ b/test/features/step_definitions/overview_kpis_steps.exs
@@ -14,6 +14,16 @@ defmodule OverviewKpisSteps do
   alias Huddlz.Communities.{Group, GroupMember, Huddl, HuddlAttendee}
   alias Huddlz.Repo
 
+  step "the summary headings omit the selected range", %{session: session} = context do
+    session
+    |> assert_has("#kpi-members .label", text: "Members", exact: true)
+    |> assert_has("#kpi-rsvps .label", text: "RSVPs", exact: true)
+    |> assert_has("#kpi-showrate .label", text: "Show rate", exact: true)
+    |> assert_has("#kpi-waitlist .label", text: "Waitlisted now", exact: true)
+
+    context
+  end
+
   step "{string} was started {int} months ago", %{args: [group_name, months]} = context do
     group = find_group(group_name)
     started_at = months_ago(months)


### PR DESCRIPTION
Remove repeated time ranges from the organizer summary headings and explain that RSVPs and show rate cover the selected period, while member and waitlist counts are current totals. Existing comparison context remains visible.

Verified period switching across 30 days, 90 days, and 12 months, and inspected the layout at desktop and 320px mobile widths.

Closes #538

![Organizer summary at desktop width](https://github.com/user-attachments/assets/d30f5a7c-e602-41db-abb7-53de49f206c0)

![Organizer summary at 320px mobile width](https://github.com/user-attachments/assets/032f012a-187b-4fe4-b006-2486cc499a83)