### PR TITLE
fix(organize): cap Also upcoming at the nearest three huddlz

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1972,6 +1972,14 @@ body .next-huddl-others ul {
 body .next-huddl-others a { color: var(--text); font-weight: 500; }
 body .next-huddl-others a:hover { color: var(--accent-ink); }
 
+body .next-huddl-others .more {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--accent-ink);
+}
+body .next-huddl-others .more:hover { text-decoration: underline; text-underline-offset: 3px; }
+
 /* ─────────────────────────────────────────  TABLES / LISTS  ──── */
 /* Activity feed */
 body .feed { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; }

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -43,6 +43,9 @@ defmodule HuddlzWeb.OrganizeLive do
   # overview; after this many days the moment has passed.
   @turnout_nudge_days 14
   @huddlz_filters [:published, :draft, :past, :cancelled]
+
+  # "Also upcoming" shows the nearest few; a recurring series can queue dozens.
+  @also_upcoming_limit 3
   @activity_limit 10
   # Rows shown before "Show more". A weekly series alone can run to a
   # hundred dates, so the list pages rather than folding anything.
@@ -597,11 +600,19 @@ defmodule HuddlzWeb.OrganizeLive do
             <div :if={@next.others != []} class="next-huddl-others">
               <div class="label">Also upcoming</div>
               <ul id="next-huddl-others">
-                <li :for={huddl <- @next.others}>
+                <li :for={huddl <- also_upcoming(@next.others)}>
                   <.link navigate={huddl_show_path(@group, huddl)}>{huddl.title}</.link>
                   <span class="count">· {signups_figure(huddl)}{waitlisted_suffix(huddl)}</span>
                 </li>
               </ul>
+              <.link
+                :if={more_upcoming?(@next.others)}
+                id="next-huddl-others-all"
+                navigate={~p"/organize/#{@group.slug}/huddlz"}
+                class="more"
+              >
+                All {length(@next.others) + 1} upcoming
+              </.link>
             </div>
           </div>
         <% else %>
@@ -1069,6 +1080,9 @@ defmodule HuddlzWeb.OrganizeLive do
     do: huddl |> HuddlCardHelpers.local_starts_at() |> DateTime.to_date()
 
   defp huddlz_filters, do: @huddlz_filters
+
+  defp also_upcoming(others), do: Enum.take(others, @also_upcoming_limit)
+  defp more_upcoming?(others), do: length(others) > @also_upcoming_limit
 
   defp huddlz_filter_label(:published), do: "Upcoming"
   defp huddlz_filter_label(:draft), do: "Drafts"

--- a/test/features/next_huddl_panel.feature
+++ b/test/features/next_huddl_panel.feature
@@ -45,6 +45,17 @@ Feature: Next huddl panel on the overview
     Then the next huddl panel names "Elixir hack night"
     And the panel lists the other upcoming huddl "Elixir office hours · 8 / 20"
     And the panel lists the other upcoming huddl "Phoenix workshop · 1 / 1 · 6 waitlisted"
+    And the panel offers no link to more upcoming huddlz
+
+  Scenario: Also upcoming shows only the nearest few
+    Given the huddl "Elixir hack night" in "Portland Elixir" starts in 3 days with room for 20 and 18 RSVPs
+    And "Portland Elixir" has 5 more upcoming huddlz called "Study group" a week apart
+    When I visit "/organize/portland-elixir"
+    Then the panel lists only these other upcoming huddlz:
+      | Study group 1 |
+      | Study group 2 |
+      | Study group 3 |
+    And the panel links to all 6 upcoming huddlz
 
   Scenario: Nothing upcoming
     When I visit "/organize/portland-elixir"

--- a/test/features/step_definitions/next_huddl_panel_steps.exs
+++ b/test/features/step_definitions/next_huddl_panel_steps.exs
@@ -168,6 +168,56 @@ defmodule NextHuddlPanelSteps do
     context
   end
 
+  step "{string} has {int} more upcoming huddlz called {string} a week apart",
+       %{args: [group_name, count, title]} = context do
+    group = find_group(group_name)
+    host = Ash.get!(Huddlz.Accounts.User, group.owner_id, authorize?: false)
+
+    for n <- 1..count//1 do
+      generate(
+        huddl(
+          title: "#{title} #{n}",
+          group_id: group.id,
+          creator_id: host.id,
+          is_private: false,
+          max_attendees: 20,
+          date: Date.add(eastern_today(), 3 + 7 * n),
+          actor: host
+        )
+      )
+    end
+
+    context
+  end
+
+  step "the panel lists only these other upcoming huddlz:", %{session: session} = context do
+    listed =
+      session.view
+      |> Phoenix.LiveViewTest.render()
+      |> LazyHTML.from_document()
+      |> LazyHTML.query("#next-huddl-others li a")
+      |> Enum.map(&LazyHTML.text/1)
+
+    expected = List.flatten(context.datatable.raw)
+    assert listed == expected, "expected #{inspect(expected)}, got #{inspect(listed)}"
+    context
+  end
+
+  step "the panel links to all {int} upcoming huddlz",
+       %{args: [count], session: session} = context do
+    assert_has(session, "#next-huddl-others-all[href$='/huddlz']",
+      text: "All #{count} upcoming",
+      exact: true
+    )
+
+    context
+  end
+
+  step "the panel offers no link to more upcoming huddlz", %{session: session} = context do
+    refute_has(session, "#next-huddl-others-all")
+    context
+  end
+
   step "the panel invites me to create a huddl", %{session: session} = context do
     session
     |> assert_has("#next-huddl", text: "Nothing on the calendar yet")


### PR DESCRIPTION
Closes #537.

"Also upcoming" on the organizer overview now shows the three nearest upcoming huddlz in start order. When more exist, the list ends with an "All N upcoming" link to the organizer's huddlz page, where N counts the next huddl as well. Groups with three or fewer other upcoming huddlz see no change.

The cap lives in the view; the overview stats still carry every upcoming huddl, so the API is unchanged.

## Tests

Two scenarios in `test/features/next_huddl_panel.feature` (`--only next_huddl_panel`): the existing listing scenario also checks that no link appears with two others, and a new one seeds five more huddlz a week apart and checks that exactly the first three are listed and the link counts all six.

`mix precommit` is clean.
