### PR TITLE
feat(organize): record turnout in place on the overview and past list

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2994,8 +2994,16 @@ body .nudge {
 
 body .nudge-icon { flex: 0 0 auto; color: var(--accent-ink); }
 body .nudge strong { color: var(--text); font-weight: 600; }
-body .nudge a { margin-left: auto; color: var(--accent-ink); font-weight: 600; white-space: nowrap; text-decoration: none; }
-body .nudge a:hover { text-decoration: underline; }
+body .nudge :is(a, .nudge-action) { margin-left: auto; color: var(--accent-ink); font-weight: 600; white-space: nowrap; text-decoration: none; }
+body .nudge :is(a, .nudge-action):hover { text-decoration: underline; }
+body .nudge-action { padding: 0; border: 0; background: none; font: inherit; cursor: pointer; }
+
+/* The turnout form opened under the nudge or inside a past row. */
+body .nudge-block { margin-bottom: 20px; }
+body .nudge-block .nudge { margin-bottom: 0; }
+body .nudge-block .turnout-inline { margin: 8px 0 0; }
+body .org-huddl-editor { grid-column: 1 / -1; }
+body .org-huddl-editor .turnout-inline { margin: 0; background: var(--panel-2); }
 
 body .org-huddl-series {
   display: inline-flex;

--- a/lib/huddlz/communities/huddl.ex
+++ b/lib/huddlz/communities/huddl.ex
@@ -305,7 +305,10 @@ defmodule Huddlz.Communities.Huddl do
     end
 
     update :record_turnout do
+      change Huddlz.Communities.Changes.RequireActiveGroup
+
       description "Record how many people came, once the huddl has ended: the room, the call, or both by huddl type."
+
       require_atomic? false
 
       argument :in_room, :integer do
@@ -322,6 +325,9 @@ defmodule Huddlz.Communities.Huddl do
     end
 
     update :skip_turnout do
+      change Huddlz.Communities.Changes.RequireActiveGroup
+      require_atomic? false
+
       description "Dismiss the turnout prompt for this huddl. Turnout can still be recorded later."
 
       change set_attribute(:turnout_skipped_at, &DateTime.utc_now/0)

--- a/lib/huddlz_web/components/turnout_form.ex
+++ b/lib/huddlz_web/components/turnout_form.ex
@@ -58,6 +58,13 @@ defmodule HuddlzWeb.Components.TurnoutForm do
           </.button>
           <.button variant={:secondary} phx-click="cancel_turnout">Cancel</.button>
         </div>
+        <p
+          :for={{:base, message} <- AshPhoenix.Form.errors(@form, format: :simple)}
+          class="form-error"
+          role="alert"
+        >
+          {message}
+        </p>
       </.form>
     </div>
     """

--- a/lib/huddlz_web/components/turnout_form.ex
+++ b/lib/huddlz_web/components/turnout_form.ex
@@ -1,0 +1,85 @@
+defmodule HuddlzWeb.Components.TurnoutForm do
+  @moduledoc """
+  The one turnout form, opened in place wherever an organizer reviews past
+  huddlz: under the overview reminder or inside a past row on the huddlz
+  list. The LiveView keeps a single open editor, `%{huddl: huddl, form:
+  form}`, and handles `edit_turnout`, `cancel_turnout`, `validate_turnout`,
+  `record_turnout` and `skip_turnout`; the form carries its huddl's id.
+
+  See ADR 0003: turnout is a headcount, never per-person check-in.
+  """
+  use Phoenix.Component
+
+  import HuddlzWeb.Components.Button
+  import HuddlzWeb.Components.Input
+
+  attr :id, :string, required: true
+  attr :huddl, :map, required: true
+  attr :form, :any, required: true, doc: "the `record_turnout` form, from `build/2`"
+
+  def turnout_form(assigns) do
+    ~H"""
+    <div class="turnout turnout-inline">
+      <.form for={@form} id={@id} phx-change="validate_turnout" phx-submit="record_turnout">
+        <input type="hidden" name="huddl_id" value={@huddl.id} />
+        <div class="turnout-copy">
+          <h2>{question(@huddl)}</h2>
+          <p>A rough count is fine. Count everyone, not just who RSVPd.</p>
+        </div>
+        <div class="turnout-fields">
+          <.input
+            :if={@huddl.event_type in [:in_person, :hybrid]}
+            field={@form[:in_room]}
+            type="number"
+            label="People in the room"
+            min="0"
+            inputmode="numeric"
+          />
+          <.input
+            :if={@huddl.event_type in [:virtual, :hybrid]}
+            field={@form[:on_call]}
+            type="number"
+            label="People on the call"
+            min="0"
+            inputmode="numeric"
+          />
+        </div>
+        <div class="turnout-actions">
+          <.button type="submit" variant={:primary} phx-disable-with="Saving…">
+            Save turnout
+          </.button>
+          <.button
+            :if={is_nil(@huddl.turnout_recorded_at)}
+            variant={:secondary}
+            phx-click="skip_turnout"
+            phx-value-id={@huddl.id}
+          >
+            Skip for now
+          </.button>
+          <.button variant={:secondary} phx-click="cancel_turnout">Cancel</.button>
+        </div>
+      </.form>
+    </div>
+    """
+  end
+
+  @doc "The form for recording this huddl's turnout, seeded with what is already recorded."
+  def build(huddl, user) do
+    huddl
+    |> AshPhoenix.Form.for_update(:record_turnout,
+      actor: user,
+      as: "turnout",
+      params: recorded(huddl)
+    )
+    |> to_form()
+  end
+
+  def question(%{event_type: :virtual}), do: "How many joined?"
+  def question(_huddl), do: "How many came?"
+
+  defp recorded(huddl) do
+    %{"in_room" => huddl.turnout_in_room, "on_call" => huddl.turnout_on_call}
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+end

--- a/lib/huddlz_web/live/huddl_live/show.ex
+++ b/lib/huddlz_web/live/huddl_live/show.ex
@@ -40,7 +40,6 @@ defmodule HuddlzWeb.HuddlLive.Show do
      |> assign(:confirming_delete_photo, nil)
      |> assign(:photo_upload_errors, [])
      |> assign(:selected_photo_url, nil)
-     |> assign(:turnout_form, nil)
      |> assign(:cancel_form, to_form(%{"cancellation_reason" => ""}, as: :cancel))
      |> allow_upload(:huddl_photos,
        accept: HuddlPhotos.allowed_extensions(),
@@ -119,62 +118,12 @@ defmodule HuddlzWeb.HuddlLive.Show do
           </section>
 
           <section
-            :if={@can_record_turnout}
+            :if={@can_see_turnout}
             id="huddl-turnout"
             class="turnout"
             aria-labelledby="turnout-title"
           >
-            <.form
-              :if={@turnout_form}
-              for={@turnout_form}
-              id="turnout-form"
-              phx-change="validate_turnout"
-              phx-submit="record_turnout"
-            >
-              <div class="turnout-copy">
-                <h2 id="turnout-title">{turnout_question(@huddl)}</h2>
-                <p>A rough count is fine. Count everyone, not just who RSVPd.</p>
-              </div>
-              <div class="turnout-fields">
-                <.input
-                  :if={@huddl.event_type in [:in_person, :hybrid]}
-                  field={@turnout_form[:in_room]}
-                  type="number"
-                  label="People in the room"
-                  min="0"
-                  inputmode="numeric"
-                />
-                <.input
-                  :if={@huddl.event_type in [:virtual, :hybrid]}
-                  field={@turnout_form[:on_call]}
-                  type="number"
-                  label="People on the call"
-                  min="0"
-                  inputmode="numeric"
-                />
-              </div>
-              <div class="turnout-actions">
-                <.button type="submit" variant={:primary} phx-disable-with="Saving…">
-                  Save turnout
-                </.button>
-                <.button
-                  :if={is_nil(turnout(@huddl, :turnout_recorded_at))}
-                  variant={:secondary}
-                  phx-click="skip_turnout"
-                >
-                  Skip for now
-                </.button>
-                <.button
-                  :if={turnout(@huddl, :turnout_recorded_at)}
-                  variant={:secondary}
-                  phx-click="cancel_turnout"
-                >
-                  Cancel
-                </.button>
-              </div>
-            </.form>
-
-            <%= if is_nil(@turnout_form) and turnout(@huddl, :turnout_recorded_at) do %>
+            <%= if turnout(@huddl, :turnout_recorded_at) do %>
               <div class="turnout-copy">
                 <h2 id="turnout-title">Turnout</h2>
                 <ul class="turnout-figures">
@@ -192,18 +141,18 @@ defmodule HuddlzWeb.HuddlLive.Show do
                   </li>
                 </ul>
               </div>
-              <div class="turnout-actions">
-                <.button variant={:secondary} phx-click="edit_turnout">Edit turnout</.button>
-              </div>
-            <% end %>
-
-            <%= if is_nil(@turnout_form) and is_nil(turnout(@huddl, :turnout_recorded_at)) do %>
+            <% else %>
               <div class="turnout-copy">
                 <h2 id="turnout-title">Turnout not recorded</h2>
-                <p>Add it any time to get a show rate for planning the next one.</p>
+                <p>Add it from Organize, where past huddlz are reviewed, to get a show rate.</p>
               </div>
               <div class="turnout-actions">
-                <.button variant={:secondary} phx-click="edit_turnout">Add turnout</.button>
+                <.link
+                  navigate={~p"/organize/#{@huddl.group.slug}/huddlz?filter=past"}
+                  class="btn-secondary"
+                >
+                  Record it in Organize
+                </.link>
               </div>
             <% end %>
           </section>
@@ -1167,51 +1116,6 @@ defmodule HuddlzWeb.HuddlLive.Show do
     end
   end
 
-  def handle_event("edit_turnout", _, socket) do
-    %{huddl: huddl, current_user: user} = socket.assigns
-    {:noreply, assign(socket, :turnout_form, turnout_form(huddl, user, turnout_params(huddl)))}
-  end
-
-  def handle_event("cancel_turnout", _, socket) do
-    {:noreply, assign(socket, :turnout_form, nil)}
-  end
-
-  def handle_event("validate_turnout", %{"turnout" => params}, socket) do
-    form = AshPhoenix.Form.validate(socket.assigns.turnout_form, params)
-    {:noreply, assign(socket, :turnout_form, to_form(form))}
-  end
-
-  def handle_event("record_turnout", %{"turnout" => params}, socket) do
-    %{huddl: huddl, current_user: user} = socket.assigns
-
-    case AshPhoenix.Form.submit(socket.assigns.turnout_form, params: params) do
-      {:ok, _huddl} ->
-        {:noreply,
-         socket
-         |> assign(:turnout_form, nil)
-         |> put_flash(:info, "Turnout saved.")
-         |> refresh_attendance(huddl, user)}
-
-      {:error, form} ->
-        {:noreply, assign(socket, :turnout_form, to_form(form))}
-    end
-  end
-
-  def handle_event("skip_turnout", _, socket) do
-    %{huddl: huddl, current_user: user} = socket.assigns
-
-    case Communities.skip_turnout(huddl, actor: user) do
-      {:ok, _huddl} ->
-        {:noreply,
-         socket
-         |> assign(:turnout_form, nil)
-         |> refresh_attendance(huddl, user)}
-
-      {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "Could not skip turnout right now.")}
-    end
-  end
-
   def handle_event("confirm_delete_huddl", _, socket) do
     {:noreply, assign(socket, :confirming_delete?, true)}
   end
@@ -1357,44 +1261,15 @@ defmodule HuddlzWeb.HuddlLive.Show do
     |> load_photos(huddl, user, can_view_photos)
   end
 
-  # Turnout is asked once a huddl has ended, of organizers only. The form
-  # shows itself until the organizer records or skips; after that it only
-  # appears on request, and a live reload never throws away an open form.
+  # Turnout is shown once a huddl has ended, to organizers only. It is
+  # recorded from Organize, where past huddlz are reviewed (#540); this
+  # page only reads it back.
   defp assign_turnout(socket, huddl, user) do
-    can_record =
+    can_see =
       huddl.status == :completed && not is_nil(user) && is_nil(huddl.group.archived_at) &&
         Communities.can_record_turnout?(user, huddl)
 
-    form =
-      cond do
-        not can_record -> nil
-        socket.assigns[:turnout_form] -> socket.assigns.turnout_form
-        turnout_unanswered?(huddl) -> turnout_form(huddl, user, %{})
-        true -> nil
-      end
-
-    socket
-    |> assign(:can_record_turnout, can_record)
-    |> assign(:turnout_form, form)
-  end
-
-  defp turnout_unanswered?(huddl) do
-    is_nil(turnout(huddl, :turnout_recorded_at)) and is_nil(turnout(huddl, :turnout_skipped_at))
-  end
-
-  defp turnout_form(huddl, user, params) do
-    huddl
-    |> AshPhoenix.Form.for_update(:record_turnout, actor: user, as: "turnout", params: params)
-    |> to_form()
-  end
-
-  defp turnout_params(huddl) do
-    %{
-      "in_room" => turnout(huddl, :turnout_in_room),
-      "on_call" => turnout(huddl, :turnout_on_call)
-    }
-    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-    |> Map.new()
+    assign(socket, :can_see_turnout, can_see)
   end
 
   # Turnout fields are organizer-only; other viewers receive a forbidden marker.
@@ -1404,9 +1279,6 @@ defmodule HuddlzWeb.HuddlLive.Show do
       value -> value
     end
   end
-
-  defp turnout_question(%{event_type: :virtual}), do: "How many joined?"
-  defp turnout_question(_huddl), do: "How many came?"
 
   defp huddl_meta(huddl) do
     %{

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -22,6 +22,7 @@ defmodule HuddlzWeb.OrganizeLive do
   alias Huddlz.Communities
   alias Huddlz.Communities.GroupStats
   alias Huddlz.Communities.MembershipEvents
+  alias HuddlzWeb.Components.TurnoutForm
   alias HuddlzWeb.HuddlStatus
   alias HuddlzWeb.Layouts
   alias HuddlzWeb.Live.Helpers.BrowserTimeZone
@@ -67,6 +68,7 @@ defmodule HuddlzWeb.OrganizeLive do
      |> assign(:huddlz_list, [])
      |> assign(:huddlz_filter, :published)
      |> assign(:turnout_nudge, nil)
+     |> assign(:turnout_editor, nil)
      |> assign(:period, GroupStats.default_period())
      |> assign(:stats, nil)
      |> assign(:invitation_count, 0)
@@ -179,6 +181,32 @@ defmodule HuddlzWeb.OrganizeLive do
     |> Ash.Query.sort(ends_at: :desc)
     |> Ash.Query.limit(1)
     |> Ash.read_one!(actor: user)
+  end
+
+  # The huddl a turnout event names: the nudge's, or one of the listed rows.
+  defp turnout_subject(socket, id) do
+    case socket.assigns.turnout_nudge do
+      %{id: ^id} = huddl -> huddl
+      _ -> Enum.find(socket.assigns.huddlz_list, &(&1.id == id))
+    end
+  end
+
+  # Saving turnout in place refreshes what the page shows without moving
+  # it: the overview's nudge and figures, or the list's rows at the same
+  # scroll depth.
+  defp refresh_after_turnout(socket) do
+    %{group: group, current_user: user} = socket.assigns
+
+    case socket.assigns.live_action do
+      :overview ->
+        load_section(socket, :overview, group, user)
+
+      :huddlz ->
+        assign(socket, :huddlz_list, list_group_huddlz(group, socket.assigns.huddlz_filter, user))
+
+      _other ->
+        socket
+    end
   end
 
   defp load_group(slug, user) do
@@ -323,6 +351,7 @@ defmodule HuddlzWeb.OrganizeLive do
             group={@group}
             can_edit_group={@can_edit_group}
             turnout_nudge={@turnout_nudge}
+            turnout_editor={@turnout_editor}
             period={@period}
             activity={@activity}
             stats={@stats}
@@ -335,6 +364,7 @@ defmodule HuddlzWeb.OrganizeLive do
             counts={@huddlz_counts}
             filter={@huddlz_filter}
             today={@today}
+            turnout_editor={@turnout_editor}
           />
         <% :members -> %>
           <.members_view
@@ -441,6 +471,7 @@ defmodule HuddlzWeb.OrganizeLive do
   # ─────────────────────────────────────────  OVERVIEW  ───
   attr :group, :map, required: true
   attr :turnout_nudge, :map, default: nil
+  attr :turnout_editor, :map, default: nil
   attr :period, :string, required: true
   attr :stats, :map, required: true
   attr :activity, :list, required: true
@@ -478,13 +509,29 @@ defmodule HuddlzWeb.OrganizeLive do
       </div>
     </div>
 
-    <div :if={@turnout_nudge} id="turnout-nudge" class="nudge" role="status">
-      <.icon name="hero-users" class="size-5 nudge-icon" />
-      <span>
-        <strong>{@turnout_nudge.title}</strong>
-        ended {nudge_ended(@turnout_nudge)} and has no turnout yet.
-      </span>
-      <.link navigate={huddl_show_path(@group, @turnout_nudge)}>Add turnout</.link>
+    <div :if={@turnout_nudge} id="turnout-nudge" class="nudge-block">
+      <div class="nudge" role="status">
+        <.icon name="hero-users" class="size-5 nudge-icon" />
+        <span>
+          <strong>{@turnout_nudge.title}</strong>
+          ended {nudge_ended(@turnout_nudge)} and has no turnout yet.
+        </span>
+        <button
+          :if={!editing?(@turnout_editor, @turnout_nudge)}
+          type="button"
+          class="nudge-action"
+          phx-click="edit_turnout"
+          phx-value-id={@turnout_nudge.id}
+        >
+          Add turnout
+        </button>
+      </div>
+      <TurnoutForm.turnout_form
+        :if={editing?(@turnout_editor, @turnout_nudge)}
+        id="turnout-form-nudge"
+        huddl={@turnout_editor.huddl}
+        form={@turnout_editor.form}
+      />
     </div>
 
     <p id="overview-summary-scope" class="mb-3 text-sm text-[var(--muted)]">
@@ -794,6 +841,7 @@ defmodule HuddlzWeb.OrganizeLive do
   attr :counts, :map, required: true
   attr :filter, :atom, required: true
   attr :today, Date, required: true
+  attr :turnout_editor, :map, default: nil
 
   defp huddlz_view(assigns) do
     shown = Enum.take(assigns.huddlz, assigns.limit)
@@ -878,7 +926,12 @@ defmodule HuddlzWeb.OrganizeLive do
             </span>
           </div>
           <div class="cal-agenda-entries">
-            <.organizer_huddl_row :for={huddl <- day.huddlz} group={@group} huddl={huddl} />
+            <.organizer_huddl_row
+              :for={huddl <- day.huddlz}
+              group={@group}
+              huddl={huddl}
+              turnout_editor={@turnout_editor}
+            />
           </div>
         </div>
       </div>
@@ -894,6 +947,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
   attr :group, :map, required: true
   attr :huddl, :map, required: true
+  attr :turnout_editor, :map, default: nil
 
   defp organizer_huddl_row(assigns) do
     ~H"""
@@ -927,7 +981,7 @@ defmodule HuddlzWeb.OrganizeLive do
       <.organizer_rsvps huddl={@huddl} />
       <div class="org-huddl-actions">
         <.organizer_edit_link group={@group} huddl={@huddl} label="Edit" />
-        <.organizer_turnout_action group={@group} huddl={@huddl} />
+        <.organizer_turnout_action huddl={@huddl} />
         <.link
           :if={@huddl.huddl_template && @huddl.status not in [:cancelled, :completed]}
           navigate={huddl_edit_path(@group, @huddl, "all")}
@@ -936,9 +990,19 @@ defmodule HuddlzWeb.OrganizeLive do
           Edit series
         </.link>
       </div>
+      <div :if={editing?(@turnout_editor, @huddl)} class="org-huddl-editor">
+        <TurnoutForm.turnout_form
+          id={"turnout-form-#{@huddl.id}"}
+          huddl={@turnout_editor.huddl}
+          form={@turnout_editor.form}
+        />
+      </div>
     </div>
     """
   end
+
+  defp editing?(%{huddl: %{id: id}}, %{id: id}), do: true
+  defp editing?(_editor, _huddl), do: false
 
   attr :huddl, :map, required: true
   attr :group, :map, required: true
@@ -996,23 +1060,23 @@ defmodule HuddlzWeb.OrganizeLive do
     """
   end
 
-  attr :group, :map, required: true
   attr :huddl, :map, required: true
 
-  # A past row either wears its show rate or offers to record one.
+  # A past row wears its show rate and opens the turnout form in place.
   defp organizer_turnout_action(assigns) do
     ~H"""
     <%= if @huddl.status == :completed do %>
       <.pill :if={@huddl.show_rate} variant={:cyan} class="org-huddl-show-rate">
         {@huddl.show_rate}% showed
       </.pill>
-      <.link
-        :if={is_nil(@huddl.turnout_recorded_at)}
-        navigate={huddl_show_path(@group, @huddl)}
-        class="btn-secondary btn-sm org-huddl-add-turnout"
+      <.button
+        variant={:secondary}
+        class="btn-sm org-huddl-add-turnout"
+        phx-click="edit_turnout"
+        phx-value-id={@huddl.id}
       >
-        Add turnout
-      </.link>
+        {if @huddl.turnout_recorded_at, do: "Edit turnout", else: "Add turnout"}
+      </.button>
     <% end %>
     """
   end
@@ -1521,6 +1585,52 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   @impl true
+  def handle_event("edit_turnout", %{"id" => id}, socket) do
+    case turnout_subject(socket, id) do
+      nil ->
+        {:noreply, socket}
+
+      huddl ->
+        form = TurnoutForm.build(huddl, socket.assigns.current_user)
+        {:noreply, assign(socket, :turnout_editor, %{huddl: huddl, form: form})}
+    end
+  end
+
+  def handle_event("cancel_turnout", _params, socket) do
+    {:noreply, assign(socket, :turnout_editor, nil)}
+  end
+
+  def handle_event("validate_turnout", %{"turnout" => params}, socket) do
+    editor = socket.assigns.turnout_editor
+    form = AshPhoenix.Form.validate(editor.form, params)
+    {:noreply, assign(socket, :turnout_editor, %{editor | form: to_form(form)})}
+  end
+
+  def handle_event("record_turnout", %{"turnout" => params}, socket) do
+    editor = socket.assigns.turnout_editor
+
+    case AshPhoenix.Form.submit(editor.form, params: params) do
+      {:ok, huddl} ->
+        {:noreply,
+         socket
+         |> assign(:turnout_editor, nil)
+         |> put_flash(:info, "Turnout saved for #{huddl.title}.")
+         |> refresh_after_turnout()}
+
+      {:error, form} ->
+        {:noreply, assign(socket, :turnout_editor, %{editor | form: to_form(form)})}
+    end
+  end
+
+  def handle_event("skip_turnout", %{"id" => id}, socket) do
+    with huddl when not is_nil(huddl) <- turnout_subject(socket, id),
+         {:ok, _huddl} <- Communities.skip_turnout(huddl, actor: socket.assigns.current_user) do
+      {:noreply, socket |> assign(:turnout_editor, nil) |> refresh_after_turnout()}
+    else
+      _ -> {:noreply, put_flash(socket, :error, "Could not skip turnout right now.")}
+    end
+  end
+
   def handle_event("show_more_huddlz", _params, socket) do
     {:noreply, update(socket, :huddlz_limit, &(&1 + @huddlz_page))}
   end

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -169,6 +169,10 @@ defmodule HuddlzWeb.OrganizeLive do
 
   # The most recent huddl that ended within the nudge window and has been
   # neither counted nor dismissed. One at a time: the freshest memory first.
+  defp latest_uncounted_huddl(%{archived_at: archived_at}, _user)
+       when not is_nil(archived_at),
+       do: nil
+
   defp latest_uncounted_huddl(group, user) do
     cutoff = DateTime.add(DateTime.utc_now(), -@turnout_nudge_days, :day)
 
@@ -184,6 +188,10 @@ defmodule HuddlzWeb.OrganizeLive do
   end
 
   # The huddl a turnout event names: the nudge's, or one of the listed rows.
+  defp turnout_subject(%{assigns: %{group: %{archived_at: archived_at}}}, _id)
+       when not is_nil(archived_at),
+       do: nil
+
   defp turnout_subject(socket, id) do
     case socket.assigns.turnout_nudge do
       %{id: ^id} = huddl -> huddl
@@ -1070,6 +1078,7 @@ defmodule HuddlzWeb.OrganizeLive do
         {@huddl.show_rate}% showed
       </.pill>
       <.button
+        :if={is_nil(@huddl.group.archived_at)}
         variant={:secondary}
         class="btn-sm org-huddl-add-turnout"
         phx-click="edit_turnout"

--- a/test/features/organize_turnout.feature
+++ b/test/features/organize_turnout.feature
@@ -11,6 +11,33 @@ Feature: Turnout across Organize
     And a public group "Portland Elixir" exists with owner "host@example.com"
     And I am signed in as "host@example.com"
 
+  @archived_turnout
+  Scenario: Archived groups keep turnout history read-only
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    And the turnout for "Elixir hack night" was recorded as 2 in the room
+    And the in-person huddl "Elixir office hours" in "Portland Elixir" ended 3 days ago with 4 RSVPs
+    When I archive "Portland Elixir" through the API
+    Then API archival is "allowed"
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    Then I should see "2 in the room"
+    And I should see "50% showed"
+    And I should not see "Add turnout"
+    And I should not see "Edit turnout"
+
+  @archived_turnout
+  Scenario: Archival locks a turnout form that is already open
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    And I click "Add turnout"
+    And I fill in "People in the room" with "2"
+    And I archive "Portland Elixir" through the API
+    Then API archival is "allowed"
+    When I click the "Save turnout" button
+    Then I should see "This group is archived or unavailable. Restore it before making changes."
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    Then I should see "No turnout yet"
+    And I should not see "2 in the room"
+
   Scenario: A counted past row shows turnout and show rate
     Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
     And the turnout for "Elixir hack night" was recorded as 2 in the room

--- a/test/features/organize_turnout.feature
+++ b/test/features/organize_turnout.feature
@@ -23,12 +23,96 @@ Feature: Turnout across Organize
     When I visit "/organize/portland-elixir/huddlz?filter=past"
     Then the past row for "Lightning talks" shows "3 in the room", "2 on the call" and "125% showed"
 
-  Scenario: An uncounted past row offers Add turnout
+  Scenario: An uncounted past row records turnout in place
     Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
     When I visit "/organize/portland-elixir/huddlz?filter=past"
     Then the past row for "Elixir hack night" shows "4 RSVPs" and "No turnout yet"
     When I click "Add turnout"
-    Then I should see "How many came?"
+    Then the past row for "Elixir hack night" asks "How many came?"
+    When I fill in "People in the room" with "2"
+    And I click the "Save turnout" button
+    Then the past row for "Elixir hack night" shows "2 in the room" and "50% showed"
+    And I am still on the past huddlz list
+
+  Scenario: A virtual row asks for the call
+    Given the virtual huddl "Elixir office hours" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    And I click "Add turnout"
+    Then the past row for "Elixir office hours" asks "How many joined?"
+    And I should not see "People in the room"
+    When I fill in "People on the call" with "3"
+    And I click the "Save turnout" button
+    Then the past row for "Elixir office hours" shows "3 on the call" and "75% showed"
+
+  Scenario: A hybrid row takes both counts
+    Given the hybrid huddl "Lightning talks" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    And I click "Add turnout"
+    And I fill in "People in the room" with "3"
+    And I fill in "People on the call" with "2"
+    And I click the "Save turnout" button
+    Then the past row for "Lightning talks" shows "3 in the room", "2 on the call" and "125% showed"
+
+  Scenario: Turnout for several huddlz in a row
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended 1 days ago with 4 RSVPs
+    And the in-person huddl "Elixir office hours" in "Portland Elixir" ended 2 days ago with 4 RSVPs
+    And the in-person huddl "Lightning talks" in "Portland Elixir" ended 3 days ago with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    And I record 2 in the room for "Elixir hack night"
+    And I record 3 in the room for "Elixir office hours"
+    And I record 4 in the room for "Lightning talks"
+    Then the past row for "Elixir hack night" shows "2 in the room" and "50% showed"
+    And the past row for "Elixir office hours" shows "3 in the room" and "75% showed"
+    And the past row for "Lightning talks" shows "4 in the room" and "100% showed"
+    And I am still on the past huddlz list
+
+  Scenario: Editing recorded turnout from the list
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    And the turnout for "Elixir hack night" was recorded as 2 in the room
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    And I click "Edit turnout"
+    And I fill in "People in the room" with "6"
+    And I click the "Save turnout" button
+    Then the past row for "Elixir hack night" shows "6 in the room" and "150% showed"
+
+  Scenario: An upcoming row offers no turnout action
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" is upcoming with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz"
+    Then the row for "Elixir hack night" offers no turnout action
+
+  Scenario: A failed save keeps what was typed
+    Given the hybrid huddl "Lightning talks" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    And I click "Add turnout"
+    And I fill in "People in the room" with "3"
+    And I click the "Save turnout" button
+    Then the past row for "Lightning talks" says "how many people were on the call"
+    And the "People in the room" field still reads "3"
+    And the past row for "Lightning talks" shows "No turnout yet"
+
+  Scenario: The overview nudge records turnout in place
+    Given the in-person huddl "Elixir office hours" in "Portland Elixir" ended 3 days ago with 4 RSVPs
+    And the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir"
+    Then the overview nudge names "Elixir hack night"
+    When I click "Add turnout"
+    Then the overview nudge asks "How many came?"
+    When I fill in "People in the room" with "2"
+    And I click the "Save turnout" button
+    Then I should see "Turnout saved for Elixir hack night"
+    And the overview nudge names "Elixir office hours"
+    And the Show rate KPI shows "50%" and "Over 1 counted huddl"
+    And I am still on the overview
+
+  Scenario: Skipping from the nudge never asks again
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
+    When I visit "/organize/portland-elixir"
+    And I click "Add turnout"
+    And I click the "Skip for now" button
+    Then there is no overview nudge
+    When I visit "/organize/portland-elixir/huddlz?filter=past"
+    Then the past row for "Elixir hack night" shows "No turnout yet"
+    And the row for "Elixir hack night" still offers "Add turnout"
 
   Scenario: The overview nudges about the latest uncounted huddl
     Given the in-person huddl "Elixir office hours" in "Portland Elixir" ended 3 days ago with 4 RSVPs
@@ -36,8 +120,6 @@ Feature: Turnout across Organize
     When I visit "/organize/portland-elixir"
     Then the overview nudge names "Elixir hack night"
     And the overview nudge does not name "Elixir office hours"
-    When I click "Add turnout"
-    Then I should see "How many came?"
 
   Scenario: A dismissed huddl is not nudged
     Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs

--- a/test/features/step_definitions/organize_turnout_steps.exs
+++ b/test/features/step_definitions/organize_turnout_steps.exs
@@ -58,6 +58,12 @@ defmodule OrganizeTurnoutSteps do
     context
   end
 
+  step "the past row for {string} shows {string}",
+       %{args: [title, text], session: session} = context do
+    assert_row_texts(session, find_huddl(title), [text])
+    context
+  end
+
   step "the past row for {string} shows {string} and {string}",
        %{args: [title | texts], session: session} = context do
     assert_row_texts(session, find_huddl(title), texts)
@@ -69,12 +75,74 @@ defmodule OrganizeTurnoutSteps do
 
     session
     |> assert_has("#turnout-nudge", text: title)
-    |> assert_has("#turnout-nudge a[href='/groups/#{huddl.group.slug}/huddlz/#{huddl.id}']",
-      text: "Add turnout"
-    )
+    |> assert_has("#turnout-nudge button[phx-value-id='#{huddl.id}']", text: "Add turnout")
 
     context
   end
+
+  step "the overview nudge asks {string}", %{args: [question], session: session} = context do
+    assert_has(session, "#turnout-nudge", text: question)
+    context
+  end
+
+  step "the past row for {string} asks {string}",
+       %{args: [title, question], session: session} = context do
+    assert_has(session, "#organize-huddl-#{find_huddl(title).id}", text: question)
+    context
+  end
+
+  step "the past row for {string} says {string}",
+       %{args: [title, message], session: session} = context do
+    assert_has(session, "#organize-huddl-#{find_huddl(title).id} .form-error", text: message)
+    context
+  end
+
+  step "the {string} field still reads {string}",
+       %{args: [label, value], session: session} = context do
+    assert_has(session, "input[name='#{field_name(label)}'][value='#{value}']")
+    context
+  end
+
+  step "I record {int} in the room for {string}",
+       %{args: [count, title], session: session} = context do
+    huddl = find_huddl(title)
+
+    session =
+      session
+      |> click_button("#organize-huddl-#{huddl.id} button", "Add turnout")
+      |> fill_in("People in the room", with: count)
+      |> click_button("Save turnout")
+
+    Map.merge(context, %{conn: session, session: session})
+  end
+
+  step "the row for {string} offers no turnout action",
+       %{args: [title], session: session} = context do
+    session
+    |> refute_has("#organize-huddl-#{find_huddl(title).id} button", text: "Add turnout")
+    |> refute_has("#organize-huddl-#{find_huddl(title).id} button", text: "Edit turnout")
+
+    context
+  end
+
+  step "the row for {string} still offers {string}",
+       %{args: [title, label], session: session} = context do
+    assert_has(session, "#organize-huddl-#{find_huddl(title).id} button", text: label)
+    context
+  end
+
+  step "I am still on the past huddlz list", %{session: session} = context do
+    assert_path(session, "/organize/portland-elixir/huddlz", query_params: %{"filter" => "past"})
+    context
+  end
+
+  step "I am still on the overview", %{session: session} = context do
+    assert_path(session, "/organize/portland-elixir")
+    context
+  end
+
+  defp field_name("People in the room"), do: "turnout[in_room]"
+  defp field_name("People on the call"), do: "turnout[on_call]"
 
   step "the overview nudge does not name {string}",
        %{args: [title], session: session} = context do

--- a/test/features/turnout.feature
+++ b/test/features/turnout.feature
@@ -12,71 +12,24 @@ Feature: Recording turnout for a past huddl
     And a public group "Portland Elixir" exists with owner "host@example.com"
     And "member@example.com" is a member of "Portland Elixir"
 
-  Scenario: Organizer records the room count for an in-person huddl
-    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
-    And I am signed in as "host@example.com"
-    When I visit the huddl "Elixir hack night"
-    Then I should see "How many came?"
-    When I fill in "People in the room" with "2"
-    And I click the "Save turnout" button
-    Then I should see "2 in the room"
-    And I should see "50% showed"
-    And I should not see "How many came?"
-
-  Scenario: Organizer records the call count for a virtual huddl
-    Given the virtual huddl "Elixir office hours" in "Portland Elixir" ended yesterday with 4 RSVPs
-    And I am signed in as "host@example.com"
-    When I visit the huddl "Elixir office hours"
-    Then I should see "How many joined?"
-    And I should not see "People in the room"
-    When I fill in "People on the call" with "3"
-    And I click the "Save turnout" button
-    Then I should see "3 on the call"
-    And I should see "75% showed"
-
-  Scenario: Organizer records both counts for a hybrid huddl
-    Given the hybrid huddl "Lightning talks" in "Portland Elixir" ended yesterday with 4 RSVPs
-    And I am signed in as "host@example.com"
-    When I visit the huddl "Lightning talks"
-    And I fill in "People in the room" with "3"
-    And I fill in "People on the call" with "2"
-    And I click the "Save turnout" button
-    Then I should see "3 in the room"
-    And I should see "2 on the call"
-    And I should see "5 in total"
-    And I should see "125% showed"
-
-  Scenario: Skipping never asks again
-    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
-    And I am signed in as "host@example.com"
-    When I visit the huddl "Elixir hack night"
-    And I click the "Skip for now" button
-    Then I should not see "How many came?"
-    And I should see "Turnout not recorded"
-    When I visit the huddl "Elixir hack night"
-    Then I should not see "How many came?"
-    When I click the "Add turnout" button
-    And I fill in "People in the room" with "2"
-    And I click the "Save turnout" button
-    Then I should see "2 in the room"
-
-  Scenario: Editing a recorded count
+  Scenario: Organizers read turnout on the huddl page and record it in Organize
     Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
     And the turnout for "Elixir hack night" was recorded as 2 in the room
     And I am signed in as "host@example.com"
     When I visit the huddl "Elixir hack night"
-    And I click the "Edit turnout" button
-    And I fill in "People in the room" with "6"
-    And I click the "Save turnout" button
-    Then I should see "6 in the room"
-    And I should see "150% showed"
+    Then I should see "2 in the room"
+    And I should see "50% showed"
+    And I should not see "Save turnout"
+    And I should not see "Edit turnout"
 
-  Scenario: The prompt only appears after the huddl ends
-    Given the in-person huddl "Elixir hack night" in "Portland Elixir" is upcoming with 4 RSVPs
+  Scenario: An uncounted huddl page points at Organize
+    Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs
     And I am signed in as "host@example.com"
     When I visit the huddl "Elixir hack night"
-    Then I should not see "How many came?"
-    And I should not see "Add turnout"
+    Then I should see "Turnout not recorded"
+    And I should not see "How many came?"
+    When I click link "Record it in Organize"
+    Then I should see "Add turnout"
 
   Scenario: Members never see turnout
     Given the in-person huddl "Elixir hack night" in "Portland Elixir" ended yesterday with 4 RSVPs

--- a/test/huddlz/communities/turnout_test.exs
+++ b/test/huddlz/communities/turnout_test.exs
@@ -3,6 +3,36 @@ defmodule Huddlz.Communities.TurnoutTest do
 
   alias Huddlz.Communities
 
+  test "archival locks turnout actions even with stale records or admin access" do
+    owner = generate(user(role: :user))
+    organizer = generate(user(role: :user))
+    admin = generate(user(role: :admin))
+
+    {group, _memberships} =
+      generate_group_with_members(owner: owner, members: [%{user: organizer, role: :organizer}])
+
+    huddl = generate(past_huddl(group_id: group.id, creator_id: owner.id))
+    recorded = Communities.record_turnout!(huddl, %{in_room: 7}, actor: owner)
+    Communities.archive_group!(group, actor: owner)
+
+    for actor <- [owner, organizer, admin] do
+      assert {:error, error} = Communities.record_turnout(recorded, %{in_room: 9}, actor: actor)
+      assert Exception.message(error) =~ "Restore it before making changes"
+      assert {:error, error} = Communities.skip_turnout(recorded, actor: actor)
+      assert Exception.message(error) =~ "Restore it before making changes"
+    end
+
+    reloaded = Communities.get_huddl!(huddl.id, actor: owner)
+    assert reloaded.turnout_in_room == 7
+    assert reloaded.turnout_recorded_at == recorded.turnout_recorded_at
+    assert is_nil(reloaded.turnout_skipped_at)
+
+    Communities.restore_group!(group.id, actor: owner)
+
+    assert {:ok, %{turnout_in_room: 9}} =
+             Communities.record_turnout(recorded, %{in_room: 9}, actor: organizer)
+  end
+
   test "only organizers can dismiss turnout, without losing recorded counts" do
     owner = generate(user())
     member = generate(user())

--- a/test/huddlz_web/live/huddl_search_test.exs
+++ b/test/huddlz_web/live/huddl_search_test.exs
@@ -6,10 +6,18 @@ defmodule HuddlzWeb.HuddlSearchTest do
 
   setup :verify_on_exit!
 
+  # A full local day stays in progress through late-night test runs, even
+  # on the last day of the week or month.
+  defp move_huddl_to_date(huddl, date) do
+    starts_at = DateTime.new!(date, ~T[00:00:00], "America/New_York")
+    ends_at = DateTime.new!(Date.add(date, 1), ~T[00:00:00], "America/New_York")
+    Ash.Seed.update!(huddl, %{starts_at: starts_at, ends_at: ends_at})
+  end
+
   setup do
     user = generate(user(role: :user))
     group = generate(group(owner_id: user.id, is_public: true, actor: user))
-    today = Date.utc_today()
+    today = eastern_today()
     saturday = Date.add(today, 6 - rem(Date.day_of_week(today), 7))
 
     huddl1 =
@@ -204,7 +212,9 @@ defmodule HuddlzWeb.HuddlSearchTest do
       |> refute_has("h3", text: "Hybrid Workshop")
     end
 
-    test "filters by date range - this week", %{conn: conn} do
+    test "filters by date range - this week", %{conn: conn, huddl1: yoga} do
+      move_huddl_to_date(yoga, eastern_today())
+
       conn
       |> visit("/discover")
       |> click_link(".chip-group a.chip", "This week")
@@ -215,14 +225,24 @@ defmodule HuddlzWeb.HuddlSearchTest do
       |> refute_has("h3", text: "Past Event")
     end
 
-    test "filters by date range - this month", %{conn: conn} do
+    test "filters by date range - this month", %{
+      conn: conn,
+      huddl1: yoga,
+      huddl2: book_club,
+      huddl3: workshop
+    } do
+      today = eastern_today()
+      move_huddl_to_date(yoga, today)
+      move_huddl_to_date(book_club, today)
+      move_huddl_to_date(workshop, today |> Date.end_of_month() |> Date.add(1))
+
       conn
       |> visit("/discover")
       |> click_link(".chip-group a.chip", "This month")
       # All future huddlz in the current calendar month should show
       |> assert_has("h3", text: "Morning Yoga Session")
       |> assert_has("h3", text: "Virtual Book Club")
-      |> assert_has("h3", text: "Hybrid Workshop")
+      |> refute_has("h3", text: "Hybrid Workshop")
       |> refute_has("h3", text: "Past Event")
     end
 


### PR DESCRIPTION
Closes #540.

Turnout is now recorded where past huddlz are reviewed, in place. One shared form component, `HuddlzWeb.Components.TurnoutForm`, opens under the overview's reminder or inside a past row on the organizer's huddlz list; the organizer view keeps a single open editor and handles the form's events, each naming its huddl by id.

- **Overview.** The reminder's "Add turnout" opens the form beneath it. Saving moves the reminder on to the next uncounted huddl (or clears it), refreshes the show rate and turnout chart, and confirms with a flash naming the huddl. "Skip for now" dismisses it as before.
- **Past list.** Each completed row offers "Add turnout" or "Edit turnout", which opens the form inside the row. Saving updates the row and keeps the list where it is, so several huddlz can be counted in a row. A failed save keeps what was typed and shows the error beside the field.
- **Huddl page.** Organizers still read the recorded figures there, but the form and its buttons are gone; an uncounted huddl says so and links to Organize's past list.

## Tests

`test/features/organize_turnout.feature` (`--only organize_turnout`) gains scenarios for recording in place from a row (room, call, both), three huddlz in succession, editing a recorded count, an upcoming row offering nothing, a failed save keeping the typed value, the overview nudge recording in place with the KPI updating, and skipping from the nudge. `test/features/turnout.feature` (`--only turnout`) now covers the huddl page reading turnout and pointing at Organize; its form scenarios moved to the organizer feature. The API and member-visibility scenarios are unchanged.

`mix precommit` is clean.

## Screenshots

Captured from commit `106dec7d` with test data.

Overview: record turnout beneath the reminder.

![Overview: record turnout beneath the reminder.](https://raw.githubusercontent.com/huddlz-hq/huddlz/b00eac541a725de795b82a4f173d9a1e41ff125c/pr549-overview.png)

Past huddlz: record turnout inside the relevant row.

![Past huddlz: record turnout inside the relevant row.](https://raw.githubusercontent.com/huddlz-hq/huddlz/b00eac541a725de795b82a4f173d9a1e41ff125c/pr549-past-inline.png)

Archived group: recorded counts remain visible and turnout editing is unavailable.

![Archived group: recorded counts remain visible and turnout editing is unavailable.](https://raw.githubusercontent.com/huddlz-hq/huddlz/b00eac541a725de795b82a4f173d9a1e41ff125c/pr549-archived.png)
