### PR TITLE
fix(ui): serve the icons under their cache-busting names

### DIFF
--- a/lib/huddlz_web.ex
+++ b/lib/huddlz_web.ex
@@ -21,6 +21,18 @@ defmodule HuddlzWeb do
     do:
       ~w(assets fonts images uploads favicon.ico favicon.svg apple-touch-icon.png icon-192.png icon-512.png)
 
+  @doc """
+  The name prefixes the endpoint serves as well as `static_paths/0`.
+
+  Digested assets carry a content hash in their file name, so `~p"/favicon.svg"`
+  renders as `/favicon-<hash>.svg` once the assets are built for production. A
+  directory keeps its own name and so still matches `static_paths/0`, but a file
+  at the root no longer does, and the endpoint would refuse to serve it. Match
+  those on their name up to the extension instead.
+  """
+  def static_prefixes,
+    do: for(path <- static_paths(), Path.extname(path) != "", uniq: true, do: Path.rootname(path))
+
   def router do
     quote do
       use Phoenix.Router, helpers: false

--- a/lib/huddlz_web/endpoint.ex
+++ b/lib/huddlz_web/endpoint.ex
@@ -43,7 +43,8 @@ defmodule HuddlzWeb.Endpoint do
     at: "/",
     from: :huddlz,
     gzip: not code_reloading?,
-    only: HuddlzWeb.static_paths()
+    only: HuddlzWeb.static_paths(),
+    only_matching: HuddlzWeb.static_prefixes()
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/test/features/favicon.feature
+++ b/test/features/favicon.feature
@@ -15,3 +15,7 @@ Feature: The favicon is the brand mark
     When a browser fetches the home page
     And a browser fetches each linked icon
     Then each is served as an image of the size it is linked as
+
+  Scenario: The icons are served under their cache-busting names
+    When a browser fetches an icon by its cache-busting name
+    Then the icon is served

--- a/test/features/step_definitions/favicon_steps.exs
+++ b/test/features/step_definitions/favicon_steps.exs
@@ -2,6 +2,7 @@ defmodule FaviconSteps do
   use Cucumber.StepDefinition
 
   import ExUnit.Assertions
+  import ExUnit.Callbacks, only: [on_exit: 1]
   import Phoenix.ConnTest
 
   @endpoint HuddlzWeb.Endpoint
@@ -57,6 +58,25 @@ defmodule FaviconSteps do
       assert served_sizes(href, response.resp_body) == expected, "#{href} sizes"
     end
 
+    context
+  end
+
+  step "a browser fetches an icon by its cache-busting name", context do
+    # Once the assets are digested, `~p` stamps a content hash into the name of
+    # every static file it knows about, so the endpoint has to serve the stamped
+    # name too. Nothing is digested under test, so stand one in by hand.
+    stamped = "favicon-#{String.duplicate("0", 32)}.svg"
+    root = Application.app_dir(:huddlz, "priv/static")
+
+    File.cp!(Path.join(root, "favicon.svg"), Path.join(root, stamped))
+    on_exit(fn -> File.rm(Path.join(root, stamped)) end)
+
+    Map.put(context, :response, get(build_conn(), "/#{stamped}?vsn=d"))
+  end
+
+  step "the icon is served", context do
+    assert context.response.status == 200
+    assert response_content_type(context.response, :svg) =~ "image/svg+xml"
     context
   end
 


### PR DESCRIPTION
Fixes #550.

The browser tab has had no icon on any page since the favicon set landed. The
layout links the icons through verified routes, which stamp a content hash into
the file name once the assets are built for production, so production serves
`/favicon-<hash>.svg`. The endpoint listed only the plain names, and Plug.Static
matches a file at the root on its exact name, so every stamped icon fell through
to the router and returned 404.

Directories were never affected. `/assets/css/app-<hash>.css` still matches on
its first segment, `assets`, which is why the stylesheet and script loaded fine
and only the icons at the root broke.

The endpoint now also allows those names up to the extension. The prefix list is
derived from the static paths rather than written out again, so adding another
root-level file cannot leave the two out of sync.

## Verification

Reproduced against production first: the plain paths return 200, while the
stamped names the page actually links return 404.

The new scenario stands a stamped copy of the SVG in place and asks the endpoint
for it, which fails before this change and passes after.

One caveat for the reviewer: I could not run the suite locally, because the test
database needs PostGIS and it is not installable against the PostgreSQL 16 on
this machine. I verified the endpoint behavior by booting the endpoint on its
own and calling it, and confirmed the new steps parse and resolve. CI covers the
rest.

<img width="1201" height="937" alt="Screenshot 2026-09-10 at 8 07 32 PM" src="https://github.com/user-attachments/assets/815e0b20-cad3-4422-815c-1f47bca2f499" />
