### PR TITLE
fix(ui): scroll the whole sidebar on short screens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -591,6 +591,7 @@ body .sidebar {
 
 body .sidebar-brand {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 10px;
   height: 64px;
@@ -789,6 +790,7 @@ body .sb-org-row.create:hover .plus-mark {
 
 body .sb-user {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 12px;
   padding: 16px 20px;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -576,6 +576,8 @@ body .sidebar-brand > a {
 
 
 /* ─────────────────────────────────────────────  SIDEBAR  ─────── */
+/* One scroll region: brand, navigation, groups, utilities and account
+   move together when the window is too short for them. */
 body .sidebar {
   display: flex;
   flex-direction: column;
@@ -584,6 +586,7 @@ body .sidebar {
   height: 100vh;
   position: sticky;
   top: 0;
+  overflow-y: auto;
 }
 
 body .sidebar-brand {
@@ -615,8 +618,7 @@ body .brand-text {
 }
 
 body .sb-nav {
-  flex: 1 1 auto;
-  overflow-y: auto;
+  flex: 1 0 auto;
   padding: 12px 8px;
 }
 

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -28,6 +28,7 @@ The command builds the actual app assets, starts the test endpoint and Chromium,
 
 | Feature | Browser-specific acceptance check |
 | --- | --- |
+| Sidebar scroll | A 1280×520 window: the aside is the one scroll region, Tab reaches Sign out with it scrolled into view, and scrolling the account area moves the same content |
 | Home location | ArrowDown/Enter select a suggestion without a native form submission |
 | Calendar | Actual `Intl` time-zone detection moves a late Denver huddl to the next New York calendar day |
 | Organizer | Native Tab, arrow keys, Space, visible focus, and switch state survive LiveView patches |

--- a/test/browser/features/sidebar_scroll.feature
+++ b/test/browser/features/sidebar_scroll.feature
@@ -3,6 +3,7 @@ Feature: The sidebar scrolls as one on short screens
   Scenario: Every sidebar control can be reached on a short screen
     Given I have opened my agenda in a browser with enough groups to overflow the sidebar
     Then the sidebar is one scroll region
+    And the brand and account rows keep their height
     When I tab through to Sign out
     Then Sign out is scrolled into view
     When I scroll the lower sidebar back to the top

--- a/test/browser/features/sidebar_scroll.feature
+++ b/test/browser/features/sidebar_scroll.feature
@@ -1,0 +1,10 @@
+@browser_smoke @short @sidebar_browser
+Feature: The sidebar scrolls as one on short screens
+  Scenario: Every sidebar control can be reached on a short screen
+    Given I have opened my agenda in a browser with enough groups to overflow the sidebar
+    Then the sidebar is one scroll region
+    When I tab through to Sign out
+    Then Sign out is scrolled into view
+    When I scroll the lower sidebar back to the top
+    Then the top navigation is in view and the account area has scrolled away
+    And the page behind the sidebar is still usable

--- a/test/browser/features/sidebar_scroll.feature
+++ b/test/browser/features/sidebar_scroll.feature
@@ -6,6 +6,8 @@ Feature: The sidebar scrolls as one on short screens
     And the brand and account rows keep their height
     When I tab through to Sign out
     Then Sign out is scrolled into view
-    When I scroll the lower sidebar back to the top
+    When I scroll up with the wheel over the account area
     Then the top navigation is in view and the account area has scrolled away
-    And the page behind the sidebar is still usable
+    When I scroll down with the wheel over the top navigation
+    Then Sign out is scrolled into view
+    And the page behind the sidebar has not moved and is still usable

--- a/test/browser/steps/sidebar_scroll_steps.exs
+++ b/test/browser/steps/sidebar_scroll_steps.exs
@@ -1,0 +1,122 @@
+defmodule BrowserSidebarScrollSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+  import PhoenixTest.Playwright, only: [press: 3]
+
+  @sidebar "document.querySelector('#mobile-navigation-drawer')"
+
+  step "I have opened my agenda in a browser with enough groups to overflow the sidebar",
+       context do
+    member = generate(user(role: :user))
+
+    for n <- 1..14 do
+      generate(
+        group(name: "Overflow group #{n}", owner_id: member.id, is_public: true, actor: member)
+      )
+    end
+
+    conn =
+      context.conn
+      |> sign_in(member)
+      |> visit("/agenda")
+      |> assert_has(".phx-connected")
+      |> assert_has(".sb-org-row", text: "Overflow group 14")
+
+    Map.merge(context, %{conn: conn, member: member})
+  end
+
+  step "the sidebar is one scroll region", context do
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const sidebar = #{@sidebar};
+        const nav = sidebar.querySelector('.sb-nav');
+        const scrolls = (el) => ['auto', 'scroll'].includes(getComputedStyle(el).overflowY);
+        return sidebar.scrollHeight > sidebar.clientHeight + 40 && scrolls(sidebar) && !scrolls(nav);
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I tab through to Sign out", context do
+    # Nothing is focused on a fresh page, so the first Tab starts from the body.
+    conn =
+      Enum.reduce_while(1..60, press(context.conn, "body", "Tab"), fn _n, conn ->
+        conn = press(conn, ":focus", "Tab")
+
+        if evaluate(conn, "document.activeElement.id === 'sign-out-link'"),
+          do: {:halt, conn},
+          else: {:cont, conn}
+      end)
+
+    Map.put(context, :conn, assert_has(conn, "#sign-out-link:focus"))
+  end
+
+  step "Sign out is scrolled into view", context do
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const sidebar = #{@sidebar};
+        const box = sidebar.getBoundingClientRect();
+        const link = document.querySelector('#sign-out-link').getBoundingClientRect();
+        return sidebar.scrollTop > 0 && link.top >= box.top && link.bottom <= box.bottom;
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I scroll the lower sidebar back to the top", context do
+    # Scrolling over the account area moves the same region as scrolling
+    # over the navigation: there is only one.
+    assert evaluate(context.conn, """
+           (() => {
+             const sidebar = #{@sidebar};
+             const account = sidebar.querySelector('.sb-account');
+             sidebar.scrollTop = account.getBoundingClientRect().top - sidebar.getBoundingClientRect().top + sidebar.scrollTop;
+             sidebar.scrollTop = 0;
+             return sidebar.scrollTop === 0;
+           })()
+           """)
+
+    context
+  end
+
+  step "the top navigation is in view and the account area has scrolled away", context do
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const sidebar = #{@sidebar};
+        const box = sidebar.getBoundingClientRect();
+        const discover = sidebar.querySelector('.sb-item').getBoundingClientRect();
+        const user = document.querySelector('#sidebar-user').getBoundingClientRect();
+        return discover.top >= box.top && discover.bottom <= box.bottom && user.top > box.bottom;
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the page behind the sidebar is still usable", context do
+    conn =
+      context.conn
+      |> assert_has("main h1", text: "Agenda")
+      |> assert_browser(
+        "!document.querySelector('main').inert && document.querySelector('main').getBoundingClientRect().left > 0"
+      )
+
+    Map.put(context, :conn, conn)
+  end
+
+  defp evaluate(conn, expression) do
+    {:ok, value} =
+      PlaywrightEx.Frame.evaluate(conn.frame_id, expression: expression, timeout: 5_000)
+
+    value
+  end
+end

--- a/test/browser/steps/sidebar_scroll_steps.exs
+++ b/test/browser/steps/sidebar_scroll_steps.exs
@@ -84,20 +84,14 @@ defmodule BrowserSidebarScrollSteps do
     Map.put(context, :conn, conn)
   end
 
-  step "I scroll the lower sidebar back to the top", context do
-    # Scrolling over the account area moves the same region as scrolling
-    # over the navigation: there is only one.
-    assert evaluate(context.conn, """
-           (() => {
-             const sidebar = #{@sidebar};
-             const account = sidebar.querySelector('.sb-account');
-             sidebar.scrollTop = account.getBoundingClientRect().top - sidebar.getBoundingClientRect().top + sidebar.scrollTop;
-             sidebar.scrollTop = 0;
-             return sidebar.scrollTop === 0;
-           })()
-           """)
+  # Real wheel events, so an intercepted wheel or a second scroll container
+  # would fail here where setting scrollTop from a script would not.
+  step "I scroll up with the wheel over the account area", context do
+    Map.put(context, :conn, wheel_over(context.conn, "#sidebar-user", -2000))
+  end
 
-    context
+  step "I scroll down with the wheel over the top navigation", context do
+    Map.put(context, :conn, wheel_over(context.conn, "#mobile-navigation-drawer .sb-item", 2000))
   end
 
   step "the top navigation is in view and the account area has scrolled away", context do
@@ -115,15 +109,37 @@ defmodule BrowserSidebarScrollSteps do
     Map.put(context, :conn, conn)
   end
 
-  step "the page behind the sidebar is still usable", context do
+  step "the page behind the sidebar has not moved and is still usable", context do
     conn =
       context.conn
       |> assert_has("main h1", text: "Agenda")
-      |> assert_browser(
-        "!document.querySelector('main').inert && document.querySelector('main').getBoundingClientRect().left > 0"
-      )
+      |> assert_browser("""
+      window.scrollY === 0 && !document.querySelector('main').inert &&
+        document.querySelector('main').getBoundingClientRect().left > 0
+      """)
 
     Map.put(context, :conn, conn)
+  end
+
+  defp wheel_over(conn, selector, delta_y) do
+    %{"x" => x, "y" => y} =
+      evaluate(conn, """
+      (() => {
+        const r = document.querySelector(#{inspect(selector)}).getBoundingClientRect();
+        return {x: r.left + r.width / 2, y: r.top + r.height / 2};
+      })()
+      """)
+
+    {:ok, _} = PlaywrightEx.Page.mouse_move(conn.page_id, x: x, y: y, timeout: 5_000)
+
+    # The wheel call answers with an empty result; the next step observes the effect.
+    %{id: _} =
+      PlaywrightEx.send(
+        %{guid: conn.page_id, method: :mouse_wheel, params: %{delta_x: 0, delta_y: delta_y}},
+        timeout: 5_000
+      )
+
+    conn
   end
 
   defp evaluate(conn, expression) do

--- a/test/browser/steps/sidebar_scroll_steps.exs
+++ b/test/browser/steps/sidebar_scroll_steps.exs
@@ -43,6 +43,19 @@ defmodule BrowserSidebarScrollSteps do
     Map.put(context, :conn, conn)
   end
 
+  step "the brand and account rows keep their height", context do
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const brand = document.querySelector('#mobile-navigation-drawer .sidebar-brand').getBoundingClientRect().height;
+        const user = document.querySelector('#sidebar-user').getBoundingClientRect().height;
+        return Math.round(brand) === 64 && user >= 60;
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+
   step "I tab through to Sign out", context do
     # Nothing is focused on a fresh page, so the first Tab starts from the body.
     conn =

--- a/test/browser/support/hooks.exs
+++ b/test/browser/support/hooks.exs
@@ -10,13 +10,22 @@ defmodule BrowserHooks do
     Mox.stub_with(Huddlz.MockPlaces, Huddlz.PlacesStub)
 
     context =
-      if Map.get(context, :mobile) do
-        Map.put(context, :browser_context_opts,
-          timezone_id: "America/New_York",
-          viewport: %{width: 320, height: 720}
-        )
-      else
-        context
+      cond do
+        Map.get(context, :mobile) ->
+          Map.put(context, :browser_context_opts,
+            timezone_id: "America/New_York",
+            viewport: %{width: 320, height: 720}
+          )
+
+        # A short desktop window: wide enough for the sidebar, too short for it.
+        Map.get(context, :short) ->
+          Map.put(context, :browser_context_opts,
+            timezone_id: "America/New_York",
+            viewport: %{width: 1280, height: 520}
+          )
+
+        true ->
+          context
       end
 
     context = Map.merge(context, Map.new(BrowserCase.do_setup_all(context)))

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -653,7 +653,7 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar/week")
+      |> visit("/agenda")
       |> assert_has("#calendar-entry-#{huddl.id} .cal-agenda-title", text: "Called Off")
       |> assert_has("#calendar-entry-#{huddl.id} .cal-entry-status[data-status=cancelled]",
         text: "Cancelled"
@@ -810,13 +810,15 @@ defmodule HuddlzWeb.CalendarLiveTest do
       rsvp!(mine, attendee, :rsvp)
       create_huddl(host, public_group, title: "Theirs", date: Date.add(tomorrow(), 1))
 
+      # The agenda counts from today onward, whatever weekday the suite runs
+      # on; the week window is covered with pinned dates in the scope feature.
       conn
       |> login(attendee)
-      |> visit("/calendar/week")
+      |> visit("/agenda")
       |> assert_has("#calendar-scope-mine.chip.is-active[aria-current='page']", text: "RSVPs")
       |> assert_has("#calendar-scope-mine .chip-count", text: "1")
       |> assert_has(
-        "#calendar-scope-groups.chip:not(.is-active)[href='/calendar/week?scope=groups']",
+        "#calendar-scope-groups.chip:not(.is-active)[href='/agenda?scope=groups']",
         text: "Groups"
       )
       |> assert_has("#calendar-scope-groups .chip-count", text: "2")
@@ -896,9 +898,9 @@ defmodule HuddlzWeb.CalendarLiveTest do
 
       conn
       |> login(attendee)
-      |> visit("/calendar/week")
+      |> visit("/agenda")
       |> assert_has("#calendar-first-run")
-      |> visit("/calendar/week?scope=groups")
+      |> visit("/agenda?scope=groups")
       |> refute_has("#calendar-first-run")
       |> assert_has("#calendar-entry-#{theirs.id} .cal-agenda-title", text: "Theirs")
       |> refute_has("#calendar-entry-#{theirs.id} .cal-entry-status")


### PR DESCRIPTION
Closes #545.

On short screens only the main navigation scrolled, in a strip above a fixed block of utility links and the account area. The aside is now the single scroll container and the navigation is no longer one of its own, so every sidebar section moves together and any item can be brought into view. On tall screens nothing changes: the navigation still grows to keep the account area at the bottom. The mobile drawer shares the rule and scrolls the same way.

## Tests

`test/browser/features/sidebar_scroll.feature` (`HUDDLZ_BROWSER_TEST=1 mix test.browser --only sidebar_browser`) runs at a new `@short` 1280×520 viewport with fourteen groups in the sidebar. It checks that the aside is the one scroll region, that tabbing reaches Sign out with the sidebar scrolled to show it, that scrolling back to the top brings the navigation into view and moves the account area away, and that the page behind is still usable. The full browser smoke suite passes.

`mix precommit` is clean.
