### PR TITLE
fix(organize): give the Show rate card an intentional empty state

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1785,6 +1785,7 @@ body .kpi .delta {
 body .kpi .value.muted { color: var(--muted); }
 body .kpi .delta.warn { color: var(--warn); }
 body .kpi .delta.muted { color: var(--muted); }
+body .kpi .delta a { color: var(--accent-ink); text-decoration: underline; text-underline-offset: 3px; }
 
 body .kpi .spark {
   margin-top: 12px;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1782,6 +1782,7 @@ body .kpi .delta {
   color: var(--accent-ink);
 }
 
+body .kpi .value.muted { color: var(--muted); }
 body .kpi .delta.warn { color: var(--warn); }
 body .kpi .delta.muted { color: var(--muted); }
 
@@ -1792,6 +1793,12 @@ body .kpi .spark {
   display: block;
   color: var(--accent-ink);
   opacity: 0.9;
+}
+
+/* Nothing to chart yet: a dashed baseline holds the tile's shape. */
+body .kpi .spark[data-empty] {
+  color: var(--line-strong);
+  opacity: 1;
 }
 
 /* ─────────────────────────────────────────  CHARTS  ──── */

--- a/lib/huddlz_web/components/sparkline.ex
+++ b/lib/huddlz_web/components/sparkline.ex
@@ -5,7 +5,10 @@ defmodule HuddlzWeb.Components.Sparkline do
   polyline.
 
   The points are also written to `data-points` so the figure can be read
-  back in words, by tests and by anyone inspecting the markup.
+  back in words, by tests and by anyone inspecting the markup. With no
+  points at all the box draws a muted dashed baseline and carries
+  `data-empty`, so a tile with nothing to chart keeps the shape of its
+  neighbours instead of ending in a blank.
   """
   use Phoenix.Component
 
@@ -25,8 +28,21 @@ defmodule HuddlzWeb.Components.Sparkline do
       aria-hidden="true"
       data-points={Enum.join(@points, ",")}
       data-count={length(@points)}
+      data-empty={@points == [] || nil}
     >
+      <line
+        :if={@points == []}
+        x1="0"
+        y1="24"
+        x2="100"
+        y2="24"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-dasharray="3 3"
+        vector-effect="non-scaling-stroke"
+      />
       <polyline
+        :if={@points != []}
         fill="none"
         stroke="currentColor"
         stroke-width="2"

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -564,7 +564,9 @@ defmodule HuddlzWeb.OrganizeLive do
       </div>
       <div id="kpi-showrate" class="kpi">
         <div class="label">Show rate</div>
-        <div class="value">{show_rate_value(@stats.turnout)}</div>
+        <div class={["value", @stats.turnout.counted == 0 && "muted"]}>
+          {show_rate_value(@stats.turnout)}
+        </div>
         <div class={["delta", @stats.turnout.counted == 0 && "muted"]}>
           <%= if @stats.turnout.counted == 0 do %>
             <.link navigate={~p"/organize/#{@group.slug}/huddlz?filter=past"}>Record turnout</.link>

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -28,6 +28,7 @@ The command builds the actual app assets, starts the test endpoint and Chromium,
 
 | Feature | Browser-specific acceptance check |
 | --- | --- |
+| Overview cards | The Show rate card is as tall as its neighbours before turnout is recorded and after recording it in place |
 | Sidebar scroll | A 1280×520 window: the aside is the one scroll region, Tab reaches Sign out with it scrolled into view, and scrolling the account area moves the same content |
 | Home location | ArrowDown/Enter select a suggestion without a native form submission |
 | Calendar | Actual `Intl` time-zone detection moves a late Denver huddl to the next New York calendar day |

--- a/test/browser/features/overview_cards.feature
+++ b/test/browser/features/overview_cards.feature
@@ -1,0 +1,7 @@
+@browser_smoke @cards_browser
+Feature: Overview summary cards in a browser
+  Scenario: The Show rate card matches its neighbours before and after turnout
+    Given I have opened the overview of a group with an uncounted past huddl
+    Then the Show rate card is as tall as the RSVPs card
+    When I record turnout from the overview reminder
+    Then the Show rate card shows a rate and is still as tall as the RSVPs card

--- a/test/browser/steps/overview_cards_steps.exs
+++ b/test/browser/steps/overview_cards_steps.exs
@@ -1,0 +1,80 @@
+defmodule BrowserOverviewCardsSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+
+  alias Huddlz.Communities.HuddlAttendee
+
+  step "I have opened the overview of a group with an uncounted past huddl", context do
+    owner = generate(user(role: :user))
+    group = generate(group(owner_id: owner.id, is_public: true, actor: owner))
+    starts_at = DateTime.add(DateTime.utc_now(), -2, :day)
+
+    huddl =
+      generate(
+        past_huddl(
+          title: "Elixir office hours",
+          group_id: group.id,
+          creator_id: owner.id,
+          is_private: false,
+          starts_at: starts_at,
+          ends_at: DateTime.add(starts_at, 2, :hour)
+        )
+      )
+
+    for _ <- 1..12 do
+      attendee = generate(user(role: :user))
+
+      HuddlAttendee
+      |> Ash.Changeset.for_create(:rsvp, %{huddl_id: huddl.id, user_id: attendee.id})
+      |> Ash.create!(authorize?: false)
+    end
+
+    conn =
+      context.conn
+      |> sign_in(owner)
+      |> visit("/organize/#{group.slug}")
+      |> assert_has(".phx-connected")
+      |> assert_has("#turnout-nudge", text: "Elixir office hours")
+
+    Map.merge(context, %{conn: conn, group: group})
+  end
+
+  step "the Show rate card is as tall as the RSVPs card", context do
+    Map.put(context, :conn, assert_same_height(context.conn))
+  end
+
+  step "I record turnout from the overview reminder", context do
+    conn =
+      context.conn
+      |> click_button("#turnout-nudge button", "Add turnout")
+      |> fill_in("People in the room", with: 6)
+      |> click_button("Save turnout")
+      |> assert_has("#flash-info", text: "Turnout saved")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the Show rate card shows a rate and is still as tall as the RSVPs card", context do
+    conn =
+      context.conn
+      |> assert_has("#kpi-showrate .value", text: "50%", exact: true)
+      |> assert_has("#spark-showrate:not([data-empty])")
+      |> assert_same_height()
+
+    Map.put(context, :conn, conn)
+  end
+
+  defp assert_same_height(conn) do
+    assert_browser(conn, """
+    (() => {
+      const rate = document.querySelector('#kpi-showrate').getBoundingClientRect();
+      const rsvps = document.querySelector('#kpi-rsvps').getBoundingClientRect();
+      const spark = document.querySelector('#spark-showrate').getBoundingClientRect();
+      return Math.abs(rate.height - rsvps.height) < 1 && rate.bottom - spark.bottom < 24;
+    })()
+    """)
+  end
+end

--- a/test/features/overview_turnout.feature
+++ b/test/features/overview_turnout.feature
@@ -51,3 +51,4 @@ Feature: Turnout on the overview
     Given the in-person huddl "Elixir office hours" in "Portland Elixir" ended 2 days ago with 12 RSVPs
     When I visit "/organize/portland-elixir"
     Then the Show rate KPI reads as not yet available and points at recording turnout
+    And the Show rate KPI draws an empty baseline where its sparkline would be

--- a/test/features/step_definitions/overview_turnout_steps.exs
+++ b/test/features/step_definitions/overview_turnout_steps.exs
@@ -85,6 +85,15 @@ defmodule OverviewTurnoutSteps do
     context
   end
 
+  step "the Show rate KPI draws an empty baseline where its sparkline would be",
+       %{session: session} = context do
+    session
+    |> assert_has("#spark-showrate[data-count='0'][data-empty] line")
+    |> assert_has("#kpi-showrate .value.muted")
+
+    context
+  end
+
   step "the turnout chart pairs {string} as {int} RSVPs and {int} came, with a capacity tick at {int}",
        %{args: [title, rsvps, came, capacity], session: session} = context do
     pair = pair(title)


### PR DESCRIPTION
Closes #547.

Before any turnout is recorded the Show rate card ended in a blank where the other summary cards draw their sparklines. The sparkline component now draws a muted dashed baseline when it has no points, and marks itself `data-empty`, so the card keeps the shape of its neighbours; the dash standing in for the rate is muted to match. The "Record turnout after a huddl" line is unchanged, so the empty state still says what is missing rather than showing a 0% rate. Recording turnout swaps the baseline for the real line without the card changing size.

## Tests

The overview turnout feature's "No show rate without counts" scenario now also checks the empty baseline and the muted value. A new browser scenario, `test/browser/features/overview_cards.feature` (`--only cards_browser`), opens the overview of a group with an uncounted past huddl, checks the Show rate card is as tall as the RSVPs card with the sparkline at the same depth, records turnout from the reminder in place, and checks the card shows the rate and is still the same height.

`mix precommit` is clean; the full browser smoke suite passes.
