### PR TITLE
Move the appearance choice to the header and rename Settings to Notifications

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -951,6 +951,72 @@ body .icon-pill .dot {
   box-sizing: content-box;
 }
 
+/* Appearance menu: a native popover anchored under its topbar trigger.
+   The fixed offsets mirror the topbar padding and control size for
+   browsers without anchor positioning. */
+body #theme-menu-trigger { anchor-name: --theme-trigger; }
+
+body .theme-menu {
+  position: fixed;
+  inset: auto;
+  top: 56px;
+  right: 86px;
+  margin: 0;
+  min-width: 232px;
+  padding: 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.24);
+}
+
+@supports (position-anchor: --theme-trigger) {
+  body .theme-menu {
+    position-anchor: --theme-trigger;
+    top: anchor(bottom);
+    right: anchor(right);
+    margin-top: 6px;
+  }
+}
+
+body .theme-menu-title {
+  padding: 6px 10px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+body .theme-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 40px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--soft);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+body .theme-option:hover { background: var(--panel-2); color: var(--text); }
+body .theme-option:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+body .theme-option[aria-checked="true"] { color: var(--text); }
+body .theme-option-icon { flex: 0 0 auto; color: var(--muted); }
+body .theme-option[aria-checked="true"] .theme-option-icon { color: var(--accent-ink); }
+body .theme-option-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+body .theme-option-hint { font-size: 12px; font-weight: 400; color: var(--muted); }
+body .theme-option-check { flex: 0 0 auto; margin-left: auto; color: var(--accent-ink); }
+
 body .icon-pill .notification-badge {
   position: absolute;
   top: -7px;
@@ -5945,6 +6011,7 @@ body .page-nav:disabled {
 @media (max-width: 760px) {
 
   body .content-topbar { height: 60px; padding: 0 12px; gap: 10px; }
+  body .theme-menu { top: 54px; right: 58px; }
   body .content-body { padding: 18px 12px 56px; }
   body .page-head { flex-direction: column; align-items: stretch; gap: 16px; margin-bottom: 20px; }
   body .page-head h1 { font-size: 26px; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5043,11 +5043,6 @@ body .settings-stack .settings-list .row {
 body .settings-stack .settings-list .row:first-child { padding-top: 8px; }
 body .settings-stack .settings-list .row .row-title { font-weight: 500; color: var(--text); }
 
-body .appearance-tabs { margin: 0; padding: 4px; border: 1px solid var(--line); }
-body .appearance-tabs .scope-tab { gap: 8px; }
-body .appearance-tabs .scope-tab .size-4 { color: var(--muted); }
-body .appearance-tabs .scope-tab.is-active .size-4 { color: var(--accent-ink); }
-
 body .settings-actions { display: flex; justify-content: flex-end; }
 
 body .toggle.is-locked { opacity: 0.6; cursor: default; }
@@ -6042,10 +6037,6 @@ body .page-nav:disabled {
   body .panel-head { margin: -14px -14px 14px; padding: 14px; }
   body .settings-stack .settings-list { margin: -14px; }
   body .settings-stack .settings-list .row { padding: 8px 14px; }
-  body .settings-stack .appearance-row { flex-direction: column; align-items: stretch; gap: 10px; padding: 12px 14px; }
-  body .settings-stack .appearance-row .row-title { text-align: left; }
-  body .appearance-tabs { display: flex; margin: 0; }
-  body .appearance-tabs .scope-tab { flex: 1 1 0; justify-content: center; }
   body .panel > .form-foot { margin: 14px -14px -14px; padding: 14px; }
   body .panel.split { gap: 18px; }
   body .visibility-panel-head { flex-direction: column; align-items: flex-start; gap: 10px; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,7 +29,7 @@ import {createCoverCropHook} from "./cover_crop.mjs"
 import {mountPageLoading} from "./page_loading.mjs"
 
 // The appearance setting lives on <html data-theme>, outside any LiveView.
-// Settings pushes a "theme" event after saving; "system" drops the attribute
+// The header menu pushes a "theme" event after saving; "system" drops the attribute
 // so the stylesheet's prefers-color-scheme rules take over.
 window.addEventListener("phx:theme", ({detail}) => {
   if (detail.theme === "system") {

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -110,7 +110,7 @@ Locked for v1, no re-litigation:
 4. `.ics` attachments ship in v1 on C2, E3, D1, D2.
 5. Defaults: Activity ON, Digest OFF, Transactional always on.
 
-## Settings page
+## Notifications page
 
 Lives under profile (`lib/huddlz_web/live/profile_live.ex`) or a new `/profile/notifications` route. One toggle per item below, stored in `User.notification_preferences` (JSONB map keyed by trigger code, e.g. `"huddl_new"`, `"huddl_reminder_24h"`, `"rsvp_received"`).
 

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -185,12 +185,12 @@ defmodule HuddlzWeb.Layouts do
             <span class="label">Profile</span>
           </.link>
           <.link
-            class={["sb-item", @active == "settings" && "active"]}
+            class={["sb-item", @active == "preferences" && "active"]}
             navigate={~p"/profile/notifications"}
-            aria-current={@active == "settings" && "page"}
+            aria-current={@active == "preferences" && "page"}
           >
-            <.nav_icon name="cog" />
-            <span class="label">Settings</span>
+            <.nav_icon name="bell" />
+            <span class="label">Notifications</span>
           </.link>
           <.link
             class={["sb-item", @active == "help" && "active"]}
@@ -513,21 +513,6 @@ defmodule HuddlzWeb.Layouts do
       stroke-linejoin="round"
     >
       <circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" />
-    </svg>
-    """
-  end
-
-  defp nav_icon(%{name: "cog"} = assigns) do
-    ~H"""
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.8"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" />
     </svg>
     """
   end

--- a/lib/huddlz_web/components/layouts.ex
+++ b/lib/huddlz_web/components/layouts.ex
@@ -264,6 +264,7 @@ defmodule HuddlzWeb.Layouts do
         </form>
         <div class="content-actions">
           <%= if @signed_in do %>
+            <.theme_menu current={theme_current(@current_user)} />
             <.link
               id="notification-nav-link"
               class={["icon-pill", @active == "notifications" && "active"]}
@@ -294,6 +295,68 @@ defmodule HuddlzWeb.Layouts do
       </div>
     </main>
     """
+  end
+
+  attr :current, :atom, required: true, values: [:system, :light, :dark]
+
+  # A native popover: the trigger's `popovertarget` opens it, each option's
+  # `popovertargetaction="hide"` closes it on pick, and the browser handles
+  # Escape, click-away and returning focus to the trigger.
+  defp theme_menu(assigns) do
+    ~H"""
+    <button
+      type="button"
+      id="theme-menu-trigger"
+      class="icon-pill"
+      popovertarget="theme-menu"
+      aria-label={"Appearance: #{theme_label(@current)}"}
+      title="Appearance"
+    >
+      <.icon name={theme_icon(@current)} class="size-4" />
+    </button>
+    <div id="theme-menu" class="theme-menu" popover="auto" role="menu" aria-label="Appearance">
+      <div class="theme-menu-title" aria-hidden="true">Appearance</div>
+      <button
+        :for={{value, label, icon, hint} <- theme_options()}
+        type="button"
+        class="theme-option"
+        role="menuitemradio"
+        aria-checked={to_string(@current == value)}
+        phx-click="set_theme"
+        phx-value-theme={value}
+        popovertarget="theme-menu"
+        popovertargetaction="hide"
+      >
+        <.icon name={icon} class="size-4 theme-option-icon" />
+        <span class="theme-option-text">
+          <span class="theme-option-label">{label}</span>
+          <span class="theme-option-hint">{hint}</span>
+        </span>
+        <.icon :if={@current == value} name="hero-check" class="size-4 theme-option-check" />
+      </button>
+    </div>
+    """
+  end
+
+  defp theme_options do
+    [
+      {:system, "System", "hero-computer-desktop", "Follows your device"},
+      {:light, "Light", "hero-sun", "Always light"},
+      {:dark, "Dark", "hero-moon", "Always dark"}
+    ]
+  end
+
+  defp theme_current(%{theme_preference: theme}) when theme in [:light, :dark], do: theme
+  defp theme_current(_user), do: :system
+
+  defp theme_label(current) do
+    {_value, label, _icon, _hint} = List.keyfind!(theme_options(), current, 0)
+    label
+  end
+
+  defp theme_icon(current) do
+    {_value, _label, icon, _hint} = List.keyfind!(theme_options(), current, 0)
+    icon
   end
 
   defp notification_label(0), do: "Notifications"

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -1,6 +1,6 @@
 defmodule HuddlzWeb.ProfileLive.Notifications do
   @moduledoc """
-  Settings page for the user's email notification preferences.
+  Notifications page: the user's email notification preferences.
 
   Renders one toggle per entry in `Huddlz.Notifications.Triggers`, grouped
   by category. Transactional triggers are shown disabled-but-on for
@@ -24,31 +24,12 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
 
     {:ok,
      socket
-     |> assign(:page_title, "Settings")
+     |> assign(:page_title, "Notifications")
      |> assign(:triggers_by_category, group_triggers())
      |> assign(:current_user, user)}
   end
 
   @impl true
-  def handle_event("set_theme", %{"theme" => theme}, socket) do
-    user = socket.assigns.current_user
-
-    user
-    |> Ash.Changeset.for_update(:update_theme_preference, %{theme_preference: theme}, actor: user)
-    |> Ash.update()
-    |> case do
-      {:ok, updated_user} ->
-        {:noreply,
-         socket
-         |> assign(:current_user, updated_user)
-         |> push_event("theme", %{theme: Atom.to_string(updated_user.theme_preference)})
-         |> put_flash(:info, "Appearance saved")}
-
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Could not save appearance")}
-    end
-  end
-
   def handle_event("save", %{"prefs" => prefs_params}, socket) do
     user = socket.assigns.current_user
     preferences = normalize_form_params(prefs_params)
@@ -80,51 +61,18 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
       current_user={@current_user}
       unread_notification_count={@unread_notification_count}
       sidebar_owned_groups={@sidebar_owned_groups}
-      active="settings"
+      active="preferences"
     >
       <div class="page-head">
         <div>
-          <h1>Settings</h1>
+          <h1>Notifications</h1>
           <p>
-            Appearance, notification preferences and other knobs. We'll add more here as huddlz grows.
+            Choose which emails huddlz sends you. Account and huddl essentials are always on.
           </p>
         </div>
       </div>
 
       <div class="settings-stack">
-        <form id="appearance-form" phx-change="set_theme">
-          <div class="panel">
-            <div class="panel-head">
-              <div>
-                <h2>Appearance</h2>
-                <div class="panel-sub">System follows your device. Light and Dark stay put.</div>
-              </div>
-            </div>
-            <div class="settings-list row-list">
-              <div class="row appearance-row">
-                <div class="row-title">Theme</div>
-                <fieldset class="scope-tabs appearance-tabs">
-                  <legend class="sr-only">Theme</legend>
-                  <label
-                    :for={{value, label, icon} <- theme_options()}
-                    class={["scope-tab", @current_user.theme_preference == value && "is-active"]}
-                  >
-                    <input
-                      type="radio"
-                      name="theme"
-                      value={value}
-                      checked={@current_user.theme_preference == value}
-                      class="sr-only"
-                    />
-                    <.icon name={icon} class="size-4" />
-                    {label}
-                  </label>
-                </fieldset>
-              </div>
-            </div>
-          </div>
-        </form>
-
         <form phx-submit="save" class="settings-stack">
           <.read_only_panel
             title="Transactional"
@@ -223,14 +171,6 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
       </div>
     </div>
     """
-  end
-
-  defp theme_options do
-    [
-      {:system, "System", "hero-computer-desktop"},
-      {:light, "Light", "hero-sun"},
-      {:dark, "Dark", "hero-moon"}
-    ]
   end
 
   defp group_triggers do

--- a/lib/huddlz_web/live_user_auth.ex
+++ b/lib/huddlz_web/live_user_auth.ex
@@ -88,8 +88,35 @@ defmodule HuddlzWeb.LiveUserAuth do
       |> assign_new(:unread_notification_count, fn -> load_unread_notification_count(socket) end)
       |> subscribe_to_organizer_access_changes()
       |> maybe_subscribe_to_unread_count()
+      |> maybe_attach_theme_menu()
 
     {:cont, socket}
+  end
+
+  # The topbar's appearance menu lives in the layout, so every LiveView that
+  # renders the app chrome answers its "set_theme" event here.
+  defp maybe_attach_theme_menu(%{assigns: %{current_user: %User{}}} = socket) do
+    Phoenix.LiveView.attach_hook(socket, :theme_menu, :handle_event, fn
+      "set_theme", %{"theme" => theme}, socket -> {:halt, set_theme(socket, theme)}
+      _event, _params, socket -> {:cont, socket}
+    end)
+  end
+
+  defp maybe_attach_theme_menu(socket), do: socket
+
+  defp set_theme(%{assigns: %{current_user: user}} = socket, theme) do
+    user
+    |> Ash.Changeset.for_update(:update_theme_preference, %{theme_preference: theme}, actor: user)
+    |> Ash.update()
+    |> case do
+      {:ok, updated} ->
+        socket
+        |> assign(:current_user, %{user | theme_preference: updated.theme_preference})
+        |> Phoenix.LiveView.push_event("theme", %{theme: Atom.to_string(updated.theme_preference)})
+
+      {:error, _changeset} ->
+        Phoenix.LiveView.put_flash(socket, :error, "Could not save appearance")
+    end
   end
 
   defp maybe_load_user_details(%{assigns: %{current_user: user}} = socket)

--- a/test/browser/features/appearance_menu.feature
+++ b/test/browser/features/appearance_menu.feature
@@ -1,0 +1,10 @@
+@browser_smoke @appearance_browser
+Feature: Appearance menu in a browser
+  Scenario: Switching appearance from the header with the keyboard
+    Given I have opened my agenda in a browser
+    When I open the appearance menu with the keyboard
+    And I pick "Dark" with the keyboard
+    Then the page uses the dark appearance and the menu is closed
+    When I open the appearance menu with the keyboard
+    And I press Escape
+    Then the menu is closed and focus is back on its trigger

--- a/test/browser/steps/appearance_menu_steps.exs
+++ b/test/browser/steps/appearance_menu_steps.exs
@@ -1,0 +1,65 @@
+defmodule BrowserAppearanceMenuSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+  import PhoenixTest.Playwright, only: [press: 3]
+
+  @menu_open "document.querySelector('#theme-menu').matches(':popover-open')"
+
+  step "I open the appearance menu with the keyboard", context do
+    conn =
+      context.conn
+      |> press("#theme-menu-trigger", "Enter")
+      |> assert_browser(@menu_open)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I pick {string} with the keyboard", %{args: [label]} = context do
+    conn = tab_to_option(context.conn, label)
+    Map.put(context, :conn, press(conn, ":focus", "Enter"))
+  end
+
+  step "the page uses the dark appearance and the menu is closed", context do
+    conn =
+      assert_browser(
+        context.conn,
+        "document.documentElement.dataset.theme === 'dark' && !#{@menu_open}"
+      )
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "I press Escape", context do
+    Map.put(context, :conn, press(context.conn, ":focus", "Escape"))
+  end
+
+  step "the menu is closed and focus is back on its trigger", context do
+    conn =
+      context.conn
+      |> assert_browser("!#{@menu_open}")
+      |> assert_has("#theme-menu-trigger:focus")
+
+    Map.put(context, :conn, conn)
+  end
+
+  # Tab from the trigger into the menu, one option at a time, until the
+  # wanted one has focus.
+  defp tab_to_option(conn, label, tries \\ 4)
+
+  defp tab_to_option(_conn, label, 0), do: flunk("no appearance option labelled #{label}")
+
+  defp tab_to_option(conn, label, tries) do
+    conn = press(conn, ":focus", "Tab")
+
+    {:ok, focused} =
+      PlaywrightEx.Frame.evaluate(conn.frame_id,
+        expression: "document.activeElement.querySelector('.theme-option-label')?.textContent",
+        timeout: 5_000
+      )
+
+    if focused == label, do: conn, else: tab_to_option(conn, label, tries - 1)
+  end
+end

--- a/test/features/appearance.feature
+++ b/test/features/appearance.feature
@@ -1,29 +1,32 @@
 @async @database @conn
 Feature: Appearance preference
   As a user
-  I want huddlz to follow my device's appearance, or to pick light or dark myself
+  I want huddlz to follow my device's appearance, or to pick light or dark myself from the header
   So that the app looks right wherever I read it
 
   Scenario: Signed-out visitors follow their device
     When I visit "/"
     Then the page should follow the device appearance
+    And there is no appearance menu
 
   Scenario: New users follow their device by default
     Given I am signed in as "theme-default@example.com" with password "Password123!"
-    When I visit "/profile/notifications"
-    Then I should see "Appearance"
+    When I visit "/agenda"
+    Then the appearance menu marks "System" as current
     And the page should follow the device appearance
 
-  Scenario: User switches to light mode
+  Scenario: User switches to light mode from the header
     Given I am signed in as "theme-light@example.com" with password "Password123!"
-    When I visit "/profile/notifications"
-    And I choose "Light"
-    Then I should see "Appearance saved"
+    When I visit "/agenda"
+    And I choose the "Light" appearance from the header
+    Then the appearance menu marks "Light" as current
     And the page should use the "light" appearance
+    When I visit "/discover"
+    Then the page should use the "light" appearance
 
   Scenario: User switches back to their device's appearance
     Given I am signed in as "theme-system@example.com" with password "Password123!"
-    When I visit "/profile/notifications"
-    And I choose "Dark"
-    And I choose "System"
+    When I visit "/agenda"
+    And I choose the "Dark" appearance from the header
+    And I choose the "System" appearance from the header
     Then the page should follow the device appearance

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -1,21 +1,23 @@
 @async @database @conn
-Feature: Notification preferences settings page
+Feature: Notification preferences page
   As a user
   I want to control which emails huddlz sends me
   So that my inbox reflects what I actually care about
 
-  Scenario: User opts out of an activity-tier notification
+  Scenario: The notifications page holds only notification preferences
     Given I am signed in as "settings@example.com" with password "Password123!"
     When I visit "/profile/notifications"
-    Then I should see "notification preferences and other knobs"
-    And I should see "Activity"
+    Then I should see "Notifications" as the page heading
+    And I should see "Choose which emails huddlz sends you"
+    And I should not see "Theme"
     And I should see "Your group role changed"
     When I uncheck "Confirmation when I RSVP to a huddl"
     And I click "Save preferences"
     Then I should see "Notification preferences saved"
 
-  Scenario: User can reach the notifications page from the profile sidebar
+  Scenario: User can reach notification preferences from the sidebar
     Given I am signed in as "linknav@example.com" with password "Password123!"
     When I go to my profile page
-    And I click "Settings"
-    Then I should see "notification preferences and other knobs"
+    And I click "Notifications" in the sidebar
+    Then I should see "Choose which emails huddlz sends you"
+    And the sidebar marks "Notifications" as the current page

--- a/test/features/step_definitions/appearance_steps.exs
+++ b/test/features/step_definitions/appearance_steps.exs
@@ -9,8 +9,30 @@ defmodule AppearanceSteps do
   use Cucumber.StepDefinition
   import ExUnit.Assertions
   import Phoenix.ConnTest
+  import PhoenixTest
 
   @endpoint HuddlzWeb.Endpoint
+
+  step "there is no appearance menu", context do
+    refute_has(session(context), "#theme-menu-trigger")
+    context
+  end
+
+  step "the appearance menu marks {string} as current", %{args: [label]} = context do
+    assert_has(
+      session(context),
+      "#theme-menu [role=menuitemradio][aria-checked=true] .theme-option-label",
+      text: label,
+      exact: true
+    )
+
+    context
+  end
+
+  step "I choose the {string} appearance from the header", %{args: [label]} = context do
+    session = click_button(session(context), "#theme-menu [role=menuitemradio]", label)
+    Map.merge(context, %{session: session, conn: session})
+  end
 
   step "the page should follow the device appearance", context do
     assert html_theme(context) == nil
@@ -22,11 +44,11 @@ defmodule AppearanceSteps do
     {:ok, context}
   end
 
-  defp html_theme(context) do
-    session = context[:session] || context[:conn]
+  defp session(context), do: context[:session] || context[:conn]
 
+  defp html_theme(context) do
     conn =
-      case session do
+      case session(context) do
         %Plug.Conn{} = conn -> conn
         %{conn: %Plug.Conn{} = conn} -> conn
       end

--- a/test/features/step_definitions/shared_ui_steps.exs
+++ b/test/features/step_definitions/shared_ui_steps.exs
@@ -78,7 +78,26 @@ defmodule SharedUISteps do
     Map.merge(context, %{session: session, conn: session})
   end
 
+  step "I click {string} in the sidebar", %{args: [text]} = context do
+    session = context[:session] || context[:conn]
+    session = click_link(session, "aside.sidebar a", text)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
   # Content assertions
+  step "I should see {string} as the page heading", %{args: [text]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "h1", text: text, exact: true)
+    context
+  end
+
+  step "the sidebar marks {string} as the current page", %{args: [text]} = context do
+    session = context[:session] || context[:conn]
+    assert_has(session, "aside.sidebar a[aria-current=page]", text: text, exact: true)
+    context
+  end
+
   step "I should see {string}", %{args: [text]} = context do
     session = context[:session] || context[:conn]
     assert_has(session, "*", text: text)

--- a/test/features/unsubscribe.feature
+++ b/test/features/unsubscribe.feature
@@ -11,7 +11,7 @@ Feature: Unsubscribe URL
     And the user "unsub@example.com" should not have trigger "rsvp_received" disabled
     When I confirm the unsubscribe
     Then I should see "Unsubscribed from"
-    And I should see "notification preferences and other knobs"
+    And I should see "Choose which emails huddlz sends you"
     And the user "unsub@example.com" should have trigger "rsvp_received" disabled
 
   Scenario: An invalid unsubscribe token redirects with an error

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -5,7 +5,7 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
   import Huddlz.Test.Helpers.Authentication
 
   setup do
-    user = create_user(%{display_name: "Settings User"})
+    user = create_user(%{display_name: "Preferences User"})
     %{user: user}
   end
 
@@ -16,13 +16,13 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       |> assert_path("/sign-in")
     end
 
-    test "renders v3 chrome with Settings sidebar item active", %{conn: conn, user: user} do
+    test "renders v3 chrome with the Notifications sidebar item active", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/profile/notifications")
-      |> assert_has("h1", text: "Settings")
+      |> assert_has("h1", text: "Notifications")
       |> assert_has("aside.sidebar")
-      |> assert_has(".sb-item.active", text: "Settings")
+      |> assert_has(".sb-item.active", text: "Notifications")
     end
 
     test "renders the three category panels in v3 chrome", %{conn: conn, user: user} do
@@ -43,17 +43,11 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       |> assert_has(".row .toggle.is-locked .toggle-text", text: "Always on")
     end
 
-    test "stacks the appearance and preference panels", %{conn: conn, user: user} do
+    test "holds only the three preference panels and a save button", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/profile/notifications")
-      |> assert_has(".settings-stack #appearance-form .panel .appearance-row .row-title",
-        text: "Theme"
-      )
-      |> assert_has(".appearance-row .appearance-tabs label.scope-tab", count: 3)
-      |> assert_has(".appearance-tabs label.scope-tab.is-active .hero-computer-desktop")
-      |> assert_has(".appearance-tabs label.scope-tab .hero-sun")
-      |> assert_has(".appearance-tabs label.scope-tab .hero-moon")
+      |> refute_has("*", text: "Theme")
       |> assert_has(".settings-stack form.settings-stack .panel", count: 3)
       |> assert_has(".settings-stack .settings-actions button[type=submit]",
         text: "Save preferences"


### PR DESCRIPTION
Closes #548

- The System / Light / Dark choice is a native popover on the topbar, left of the bell, shown when signed in. Picking an option saves it as before and closes the menu; Escape and click-away close it and the browser returns focus to the trigger.
- The layout renders the menu and the `:app` on_mount answers its `set_theme` event, so it works on every page with the app chrome.
- The page under `/profile/notifications` is now Notifications: sidebar label and bell icon, heading, browser title and intro copy. The Appearance panel and its CSS are gone. The route is unchanged.
- Features: `appearance.feature` drives the header menu; `notification_settings.feature` and `unsubscribe.feature` read the new copy; a browser scenario opens the menu with the keyboard, picks Dark, and closes it with Escape.
