### PR TITLE
Save notification preferences as they are flipped

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5043,9 +5043,60 @@ body .settings-stack .settings-list .row {
 body .settings-stack .settings-list .row:first-child { padding-top: 8px; }
 body .settings-stack .settings-list .row .row-title { font-weight: 500; color: var(--text); }
 
-body .settings-actions { display: flex; justify-content: flex-end; }
+/* Preference rows: label on the left, a switch on the right with a fading
+   "Saved" beside it. Transactional emails are a plain locked list. */
+body .pref-row .row-title { cursor: pointer; }
+body .pref-control { display: inline-flex; align-items: center; gap: 12px; flex: 0 0 auto; }
+body .pref-control .toggle { align-self: center; }
 
-body .toggle.is-locked { opacity: 0.6; cursor: default; }
+body .pref-saved {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-ink);
+  animation: pref-saved-fade 2.4s ease forwards;
+}
+
+body .pref-saved::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+@keyframes pref-saved-fade {
+  0%, 60% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body .pref-saved { animation: none; }
+}
+
+body .pref-failed { font-size: 12px; font-weight: 600; color: var(--danger); }
+
+body .always-sent {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 24px;
+}
+
+body .always-sent li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--soft);
+  line-height: 1.4;
+}
+
+body .always-sent li .size-4 { flex: 0 0 auto; margin-top: 2px; color: var(--muted); }
 
 /* daisyUI's .toggle paints its own knob in ::before on a non-input element;
    the knob here lives in .track::after. */
@@ -6036,6 +6087,7 @@ body .page-nav:disabled {
   body .panel { padding: 14px 14px; }
   body .panel-head { margin: -14px -14px 14px; padding: 14px; }
   body .settings-stack .settings-list { margin: -14px; }
+  body .always-sent { grid-template-columns: 1fr; }
   body .settings-stack .settings-list .row { padding: 8px 14px; }
   body .panel > .form-foot { margin: 14px -14px -14px; padding: 14px; }
   body .panel.split { gap: 18px; }

--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -32,7 +32,10 @@ defmodule HuddlzWeb.Components.Input do
     assigns =
       assigns
       |> assign(:checked, checked)
-      |> assign(:visible_label, toggle_label(assigns.label, assigns.show_state_text, checked))
+      |> assign(
+        :visible_label,
+        toggle_label(assigns.label, assigns.show_state_text, assigns.labelled_externally, checked)
+      )
 
     ~H"""
     <div class="toggle">
@@ -49,7 +52,7 @@ defmodule HuddlzWeb.Components.Input do
         disabled={@disabled}
       />
       <span class="track" aria-hidden="true"></span>
-      <span class="toggle-text" aria-hidden="true">{@visible_label}</span>
+      <span :if={@visible_label} class="toggle-text" aria-hidden="true">{@visible_label}</span>
       <label for={@field.id} class="toggle-hitbox" aria-hidden={@labelled_externally}>
         <span :if={!@labelled_externally} class="sr-only">{@label}</span>
       </label>
@@ -320,7 +323,10 @@ defmodule HuddlzWeb.Components.Input do
   defp help_id(id), do: "#{id}-help"
   defp error_id(id, index), do: "#{id}-error-#{index}"
 
-  defp toggle_label(_label, true, true), do: "On"
-  defp toggle_label(_label, true, false), do: "Off"
-  defp toggle_label(label, false, _checked), do: label
+  # State words when asked for; otherwise the label, unless a visible label
+  # already sits outside the switch.
+  defp toggle_label(_label, true, _external, true), do: "On"
+  defp toggle_label(_label, true, _external, false), do: "Off"
+  defp toggle_label(_label, false, true, _checked), do: nil
+  defp toggle_label(label, false, false, _checked), do: label
 end

--- a/lib/huddlz_web/components/input.ex
+++ b/lib/huddlz_web/components/input.ex
@@ -19,6 +19,7 @@ defmodule HuddlzWeb.Components.Input do
   attr :show_state_text, :boolean, default: false
   attr :labelled_externally, :boolean, default: false
   attr :disabled, :boolean, default: false
+  attr :rest, :global
 
   @doc """
   Renders a native checkbox with switch semantics.
@@ -50,6 +51,7 @@ defmodule HuddlzWeb.Components.Input do
         aria-checked={to_string(@checked)}
         aria-label={!@labelled_externally && @label}
         disabled={@disabled}
+        {@rest}
       />
       <span class="track" aria-hidden="true"></span>
       <span :if={@visible_label} class="toggle-text" aria-hidden="true">{@visible_label}</span>

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -2,14 +2,17 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   @moduledoc """
   Notifications page: the user's email notification preferences.
 
-  Renders one toggle per entry in `Huddlz.Notifications.Triggers`, grouped
-  by category. Transactional triggers are shown disabled-but-on for
-  transparency. Activity and digest triggers are editable. Submitting the
-  form merges the changes onto `User.notification_preferences` via the
-  `:update_notification_preferences` Ash action.
+  Renders one switch per editable entry in `Huddlz.Notifications.Triggers`,
+  grouped by category. Each switch saves as soon as it is flipped, merging
+  that one key onto `User.notification_preferences` through the
+  `:update_notification_preferences` action, and the row confirms with a
+  fading "Saved". Transactional triggers are listed as always sent, without
+  controls.
   """
 
   use HuddlzWeb, :live_view
+
+  import HuddlzWeb.Components.Input, only: [toggle: 1]
 
   alias Huddlz.Notifications
   alias Huddlz.Notifications.Triggers
@@ -26,18 +29,22 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
      socket
      |> assign(:page_title, "Notifications")
      |> assign(:triggers_by_category, group_triggers())
-     |> assign(:current_user, user)}
+     |> assign(:current_user, user)
+     |> assign(:form, preferences_form(user))
+     |> assign(:saved, nil)
+     |> assign(:failed, nil)
+     |> assign(:save_seq, 0)}
   end
 
   @impl true
-  def handle_event("save", %{"prefs" => prefs_params}, socket) do
+  def handle_event("toggle", %{"_target" => ["prefs", key], "prefs" => prefs}, socket) do
     user = socket.assigns.current_user
-    preferences = normalize_form_params(prefs_params)
+    enabled = Map.get(prefs, key) == "true"
 
     user
     |> Ash.Changeset.for_update(
       :update_notification_preferences,
-      %{preferences: preferences},
+      %{preferences: %{key => enabled}},
       actor: user
     )
     |> Ash.update()
@@ -46,12 +53,21 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
         {:noreply,
          socket
          |> assign(:current_user, updated_user)
-         |> put_flash(:info, "Notification preferences saved")}
+         |> assign(:form, preferences_form(updated_user))
+         |> assign(:saved, key)
+         |> assign(:failed, nil)
+         |> update(:save_seq, &(&1 + 1))}
 
       {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Could not save preferences")}
+        {:noreply,
+         socket
+         |> assign(:form, preferences_form(user))
+         |> assign(:saved, nil)
+         |> assign(:failed, key)}
     end
   end
+
+  def handle_event("toggle", _params, socket), do: {:noreply, socket}
 
   @impl true
   def render(assigns) do
@@ -66,39 +82,33 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
       <div class="page-head">
         <div>
           <h1>Notifications</h1>
-          <p>
-            Choose which emails huddlz sends you. Account and huddl essentials are always on.
-          </p>
+          <p>Choose which emails huddlz sends you. Changes save as you flip them.</p>
         </div>
       </div>
 
-      <div class="settings-stack">
-        <form phx-submit="save" class="settings-stack">
-          <.read_only_panel
-            title="Transactional"
-            description="Critical account and huddl updates. Always on, these can't be disabled."
-            triggers={@triggers_by_category.transactional}
-          />
+      <form id="notification-preferences" phx-change="toggle" class="settings-stack">
+        <.category_panel
+          title="Activity"
+          description="Things that happen in groups and huddlz you're part of."
+          triggers={@triggers_by_category.activity}
+          form={@form}
+          saved={@saved}
+          failed={@failed}
+          save_seq={@save_seq}
+        />
 
-          <.category_panel
-            title="Activity"
-            description="Things that happen in groups and huddlz you're part of."
-            triggers={@triggers_by_category.activity}
-            user={@current_user}
-          />
+        <.category_panel
+          title="Digests"
+          description="Optional summaries. Off unless you turn them on."
+          triggers={@triggers_by_category.digest}
+          form={@form}
+          saved={@saved}
+          failed={@failed}
+          save_seq={@save_seq}
+        />
 
-          <.category_panel
-            title="Digest"
-            description="Optional summaries. Off by default."
-            triggers={@triggers_by_category.digest}
-            user={@current_user}
-          />
-
-          <div class="settings-actions">
-            <.button variant={:primary} type="submit">Save preferences</.button>
-          </div>
-        </form>
-      </div>
+        <.always_sent_panel triggers={@triggers_by_category.transactional} />
+      </form>
     </Layouts.app>
     """
   end
@@ -106,7 +116,10 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   attr :title, :string, required: true
   attr :description, :string, required: true
   attr :triggers, :list, required: true
-  attr :user, :any, required: true
+  attr :form, Phoenix.HTML.Form, required: true
+  attr :saved, :string, default: nil
+  attr :failed, :string, default: nil
+  attr :save_seq, :integer, required: true
 
   defp category_panel(assigns) do
     ~H"""
@@ -118,59 +131,62 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
         </div>
       </div>
       <div class="settings-list row-list pref-list">
-        <div :for={{trigger, entry} <- @triggers} class="row">
-          <div>
-            <label class="row-title" for={"prefs-#{Triggers.preference_key(trigger)}"}>
-              {entry.label}
-            </label>
-          </div>
-          <label class="toggle">
-            <input type="hidden" name={"prefs[#{Triggers.preference_key(trigger)}]"} value="false" />
-            <input
-              id={"prefs-#{Triggers.preference_key(trigger)}"}
-              type="checkbox"
-              name={"prefs[#{Triggers.preference_key(trigger)}]"}
-              value="true"
-              checked={Notifications.preference_for(@user, trigger)}
-            />
-            <span class="track"></span>
-            <span class="toggle-text">
-              {if Notifications.preference_for(@user, trigger), do: "On", else: "Off"}
-            </span>
+        <div :for={{trigger, entry} <- @triggers} class="row pref-row">
+          <label class="row-title" for={@form[Triggers.preference_key(trigger)].id}>
+            {entry.label}
           </label>
+          <div class="pref-control">
+            <span
+              :if={@saved == Triggers.preference_key(trigger)}
+              id={"pref-saved-#{Triggers.preference_key(trigger)}-#{@save_seq}"}
+              class="pref-saved"
+              role="status"
+            >
+              Saved
+            </span>
+            <span :if={@failed == Triggers.preference_key(trigger)} class="pref-failed" role="alert">
+              Couldn't save. Try again.
+            </span>
+            <.toggle
+              field={@form[Triggers.preference_key(trigger)]}
+              label={entry.label}
+              labelled_externally
+            />
+          </div>
         </div>
       </div>
     </div>
     """
   end
 
-  attr :title, :string, required: true
-  attr :description, :string, required: true
   attr :triggers, :list, required: true
 
-  defp read_only_panel(assigns) do
+  defp always_sent_panel(assigns) do
     ~H"""
     <div class="panel">
       <div class="panel-head">
         <div>
-          <h2>{@title}</h2>
-          <div class="panel-sub">{@description}</div>
+          <h2>Always sent</h2>
+          <div class="panel-sub">Account and huddl essentials. These go out no matter what.</div>
         </div>
       </div>
-      <div class="settings-list row-list pref-list">
-        <div :for={{_trigger, entry} <- @triggers} class="row">
-          <div>
-            <div class="row-title">{entry.label}</div>
-          </div>
-          <span class="toggle is-locked">
-            <input type="checkbox" checked disabled />
-            <span class="track"></span>
-            <span class="toggle-text">Always on</span>
-          </span>
-        </div>
-      </div>
+      <ul id="always-sent" class="always-sent">
+        <li :for={{_trigger, entry} <- @triggers}>
+          <.icon name="hero-lock-closed" class="size-4" />
+          <span>{entry.label}</span>
+        </li>
+      </ul>
     </div>
     """
+  end
+
+  defp preferences_form(user) do
+    Triggers.all()
+    |> Enum.reject(fn {_trigger, entry} -> entry.category == :transactional end)
+    |> Map.new(fn {trigger, _entry} ->
+      {Triggers.preference_key(trigger), Notifications.preference_for(user, trigger)}
+    end)
+    |> to_form(as: :prefs)
   end
 
   defp group_triggers do
@@ -182,21 +198,6 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   end
 
   defp sort_entries(entries) do
-    entries
-    |> Enum.sort_by(fn {_atom, entry} -> entry.label end)
-  end
-
-  # The form only sends keys for *checked* boxes (we don't render a hidden
-  # paired input). Iterate every editable trigger so the saved map stays
-  # exhaustive: missing keys become `false`.
-  defp normalize_form_params(form_prefs) do
-    all_editable_keys =
-      Triggers.all()
-      |> Enum.reject(fn {_atom, entry} -> entry.category == :transactional end)
-      |> Enum.map(fn {atom, _entry} -> Triggers.preference_key(atom) end)
-
-    Enum.into(all_editable_keys, %{}, fn key ->
-      {key, Map.get(form_prefs, key) == "true"}
-    end)
+    Enum.sort_by(entries, fn _atom_entry = {_atom, entry} -> entry.label end)
   end
 end

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -67,7 +67,8 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
          socket
          |> assign(:form, preferences_form(user))
          |> assign(:saved, nil)
-         |> assign(:failed, key)}
+         |> assign(:failed, key)
+         |> update(:save_seq, &(&1 + 1))}
     end
   end
 
@@ -141,10 +142,12 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
             <span :if={@failed == Triggers.preference_key(trigger)} class="pref-failed" role="alert">
               Couldn't save. Try again.
             </span>
+            <%!-- Patch the switch on every failed attempt even when its saved value is unchanged. --%>
             <.toggle
               field={@form[Triggers.preference_key(trigger)]}
               label={entry.label}
               labelled_externally
+              data-save-failure={if @failed == Triggers.preference_key(trigger), do: @save_seq}
             />
           </div>
         </div>

--- a/lib/huddlz_web/live/profile_live/notifications.ex
+++ b/lib/huddlz_web/live/profile_live/notifications.ex
@@ -2,12 +2,16 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   @moduledoc """
   Notifications page: the user's email notification preferences.
 
-  Renders one switch per editable entry in `Huddlz.Notifications.Triggers`,
-  grouped by category. Each switch saves as soon as it is flipped, merging
-  that one key onto `User.notification_preferences` through the
+  Renders one switch per activity entry in `Huddlz.Notifications.Triggers`.
+  Each switch saves as soon as it is flipped, merging that one key onto
+  `User.notification_preferences` through the
   `:update_notification_preferences` action, and the row confirms with a
   fading "Saved". Transactional triggers are listed as always sent, without
   controls.
+
+  Digest triggers are registered but have no senders yet (issue #561), so
+  the page hides them rather than offering switches that do nothing. Saved
+  digest preferences are kept for when they ship.
   """
 
   use HuddlzWeb, :live_view
@@ -97,16 +101,6 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
           save_seq={@save_seq}
         />
 
-        <.category_panel
-          title="Digests"
-          description="Optional summaries. Off unless you turn them on."
-          triggers={@triggers_by_category.digest}
-          form={@form}
-          saved={@saved}
-          failed={@failed}
-          save_seq={@save_seq}
-        />
-
         <.always_sent_panel triggers={@triggers_by_category.transactional} />
       </form>
     </Layouts.app>
@@ -181,8 +175,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   end
 
   defp preferences_form(user) do
-    Triggers.all()
-    |> Enum.reject(fn {_trigger, entry} -> entry.category == :transactional end)
+    Triggers.by_category(:activity)
     |> Map.new(fn {trigger, _entry} ->
       {Triggers.preference_key(trigger), Notifications.preference_for(user, trigger)}
     end)
@@ -192,8 +185,7 @@ defmodule HuddlzWeb.ProfileLive.Notifications do
   defp group_triggers do
     %{
       transactional: sort_entries(Triggers.by_category(:transactional)),
-      activity: sort_entries(Triggers.by_category(:activity)),
-      digest: sort_entries(Triggers.by_category(:digest))
+      activity: sort_entries(Triggers.by_category(:activity))
     }
   end
 

--- a/test/browser/features/notification_preferences.feature
+++ b/test/browser/features/notification_preferences.feature
@@ -1,0 +1,8 @@
+@browser_smoke @preferences_browser
+Feature: Notification preferences in a browser
+  Scenario: A save that fails puts the switch back
+    Given I have opened my notification preferences in a browser
+    And my account has been removed underneath the page
+    When I flip "Confirmation when I RSVP to a huddl" off
+    Then the row says the change could not be saved
+    And "Confirmation when I RSVP to a huddl" is shown as on

--- a/test/browser/features/notification_preferences.feature
+++ b/test/browser/features/notification_preferences.feature
@@ -6,3 +6,7 @@ Feature: Notification preferences in a browser
     When I flip "Confirmation when I RSVP to a huddl" off
     Then the row says the change could not be saved
     And "Confirmation when I RSVP to a huddl" is shown as on
+    When I flip "Confirmation when I RSVP to a huddl" off
+    Then the row says the change could not be saved
+    And "Confirmation when I RSVP to a huddl" is shown as on
+    And the preference switch keeps keyboard focus

--- a/test/browser/steps/notification_preferences_steps.exs
+++ b/test/browser/steps/notification_preferences_steps.exs
@@ -1,0 +1,50 @@
+defmodule BrowserNotificationPreferencesSteps do
+  use Cucumber.StepDefinition
+
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+  import PhoenixTest.Playwright, only: [click: 3]
+
+  step "I have opened my notification preferences in a browser", context do
+    member = generate(user(role: :user))
+
+    conn =
+      context.conn
+      |> sign_in(member)
+      |> visit("/profile/notifications")
+      |> assert_has(".phx-connected")
+      |> assert_has("h1", text: "Notifications")
+
+    Map.merge(context, %{conn: conn, member: member})
+  end
+
+  step "my account has been removed underneath the page", context do
+    Huddlz.Repo.delete!(context.member)
+    context
+  end
+
+  # A person flips a switch by clicking its row label; the checkbox itself
+  # is visually hidden behind the track.
+  step "I flip {string} off", %{args: [label]} = context do
+    Map.put(context, :conn, click(context.conn, "label.row-title", label))
+  end
+
+  step "the row says the change could not be saved", context do
+    Map.put(context, :conn, assert_has(context.conn, "[role=alert]", text: "Couldn't save"))
+  end
+
+  step "{string} is shown as on", %{args: [label]} = context do
+    conn =
+      assert_browser(context.conn, """
+      (() => {
+        const label = [...document.querySelectorAll('label')]
+          .find((l) => l.textContent.trim() === #{Jason.encode!(label)});
+        const input = label && document.getElementById(label.htmlFor);
+        return !!input && input.checked && input.getAttribute('aria-checked') === 'true';
+      })()
+      """)
+
+    Map.put(context, :conn, conn)
+  end
+end

--- a/test/browser/steps/notification_preferences_steps.exs
+++ b/test/browser/steps/notification_preferences_steps.exs
@@ -27,7 +27,7 @@ defmodule BrowserNotificationPreferencesSteps do
   # A person flips a switch by clicking its row label; the checkbox itself
   # is visually hidden behind the track.
   step "I flip {string} off", %{args: [label]} = context do
-    Map.put(context, :conn, click(context.conn, "label.row-title", label))
+    Map.put(context, :conn, click(context.conn, "label", label))
   end
 
   step "the row says the change could not be saved", context do
@@ -44,6 +44,13 @@ defmodule BrowserNotificationPreferencesSteps do
         return !!input && input.checked && input.getAttribute('aria-checked') === 'true';
       })()
       """)
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the preference switch keeps keyboard focus", context do
+    conn =
+      assert_browser(context.conn, "document.activeElement?.getAttribute('role') === 'switch'")
 
     Map.put(context, :conn, conn)
   end

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -13,13 +13,11 @@ Feature: Notification preferences
     When I visit "/profile/notifications"
     Then "Confirmation when I RSVP to a huddl" is off
 
-  Scenario: Turning a digest on saves right away
+  Scenario: Digests stay hidden until they exist
     Given I am signed in as "digest@example.com" with password "Password123!"
     When I visit "/profile/notifications"
-    And I turn on "Weekly digest of upcoming huddlz"
-    Then the page confirms the change was saved
-    When I visit "/profile/notifications"
-    Then "Weekly digest of upcoming huddlz" is on
+    Then I should not see "Digests"
+    And "Weekly digest of upcoming huddlz" has no switch
 
   Scenario: Essentials are listed without switches
     Given I am signed in as "essentials@example.com" with password "Password123!"

--- a/test/features/notification_settings.feature
+++ b/test/features/notification_settings.feature
@@ -1,19 +1,31 @@
 @async @database @conn
-Feature: Notification preferences page
+Feature: Notification preferences
   As a user
   I want to control which emails huddlz sends me
   So that my inbox reflects what I actually care about
 
-  Scenario: The notifications page holds only notification preferences
+  Scenario: Turning an email off saves right away
     Given I am signed in as "settings@example.com" with password "Password123!"
     When I visit "/profile/notifications"
-    Then I should see "Notifications" as the page heading
-    And I should see "Choose which emails huddlz sends you"
-    And I should not see "Theme"
-    And I should see "Your group role changed"
-    When I uncheck "Confirmation when I RSVP to a huddl"
-    And I click "Save preferences"
-    Then I should see "Notification preferences saved"
+    And I turn off "Confirmation when I RSVP to a huddl"
+    Then the page confirms the change was saved
+    And there is no Save button
+    When I visit "/profile/notifications"
+    Then "Confirmation when I RSVP to a huddl" is off
+
+  Scenario: Turning a digest on saves right away
+    Given I am signed in as "digest@example.com" with password "Password123!"
+    When I visit "/profile/notifications"
+    And I turn on "Weekly digest of upcoming huddlz"
+    Then the page confirms the change was saved
+    When I visit "/profile/notifications"
+    Then "Weekly digest of upcoming huddlz" is on
+
+  Scenario: Essentials are listed without switches
+    Given I am signed in as "essentials@example.com" with password "Password123!"
+    When I visit "/profile/notifications"
+    Then the always-sent list names "Password changed"
+    And "Password changed" has no switch
 
   Scenario: User can reach notification preferences from the sidebar
     Given I am signed in as "linknav@example.com" with password "Password123!"

--- a/test/features/private_group_invitations.feature
+++ b/test/features/private_group_invitations.feature
@@ -143,9 +143,8 @@ Feature: Private group invitations
   Scenario: Registered recipients keep their invitation email preference
     Given I am signed in as "invitee@example.com"
     When I visit "/profile/notifications"
-    And I uncheck "I was invited to a group"
-    And I click "Save preferences"
-    Then I should see "Notification preferences saved"
+    And I turn off "I was invited to a group"
+    Then the page confirms the change was saved
     Given I am signed in as "owner@example.com"
     When I open the member workspace for "Quiet Makers"
     And I submit a member invitation for "invitee@example.com"
@@ -164,9 +163,8 @@ Feature: Private group invitations
     And I start registration without an invitation link
     And I complete registration as "new-maker@example.com"
     And I visit "/profile/notifications"
-    And I uncheck "I was invited to a group"
-    And I click "Save preferences"
-    Then I should see "Notification preferences saved"
+    And I turn off "I was invited to a group"
+    Then the page confirms the change was saved
     And no invitation email should be sent to "new-maker@example.com"
 
     When I confirm the registration email sent to "new-maker@example.com"

--- a/test/features/step_definitions/notification_preferences_steps.exs
+++ b/test/features/step_definitions/notification_preferences_steps.exs
@@ -4,8 +4,6 @@ defmodule NotificationPreferencesSteps do
   import ExUnit.Assertions
   import PhoenixTest
 
-  alias Huddlz.Notifications.Triggers
-
   step "I turn off {string}", %{args: [label]} = context do
     session = uncheck(session(context), label)
     Map.merge(context, %{session: session, conn: session})
@@ -27,12 +25,12 @@ defmodule NotificationPreferencesSteps do
   end
 
   step "{string} is off", %{args: [label]} = context do
-    assert_has(session(context), switch_for(label) <> "[aria-checked=false]")
+    assert switch_state(session(context), label) == "false"
     context
   end
 
   step "{string} is on", %{args: [label]} = context do
-    assert_has(session(context), switch_for(label) <> "[aria-checked=true]")
+    assert switch_state(session(context), label) == "true"
     context
   end
 
@@ -42,17 +40,34 @@ defmodule NotificationPreferencesSteps do
   end
 
   step "{string} has no switch", %{args: [label]} = context do
-    refute_has(session(context), switch_for(label))
+    assert switch_state(session(context), label) == nil
     context
   end
 
   defp session(context), do: context[:session] || context[:conn]
 
-  defp switch_for(label) do
-    {trigger, _entry} =
-      Enum.find(Triggers.all(), fn {_trigger, entry} -> entry.label == label end) ||
-        flunk("no notification trigger labelled #{inspect(label)}")
+  # Follow the visible label to its switch and read the switch's state:
+  # "true" / "false", or nil when nothing labelled that way is a switch.
+  defp switch_state(session, label) do
+    document = Floki.parse_document!(page_html(session))
 
-    "input[role=switch][name='prefs[#{Triggers.preference_key(trigger)}]']"
+    document
+    |> Floki.find("label")
+    |> Enum.find(fn node -> String.trim(Floki.text(node)) == label end)
+    |> case do
+      nil ->
+        nil
+
+      node ->
+        [id] = Floki.attribute(node, "for")
+
+        case Floki.find(document, "##{id}[role=switch]") do
+          [switch] -> switch |> Floki.attribute("aria-checked") |> List.first()
+          [] -> nil
+        end
+    end
   end
+
+  defp page_html(%PhoenixTest.Live{view: view}), do: Phoenix.LiveViewTest.render(view)
+  defp page_html(%PhoenixTest.Static{conn: conn}), do: conn.resp_body
 end

--- a/test/features/step_definitions/notification_preferences_steps.exs
+++ b/test/features/step_definitions/notification_preferences_steps.exs
@@ -1,0 +1,58 @@
+defmodule NotificationPreferencesSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import PhoenixTest
+
+  alias Huddlz.Notifications.Triggers
+
+  step "I turn off {string}", %{args: [label]} = context do
+    session = uncheck(session(context), label)
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I turn on {string}", %{args: [label]} = context do
+    session = check(session(context), label)
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "the page confirms the change was saved", context do
+    assert_has(session(context), "*", text: "Saved", exact: true)
+    context
+  end
+
+  step "there is no Save button", context do
+    refute_has(session(context), "button", text: "Save")
+    context
+  end
+
+  step "{string} is off", %{args: [label]} = context do
+    assert_has(session(context), switch_for(label) <> "[aria-checked=false]")
+    context
+  end
+
+  step "{string} is on", %{args: [label]} = context do
+    assert_has(session(context), switch_for(label) <> "[aria-checked=true]")
+    context
+  end
+
+  step "the always-sent list names {string}", %{args: [label]} = context do
+    assert_has(session(context), "#always-sent li", text: label)
+    context
+  end
+
+  step "{string} has no switch", %{args: [label]} = context do
+    refute_has(session(context), switch_for(label))
+    context
+  end
+
+  defp session(context), do: context[:session] || context[:conn]
+
+  defp switch_for(label) do
+    {trigger, _entry} =
+      Enum.find(Triggers.all(), fn {_trigger, entry} -> entry.label == label end) ||
+        flunk("no notification trigger labelled #{inspect(label)}")
+
+    "input[role=switch][name='prefs[#{Triggers.preference_key(trigger)}]']"
+  end
+end

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -25,13 +25,13 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       |> assert_has(".sb-item.active", text: "Notifications")
     end
 
-    test "renders the three category panels in v3 chrome", %{conn: conn, user: user} do
+    test "renders the activity and always-sent panels", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/profile/notifications")
       |> assert_has(".panel-head h2", text: "Activity")
-      |> assert_has(".panel-head h2", text: "Digests")
       |> assert_has(".panel-head h2", text: "Always sent")
+      |> refute_has(".panel-head h2", text: "Digests")
     end
 
     test "lists the essentials without switches", %{conn: conn, user: user} do
@@ -49,17 +49,17 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       |> visit("/profile/notifications")
       |> uncheck("Confirmation when I RSVP to a huddl")
       |> assert_has("[role=status]", text: "Saved")
-      |> check("Weekly digest of upcoming huddlz")
+      |> check("Someone joined a group I organize")
 
       reloaded = Ash.get!(Huddlz.Accounts.User, user.id, actor: user)
       assert reloaded.notification_preferences["rsvp_confirmation"] == false
-      assert reloaded.notification_preferences["weekly_digest"] == true
+      assert reloaded.notification_preferences["group_member_joined"] == true
 
       conn
       |> login(user)
       |> visit("/profile/notifications")
       |> assert_has("input[role=switch][name='prefs[rsvp_confirmation]'][aria-checked=false]")
-      |> assert_has("input[role=switch][name='prefs[weekly_digest]'][aria-checked=true]")
+      |> assert_has("input[role=switch][name='prefs[group_member_joined]'][aria-checked=true]")
     end
   end
 end

--- a/test/huddlz_web/live/profile_live/notifications_test.exs
+++ b/test/huddlz_web/live/profile_live/notifications_test.exs
@@ -29,40 +29,27 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       conn
       |> login(user)
       |> visit("/profile/notifications")
-      |> assert_has(".panel-head h2", text: "Transactional")
-      |> assert_has("*", text: "Critical account and huddl updates")
       |> assert_has(".panel-head h2", text: "Activity")
-      |> assert_has(".panel-head h2", text: "Digest")
+      |> assert_has(".panel-head h2", text: "Digests")
+      |> assert_has(".panel-head h2", text: "Always sent")
     end
 
-    test "transactional toggles are disabled", %{conn: conn, user: user} do
+    test "lists the essentials without switches", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/profile/notifications")
-      |> assert_has(".row .toggle.is-locked input[type=checkbox][disabled]")
-      |> assert_has(".row .toggle.is-locked .toggle-text", text: "Always on")
+      |> assert_has("#always-sent li", text: "Password changed")
+      |> refute_has("input[role=switch][name='prefs[password_changed]']")
+      |> refute_has("button", text: "Save")
     end
 
-    test "holds only the three preference panels and a save button", %{conn: conn, user: user} do
-      conn
-      |> login(user)
-      |> visit("/profile/notifications")
-      |> refute_has("*", text: "Theme")
-      |> assert_has(".settings-stack form.settings-stack .panel", count: 3)
-      |> assert_has(".settings-stack .settings-actions button[type=submit]",
-        text: "Save preferences"
-      )
-    end
-
-    test "saving with an activity preference unchecked persists the change",
-         %{conn: conn, user: user} do
+    test "flipping a switch saves that preference on its own", %{conn: conn, user: user} do
       conn
       |> login(user)
       |> visit("/profile/notifications")
       |> uncheck("Confirmation when I RSVP to a huddl")
+      |> assert_has("[role=status]", text: "Saved")
       |> check("Weekly digest of upcoming huddlz")
-      |> click_button("Save preferences")
-      |> assert_has("*", text: "Notification preferences saved")
 
       reloaded = Ash.get!(Huddlz.Accounts.User, user.id, actor: user)
       assert reloaded.notification_preferences["rsvp_confirmation"] == false
@@ -71,8 +58,8 @@ defmodule HuddlzWeb.ProfileLive.NotificationsTest do
       conn
       |> login(user)
       |> visit("/profile/notifications")
-      |> assert_has("#prefs-rsvp_confirmation:not([checked])")
-      |> assert_has("#prefs-weekly_digest[checked]")
+      |> assert_has("input[role=switch][name='prefs[rsvp_confirmation]'][aria-checked=false]")
+      |> assert_has("input[role=switch][name='prefs[weekly_digest]'][aria-checked=true]")
     end
   end
 end


### PR DESCRIPTION
Closes #559

- Every switch saves as soon as it is flipped: the form's `phx-change` names the changed key, and only that key is merged through `update_notification_preferences`. The row shows a fading "Saved"; a failed save shows "Couldn't save. Try again." on the row instead.
- The Save button and the On/Off words are gone. Switches are the shared `toggle/1` with `role="switch"`, labelled by the row title.
- Transactional emails are an "Always sent" list with a lock mark, two columns on desktop, instead of eight disabled switches.
- The Digests panel is hidden: its two triggers have no senders yet (#561), so a switch there saved but never sent anything. Saved digest preferences are kept.
- `toggle/1` no longer repeats the label beside the track when the label sits outside the switch.
- Features: the preferences, private-group invitation and unsubscribe scenarios flip a switch and read the confirmation instead of pressing Save; a new scenario checks digests stay hidden.
