### PR TITLE
Redesign the organizer members page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2240,12 +2240,7 @@ body .row.member-row {
 }
 body .member-row .member-mark { width: 36px; height: 36px; font-size: 12px; }
 body .member-copy { min-width: 0; }
-body .member-copy .row-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-body .member-copy .meta { white-space: nowrap; }
+body .member-copy .row-title { overflow-wrap: anywhere; }
 body .invitation-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
 body .member-menu-trigger { color: var(--muted); cursor: pointer; }
 body .member-menu-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2165,7 +2165,6 @@ body .row .row-title .title-tag {
 
 /* Used by org-huddlz / org-members lists */
 body .row.huddlz-row { grid-template-columns: 56px 1fr 130px 120px 120px 80px; }
-body .row.members-row { grid-template-columns: 48px 1fr 120px 110px; }
 
 /* Used by /groups/:slug/locations — title + trailing Rename/Delete buttons. */
 body .row.location-row { grid-template-columns: 1fr auto; gap: 18px; }
@@ -2233,6 +2232,57 @@ body .role-section-head h3 {
 }
 body .role-section-head .count { font-size: 12px; }
 body .role-section-empty { font-size: 13px; }
+
+/* Roster rows: the person's mark, name and join date, then one quiet menu. */
+body .row.member-row {
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  gap: 12px;
+}
+body .member-row .member-mark { width: 36px; height: 36px; font-size: 12px; }
+body .member-copy { min-width: 0; }
+body .member-copy .row-title { overflow-wrap: anywhere; }
+body .member-menu-trigger { color: var(--muted); cursor: pointer; }
+body .member-menu-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* A native popover menu; the PopoverMenu hook places it beside its trigger. */
+body .row-menu {
+  position: fixed;
+  inset: auto;
+  margin: 0;
+  width: 232px;
+  padding: 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.24);
+}
+
+body .row-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 40px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+body .row-menu-item:hover { background: var(--panel-2); }
+body .row-menu-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+body .row-menu-icon { flex: 0 0 auto; color: var(--muted); }
+body .row-menu-item.is-danger,
+body .row-menu-item.is-danger .row-menu-icon { color: var(--danger); }
+body .row-menu-item.is-danger:hover { background: var(--danger-soft); }
 
 /* Trailing CTA inside a panel (e.g. "Create your first huddl" empty state). */
 body .panel-cta { margin-top: 16px; }
@@ -6119,8 +6169,7 @@ body .page-nav:disabled {
   body .grid { gap: 16px; }
   body .insight-strip { gap: 8px; }
   /* Listings on org pages: collapse multi-column rows */
-  body .row.huddlz-row, body .row.members-row { grid-template-columns: 56px 1fr; row-gap: 8px; }
-  body .row.members-row { grid-template-columns: 48px 1fr; }
+  body .row.huddlz-row { grid-template-columns: 56px 1fr; row-gap: 8px; }
   /* Land marketing */
   body .land-topbar { height: 64px; padding: 0 16px; }
   body .land-hero { padding: 48px 16px 40px; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2240,7 +2240,13 @@ body .row.member-row {
 }
 body .member-row .member-mark { width: 36px; height: 36px; font-size: 12px; }
 body .member-copy { min-width: 0; }
-body .member-copy .row-title { overflow-wrap: anywhere; }
+body .member-copy .row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+body .member-copy .meta { white-space: nowrap; }
+body .invitation-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
 body .member-menu-trigger { color: var(--muted); cursor: pointer; }
 body .member-menu-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,6 +27,7 @@ import {mountMobileNavigation} from "./mobile_navigation.mjs"
 import {createCoverImageHook} from "./cover_image.mjs"
 import {createCoverCropHook} from "./cover_crop.mjs"
 import {mountPageLoading} from "./page_loading.mjs"
+import {createPopoverMenuHook} from "./popover_menu.mjs"
 
 // The appearance setting lives on <html data-theme>, outside any LiveView.
 // The header menu pushes a "theme" event after saving; "system" drops the attribute
@@ -43,6 +44,7 @@ const Hooks = {}
 
 Hooks.CoverImage = createCoverImageHook()
 Hooks.CoverCrop = createCoverCropHook()
+Hooks.PopoverMenu = createPopoverMenuHook()
 
 Hooks.LocationAutocomplete = {
   mounted() {

--- a/assets/js/popover_menu.mjs
+++ b/assets/js/popover_menu.mjs
@@ -1,0 +1,60 @@
+// Places a native popover menu beside the button that opened it.
+//
+// Popovers render in the top layer, so without CSS anchor positioning a
+// stylesheet cannot pin one to its trigger. This hook does the same
+// arithmetic on `beforetoggle`, measuring in the next animation frame so
+// the menu is placed before its first paint. The browser still owns
+// opening, light dismiss, Escape and focus return.
+const GAP = 6
+const EDGE = 8
+
+// Where a menu of `menu` size goes for a `trigger` rectangle inside
+// `viewport`: below the trigger and right-aligned to it, flipped above when
+// there is no room below, never past the viewport's edges.
+export function placeMenu({trigger, menu, viewport}) {
+  const rightAligned = trigger.right - menu.width
+  const left = Math.max(EDGE, Math.min(rightAligned, viewport.width - menu.width - EDGE))
+
+  const below = trigger.bottom + GAP
+  const fitsBelow = below + menu.height <= viewport.height - EDGE
+  const top = fitsBelow ? below : Math.max(EDGE, trigger.top - GAP - menu.height)
+
+  return {top, left}
+}
+
+export function createPopoverMenuHook({windowRef = window, requestFrame = requestAnimationFrame} = {}) {
+  return {
+    mounted() {
+      this.onBeforeToggle = event => {
+        if (event.newState === "open") requestFrame(() => this.place())
+      }
+      this.onViewportChange = () => {
+        if (this.el.matches(":popover-open")) this.el.hidePopover()
+      }
+
+      this.el.addEventListener("beforetoggle", this.onBeforeToggle)
+      windowRef.addEventListener("scroll", this.onViewportChange, {capture: true, passive: true})
+      windowRef.addEventListener("resize", this.onViewportChange)
+    },
+
+    destroyed() {
+      this.el.removeEventListener("beforetoggle", this.onBeforeToggle)
+      windowRef.removeEventListener("scroll", this.onViewportChange, {capture: true})
+      windowRef.removeEventListener("resize", this.onViewportChange)
+    },
+
+    place() {
+      const trigger = document.querySelector(`[popovertarget="${this.el.id}"]`)
+      if (!trigger) return
+
+      const {top, left} = placeMenu({
+        trigger: trigger.getBoundingClientRect(),
+        menu: {width: this.el.offsetWidth, height: this.el.offsetHeight},
+        viewport: {width: windowRef.innerWidth, height: windowRef.innerHeight}
+      })
+
+      this.el.style.top = `${top}px`
+      this.el.style.left = `${left}px`
+    }
+  }
+}

--- a/assets/js/popover_menu_test.mjs
+++ b/assets/js/popover_menu_test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {placeMenu} from "./popover_menu.mjs"
+
+const viewport = {width: 1000, height: 800}
+const menu = {width: 232, height: 130}
+
+test("opens below the trigger, right-aligned to it", () => {
+  const trigger = {top: 300, bottom: 336, right: 900}
+  assert.deepEqual(placeMenu({trigger, menu, viewport}), {top: 342, left: 668})
+})
+
+test("flips above the trigger when there is no room below", () => {
+  const trigger = {top: 720, bottom: 756, right: 900}
+  assert.deepEqual(placeMenu({trigger, menu, viewport}), {top: 584, left: 668})
+})
+
+test("stays inside a narrow viewport", () => {
+  const trigger = {top: 100, bottom: 136, right: 200}
+  const phone = {width: 320, height: 720}
+  assert.deepEqual(placeMenu({trigger, menu, viewport: phone}), {top: 142, left: 8})
+})

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -1289,7 +1289,7 @@ defmodule HuddlzWeb.OrganizeLive do
           <div :for={{id, entry} <- rows} id={id} class="row member-row">
             <.person_mark user={entry.user} />
             <div class="member-copy">
-              <div class="row-title">{member_name(entry)}</div>
+              <div class="row-title" title={member_name(entry)}>{member_name(entry)}</div>
               <div class="meta">{format_member_meta(entry)}</div>
             </div>
             <.member_menu
@@ -1432,32 +1432,40 @@ defmodule HuddlzWeb.OrganizeLive do
           <p id="invitations-empty" class="hidden only:block muted role-section-empty">
             No invitations yet.
           </p>
-          <div :for={{id, invitation} <- @invitations} id={id} class="row row-split">
-            <div>
-              <div class="row-title">{invitation_recipient(invitation)}</div>
-              <div class="meta">
-                {role_label(invitation.role)} · {invitation_status_label(invitation.status)}
+          <div :for={{id, invitation} <- @invitations} id={id} class="row member-row">
+            <.person_mark user={invitation_person(invitation)} />
+            <div class="member-copy">
+              <div class="row-title" title={invitation_recipient(invitation)}>
+                {invitation_recipient(invitation)}
+              </div>
+              <div class="meta invitation-meta">
+                {role_label(invitation.role)}
+                <span class="pill">{invitation_status_label(invitation.status)}</span>
               </div>
             </div>
-            <button
-              :if={invitation.status == :pending && Ash.can?({invitation, :revoke}, @current_user)}
-              id={"revoke-invitation-#{invitation.id}"}
-              type="button"
-              class="pill"
-              phx-click="revoke_invitation"
-              phx-value-id={invitation.id}
-            >
-              Revoke
-            </button>
-            <span :if={invitation.status != :pending} class="pill">
-              {invitation_status_label(invitation.status)}
-            </span>
+            <div>
+              <button
+                :if={invitation.status == :pending && Ash.can?({invitation, :revoke}, @current_user)}
+                id={"revoke-invitation-#{invitation.id}"}
+                type="button"
+                class="pill"
+                phx-click="revoke_invitation"
+                phx-value-id={invitation.id}
+              >
+                Revoke
+              </button>
+            </div>
           </div>
         </div>
       </div>
     </div>
     """
   end
+
+  defp invitation_person(%{invitee: nil, email: email}),
+    do: %{id: to_string(email), display_name: to_string(email)}
+
+  defp invitation_person(%{invitee: invitee}), do: invitee
 
   defp invitation_recipient(%{invitee: nil, email: email}), do: to_string(email)
   defp invitation_recipient(invitation), do: member_name(%{user: invitation.invitee})

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -9,7 +9,7 @@ defmodule HuddlzWeb.OrganizeLive do
     * `/organize` — landing picker (owned groups + create CTA, or empty state)
     * `/organize/:group_slug` — overview (KPIs + next huddl)
     * `/organize/:group_slug/huddlz` — huddlz list, lifecycle filters
-    * `/organize/:group_slug/members` — roster grouped by role
+    * `/organize/:group_slug/members` — roster grouped by role, one menu per person
     * `/organize/:group_slug/settings` — owner-only group administration
   """
   use HuddlzWeb, :live_view
@@ -1262,54 +1262,45 @@ defmodule HuddlzWeb.OrganizeLive do
     <div class="page-head">
       <div>
         <h1>Members</h1>
-        <p>Who's part of {@group.name}.</p>
+        <p>{people_count(@group.member_count)} · {visibility_label(@group.is_public)} group</p>
       </div>
       <div class="actions">
         <a :if={@can_edit_group} class="btn-secondary" href={~p"/groups/#{@group.slug}/edit"}>Edit group</a>
       </div>
     </div>
 
-    <div class="panel">
-      <div class="panel-head">
-        <div>
-          <h2>{member_count_heading(@group.member_count)}</h2>
-          <div class="panel-sub">
-            {visibility_label(@group.is_public)} group · {member_label(@group.member_count)}
-          </div>
+    <div class="panel roster">
+      <section
+        :for={{role, rows, count} <- @grouped}
+        class="role-section"
+        aria-labelledby={"role-#{role}-heading"}
+      >
+        <div class="role-section-head">
+          <h3 id={"role-#{role}-heading"}>{role_heading(role)}</h3>
+          <span :if={role != :owner} class="muted count">{count}</span>
         </div>
-      </div>
-
-      <%= for {role, rows, count} <- @grouped do %>
-        <div class="role-section">
-          <div class="role-section-head">
-            <h3>{role_heading(role)}</h3>
-            <span :if={role != :owner} class="muted count">({count})</span>
-          </div>
-          <div id={"#{role}-member-rows"} class="row-list" phx-update="stream">
-            <p
-              id={"#{role}-member-rows-empty"}
-              class="hidden only:block muted role-section-empty"
-            >
-              {role_empty_copy(role)}
-            </p>
-            <div :for={{id, entry} <- rows} id={id} class="row row-split gap-4">
-              <div>
-                <div class="row-title">{member_name(entry)}</div>
-                <div class="meta">{format_member_meta(entry)}</div>
-              </div>
-              <div class="flex flex-wrap items-center justify-end gap-2">
-                <span class={["pill", role_pill_class(role)]}>{role_label(role)}</span>
-                <.member_actions
-                  :if={is_nil(@group.archived_at)}
-                  entry={entry}
-                  group={@group}
-                  current_user={@current_user}
-                />
-              </div>
+        <div id={"#{role}-member-rows"} class="row-list" phx-update="stream">
+          <p
+            id={"#{role}-member-rows-empty"}
+            class="hidden only:block muted role-section-empty"
+          >
+            {role_empty_copy(role)}
+          </p>
+          <div :for={{id, entry} <- rows} id={id} class="row member-row">
+            <.person_mark user={entry.user} />
+            <div class="member-copy">
+              <div class="row-title">{member_name(entry)}</div>
+              <div class="meta">{format_member_meta(entry)}</div>
             </div>
+            <.member_menu
+              :if={is_nil(@group.archived_at)}
+              entry={entry}
+              group={@group}
+              current_user={@current_user}
+            />
           </div>
         </div>
-      <% end %>
+      </section>
     </div>
     """
   end
@@ -1482,11 +1473,16 @@ defmodule HuddlzWeb.OrganizeLive do
   defp invitation_status_label(:revoked), do: "Revoked"
   defp invitation_status_label(:expired), do: "Expired"
 
+  # One quiet menu per person holding exactly the actions the viewer may
+  # take on them. A native popover: the trigger's `popovertarget` opens it,
+  # each item's `popovertargetaction="hide"` closes it on pick, the browser
+  # handles Escape, click-away and focus return, and the PopoverMenu hook
+  # places it beside its trigger.
   attr :entry, :map, required: true
   attr :group, :map, required: true
   attr :current_user, :map, required: true
 
-  defp member_actions(assigns) do
+  defp member_menu(assigns) do
     assigns =
       assign(assigns,
         can_promote:
@@ -1494,47 +1490,91 @@ defmodule HuddlzWeb.OrganizeLive do
         can_demote:
           member_action_allowed?(:demote, assigns.entry, assigns.group, assigns.current_user),
         can_remove:
-          member_action_allowed?(:remove, assigns.entry, assigns.group, assigns.current_user)
+          member_action_allowed?(:remove, assigns.entry, assigns.group, assigns.current_user),
+        label: "Manage #{member_name(assigns.entry)}",
+        menu_id: "member-menu-#{assigns.entry.id}"
       )
 
     ~H"""
-    <div
-      :if={@can_promote or @can_demote or @can_remove}
-      class="flex flex-wrap justify-end gap-2"
-      aria-label={"Manage #{member_name(@entry)}"}
-    >
-      <.button
-        :if={@can_promote}
-        id={"promote-member-#{@entry.id}"}
-        phx-click="open_member_action"
-        phx-value-id={@entry.id}
-        phx-value-action="promote"
-        class="text-sm"
+    <div :if={@can_promote or @can_demote or @can_remove} class="member-menu">
+      <button
+        type="button"
+        id={"#{@menu_id}-trigger"}
+        class="icon-pill member-menu-trigger"
+        popovertarget={@menu_id}
+        aria-label={@label}
+        aria-haspopup="menu"
       >
-        Promote
-      </.button>
-      <.button
-        :if={@can_demote}
-        id={"demote-member-#{@entry.id}"}
-        phx-click="open_member_action"
-        phx-value-id={@entry.id}
-        phx-value-action="demote"
-        class="text-sm"
+        <.icon name="hero-ellipsis-horizontal" class="size-4" />
+      </button>
+      <div
+        id={@menu_id}
+        class="row-menu"
+        popover="auto"
+        role="menu"
+        aria-label={@label}
+        phx-hook="PopoverMenu"
       >
-        Demote
-      </.button>
-      <.button
-        :if={@can_remove}
-        id={"remove-member-#{@entry.id}"}
-        variant={:destructive}
-        phx-click="open_member_action"
-        phx-value-id={@entry.id}
-        phx-value-action="remove"
-        class="text-sm"
-      >
-        Remove
-      </.button>
+        <.member_menu_item
+          :if={@can_promote}
+          id={"promote-member-#{@entry.id}"}
+          menu={@menu_id}
+          entry={@entry}
+          action="promote"
+          icon="hero-arrow-up-circle"
+        >
+          Promote to organizer
+        </.member_menu_item>
+        <.member_menu_item
+          :if={@can_demote}
+          id={"demote-member-#{@entry.id}"}
+          menu={@menu_id}
+          entry={@entry}
+          action="demote"
+          icon="hero-arrow-down-circle"
+        >
+          Demote to member
+        </.member_menu_item>
+        <.member_menu_item
+          :if={@can_remove}
+          id={"remove-member-#{@entry.id}"}
+          menu={@menu_id}
+          entry={@entry}
+          action="remove"
+          icon="hero-user-minus"
+          danger
+        >
+          Remove from group
+        </.member_menu_item>
+      </div>
     </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :menu, :string, required: true
+  attr :entry, :map, required: true
+  attr :action, :string, required: true
+  attr :icon, :string, required: true
+  attr :danger, :boolean, default: false
+  slot :inner_block, required: true
+
+  defp member_menu_item(assigns) do
+    ~H"""
+    <button
+      type="button"
+      id={@id}
+      class={["row-menu-item", @danger && "is-danger"]}
+      role="menuitem"
+      phx-click="open_member_action"
+      phx-value-id={@entry.id}
+      phx-value-action={@action}
+      popovertarget={@menu}
+      popovertargetaction="hide"
+    >
+      <.icon name={@icon} class="size-4 row-menu-icon" />
+      {render_slot(@inner_block)}
+    </button>
     """
   end
 
@@ -1970,18 +2010,14 @@ defmodule HuddlzWeb.OrganizeLive do
   defp role_label(:organizer), do: "Organizer"
   defp role_label(:member), do: "Member"
 
-  defp role_pill_class(:owner), do: "cyan"
-  defp role_pill_class(:organizer), do: "warn"
-  defp role_pill_class(_), do: nil
-
   defp role_empty_copy(:organizer),
     do: "No organizers yet. Promote a member to organizer to share the load."
 
   defp role_empty_copy(:member), do: "Nobody has joined yet."
   defp role_empty_copy(_), do: ""
 
-  defp member_count_heading(1), do: "1 person in this group"
-  defp member_count_heading(n), do: "#{n} people in this group"
+  defp people_count(1), do: "1 person"
+  defp people_count(n), do: "#{n} people"
 
   defp member_name(%{user: %{display_name: name}}) when is_binary(name) and name != "", do: name
   defp member_name(%{user: %{email: email}}) when is_binary(email), do: email
@@ -1992,7 +2028,7 @@ defmodule HuddlzWeb.OrganizeLive do
 
   defp format_member_meta(_), do: ""
 
-  defp format_date_short(%DateTime{} = at), do: Calendar.strftime(at, "%b %d, %Y")
+  defp format_date_short(%DateTime{} = at), do: Calendar.strftime(at, "%b %-d, %Y")
 
   defp visibility_label(true), do: "Public"
   defp visibility_label(false), do: "Private"

--- a/lib/huddlz_web/live/organize_live.ex
+++ b/lib/huddlz_web/live/organize_live.ex
@@ -1289,7 +1289,7 @@ defmodule HuddlzWeb.OrganizeLive do
           <div :for={{id, entry} <- rows} id={id} class="row member-row">
             <.person_mark user={entry.user} />
             <div class="member-copy">
-              <div class="row-title" title={member_name(entry)}>{member_name(entry)}</div>
+              <div class="row-title">{member_name(entry)}</div>
               <div class="meta">{format_member_meta(entry)}</div>
             </div>
             <.member_menu
@@ -1435,9 +1435,7 @@ defmodule HuddlzWeb.OrganizeLive do
           <div :for={{id, invitation} <- @invitations} id={id} class="row member-row">
             <.person_mark user={invitation_person(invitation)} />
             <div class="member-copy">
-              <div class="row-title" title={invitation_recipient(invitation)}>
-                {invitation_recipient(invitation)}
-              </div>
+              <div class="row-title">{invitation_recipient(invitation)}</div>
               <div class="meta invitation-meta">
                 {role_label(invitation.role)}
                 <span class="pill">{invitation_status_label(invitation.status)}</span>

--- a/test/browser/features/member_menu.feature
+++ b/test/browser/features/member_menu.feature
@@ -1,0 +1,10 @@
+@browser_smoke @member_menu_browser
+Feature: Member menu in a browser
+  Scenario: Working a member's menu with the keyboard
+    Given I have opened a group's roster in a browser
+    When I open the menu for "Member Maya" with the keyboard
+    And I press Escape
+    Then the member menu is closed and focus is back on its button
+    When I open the menu for "Member Maya" with the keyboard
+    And I choose "Promote to organizer" with the keyboard
+    Then the promotion confirmation is open and the menu is closed

--- a/test/browser/steps/member_menu_steps.exs
+++ b/test/browser/steps/member_menu_steps.exs
@@ -1,0 +1,87 @@
+defmodule BrowserMemberMenuSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import Huddlz.Generator
+  import Huddlz.Test.BrowserHelpers
+  import PhoenixTest
+  import PhoenixTest.Playwright, only: [press: 3]
+
+  step "I have opened a group's roster in a browser", context do
+    owner = generate(user(role: :user, display_name: "Owner Olive"))
+    member = generate(user(role: :user, display_name: "Member Maya"))
+
+    {group, _memberships} =
+      generate_group_with_members(
+        owner: owner,
+        group: [name: "Roster Keyboard", slug: "roster-keyboard"],
+        members: [%{user: member, role: :member}]
+      )
+
+    conn =
+      context.conn
+      |> sign_in(owner)
+      |> visit("/organize/#{group.slug}/members")
+      |> assert_has("h1", text: "Members")
+
+    Map.merge(context, %{conn: conn, owner: owner, member: member, group: group})
+  end
+
+  step "I open the menu for {string} with the keyboard", %{args: [name]} = context do
+    conn =
+      context.conn
+      |> press(trigger_for(name), "Enter")
+      |> assert_browser(menu_open(name))
+
+    Map.merge(context, %{conn: conn, menu_name: name})
+  end
+
+  step "I choose {string} with the keyboard", %{args: [label]} = context do
+    conn = tab_to_item(context.conn, label)
+    Map.put(context, :conn, press(conn, ":focus", "Enter"))
+  end
+
+  step "the member menu is closed and focus is back on its button", context do
+    name = context.menu_name
+
+    conn =
+      context.conn
+      |> assert_browser("!#{menu_open(name)}")
+      |> assert_has("#{trigger_for(name)}:focus")
+
+    Map.put(context, :conn, conn)
+  end
+
+  step "the promotion confirmation is open and the menu is closed", context do
+    conn =
+      context.conn
+      |> assert_has("[role='dialog']", text: "Promote #{context.menu_name}?")
+      |> assert_browser("!#{menu_open(context.menu_name)}")
+
+    Map.put(context, :conn, conn)
+  end
+
+  defp trigger_for(name), do: "button[aria-label='Manage #{name}']"
+
+  defp menu_open(name),
+    do:
+      "document.querySelector(\"[role='menu'][aria-label='Manage #{name}']\").matches(':popover-open')"
+
+  # Tab from the trigger into the menu, one item at a time, until the wanted
+  # one has focus.
+  defp tab_to_item(conn, label, tries \\ 4)
+
+  defp tab_to_item(_conn, label, 0), do: flunk("no menu item labelled #{label}")
+
+  defp tab_to_item(conn, label, tries) do
+    conn = press(conn, ":focus", "Tab")
+
+    {:ok, focused} =
+      PlaywrightEx.Frame.evaluate(conn.frame_id,
+        expression: "document.activeElement.textContent.trim()",
+        timeout: 5_000
+      )
+
+    if focused == label, do: conn, else: tab_to_item(conn, label, tries - 1)
+  end
+end

--- a/test/features/organizer_members_page.feature
+++ b/test/features/organizer_members_page.feature
@@ -1,0 +1,43 @@
+@async @database @conn @organizer_members_page
+Feature: Organizer members page
+  Organizers scan the roster by role and manage each person from one menu.
+
+  Background:
+    Given the following users exist:
+      | email                 | role | display_name    |
+      | owner552@example.com  | user | Owner Olive     |
+      | helper552@example.com | user | Organizer Oscar |
+      | member552@example.com | user | Member Maya     |
+    And a public group "Roster Redesign" exists with owner "owner552@example.com"
+    And "helper552@example.com" is an organizer of "Roster Redesign"
+    And "member552@example.com" is a member of "Roster Redesign"
+
+  Scenario: The roster reads as people grouped by role
+    Given I am signed in as "owner552@example.com"
+    When I open the organizer roster for "Roster Redesign"
+    Then I should see "3 people"
+    And "Owner Olive" is listed under "Owner"
+    And "Organizer Oscar" is listed under "Organizers"
+    And "Member Maya" is listed under "Members"
+
+  Scenario: Membership actions sit behind a per-person menu
+    Given I am signed in as "owner552@example.com"
+    When I open the organizer roster for "Roster Redesign"
+    Then the menu for "Member Maya" offers "Promote to organizer"
+    And the menu for "Member Maya" offers "Remove from group"
+    And the menu for "Organizer Oscar" offers "Demote to member"
+    And there is no menu for "Owner Olive"
+
+  Scenario: An organizer's menu offers only what they may do
+    Given I am signed in as "helper552@example.com"
+    When I open the organizer roster for "Roster Redesign"
+    Then the menu for "Member Maya" offers "Remove from group"
+    And the menu for "Member Maya" does not offer "Promote to organizer"
+    And there is no menu for "Organizer Oscar"
+
+  Scenario: Promoting from the menu moves the person to Organizers
+    Given I am signed in as "owner552@example.com"
+    When I open the organizer roster for "Roster Redesign"
+    And I choose "Promote to organizer" from the menu for "Member Maya"
+    And I confirm with "Promote to organizer"
+    Then "Member Maya" is listed under "Organizers"

--- a/test/features/step_definitions/group_membership_visibility_steps.exs
+++ b/test/features/step_definitions/group_membership_visibility_steps.exs
@@ -22,7 +22,7 @@ defmodule GroupMembershipVisibilitySteps do
 
   step "I open the promotion confirmation for {string}", %{args: [name]} = context do
     session =
-      within(context.session, "[aria-label='Manage #{name}']", fn session ->
+      within(context.session, "[role='menu'][aria-label='Manage #{name}']", fn session ->
         click_button(session, "Promote")
       end)
 
@@ -184,10 +184,13 @@ defmodule GroupMembershipVisibilitySteps do
     Phoenix.ConnTest.build_conn()
     |> login(owner)
     |> visit("/organize/#{group.slug}/members")
-    |> within("[aria-label='Manage #{context.current_user.display_name}']", fn session ->
-      click_button(session, action)
-    end)
-    |> click_button(confirmation)
+    |> within(
+      "[role='menu'][aria-label='Manage #{context.current_user.display_name}']",
+      fn session ->
+        click_button(session, action)
+      end
+    )
+    |> within("[role='dialog']", fn session -> click_button(session, confirmation) end)
 
     context
   end

--- a/test/features/step_definitions/organizer_members_page_steps.exs
+++ b/test/features/step_definitions/organizer_members_page_steps.exs
@@ -5,10 +5,7 @@ defmodule OrganizerMembersPageSteps do
   import PhoenixTest
 
   step "{string} is listed under {string}", %{args: [name, heading]} = context do
-    names = names_under(context.session, heading)
-
-    assert name in names,
-           "expected #{inspect(name)} under #{inspect(heading)}, found #{inspect(names)}"
+    assert_has(context.session, role_section(context.session, heading), text: name)
 
     context
   end
@@ -49,8 +46,8 @@ defmodule OrganizerMembersPageSteps do
 
   defp menu_for(name), do: "[role='menu'][aria-label='Manage #{name}']"
 
-  # The people named inside the roster section whose heading reads `heading`.
-  defp names_under(session, heading) do
+  # Resolve the roster region by its accessible heading.
+  defp role_section(session, heading) do
     doc = session |> page_html() |> Floki.parse_document!()
 
     section =
@@ -67,9 +64,8 @@ defmodule OrganizerMembersPageSteps do
 
     assert section, "no roster section headed #{inspect(heading)}"
 
-    section
-    |> Floki.find(".row-title")
-    |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+    [labelled_by] = Floki.attribute(section, "aria-labelledby")
+    "section[aria-labelledby='#{labelled_by}']"
   end
 
   defp page_html(%PhoenixTest.Live{view: view}), do: Phoenix.LiveViewTest.render(view)

--- a/test/features/step_definitions/organizer_members_page_steps.exs
+++ b/test/features/step_definitions/organizer_members_page_steps.exs
@@ -1,0 +1,77 @@
+defmodule OrganizerMembersPageSteps do
+  use Cucumber.StepDefinition
+
+  import ExUnit.Assertions
+  import PhoenixTest
+
+  step "{string} is listed under {string}", %{args: [name, heading]} = context do
+    names = names_under(context.session, heading)
+
+    assert name in names,
+           "expected #{inspect(name)} under #{inspect(heading)}, found #{inspect(names)}"
+
+    context
+  end
+
+  step "the menu for {string} offers {string}", %{args: [name, action]} = context do
+    assert_has(context.session, menu_for(name), text: action)
+    context
+  end
+
+  step "the menu for {string} does not offer {string}", %{args: [name, action]} = context do
+    assert_has(context.session, menu_for(name))
+    refute_has(context.session, "#{menu_for(name)} button", text: action)
+    context
+  end
+
+  step "there is no menu for {string}", %{args: [name]} = context do
+    refute_has(context.session, menu_for(name))
+    context
+  end
+
+  step "I choose {string} from the menu for {string}", %{args: [action, name]} = context do
+    session =
+      within(context.session, menu_for(name), fn session ->
+        click_button(session, action)
+      end)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  step "I confirm with {string}", %{args: [label]} = context do
+    session =
+      within(context.session, "[role='dialog']", fn session ->
+        click_button(session, label)
+      end)
+
+    Map.merge(context, %{session: session, conn: session})
+  end
+
+  defp menu_for(name), do: "[role='menu'][aria-label='Manage #{name}']"
+
+  # The people named inside the roster section whose heading reads `heading`.
+  defp names_under(session, heading) do
+    doc = session |> page_html() |> Floki.parse_document!()
+
+    section =
+      doc
+      |> Floki.find("section[aria-labelledby]")
+      |> Enum.find(fn section ->
+        [id] = Floki.attribute(section, "aria-labelledby")
+
+        doc
+        |> Floki.find("##{id}")
+        |> Floki.text()
+        |> String.trim() == heading
+      end)
+
+    assert section, "no roster section headed #{inspect(heading)}"
+
+    section
+    |> Floki.find(".row-title")
+    |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+  end
+
+  defp page_html(%PhoenixTest.Live{view: view}), do: Phoenix.LiveViewTest.render(view)
+  defp page_html(%PhoenixTest.Static{conn: conn}), do: conn.resp_body
+end


### PR DESCRIPTION
Closes #552.

The organizer members page is rebuilt as a roster: one summary line under the title ("39 people · Public group"), one panel grouped Owner / Organizers / Members with counts, and rows made of the person's mark, their name and the date they joined. The role pill and the two inline buttons per row are gone; each person who can be managed gets one quiet menu button that opens a native popover listing exactly the permitted actions (Promote to organizer, Demote to member, Remove from group). Picking one opens the existing confirmation dialog. Rows stay one line on phones.

- `member_menu/1` replaces `member_actions/1`; ids and events are unchanged, so permissions and the confirmation flow are untouched.
- `assets/js/popover_menu.mjs` adds a `PopoverMenu` hook that places a row's popover beside its trigger on `beforetoggle` (measured in the next animation frame, before the first paint) and hides it on scroll or resize. The browser still owns light dismiss, Escape and focus return. `placeMenu/1` is unit-tested.
- Features: `organizer_members_page.feature` (grouping by role, per-person menus for owner and organizer, promoting through the menu); browser scenario `member_menu.feature` works the menu with the keyboard. Steps resolve the roster through headings and menus through their accessible names.
- Design board added to the canvas: "Organize · Members" (desktop and phone), with a note.

Invitations for private groups keep their panel below the roster, unchanged.
