### PR TITLE
test(calendar): pin dates so the suite passes on Saturdays

### DIFF
--- a/test/huddlz/notifications/layout_test.exs
+++ b/test/huddlz/notifications/layout_test.exs
@@ -170,7 +170,8 @@ defmodule Huddlz.Notifications.LayoutTest do
             group_id: group.id,
             creator_id: owner.id,
             actor: owner,
-            date: ~D[2026-09-12],
+            # Pinned to a future Saturday: huddlz must start in the future.
+            date: ~D[2030-10-05],
             start_time: ~T[10:00:00],
             duration_minutes: 120
           )

--- a/test/huddlz_web/live/calendar_live_test.exs
+++ b/test/huddlz_web/live/calendar_live_test.exs
@@ -865,19 +865,22 @@ defmodule HuddlzWeb.CalendarLiveTest do
       host: host,
       public_group: public_group
     } do
+      # The week view needs a pinned window: "tomorrow" falls into next week
+      # whenever the suite runs on a Saturday.
+      in_week = ~D[2030-10-02]
       gone = create_past_huddl(host, public_group, title: "Missed It")
-      off = create_huddl(host, public_group, title: "Called Off", date: tomorrow())
+      off = create_huddl(host, public_group, title: "Called Off", date: in_week)
       Communities.cancel_huddl!(off, "Venue unavailable", actor: host)
-      answered = create_huddl(host, public_group, title: "Answered", date: tomorrow())
+      answered = create_huddl(host, public_group, title: "Answered", date: in_week)
       Communities.cancel_huddl!(answered, "Venue unavailable", actor: host)
-      rsvp_before_cancel = create_huddl(host, public_group, title: "Was Going", date: tomorrow())
+      rsvp_before_cancel = create_huddl(host, public_group, title: "Was Going", date: in_week)
       rsvp!(rsvp_before_cancel, attendee, :rsvp)
       Communities.cancel_huddl!(rsvp_before_cancel, "Venue unavailable", actor: host)
       gone_day = DateTime.to_date(HuddlCardHelpers.local_starts_at(gone))
 
       conn
       |> login(attendee)
-      |> visit("/calendar/week?scope=groups")
+      |> visit("/calendar/week?week=2030-09-29&scope=groups")
       |> refute_has("#calendar-entry-#{off.id}")
       |> refute_has("#calendar-entry-#{answered.id}")
       |> assert_has("#calendar-entry-#{rsvp_before_cancel.id} [data-status=cancelled]")


### PR DESCRIPTION
Two tests failed on Saturday 2026-09-12 with no code change and pass on every other weekday.

- The week-view scope test built its cancelled huddlz with `tomorrow()`, which on a Saturday is the Sunday that opens the next week, so the default week window never contained them. The huddlz are now pinned to the week of 2030-09-29 and the test visits that week explicitly, matching the other week-view tests.
- The `huddl_facts/1` row test pinned its huddl to 2026-09-12 at 10:00, which became a past date on that day and failed the future-date validation. It now uses a future Saturday so the "Saturday Soccer" title still reads right.

Week and month views need pinned dates; only agenda tests should use dates relative to today.